### PR TITLE
fix(kiro): explain empty exec output and stop reopening a delivered final answer

### DIFF
--- a/devlog/_plan/260828_kiro_turn_termination/000_research.md
+++ b/devlog/_plan/260828_kiro_turn_termination/000_research.md
@@ -1,0 +1,63 @@
+# Kiro turn termination — residual defect research
+
+Observed 2026-08-28 21:20 KST by the user in a Codex desktop session routed
+`kiro/claude-opus-5` through the local proxy on port 10100.
+
+## Symptom
+
+1. A plain question ("근데 코드 모드가 뭐임") produced the final answer TWICE in
+   one turn, the second a near-duplicate rewrite of the first.
+2. The user reports the "answer finishes, then continues like a goal" loop is
+   still present after `cf1a5720c`.
+
+## Live-state evidence
+
+- Listener PID 3653, started 2026-08-28 21:17:50, running the checkout at
+  `/Users/jun/Developer/new/700_projects/opencodex/src/cli/index.ts start --port 10100`.
+- `cf1a5720c` committed 21:09:50 — the running process DID load that fix.
+  Confirmed independently: a probe that produced no stdout in this session
+  returned the new empty-exec wording added by that commit.
+- HEAD advanced to `60537f067` at 21:26:53 (a different session's commit), so
+  the running proxy is stale relative to HEAD but not relative to `cf1a5720c`.
+
+So the residual behaviour is a real defect, not a stale process.
+
+## Mechanism 1 — duplicate final answer (rendering)
+
+Kiro emits answer-like ordinary text, then calls the private completion tool in
+the SAME inference. The adapter releases the prose as `phase: "commentary"` and
+the completion `answer` as `phase: "final_answer"`. `src/bridge.ts` closes the
+commentary message on the phase change and opens a new assistant message, so the
+client renders two assistant messages whose text is nearly identical.
+
+This is pinned by the existing suite, so it is verified behaviour rather than a
+hypothesis — `tests/kiro-stream.test.ts` asserts exactly:
+
+```
+{ type: "text_delta", text: "Done.", phase: "commentary" },
+{ type: "text_delta", text: "Done.", phase: "final_answer" },
+```
+
+## Mechanism 2 — non-terminating turn (upstream fetch)
+
+When replayed history ends in a delivered final answer, `buildKiroPayload` still
+appends a synthetic trailing user turn carrying `KIRO_ANSWER_DELIVERED_MESSAGE`
+and performs a real upstream inference. Neutral wording removes the instruction
+to resume but does not remove the prompt: the model is asked again and answers
+again. `60537f067` additionally suppresses the completion contract for that
+shape, which narrows the loop, but there is still no terminal boundary that
+avoids the fetch.
+
+## Hypotheses tested
+
+| id | claim | verdict | evidence |
+|----|-------|---------|----------|
+| H1 | the completion TOOL CALL never sets the phase flag | refuted | the proxy consumes the completion tool; a replayed history containing it throws at `src/adapters/kiro-wire.ts:88` (reproduced directly) |
+| H2 | any synthetic trailing user turn re-invokes the model | confirmed | `src/adapters/kiro.ts` trailing-turn append still yields an upstream inference |
+| H3 | another layer replays the answer | partial | the generic Responses guard is not involved; the Kiro-owned bounded completion fallback does perform a second fetch |
+| H4 | commentary is the last recorded component | confirmed | ordinary text is forced to commentary; the completion answer is a separate final message, split at `src/bridge.ts:922` |
+
+## Verification baseline
+
+`bun test tests/kiro-adapter.test.ts tests/kiro-stream.test.ts tests/server-kiro-completion-e2e.test.ts`
+-> 180 pass, 0 fail at `60537f067`.

--- a/devlog/_plan/260828_kiro_turn_termination/010_wp1_terminal_boundary.md
+++ b/devlog/_plan/260828_kiro_turn_termination/010_wp1_terminal_boundary.md
@@ -1,0 +1,81 @@
+# wp1 — terminal boundary for a delivered final answer
+
+Consumes: `000_research.md` mechanism 2.
+
+## Problem
+
+`buildKiroPayload` (`src/adapters/kiro.ts`) turns a trailing delivered final
+answer into a synthetic user turn carrying `KIRO_ANSWER_DELIVERED_MESSAGE` and
+then performs a real upstream inference. Neutral wording is still a prompt, so
+the model answers again — the closed task reads as an open goal.
+
+`60537f067` suppresses the completion contract for that shape. Keep that as
+defence in depth; it is not the boundary.
+
+## Change (revised after the A-phase audit — audit verdict was FAIL on the
+## original placement, see 011_audit_round1.md)
+
+Short-circuit BEFORE the provider fetch, but NOT inside `buildRequest` and NOT
+as a bare outputless `done`. Three constraints the audit established, each
+verified against current source:
+
+1. **An outputless `done` is retried, not accepted.** `guardEmptyCompletionEventStream`
+   treats a `done` with no content event as an empty completion, suppresses the
+   terminal, and re-invokes the identical turn; a second empty terminal becomes
+   `empty_completion_retry_failed`
+   (`src/server/responses/empty-completion-guard.ts:246-270`). So the naive
+   terminal turns one loop into either another inference or a stated error.
+   The local terminal must therefore bypass the empty-completion guard as well as
+   the transport.
+2. **`buildRequest` cannot emit events.** The adapter contract returns an
+   `AdapterRequest`; events only exist once a `Response` reaches `parseStream`
+   (`src/adapters/base.ts`). The server then records and sends the attempt
+   unconditionally. Manufacturing a fake `Response` inside `fetchResponse` is
+   also wrong: it records a physical send and still meets the guard.
+3. **A phantom estimate must not be logged.** Kiro attaches an estimated input
+   count during build and the server notes the attempt send before fetching, so
+   short-circuiting after a build would log a request that never happened.
+
+Placement: an explicit adapter-owned local-terminal decision consulted in
+`handleResponsesInner` AFTER adapter resolution and BEFORE the ordinary
+build/send path, short-circuiting to a locally constructed terminal response.
+Reuse `hasTrailingDeliveredFinalAnswer` as the predicate; do not introduce a
+second notion of "delivered". The hook must not intercept the adapter-owned
+bounded retry, which builds with a forced `text_fallback` mode.
+
+Usage accounting for the local terminal: no build-time estimate, `sendCount`
+zero, response usage explicitly zero for input/output/total, and no estimated
+usage in the request log.
+
+## Out of scope
+
+- Any change to how the completion tool is parsed or consumed.
+- Any change to the empty-exec normalisation from `cf1a5720c` / `60537f067`.
+- The duplicate-rendering defect, which is wp2.
+
+## Criteria
+
+1. Replaying a delivered final answer issues ZERO upstream requests and yields a
+   completed turn with `endTurn: true`.
+2. Criterion 1 holds with `emptyCompletionRetry` BOTH enabled and disabled, for
+   streaming and non-streaming Responses. This is the criterion the audit added;
+   without it the fix passes a test and still loops in the user's config.
+3. The short-circuited turn logs `sendCount === 0` and no estimated usage.
+4. A genuine later user message after a delivered final answer still performs a
+   normal inference (control).
+5. An unfinished trailing assistant turn still gets the continuation prompt and
+   still performs an inference (control, already covered — must stay green).
+6. The adapter-owned bounded `text_fallback` retry is NOT intercepted.
+7. `60537f067`'s completion-mode suppression remains asserted.
+
+## Completion language
+
+Closing wp1 fixes the repeated inference ONLY. The user-visible duplicate answer
+remains until wp2 lands, and the wp1 report must say so rather than implying the
+reported symptom is fully resolved.
+
+## Evidence
+
+`bun test tests/kiro-adapter.test.ts tests/kiro-stream.test.ts tests/server-kiro-completion-e2e.test.ts`
+plus new public-server coverage in `tests/server-kiro-completion-e2e.test.ts`,
+each new assertion driven red once by reverting the change.

--- a/devlog/_plan/260828_kiro_turn_termination/011_audit_round1.md
+++ b/devlog/_plan/260828_kiro_turn_termination/011_audit_round1.md
@@ -1,0 +1,25 @@
+# A-phase audit round 1 — verdict FAIL
+
+Reviewer: independent subagent (gpt-5.6-sol, medium effort), read-only lane.
+Audited: `000_research.md`, `010_wp1_terminal_boundary.md` as first written.
+Reviewer's own checks: 180 pass / 0 fail on the three Kiro suites,
+`bun x tsc --noEmit` exit 0, live proxy untouched.
+
+The plan was rewritten rather than argued with. Findings and dispositions:
+
+| # | Finding | Disposition |
+|---|---------|-------------|
+| 1 | An outputless `done` is consumed by the empty-completion guard, which suppresses the terminal and re-invokes the identical turn (`src/server/responses/empty-completion-guard.ts:246-270`). The "safe terminal" becomes another inference or `empty_completion_retry_failed`. | ACCEPTED. Verified independently by reading the guard. wp1 now requires bypassing the guard as well as the transport, and adds a criterion covering `emptyCompletionRetry` both ON and OFF. |
+| 2 | `buildRequest` cannot emit events under the adapter contract, and faking a `Response` in `fetchResponse` still records a physical send. | ACCEPTED. Placement moved to an adapter-owned local-terminal decision consulted in `handleResponsesInner` before the build/send path. |
+| 3 | Short-circuiting after a build logs a phantom estimated request. | ACCEPTED. Criteria now demand no build-time estimate, `sendCount === 0`, zero response usage, and no estimated usage in the request log. |
+| 4 | `hasTrailingDeliveredFinalAnswer` is sound, but the hook must not intercept the forced `text_fallback` build. | ACCEPTED as a criterion. The predicate was re-read directly: role-and-phase based, so a user message merely QUOTING the acknowledgement is unaffected. |
+| 5 | wp1/wp2 separation is legitimate, but wp1's completion language must not imply the reported symptom is fully fixed. | ACCEPTED. wp1 now carries an explicit completion-language section. |
+| 6 | The broad "buffer commentary" direction is wrong; required-mode commentary is ALREADY deferred, and the real defect is the unconditional flush before the validated answer. Retaining across the bounded fallback would hide progress during a long second inference. | ACCEPTED, and it improves the design: wp2 is now a change to WHEN the existing deferred run is released, not a new buffer. |
+| 7 | No user-visible Responses-level regression was specified; adapter-event coverage cannot prove the rendered duplicate is gone. | ACCEPTED. Both work-phases now name `tests/server-kiro-completion-e2e.test.ts`. |
+
+Process note the reviewer raised: it expected a staged diff and found none, and
+observed HEAD had moved to `761cb4cfe`. Correct on both counts — the plan unit is
+untracked while in P, and two unrelated commits landed from another session
+during the audit. Neither invalidates the substance, and the untracked worktree
+changes in `src/adapters/cursor/` at dispatch time belonged to that other session
+and were left alone.

--- a/devlog/_plan/260828_kiro_turn_termination/012_audit_round2.md
+++ b/devlog/_plan/260828_kiro_turn_termination/012_audit_round2.md
@@ -1,0 +1,55 @@
+# A-phase audit round 2 — verdict FAIL on wp2, wp1 cleared
+
+Same reviewer as round 1 (blocker-closure reuse). Round 1's seven findings were
+all accepted; this round re-read the revised plan.
+
+## wp1 — cleared
+
+The reviewer confirms the revised placement, criteria, and completion language
+are sufficient: bypassing transport, request building, and the empty-completion
+guard, with guard-on/guard-off and streaming/non-streaming coverage, zero sends,
+no estimated usage, and the forced `text_fallback` exclusion.
+
+It also rejected `runTurn` as the seam, with specifics worth keeping: adopting
+`runTurn` routes EVERY Kiro request into the custom transport branch, which waits
+on provider pacing and increments `sendCount` before any local decision, still
+meets the empty-completion guard afterwards, and would force Kiro to re-own
+transport, retries, failover, cancellation, and accounting that its existing
+`buildRequest`/`fetchResponse`/`parseStream` path already provides. The local
+terminal therefore belongs immediately after adapter resolution and before
+`buildRequest`.
+
+## wp2 — two execution-path blockers, both accepted
+
+1. **The outer drain.** Skipping the inner flush at `src/adapters/kiro.ts:1467`
+   is not enough: `parseKiroAttempt` independently drains `deferred` at
+   `src/adapters/kiro.ts:996-999` after the inner generator returns. The final
+   answer would be emitted first and the commentary after it — the duplicate
+   survives, reversed. Found independently while reading the same file, so this
+   is confirmed twice. The deferred collection must be consumed, and the claim
+   that this stays clear of retention machinery is withdrawn.
+2. **`text_fallback` has the same shape through a different collection.** It
+   retains in `fallbackEvents`, and `src/adapters/kiro.ts:1470-1477` emits all of
+   them and then the completion answer. The rule must apply independently inside
+   each inference.
+
+Criterion 3 was also overbroad — "any turn whose completion never arrives enters
+the fallback exactly once" is false for real tools, provider/protocol failures,
+and explicit stops like `MAX_TOKENS`. Narrowed to a clean required-mode
+inference, with added controls for failure, explicit incomplete stop,
+text_fallback duplication, and budget return-to-baseline.
+
+The six release paths the reviewer enumerated from source are now a table in
+`020_wp2_duplicate_answer.md` and are treated as controls.
+
+## HEAD movement
+
+Verified: `60537f067..761cb4cfe` touches only
+`src/adapters/cursor/tool-result-normalize.ts` and
+`tests/cursor-exec-empty-result.test.ts`. No Kiro adapter, adapter contract,
+Responses core, bridge, or Kiro test file changed. The plan is unaffected.
+
+## Disposition
+
+wp1 proceeds to implementation. wp2's plan page is corrected here and will be
+re-audited as part of its own cycle rather than blocking wp1.

--- a/devlog/_plan/260828_kiro_turn_termination/020_wp2_duplicate_answer.md
+++ b/devlog/_plan/260828_kiro_turn_termination/020_wp2_duplicate_answer.md
@@ -1,0 +1,124 @@
+# wp2 — one visible answer per turn
+
+Consumes: `000_research.md` mechanism 1.
+
+## Problem
+
+Kiro emits answer-like ordinary text and then calls the private completion tool
+in the SAME inference. The adapter releases the prose as `phase: "commentary"`
+and the completion `answer` as `phase: "final_answer"`;
+`src/bridge.ts` closes the commentary message on the phase change and opens a
+new assistant message. The client renders two assistant messages whose text is
+nearly identical. This is what the user saw.
+
+The existing suite pins this pair, so the fix necessarily REPLACES an asserted
+expectation rather than adding to it:
+
+```
+tests/kiro-stream.test.ts
+{ type: "text_delta", text: "Done.", phase: "commentary" },
+{ type: "text_delta", text: "Done.", phase: "final_answer" },
+```
+
+## Constraint that shapes the design
+
+Progress prose is load-bearing UX: a long tool-using turn streams commentary so
+the user is not left staring at nothing. Withholding ALL commentary until the
+turn resolves would trade a cosmetic duplicate for a silent turn, which the
+repository's own comments call out (`#520` gates exist precisely to avoid
+re-emitting or losing flushed progress).
+
+So the buffering must be NARROW: hold back only the trailing commentary run that
+has not yet been followed by a real tool call, and only while the completion tool
+is still capable of arriving. Release it unchanged the moment a real tool starts,
+the stream ends without a completion answer, or the bounded fallback engages.
+
+## Options
+
+1. **Consume the same inference's retained text on a valid completion.** (CHOSEN —
+   narrowed in audit round 1, corrected in round 2.) No new buffer is needed:
+   required-mode commentary is ALREADY deferred. But skipping the inner flush is
+   NOT sufficient, and this is the correction that matters:
+
+   - The inner flush is at `src/adapters/kiro.ts:1467`.
+   - `parseKiroAttempt` INDEPENDENTLY drains whatever remains in `deferred` at
+     `src/adapters/kiro.ts:996-999`, after the inner generator returns.
+
+   So merely skipping the inner flush emits the final answer first and then the
+   commentary from the outer drain — the duplicate survives, in reversed order.
+   The deferred collection must be CONSUMED on a valid completion: discard and
+   release the redundant `text_delta` events, preserve and release every
+   non-text event, and leave nothing for the outer drain. That necessarily
+   touches retention ownership, so the earlier claim that this change stays
+   clear of the retention machinery is withdrawn.
+
+   `text_fallback` has the SAME shape through a DIFFERENT collection: it retains
+   in `fallbackEvents`, and `src/adapters/kiro.ts:1470-1477` emits all of them
+   and then the completion answer. The rule must therefore apply independently
+   inside EACH inference:
+
+   - required inference + valid completion -> suppress its deferred text, keep
+     non-text events, emit the completion answer;
+   - text_fallback inference + valid completion -> suppress that inference's
+     retained text, keep non-text events, emit the completion answer;
+   - never retain one inference's progress across the next inference.
+2. **Retain commentary ACROSS the bounded fallback.** Rejected by the audit: the
+   second inference can be long, so withholding first-attempt progress across it
+   would make the turn look dead and contradicts the deliberate "first attempt
+   already flushed" gate.
+3. **Suppress only on redundancy.** Emit commentary live, and skip the completion
+   answer if it is substantially the same text. Rejected: "substantially the same"
+   is a similarity heuristic, and a wrong guess either drops the real answer or
+   keeps the duplicate.
+4. **Bridge-side coalesce.** Merge a commentary message and an immediately
+   following final answer into one assistant message. Rejected as the primary
+   seam: the phase distinction is deliberate protocol information, and the same
+   split is correct when the commentary genuinely preceded tool work.
+
+Because the deferral already exists, this is a change to WHEN the deferred run is
+released, not a new retention mechanism — which also keeps it clear of the
+retention/budget machinery where duplication bugs have previously lived.
+
+## Criteria
+
+1. A single inference emitting answer-like prose plus a completion answer yields
+   exactly ONE visible answer to the client.
+2. Commentary followed by a REAL tool call is still emitted live and in order.
+3. A CLEAN required-mode inference — text or reasoning present, no real tool, no
+   completion answer, no explicit non-completion stop reason — still shows its
+   progress prose and enters the bounded fallback exactly once. (Narrowed in
+   audit round 2: the unqualified form was false for real tools, provider and
+   protocol failures, and explicit stops such as `MAX_TOKENS` or
+   `CONTENT_FILTERED`.)
+4. A Responses-protocol-level assertion, not only adapter events: the user-visible
+   duplicate must be proven gone through the bridge. Adapter-event coverage cannot
+   prove this, because the split happens in the bridge on the phase change. The
+   assertion belongs in `tests/server-kiro-completion-e2e.test.ts`: one upstream
+   request, exactly one visible assistant answer, one terminal completion, and the
+   near-duplicate prose absent.
+5. The existing `tests/kiro-stream.test.ts` expectation that asserts the
+   commentary/final pair is UPDATED, not deleted — the replacement states the new
+   contract for the same scenario.
+6. `text_fallback` ordinary text plus a valid completion also yields exactly one
+   visible answer.
+7. The translator budget returns to baseline after suppressed events — suppression
+   must release retention, not leak it.
+
+## Release paths that must remain intact
+
+Enumerated from source in audit round 2; each is a control the implementation may
+not regress:
+
+| trigger | release point |
+|---------|---------------|
+| a real tool starts (`sawRealTool`) | `src/adapters/kiro.ts:1172-1177`, released with the tool event |
+| clean no-completion turn needing fallback | flush before `needsFallback` returns, `src/adapters/kiro.ts:1535-1542` / `1600-1603` |
+| stream / protocol / provider failure | outer failure drain, `src/adapters/kiro.ts:996-999` |
+| explicit non-completion stop | released before the incomplete/error branches, `src/adapters/kiro.ts:1545-1598` |
+| plain-text fallback without completion | retained text promoted to `final_answer`, `src/adapters/kiro.ts:1488-1501` |
+| empty / reasoning-only fallback | diagnostics released before the structured incomplete, `src/adapters/kiro.ts:1503-1517` |
+
+## Out of scope
+
+- The terminal-boundary fix (wp1).
+- Changing what `phase` means in the Responses protocol.

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -37,6 +37,21 @@ export interface ProviderAdapter {
    */
   buildRequest(parsed: OcxParsedRequest, incoming: IncomingMeta): AdapterRequest | Promise<AdapterRequest>;
 
+  /**
+   * Decide, BEFORE any request is built or sent, that this turn has nothing to ask upstream.
+   *
+   * Returning a reason short-circuits the turn to a locally constructed completed response: no
+   * `buildRequest`, no send, no token estimate, and no empty-completion retry. That last part is
+   * why this cannot be expressed as an outputless `done` from `parseStream`: the empty-completion
+   * guard treats a terminal with no content as a failed turn and re-invokes the identical request,
+   * so an adapter that "successfully returned nothing" would be retried into the very loop it was
+   * trying to end.
+   *
+   * Only for turns whose input already contains the answer — see the Kiro adapter, where replayed
+   * history ending in a delivered final answer has nothing left to complete.
+   */
+  localTerminal?(parsed: OcxParsedRequest): AdapterLocalTerminal | undefined;
+
   fetchResponse?(request: AdapterRequest, ctx?: AdapterFetchContext): Promise<Response>;
 
   /**
@@ -118,4 +133,15 @@ export interface AdapterFetchContext {
   stream?: boolean;
   /** Custom fetch executor to use for physical upstream network requests (defaults to globalThis.fetch). */
   executor?: typeof globalThis.fetch;
+}
+
+/**
+ * An adapter's decision that a turn needs no upstream inference at all.
+ *
+ * `reason` is diagnostic only. It is never sent to the client and never logged as request
+ * content: it names the code path for a maintainer reading a request log, so it must stay a
+ * fixed identifier rather than anything derived from the conversation.
+ */
+export interface AdapterLocalTerminal {
+  reason: string;
 }

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -3,6 +3,7 @@ import { ValueSchema } from "@bufbuild/protobuf/wkt";
 import type { OcxRequestOptions, OcxTool } from "../../types";
 import { namespacedToolName, toolChoiceAliases } from "../../types";
 import { McpToolDefinitionSchema, McpToolsSchema, type McpToolDefinition } from "./gen/agent_pb";
+import { CODE_MODE_RESULT_ECHO_SENTENCE } from "../exec-tool-result-normalize";
 
 export const OCX_RESPONSES_TOOL_PROVIDER = "opencodex-responses";
 export const CODEX_EXEC_COMMAND_TOOL = "exec_command";
@@ -654,7 +655,7 @@ export function buildCursorToolGuidanceSystemNote(
       ? `\`${CODEX_UNIFIED_EXEC_TOOL}\` is Codex code mode: its body is JavaScript evaluated in a V8 isolate, not a shell command and not Node. Shell, file edits, and MCP are nested helpers called INSIDE that body as \`await tools.<name>(...)\`, for example \`await tools.exec_command({cmd: \"ls\"})\`. Read the tool description and the isolate global \`ALL_TOOLS\` (not \`tools.ALL_TOOLS\`) for helpers this turn provides; absence from the top-level catalog or from \`exec\`'s description is not absence. Those nested helpers are not themselves top-level tools, so do not call \`exec_command\` or \`shell_command\` at the top level here${codeModeOtherTopLevelNames.length > 0 ? `; every other tool this turn lists, including ${quotedNames(codeModeOtherTopLevelNames)}, remains callable at the top level as usual` : ""}. Nested \`tools.apply_patch(input)\` is host-executed: the string must begin exactly with \`*** Begin Patch\` and end with \`*** End Patch\` (no trailing \`***\` on those lines). OpenCodex does not rewrite JavaScript inside exec, so a decorated \`*** Begin Patch ***\` envelope is rejected by Codex before the file is touched.`
       : undefined,
     codeMode
-      ? "In code mode the isolate returns nothing on its own: call `text(...)` (or `notify(...)`) on any value you need to see, or the call completes with empty output. There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers."
+      ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers."
       : undefined,
     codeMode
       ? "NEVER attempt Cursor-native Shell, Read, Grep, List, or any tool absent from the catalog — they are not executed in this environment and every probe wastes a turn. The exec code cell (with its nested helpers) is the ONLY execution surface; go to it directly on the FIRST attempt and do not narrate switching surfaces."

--- a/src/adapters/cursor/tool-result-normalize.ts
+++ b/src/adapters/cursor/tool-result-normalize.ts
@@ -12,8 +12,18 @@
 import {
   EMPTY_EXEC_OUTPUT_MESSAGE,
   EMPTY_EXEC_OUTPUT_REGEX,
+  FAILED_EXEC_OUTPUT_REGEX,
   isCodexExecBridgeTool,
 } from "../exec-tool-result-normalize";
+
+/**
+ * Cursor treats a failed-but-empty wrapper as an empty result too (its Computer Use branch marks
+ * such results `isError` separately). The shared success regex deliberately excludes
+ * `Script failed`, so restore that arm here rather than widening the shared one.
+ */
+function isEmptyOrFailedExecWrapper(text: string): boolean {
+  return EMPTY_EXEC_OUTPUT_REGEX.test(text) || FAILED_EXEC_OUTPUT_REGEX.test(text);
+}
 
 const COMPUTER_USE_TOOL_NAMES = new Set([
   "node_repl",
@@ -76,14 +86,14 @@ export function normalizeCursorToolResultText(
 ): NormalizedToolResultText {
   const isError = options.isError === true;
   const computerUse = isNodeReplOrComputerUseTool(options.toolName, options.toolNamespace);
-  if (computerUse && EMPTY_EXEC_OUTPUT_REGEX.test(text.trim())) {
+  if (computerUse && isEmptyOrFailedExecWrapper(text.trim())) {
     return {
       text: "[empty output: the tool ran but produced no stdout or return value. Verify application state with get_app_state, or make the script emit output.]",
       isError: true,
       changed: true,
     };
   }
-  if (isCodexExecBridgeTool(options.toolName, options.toolNamespace) && EMPTY_EXEC_OUTPUT_REGEX.test(text.trim())) {
+  if (isCodexExecBridgeTool(options.toolName, options.toolNamespace) && isEmptyOrFailedExecWrapper(text.trim())) {
     return {
       text: EMPTY_EXEC_OUTPUT_MESSAGE,
       isError: false,

--- a/src/adapters/cursor/tool-result-normalize.ts
+++ b/src/adapters/cursor/tool-result-normalize.ts
@@ -12,6 +12,7 @@
 import {
   EMPTY_EXEC_OUTPUT_MESSAGE,
   EMPTY_EXEC_OUTPUT_REGEX,
+  FAILED_EXEC_OUTPUT_MESSAGE,
   FAILED_EXEC_OUTPUT_REGEX,
   isCodexExecBridgeTool,
 } from "../exec-tool-result-normalize";
@@ -95,7 +96,10 @@ export function normalizeCursorToolResultText(
   }
   if (isCodexExecBridgeTool(options.toolName, options.toolNamespace) && isEmptyOrFailedExecWrapper(text.trim())) {
     return {
-      text: EMPTY_EXEC_OUTPUT_MESSAGE,
+      // A `Script failed` wrapper is empty but NOT a success: reporting it as an empty success
+      // would erase the only failure signal. Text classification stays separate from Cursor's
+      // isError policy, which the Computer Use branch above owns.
+      text: FAILED_EXEC_OUTPUT_REGEX.test(text.trim()) ? FAILED_EXEC_OUTPUT_MESSAGE : EMPTY_EXEC_OUTPUT_MESSAGE,
       isError: false,
       changed: true,
     };

--- a/src/adapters/cursor/tool-result-normalize.ts
+++ b/src/adapters/cursor/tool-result-normalize.ts
@@ -9,6 +9,12 @@
  * dropping images oldest-first — see toolCallStep in protobuf-request.ts).
  */
 
+import {
+  EMPTY_EXEC_OUTPUT_MESSAGE,
+  EMPTY_EXEC_OUTPUT_REGEX,
+  isCodexExecBridgeTool,
+} from "../exec-tool-result-normalize";
+
 const COMPUTER_USE_TOOL_NAMES = new Set([
   "node_repl",
   "node_repl__js",
@@ -27,31 +33,6 @@ function isNodeReplOrComputerUseTool(toolName?: string, toolNamespace?: string):
   const lower = toolName.toLowerCase();
   if (COMPUTER_USE_TOOL_NAMES.has(lower)) return true;
   return lower.startsWith("mcp__node_repl") || lower.startsWith("mcp__computer_use");
-}
-
-/**
- * Codex exec / shell-bridge tool names (flat and MCP-prefixed display aliases). An empty result
- * here is almost always a code-mode cell that never called text()/notify() — the cursor model
- * reads the blank [tool_result], concludes prior results were lost, and spirals into
- * re-orientation retries (devlog 260826_cursor_responses_gap, live subagent transcripts).
- */
-function isCodexExecBridgeTool(toolName?: string, toolNamespace?: string): boolean {
-  if (toolNamespace && toolNamespace.includes("opencodex-responses")) return true;
-  if (!toolName) return false;
-  const lower = toolName.toLowerCase();
-  return (
-    lower === "exec"
-    || lower === "exec_command"
-    || lower === "shell_command"
-    // Codex CLI/desktop native tool names: the multi-round "이전 출력이 비어 있어 처음부터"
-    // restart loop reproduced via codex exec because `shell` was not in this set
-    // (devlog 260826 gap-8 QA round 2).
-    || lower === "shell"
-    || lower === "local_shell"
-    || lower === "container.exec"
-    || lower.startsWith("mcp_opencodex-responses_")
-    || lower.startsWith("mcp__opencodex-responses__")
-  );
 }
 
 /** Failure states the Computer Use / node_repl runtime reports as PLAIN TEXT inside a non-error result. */
@@ -73,9 +54,6 @@ const RUNTIME_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; guidance: string
     guidance: "Imports are not available in this exec context; use the injected globals instead.",
   },
 ];
-
-/** Matches exec wrappers whose only payload is an empty-output marker. */
-const EMPTY_EXEC_OUTPUT_REGEX = /^(?:(?:Script completed|Script failed|Command finished|Execution finished)[^\n]*\n+)?(?:Wall time[^\n]*\n+)?(?:Output:\s*)?(?:<empty>)?\s*$/;
 
 export interface NormalizedToolResultText {
   text: string;
@@ -107,7 +85,7 @@ export function normalizeCursorToolResultText(
   }
   if (isCodexExecBridgeTool(options.toolName, options.toolNamespace) && EMPTY_EXEC_OUTPUT_REGEX.test(text.trim())) {
     return {
-      text: "[empty output: the exec cell completed but emitted nothing. This is NOT lost context and NOT a blocked tool — in code mode call text(...) or notify(...) on any value you need to see (a bare await tools.exec_command(...) is not echoed automatically); in shell mode the command simply printed nothing. Do not re-run the same call expecting different output.]",
+      text: EMPTY_EXEC_OUTPUT_MESSAGE,
       isError: false,
       changed: true,
     };

--- a/src/adapters/exec-tool-result-normalize.ts
+++ b/src/adapters/exec-tool-result-normalize.ts
@@ -1,0 +1,66 @@
+/**
+ * Provider-neutral empty-exec-output normalization.
+ *
+ * A code-mode `exec` cell that never calls `text()`/`notify()` returns nothing: the last
+ * expression value is NOT echoed automatically. The routed model reads a blank tool result,
+ * concludes its earlier output was lost, and burns turns re-running the same call or restarting
+ * the task from scratch. Naming that state explicitly is what breaks the loop.
+ *
+ * This module owns the shared detection so every adapter reports the same thing. Cursor keeps its
+ * own wrapper (`normalizeCursorToolResultText`) for Computer Use precedence and isError policy;
+ * Kiro consumes this helper directly.
+ */
+
+/** Matches exec wrappers whose only payload is an empty-output marker. */
+export const EMPTY_EXEC_OUTPUT_REGEX = /^(?:(?:Script completed|Script failed|Command finished|Execution finished)[^\n]*\n+)?(?:Wall time[^\n]*\n+)?(?:Output:\s*)?(?:<empty>)?\s*$/;
+
+/**
+ * The guidance itself. Worded to close all three wrong conclusions a model draws from a blank
+ * result: that context was lost, that the tool is blocked, and that retrying will differ.
+ */
+export const EMPTY_EXEC_OUTPUT_MESSAGE =
+  "[empty output: the exec cell completed but emitted nothing. This is NOT lost context and NOT a blocked tool — in code mode call text(...) or notify(...) on any value you need to see (a bare await tools.exec_command(...) is not echoed automatically); in shell mode the command simply printed nothing. Do not re-run the same call expecting different output.]";
+
+/**
+ * Codex exec / shell-bridge tool names (flat and MCP-prefixed display aliases). An empty result
+ * here is almost always a code-mode cell that never called text()/notify().
+ */
+export function isCodexExecBridgeTool(toolName?: string, toolNamespace?: string): boolean {
+  if (toolNamespace && toolNamespace.includes("opencodex-responses")) return true;
+  if (!toolName) return false;
+  const lower = toolName.toLowerCase();
+  return (
+    lower === "exec"
+    || lower === "exec_command"
+    || lower === "shell_command"
+    // Codex CLI/desktop native tool names: the multi-round "이전 출력이 비어 있어 처음부터"
+    // restart loop reproduced via codex exec because `shell` was not in this set
+    // (devlog 260826 gap-8 QA round 2).
+    || lower === "shell"
+    || lower === "local_shell"
+    || lower === "container.exec"
+    || lower.startsWith("mcp_opencodex-responses_")
+    || lower.startsWith("mcp__opencodex-responses__")
+  );
+}
+
+/** True when this result is an exec-bridge call that produced no usable output. */
+export function isEmptyExecToolResult(
+  text: string,
+  options: { toolName?: string; toolNamespace?: string } = {},
+): boolean {
+  return isCodexExecBridgeTool(options.toolName, options.toolNamespace)
+    && EMPTY_EXEC_OUTPUT_REGEX.test(text.trim());
+}
+
+/**
+ * Returns the guidance text when this is an empty exec-bridge result, else `undefined` so the
+ * caller keeps its own fallback. Undefined rather than the original text: an adapter must be able
+ * to tell "not my case" from "normalized to the same string".
+ */
+export function normalizeEmptyExecToolResultText(
+  text: string,
+  options: { toolName?: string; toolNamespace?: string } = {},
+): string | undefined {
+  return isEmptyExecToolResult(text, options) ? EMPTY_EXEC_OUTPUT_MESSAGE : undefined;
+}

--- a/src/adapters/exec-tool-result-normalize.ts
+++ b/src/adapters/exec-tool-result-normalize.ts
@@ -11,8 +11,23 @@
  * Kiro consumes this helper directly.
  */
 
-/** Matches exec wrappers whose only payload is an empty-output marker. */
-export const EMPTY_EXEC_OUTPUT_REGEX = /^(?:(?:Script completed|Script failed|Command finished|Execution finished)[^\n]*\n+)?(?:Wall time[^\n]*\n+)?(?:Output:\s*)?(?:<empty>)?\s*$/;
+/**
+ * Matches exec wrappers whose only payload is an empty-output marker.
+ *
+ * `Script failed` is deliberately NOT in this set. A failed cell with no captured output is still
+ * a FAILURE, and the success guidance below ("not a blocked tool", "do not re-run") would erase the
+ * only signal that anything went wrong — reachable through Responses history, where
+ * `function_call_output` is parsed with `isError: false`. Cursor keeps its own broader regex for
+ * Computer Use, where a failed wrapper is separately marked `isError`.
+ */
+export const EMPTY_EXEC_OUTPUT_REGEX = /^(?:(?:Script completed|Command finished|Execution finished)[^\n]*\n+)?(?:Wall time[^\n]*\n+)?(?:Output:\s*)?(?:<empty>)?\s*$/;
+
+/** Wrapper for a cell that FAILED without emitting output: empty, but not a success. */
+export const FAILED_EXEC_OUTPUT_REGEX = /^Script failed[^\n]*\n*(?:Wall time[^\n]*\n*)?(?:Output:\s*)?(?:<empty>)?\s*$/;
+
+/** Guidance for a failed cell whose output was empty: the failure must survive normalization. */
+export const FAILED_EXEC_OUTPUT_MESSAGE =
+  "[exec failed with no captured output: the cell raised before emitting anything. This is a real failure, not an empty success — inspect the call for a thrown error or syntax problem before retrying.]";
 
 /**
  * The guidance itself. Worded to close all three wrong conclusions a model draws from a blank
@@ -62,5 +77,9 @@ export function normalizeEmptyExecToolResultText(
   text: string,
   options: { toolName?: string; toolNamespace?: string } = {},
 ): string | undefined {
-  return isEmptyExecToolResult(text, options) ? EMPTY_EXEC_OUTPUT_MESSAGE : undefined;
+  if (!isCodexExecBridgeTool(options.toolName, options.toolNamespace)) return undefined;
+  const trimmed = text.trim();
+  // Failure first: a failed wrapper must never be described as an empty success.
+  if (FAILED_EXEC_OUTPUT_REGEX.test(trimmed)) return FAILED_EXEC_OUTPUT_MESSAGE;
+  return EMPTY_EXEC_OUTPUT_REGEX.test(trimmed) ? EMPTY_EXEC_OUTPUT_MESSAGE : undefined;
 }

--- a/src/adapters/exec-tool-result-normalize.ts
+++ b/src/adapters/exec-tool-result-normalize.ts
@@ -37,6 +37,20 @@ export const EMPTY_EXEC_OUTPUT_MESSAGE =
   "[empty output: the exec cell completed but emitted nothing. This is NOT lost context and NOT a blocked tool — in code mode call text(...) or notify(...) on any value you need to see (a bare await tools.exec_command(...) is not echoed automatically); in shell mode the command simply printed nothing. Do not re-run the same call expecting different output.]";
 
 /**
+ * The SAME rule stated BEFORE the first call, for the code-mode tool-catalog nudge.
+ *
+ * `EMPTY_EXEC_OUTPUT_MESSAGE` above is a repair: it fires only after a model has already spent a
+ * call and read a blank result. That recovers the turn but cannot prevent the wasted round trip,
+ * and the model still has to guess whether its command failed or its output was merely dropped.
+ * Stating the echo rule up front removes the failure instead of explaining it afterwards.
+ *
+ * Kept beside the recovery text on purpose: the two are one pair guarding one defect, and wording
+ * that drifts apart is how a model gets told two different things about the same isolate.
+ */
+export const CODE_MODE_RESULT_ECHO_SENTENCE =
+  "Nothing in the isolate is echoed automatically: a bare trailing `await tools.<name>(...)` or final expression value is DISCARDED, and the cell reports empty output. Pass anything you need to read to `text(...)` (or `notify(...)`) in the same cell — for example `text(JSON.stringify(await tools.exec_command({cmd: \"ls\"})))` — and treat an empty result as your own missing `text(...)` call rather than a failed command or lost context.";
+
+/**
  * Codex exec / shell-bridge tool names (flat and MCP-prefixed display aliases). An empty result
  * here is almost always a code-mode cell that never called text()/notify().
  */

--- a/src/adapters/kiro-constants.ts
+++ b/src/adapters/kiro-constants.ts
@@ -22,6 +22,18 @@ export const KIRO_COMPLETION_RETRY_MESSAGE =
 export const KIRO_TOOL_RESULT_CARRIER_MESSAGE = "The requested tool result is attached.";
 export const KIRO_EMPTY_TOOL_RESULT_MESSAGE = "The tool completed without textual output.";
 
+/**
+ * Placeholder for the user turn Kiro requires after an assistant turn that ALREADY delivered its
+ * final answer.
+ *
+ * The protocol needs a trailing user turn, but the usual continuation/retry text instructs the
+ * model to keep working, which reopens a finished task and reads as a still-open goal. This states
+ * the delivered state and explicitly withholds a new request, so the turn stays structurally valid
+ * without asking for more work.
+ */
+export const KIRO_ANSWER_DELIVERED_MESSAGE =
+  "The previous final answer was delivered to the user and that task is closed. No new request has been made yet. Do not repeat, revise, or continue that work; wait for the user's next instruction.";
+
 export const KIRO_COMPLETION_INSTRUCTIONS =
   `When tools are available, ordinary assistant text is mid-task commentary and does not end the turn. Continue using tools after progress updates. When the task is fully complete and no more tool calls are needed, call ${KIRO_COMPLETION_TOOL_NAME} exactly once with the complete user-facing final answer in \`answer\`. Do not provide the final answer as ordinary assistant text.`;
 

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -36,6 +36,7 @@ import type {
   OcxTool,
   OcxUsage,
 } from "../types";
+import { hasRecordedTrailingDeliveredFinalAnswer } from "../responses/turn-termination";
 import type { ProviderAdapter } from "./base";
 import type { AdapterFetchContext, AdapterRequest } from "./base";
 import { extractKiroImages, normalizeKiroImages, type KiroImage } from "./kiro-images";
@@ -379,7 +380,7 @@ type KiroTurn =
  * means work continued, so the turn is no longer terminal. Empty assistant messages are skipped
  * rather than treated as continuation, since they carry no visible turn.
  */
-function hasTrailingDeliveredFinalAnswer(messages: readonly OcxMessage[]): boolean {
+function hasTrailingDeliveredFinalAnswer(messages: readonly OcxMessage[], parsed?: OcxParsedRequest): boolean {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== "assistant") return false;
@@ -388,7 +389,8 @@ function hasTrailingDeliveredFinalAnswer(messages: readonly OcxMessage[]): boole
     if (hasToolCall) return false;
     const hasText = (aMsg.content ?? []).some(part => part.type === "text" && part.text.trim());
     if (!hasText) continue;
-    return aMsg.phase === "final_answer";
+    return aMsg.phase === "final_answer"
+      || (parsed !== undefined && hasRecordedTrailingDeliveredFinalAnswer(parsed, messages));
   }
   return false;
 }
@@ -510,7 +512,7 @@ export function buildKiroPayload(
   // Read from parsed messages because `completionMode` is needed to build the tool catalog, which
   // happens before the turn list exists. `forcedCompletionMode` still wins: the fallback retry
   // passes "text_fallback" explicitly and must not be silently downgraded.
-  const trailingDeliveredAnswer = hasTrailingDeliveredFinalAnswer(kiroPayloadMessages(parsed));
+  const trailingDeliveredAnswer = hasTrailingDeliveredFinalAnswer(kiroPayloadMessages(parsed), parsed);
   const completionMode: KiroCompletionMode = forcedCompletionMode
     ?? (ordinaryTools.length > 0 && !trailingDeliveredAnswer ? "required" : "disabled");
   const kiroTools = completionMode === "disabled"
@@ -2015,7 +2017,7 @@ export function createKiroAdapter(provider: OcxProviderConfig): ProviderAdapter 
     // turn only, and the adapter-owned bounded retry passes "text_fallback" through `build`
     // directly, never through this path.
     localTerminal(parsed: OcxParsedRequest) {
-      return hasTrailingDeliveredFinalAnswer(kiroPayloadMessages(parsed))
+      return hasTrailingDeliveredFinalAnswer(kiroPayloadMessages(parsed), parsed)
         ? { reason: "kiro_final_answer_already_delivered" }
         : undefined;
     },

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -2002,6 +2002,24 @@ export function createKiroAdapter(provider: OcxProviderConfig): ProviderAdapter 
 
   return {
     name: "kiro",
+    // A replayed history that already ENDS with a delivered final answer has nothing to ask Kiro.
+    // Before this hook the adapter still appended a trailing user turn — a neutral acknowledgement,
+    // but structurally still a prompt — and performed a real inference, so the model answered the
+    // closed task again and the finished turn behaved like a still-open goal.
+    //
+    // Suppressing the completion contract (above) removed the instruction to complete; it could not
+    // remove the inference. This is the boundary: no request is built, nothing is sent, and no token
+    // estimate is recorded.
+    //
+    // The forced-fallback build is deliberately NOT consulted here: this hook runs on the inbound
+    // turn only, and the adapter-owned bounded retry passes "text_fallback" through `build`
+    // directly, never through this path.
+    localTerminal(parsed: OcxParsedRequest) {
+      return hasTrailingDeliveredFinalAnswer(kiroPayloadMessages(parsed))
+        ? { reason: "kiro_final_answer_already_delivered" }
+        : undefined;
+    },
+
     async buildRequest(parsed: OcxParsedRequest, incoming) {
       const built = await build(parsed);
       modelId = parsed.modelId;

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -345,7 +345,19 @@ function validateKiroCapabilities(parsed: OcxParsedRequest): void {
 }
 
 type KiroTurn =
-  | { kind: "user"; content: string; images: KiroImage[]; toolResults: KiroToolResult[] }
+  | {
+      kind: "user";
+      content: string;
+      images: KiroImage[];
+      toolResults: KiroToolResult[];
+      /**
+       * True only for the proxy-generated acknowledgement that follows a delivered final answer.
+       * A flag rather than a content comparison: a real user message may legitimately quote the
+       * same sentence, and treating that as internal state would strip its thinking tags and
+       * completion retry.
+       */
+       answerDeliveredAck?: boolean;
+    }
   | {
       kind: "assistant";
       content: string;
@@ -359,6 +371,27 @@ type KiroTurn =
        */
       finalAnswer?: boolean;
     };
+
+/**
+ * True when the LAST content-bearing message is an assistant final answer that closed its turn.
+ *
+ * Mirrors the turn-merge rule: a tool call in that message, or any later user/tool-result message,
+ * means work continued, so the turn is no longer terminal. Empty assistant messages are skipped
+ * rather than treated as continuation, since they carry no visible turn.
+ */
+function hasTrailingDeliveredFinalAnswer(messages: readonly OcxMessage[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "assistant") return false;
+    const aMsg = msg as OcxAssistantMessage;
+    const hasToolCall = (aMsg.content ?? []).some(part => part.type === "toolCall");
+    if (hasToolCall) return false;
+    const hasText = (aMsg.content ?? []).some(part => part.type === "text" && part.text.trim());
+    if (!hasText) continue;
+    return aMsg.phase === "final_answer";
+  }
+  return false;
+}
 
 function appendTurnText(target: string, next: string): string {
   if (!next) return target;
@@ -467,8 +500,19 @@ export function buildKiroPayload(
   const registry = createKiroToolNameRegistry();
   const toolContext = convertKiroToolContext(parsed, registry);
   const ordinaryTools = toolContext.tools;
+  // A turn whose history already ENDS with a delivered final answer has nothing to complete.
+  // Leaving completion "required" here would keep advertising codex_kiro_final_answer with its
+  // instructions, so the model answers again, or replies with ordinary text and trips the
+  // `needsFallback` retry, which ends its payload with KIRO_COMPLETION_RETRY_MESSAGE and reopens
+  // the finished task. Suppressing the mode is what actually closes that loop; the neutral
+  // acknowledgement below only stops the resume wording.
+  //
+  // Read from parsed messages because `completionMode` is needed to build the tool catalog, which
+  // happens before the turn list exists. `forcedCompletionMode` still wins: the fallback retry
+  // passes "text_fallback" explicitly and must not be silently downgraded.
+  const trailingDeliveredAnswer = hasTrailingDeliveredFinalAnswer(kiroPayloadMessages(parsed));
   const completionMode: KiroCompletionMode = forcedCompletionMode
-    ?? (ordinaryTools.length > 0 ? "required" : "disabled");
+    ?? (ordinaryTools.length > 0 && !trailingDeliveredAnswer ? "required" : "disabled");
   const kiroTools = completionMode === "disabled"
     ? ordinaryTools
     : [...ordinaryTools, kiroCompletionTool()];
@@ -636,6 +680,7 @@ export function buildKiroPayload(
       content: trailing.finalAnswer ? KIRO_ANSWER_DELIVERED_MESSAGE : resumeText,
       images: [],
       toolResults: [],
+      ...(trailing.finalAnswer ? { answerDeliveredAck: true } : {}),
     });
   }
 
@@ -651,6 +696,8 @@ export function buildKiroPayload(
 
   const currentTurn = turns.pop();
   if (!currentTurn || currentTurn.kind !== "user") throw new Error("Kiro request must end with a user turn");
+  // Survives the pop as state, so the checks below never infer intent from user-supplied text.
+  const answerDeliveredAck = currentTurn.answerDeliveredAck === true;
   const toEntry = (turn: KiroTurn): KiroHistoryEntry => turn.kind === "assistant"
     ? {
         assistantResponseMessage: {
@@ -681,16 +728,16 @@ export function buildKiroPayload(
     currentUim.userInputMessageContext = { ...(currentUim.userInputMessageContext ?? {}), tools: kiroTools };
   }
   if (completionMode === "text_fallback") {
-    // Never append the retry instruction onto the answer-delivered placeholder: that placeholder
-    // exists precisely to avoid asking a finished turn for another completion call, and appending
-    // here would reinstate the loop the placeholder prevents.
-    if (currentUim.content !== KIRO_COMPLETION_RETRY_MESSAGE && currentUim.content !== KIRO_ANSWER_DELIVERED_MESSAGE) {
+    // Never append the retry instruction onto the answer-delivered acknowledgement: it exists
+    // precisely to avoid asking a finished turn for another completion call, and appending here
+    // would reinstate the loop it prevents.
+    if (currentUim.content !== KIRO_COMPLETION_RETRY_MESSAGE && !answerDeliveredAck) {
       currentUim.content = appendTurnText(currentUim.content, KIRO_COMPLETION_RETRY_MESSAGE);
     }
   } else if (
     !currentUim.userInputMessageContext?.toolResults
     && currentUim.content !== KIRO_CONTINUATION_MESSAGE
-    && currentUim.content !== KIRO_ANSWER_DELIVERED_MESSAGE
+    && !answerDeliveredAck
   ) {
     currentUim.content = injectKiroThinkingTags(currentUim.content, parsed);
   }

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -42,9 +42,11 @@ import { extractKiroImages, normalizeKiroImages, type KiroImage } from "./kiro-i
 import { sniffImageDimensions } from "./anthropic-image-guard";
 import { fetchKiroWithRetry, noteKiroTransientThrottle } from "./kiro-retry";
 import { convertKiroToolContext } from "./kiro-tools";
+import { normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 import { identifyRoutedModel } from "./identity";
 import { buildNonOpenAIToolCatalogNudgeFromNames, isBareShellBridgeTool, isCodexCodeModeExecTool } from "./tool-catalog-nudge";
 import {
+  KIRO_ANSWER_DELIVERED_MESSAGE,
   KIRO_COMPLETION_INSTRUCTIONS,
   KIRO_COMPLETION_RETRY_MESSAGE,
   KIRO_COMPLETION_TOOL_NAME,
@@ -344,7 +346,19 @@ function validateKiroCapabilities(parsed: OcxParsedRequest): void {
 
 type KiroTurn =
   | { kind: "user"; content: string; images: KiroImage[]; toolResults: KiroToolResult[] }
-  | { kind: "assistant"; content: string; toolUses: KiroToolUse[]; redactedReasoning?: string };
+  | {
+      kind: "assistant";
+      content: string;
+      toolUses: KiroToolUse[];
+      redactedReasoning?: string;
+      /**
+       * True when this assistant turn was the DELIVERED final answer (Responses
+       * `phase: "final_answer"`). A trailing assistant turn normally means the model stopped
+       * mid-task and needs a continuation prompt, but a delivered final answer already ended its
+       * turn — prompting it again restarts finished work as if a goal were still open.
+       */
+      finalAnswer?: boolean;
+    };
 
 function appendTurnText(target: string, next: string): string {
   if (!next) return target;
@@ -521,15 +535,24 @@ export function buildKiroPayload(
       turns.push({ kind: "user", content, images: [...images], toolResults: [...toolResults] });
     }
   };
-  const pushAssistant = (content: string, toolUses: KiroToolUse[], redactedReasoning?: string): void => {
+  const pushAssistant = (content: string, toolUses: KiroToolUse[], redactedReasoning?: string, finalAnswer?: boolean): void => {
     const last = turns.at(-1);
     if (last?.kind === "assistant") {
       last.content = appendTurnText(last.content, content);
       last.toolUses.push(...toolUses);
       // Merged turns keep the newest blob: it covers the reasoning up to the merged turn's end.
       if (redactedReasoning) last.redactedReasoning = redactedReasoning;
+      // A merged turn is final only if its LAST component was: commentary appended after a final
+      // answer means the model kept working, so the turn is no longer terminal.
+      last.finalAnswer = finalAnswer === true;
     } else {
-      turns.push({ kind: "assistant", content, toolUses: [...toolUses], ...(redactedReasoning ? { redactedReasoning } : {}) });
+      turns.push({
+        kind: "assistant",
+        content,
+        toolUses: [...toolUses],
+        ...(redactedReasoning ? { redactedReasoning } : {}),
+        ...(finalAnswer ? { finalAnswer: true } : {}),
+      });
     }
   };
 
@@ -559,14 +582,24 @@ export function buildKiroPayload(
         const hasReasoning = aMsg.content.some(part => part.type === "thinking" && part.thinking.trim());
         if (hasReasoning) continue;
       }
-      pushAssistant(text, toolUses, aMsg.kiroRedactedReasoning);
+      // `phase` survives the Responses round trip (parser.ts assistant branch), so a replayed
+      // final answer is identifiable here rather than guessed from turn position.
+      pushAssistant(text, toolUses, aMsg.kiroRedactedReasoning, aMsg.phase === "final_answer" && toolUses.length === 0);
     } else if (msg.role === "toolResult") {
       const tr = msg as OcxToolResultMessage;
       if (tr.containsEncryptedContent) {
         throw new Error(`Kiro cannot translate encrypted output for tool call ${JSON.stringify(tr.toolCallId)}`);
       }
       const text = userContentText(tr.content);
-      const resultText = text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE;
+      // An empty code-mode exec result needs the SPECIFIC reason, not the generic fallback: the
+      // model otherwise reads a blank result, concludes its earlier context was lost, and restarts
+      // the task instead of calling text()/notify(). Checked before `text.trim()` because the
+      // wrapper form ("Script completed\nWall time ...\nOutput:\n") is non-blank and would
+      // otherwise pass through as if it were real output.
+      const resultText = normalizeEmptyExecToolResultText(text, {
+        toolName: tr.toolName,
+        toolNamespace: tr.toolNamespace,
+      }) ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
       const images = extractKiroImages(tr.content);
       const toolUseId = normalizeToolId(tr.toolCallId);
       if (!priorCalls.has(toolUseId)) {
@@ -587,10 +620,20 @@ export function buildKiroPayload(
   if (turns.length === 0 || turns[0].kind === "assistant") {
     turns.unshift({ kind: "user", content: KIRO_CONTINUATION_MESSAGE, images: [], toolResults: [] });
   }
-  if (turns.at(-1)?.kind === "assistant") {
+  // Kiro requires the request to end with a user turn, so a trailing assistant turn always gets
+  // one appended (the pop below throws otherwise). What that turn SAYS is the load-bearing part.
+  //
+  // Normally a trailing assistant turn means the model stopped mid-task, and a continuation/retry
+  // prompt is correct. A DELIVERED final answer is the exception: the turn already ended, and
+  // telling that model to "continue" or to call the completion tool again reopens finished work —
+  // the completed-task-behaves-like-an-open-goal loop. It gets a neutral acknowledgement instead:
+  // structurally valid, but carrying no instruction to resume.
+  const trailing = turns.at(-1);
+  if (trailing?.kind === "assistant") {
+    const resumeText = completionMode === "text_fallback" ? KIRO_COMPLETION_RETRY_MESSAGE : KIRO_CONTINUATION_MESSAGE;
     turns.push({
       kind: "user",
-      content: completionMode === "text_fallback" ? KIRO_COMPLETION_RETRY_MESSAGE : KIRO_CONTINUATION_MESSAGE,
+      content: trailing.finalAnswer ? KIRO_ANSWER_DELIVERED_MESSAGE : resumeText,
       images: [],
       toolResults: [],
     });
@@ -638,10 +681,17 @@ export function buildKiroPayload(
     currentUim.userInputMessageContext = { ...(currentUim.userInputMessageContext ?? {}), tools: kiroTools };
   }
   if (completionMode === "text_fallback") {
-    if (currentUim.content !== KIRO_COMPLETION_RETRY_MESSAGE) {
+    // Never append the retry instruction onto the answer-delivered placeholder: that placeholder
+    // exists precisely to avoid asking a finished turn for another completion call, and appending
+    // here would reinstate the loop the placeholder prevents.
+    if (currentUim.content !== KIRO_COMPLETION_RETRY_MESSAGE && currentUim.content !== KIRO_ANSWER_DELIVERED_MESSAGE) {
       currentUim.content = appendTurnText(currentUim.content, KIRO_COMPLETION_RETRY_MESSAGE);
     }
-  } else if (!currentUim.userInputMessageContext?.toolResults && currentUim.content !== KIRO_CONTINUATION_MESSAGE) {
+  } else if (
+    !currentUim.userInputMessageContext?.toolResults
+    && currentUim.content !== KIRO_CONTINUATION_MESSAGE
+    && currentUim.content !== KIRO_ANSWER_DELIVERED_MESSAGE
+  ) {
     currentUim.content = injectKiroThinkingTags(currentUim.content, parsed);
   }
 

--- a/src/adapters/tool-catalog-nudge.ts
+++ b/src/adapters/tool-catalog-nudge.ts
@@ -5,6 +5,7 @@ import {
   type OcxTool,
   type OcxProviderConfig,
 } from "../types";
+import { CODE_MODE_RESULT_ECHO_SENTENCE } from "./exec-tool-result-normalize";
 
 // Tool names that exist only in OTHER agent harnesses (Claude Code and friends). Naming one
 // here tells a routed model not to call it unless this turn's catalog really lists it.
@@ -120,7 +121,7 @@ export function buildNonOpenAIToolCatalogNudgeFromNames(
     "Call only listed names with their listed argument keys; do not invent, translate, or rename tools.",
     "Names mentioned only in instructions, tool descriptions, argument descriptions, or nested helper APIs are not additional top-level tools.",
     verifiedCodeModeExecName
-      ? "`" + verifiedCodeModeExecName + "` is Codex code mode: its body is JavaScript evaluated in a V8 isolate. Nested helpers are called INSIDE that body as `await tools.<name>(...)`, for example `await tools.exec_command({cmd: \"ls\"})` or `await tools.codex_app__list_threads({})`. Absence from the top-level catalog or from `" + verifiedCodeModeExecName + "`'s description is not absence: deferred helpers stay callable on `tools.<name>`. Discover them from the isolate global `ALL_TOOLS`, not `tools.ALL_TOOLS`. Do not skip an available nested helper because it is omitted from the listed top-level names. Nested `tools.apply_patch(input)` is host-executed: the string must begin exactly with `*** Begin Patch` and end with `*** End Patch` (no trailing `***` on those lines). OpenCodex does not rewrite JavaScript inside exec, so a decorated `*** Begin Patch ***` envelope is rejected by Codex before the file is touched."
+      ? "`" + verifiedCodeModeExecName + "` is Codex code mode: its body is JavaScript evaluated in a V8 isolate. Nested helpers are called INSIDE that body as `await tools.<name>(...)`, for example `await tools.exec_command({cmd: \"ls\"})` or `await tools.codex_app__list_threads({})`. Absence from the top-level catalog or from `" + verifiedCodeModeExecName + "`'s description is not absence: deferred helpers stay callable on `tools.<name>`. Discover them from the isolate global `ALL_TOOLS`, not `tools.ALL_TOOLS`. Do not skip an available nested helper because it is omitted from the listed top-level names. " + CODE_MODE_RESULT_ECHO_SENTENCE + " Nested `tools.apply_patch(input)` is host-executed: the string must begin exactly with `*** Begin Patch` and end with `*** End Patch` (no trailing `***` on those lines). OpenCodex does not rewrite JavaScript inside exec, so a decorated `*** Begin Patch ***` envelope is rejected by Codex before the file is touched."
       : "If a listed tool exposes nested helpers such as a tools.* API, call the listed parent tool and use those helpers only inside that tool's input.",
     unavailableNeighborNames.length > 0
       ? "Do not use neighboring-agent tool names " + quoteNames(unavailableNeighborNames) + " unless this turn's catalog lists those exact names."

--- a/src/responses/turn-termination.ts
+++ b/src/responses/turn-termination.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import type { OcxAssistantMessage, OcxMessage, OcxParsedRequest } from "../types";
+
+const DELIVERED_FINAL_ANSWER_TTL_MS = 60 * 60 * 1_000;
+const DELIVERED_FINAL_ANSWER_MAX_ENTRIES = 1_024;
+
+interface DeliveredFinalAnswerRecord {
+  fingerprint: string;
+  createdAt: number;
+}
+
+const scopesByRequest = new WeakMap<OcxParsedRequest, string>();
+const deliveredFinalAnswers = new Map<string, DeliveredFinalAnswerRecord>();
+
+function pruneDeliveredFinalAnswers(at = Date.now()): void {
+  for (const [scope, record] of deliveredFinalAnswers) {
+    if (at - record.createdAt > DELIVERED_FINAL_ANSWER_TTL_MS) deliveredFinalAnswers.delete(scope);
+  }
+  while (deliveredFinalAnswers.size > DELIVERED_FINAL_ANSWER_MAX_ENTRIES) {
+    const oldest = deliveredFinalAnswers.keys().next().value;
+    if (oldest === undefined) break;
+    deliveredFinalAnswers.delete(oldest);
+  }
+}
+
+function textFingerprint(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function assistantText(message: OcxAssistantMessage): string | undefined {
+  if (message.content.some(part => part.type === "toolCall")) return undefined;
+  const text = message.content
+    .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+    .map(part => part.text)
+    .join("");
+  return text.trim().length > 0 ? text : undefined;
+}
+
+function deliveredFinalAnswerText(response: unknown): string | undefined {
+  if (!response || typeof response !== "object" || Array.isArray(response)) return undefined;
+  const output = (response as { output?: unknown }).output;
+  if (!Array.isArray(output)) return undefined;
+  for (let i = output.length - 1; i >= 0; i--) {
+    const item = output[i];
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const message = item as { type?: unknown; role?: unknown; phase?: unknown; content?: unknown };
+    if (message.type !== "message" || message.role !== "assistant" || message.phase !== "final_answer") continue;
+    if (!Array.isArray(message.content)) return undefined;
+    const text = message.content
+      .filter(part => !!part && typeof part === "object" && !Array.isArray(part)
+        && (part as { type?: unknown }).type === "output_text"
+        && typeof (part as { text?: unknown }).text === "string")
+      .map(part => (part as { text: string }).text)
+      .join("");
+    return text.trim().length > 0 ? text : undefined;
+  }
+  return undefined;
+}
+
+/** Bind the normalized per-conversation digest without adding proxy-private fields to the wire body. */
+export function bindTurnTerminationScope(parsed: OcxParsedRequest, scope: string | undefined): void {
+  // Only the normalized log-conversation digest may key this process-wide map. Refusing any raw
+  // fallback prevents a future caller from retaining a client header or account identifier here.
+  if (!scope || !/^[0-9a-f]{32}$/.test(scope)) return;
+  scopesByRequest.set(parsed, scope);
+}
+
+/** Remember only a final-answer message the proxy actually emitted for this exact conversation. */
+export function rememberDeliveredFinalAnswer(parsed: OcxParsedRequest, response: unknown): void {
+  const scope = scopesByRequest.get(parsed);
+  if (!scope) return;
+  const text = deliveredFinalAnswerText(response);
+  if (!text) return;
+  const at = Date.now();
+  pruneDeliveredFinalAnswers(at);
+  // Refresh insertion order so cap eviction removes the least recently delivered conversation.
+  deliveredFinalAnswers.delete(scope);
+  deliveredFinalAnswers.set(scope, { fingerprint: textFingerprint(text), createdAt: at });
+  pruneDeliveredFinalAnswers(at);
+}
+
+/**
+ * Match only when the delivered assistant answer is still the trailing content-bearing message.
+ * A later user/tool-result message is new work and must reach the provider, even though every
+ * legitimate next turn necessarily contains such a message somewhere in its history.
+ */
+export function hasRecordedTrailingDeliveredFinalAnswer(
+  parsed: OcxParsedRequest,
+  messages: readonly OcxMessage[],
+): boolean {
+  const scope = scopesByRequest.get(parsed);
+  if (!scope) return false;
+  pruneDeliveredFinalAnswers();
+  const record = deliveredFinalAnswers.get(scope);
+  if (!record) return false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== "assistant") return false;
+    const text = assistantText(message as OcxAssistantMessage);
+    if (text === undefined) {
+      if ((message as OcxAssistantMessage).content.some(part => part.type === "toolCall")) return false;
+      continue;
+    }
+    return textFingerprint(text) === record.fingerprint;
+  }
+  return false;
+}

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -140,6 +140,12 @@ export interface RequestLogEntry {
   /** TTFT: ms from request start to the first non-empty model output delta; unset for non-streaming/tool-only. */
   firstOutputMs?: number;
   surface?: "claude" | "claude-desktop" | "grok";
+  /**
+   * Set when the proxy answered this turn locally and sent nothing upstream. Without it a zero-send
+   * row is indistinguishable from a request that vanished. A fixed adapter-supplied identifier,
+   * never conversation-derived.
+   */
+  localTerminalReason?: string;
   /** The matched configured key's id. Set ONLY for admissionKind "configured" —
    *  never a sentinel, so a hand-edited entry whose id happens to be "loopback"
    *  cannot absorb unrelated traffic. */
@@ -949,6 +955,7 @@ export function addFinalRequestLog(
     logCtx.usage,
     logCtx.usageLogInputTokens,
     contextWindowForModel(logCtx.providerAdapter ?? logCtx.provider, logCtx.model),
+    logCtx.localTerminalReason !== undefined,
   );
   const attempts = logCtx.attempts?.map(attempt => ({
     ...attempt,
@@ -976,6 +983,9 @@ export function addFinalRequestLog(
     ...(logCtx.apiKeyId ? { apiKeyId: logCtx.apiKeyId } : {}),
     ...(logCtx.admissionKind ? { admissionKind: logCtx.admissionKind } : {}),
     ...(logCtx.inboundProtocol ? { inboundProtocol: logCtx.inboundProtocol } : {}),
+    ...(logCtx.localTerminalReason
+      ? { localTerminalReason: sanitizeLogMetadataString(logCtx.localTerminalReason) }
+      : {}),
     ...(isCodexUsageAccountLogLabel(logCtx.accountLogLabel)
       ? { accountLogLabel: logCtx.accountLogLabel }
       : {}),
@@ -1109,6 +1119,7 @@ function finalizedUsage(
   usage: OcxUsage | undefined,
   inputTokenEstimate: number | undefined,
   contextWindow: number | undefined,
+  locallyAnswered = false,
 ): FinalizedUsageResult {
   // The ESTIMATE itself is capped at the model's context window (codex-router PR #140). The
   // combined value below keeps its max(inputTokens, estimate) behavior — a provider-reported
@@ -1118,7 +1129,7 @@ function finalizedUsage(
     && inputTokenEstimate >= 0
     ? capEstimateAtContextWindow(inputTokenEstimate, contextWindow)
     : undefined;
-  const finalUsage = usageForFinalLog(adapter, usage);
+  const finalUsage = usageForFinalLog(adapter, usage, locallyAnswered);
   const usageFallback = !finalUsage && estimate !== undefined
     ? { inputTokens: estimate, outputTokens: 0, estimated: true }
     : undefined;

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -63,6 +63,13 @@ export interface RequestLogContext {
    *  product: widening that enum would merge Responses and Chat Completions,
    *  since both leave it undefined. */
   inboundProtocol?: "responses" | "chat" | "messages";
+  /**
+   * Set when an adapter answered the turn locally and no upstream request was made
+   * (`ProviderAdapter.localTerminal`). A fixed identifier naming the code path, never
+   * conversation-derived: it exists so a request log showing zero sends is explainable
+   * rather than looking like a lost request.
+   */
+  localTerminalReason?: string;
   /** Stable non-PII Codex Pool account identity for durable usage attribution. */
   accountLogLabel?: string;
   requestedModel?: string;

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -1229,6 +1229,7 @@ export function finishRequestAttempt(
     usage ?? attempt.usage,
     attempt.inputTokenEstimate,
     contextWindowForModel(attempt.adapter, attempt.model),
+    attempt.locallyAnswered === true,
   );
   attempt.status = status;
   attempt.durationMs = Math.max(0, durationMs);

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -4866,6 +4866,11 @@ async function handleResponsesInner(
   const localTerminal = activeAdapter.localTerminal?.(parsed);
   if (localTerminal) {
     logCtx.localTerminalReason = localTerminal.reason;
+    // Mark the physical attempt too, not just the parent row. `finishRequestAttempt` finalizes the
+    // attempt through the same estimated-provider path, so without this the row reads exact while
+    // its own attempt still claims an estimate — the detailed accounting a maintainer actually
+    // reads for a zero-send turn.
+    if (logCtx.activeAttempt) logCtx.activeAttempt.locallyAnswered = true;
     cleanupUpstreamAbort();
     upstream.abort();
     const terminalEvents: AdapterEvent[] = [{

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -4874,21 +4874,26 @@ async function handleResponsesInner(
       usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     }];
     if (parsed.stream) {
+      const localSse = bridgeToResponsesSSE(
+        (async function* () { yield* terminalEvents; })(),
+        parsed._responseModelId ?? parsed.modelId,
+        toolBridgeMaps.toolNsMap,
+        toolBridgeMaps.freeformToolNames,
+        toolBridgeMaps.toolSearchToolNames,
+        undefined,
+        2_000,
+        {
+          translatorBudget,
+          ...(options.forceEmptyResponseId ? { responseId: "" } : {}),
+          ...(options.onFirstOutput ? { onFirstOutput: options.onFirstOutput } : {}),
+        },
+      );
+      // Same lifetime tracking as every other streaming return in this function: the turn
+      // admission lease is released when the body finishes or the client disconnects. Returning
+      // the raw stream would hold a lease for a turn that already has all of its output.
+      const localTurnAc = new AbortController();
       return new Response(
-        bridgeToResponsesSSE(
-          (async function* () { yield* terminalEvents; })(),
-          parsed._responseModelId ?? parsed.modelId,
-          toolBridgeMaps.toolNsMap,
-          toolBridgeMaps.freeformToolNames,
-          toolBridgeMaps.toolSearchToolNames,
-          undefined,
-          2_000,
-          {
-            translatorBudget,
-            ...(options.forceEmptyResponseId ? { responseId: "" } : {}),
-            ...(options.onFirstOutput ? { onFirstOutput: options.onFirstOutput } : {}),
-          },
-        ),
+        trackStreamLifetime(localSse, localTurnAc, undefined, options.turnAdmissionLease),
         {
           headers: {
             "Content-Type": "text/event-stream",

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -41,6 +41,10 @@ import {
   rememberResponseState,
 } from "../../responses/state";
 import {
+  bindTurnTerminationScope,
+  rememberDeliveredFinalAnswer,
+} from "../../responses/turn-termination";
+import {
   isValidProviderContinuationOwner,
   mergeProviderContinuationPayload,
   providerContinuationOwnerFromReplayIdentity,
@@ -2380,6 +2384,10 @@ async function handleResponsesInner(
     threadIdHeader: req.headers.get("thread-id"),
     cursorConversationId: parsed._cursorConversationId,
   });
+  bindTurnTerminationScope(parsed, resolvedConversationId);
+  const rememberKiroDeliveredFinalAnswer = (adapterName: string, response: unknown): void => {
+    if (adapterName === "kiro") rememberDeliveredFinalAnswer(parsed, response);
+  };
   // _clientThreadId remains the routing/continuation identity supplied by Codex. Replay state uses
   // a dedicated raw conversation namespace so mixed headers that carry the same identity still
   // match, and a shared/synthetic session_id cannot coalesce distinct thread/Cursor conversations.
@@ -4440,6 +4448,7 @@ async function handleResponsesInner(
       ...(options.forceEmptyResponseId ? { forceEmptyResponseId: true } : {}),
       onCompletedResponse: (response, providerState) => {
         commitReasoningReplayServingRoute();
+        rememberKiroDeliveredFinalAnswer(adapter.name, response);
         rememberResponseState(
           parsed._rawBody,
           response,
@@ -4755,6 +4764,7 @@ async function handleResponsesInner(
           },
           onCompletedResponse: (response: Record<string, unknown>, providerState?: OcxProviderContinuationState) => {
             commitReasoningReplayServingRoute();
+            rememberKiroDeliveredFinalAnswer(adapter.name, response);
             if (!routedCompaction) {
               rememberResponseState(
                 parsed._rawBody,
@@ -4824,6 +4834,7 @@ async function handleResponsesInner(
       },
     });
     if (!routedCompaction) {
+      rememberKiroDeliveredFinalAnswer(adapter.name, json);
       rememberResponseState(
         parsed._rawBody,
         json,
@@ -5764,6 +5775,7 @@ async function handleResponsesInner(
         },
         onCompletedResponse: (response: Record<string, unknown>, providerState?: OcxProviderContinuationState) => {
           commitReasoningReplayServingRoute();
+          rememberKiroDeliveredFinalAnswer(activeAdapter.name, response);
           // Compaction turns must NOT enter the continuation cache: _rawBody still holds the full
           // PRE-compaction history, and a later previous_response_id expansion would rehydrate the
           // giant stale chain Codex just replaced.
@@ -5841,6 +5853,7 @@ async function handleResponsesInner(
     });
     // See the streaming branch: compaction turns skip the continuation cache.
     if (!routedCompaction) {
+      rememberKiroDeliveredFinalAnswer(activeAdapter.name, json);
       rememberResponseState(
         parsed._rawBody,
         json,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -4858,6 +4858,54 @@ async function handleResponsesInner(
   // reuse is safe, and releaseBodyObservation is idempotent per build.
   let initialRequest: AdapterRequest | undefined;
   let inputTokenEstimate: number | undefined;
+  // An adapter may know the turn needs no inference at all — Kiro's replayed history ending in a
+  // delivered final answer. Answer it locally: no build (so no token estimate), no send (so
+  // sendCount stays 0), and crucially no empty-completion guard, which treats an outputless
+  // terminal as a failed turn and re-invokes the identical request. Routing this through the
+  // ordinary event path would therefore reinstate the loop it exists to end.
+  const localTerminal = activeAdapter.localTerminal?.(parsed);
+  if (localTerminal) {
+    logCtx.localTerminalReason = localTerminal.reason;
+    cleanupUpstreamAbort();
+    upstream.abort();
+    const terminalEvents: AdapterEvent[] = [{
+      type: "done",
+      endTurn: true,
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    }];
+    if (parsed.stream) {
+      return new Response(
+        bridgeToResponsesSSE(
+          (async function* () { yield* terminalEvents; })(),
+          parsed._responseModelId ?? parsed.modelId,
+          toolBridgeMaps.toolNsMap,
+          toolBridgeMaps.freeformToolNames,
+          toolBridgeMaps.toolSearchToolNames,
+          undefined,
+          2_000,
+          {
+            translatorBudget,
+            ...(options.forceEmptyResponseId ? { responseId: "" } : {}),
+            ...(options.onFirstOutput ? { onFirstOutput: options.onFirstOutput } : {}),
+          },
+        ),
+        {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+          },
+        },
+      );
+    }
+    return new Response(
+      JSON.stringify(buildResponseJSON(terminalEvents, parsed._responseModelId ?? parsed.modelId, {
+        translatorBudget,
+      })),
+      { headers: { "Content-Type": "application/json" } },
+    );
+  }
   try {
     initialRequest = await activeAdapter.buildRequest(parsed, { headers: selectedForwardHeaders, translatorBudget });
     refreshRoutedNamespaceToolAliases(initialRequest);

--- a/src/usage/log.ts
+++ b/src/usage/log.ts
@@ -181,8 +181,20 @@ function isEstimatedUsageProvider(providerOrAdapter: string): boolean {
     || providerOrAdapter === "cursor" || providerOrAdapter.startsWith("cursor-");
 }
 
-export function usageForFinalLog(provider: string, usage: OcxUsage | undefined): OcxUsage | undefined {
+export function usageForFinalLog(
+  provider: string,
+  usage: OcxUsage | undefined,
+  /**
+   * True when the proxy answered this turn locally and issued no upstream request. Such a turn's
+   * zero counts are EXACT, so the provider-wide estimated marking must not apply: Kiro and Cursor
+   * are marked estimated because their adapters can only guess a real inference's usage, and a
+   * turn with no inference has nothing to guess. Without this, a no-send turn is indistinguishable
+   * from a real one whose usage frame never arrived.
+   */
+  locallyAnswered = false,
+): OcxUsage | undefined {
   if (!usage) return undefined;
+  if (locallyAnswered) return usage;
   if (usage.estimated || isEstimatedUsageProvider(provider)) return { ...usage, estimated: true };
   return usage;
 }

--- a/src/usage/log.ts
+++ b/src/usage/log.ts
@@ -51,6 +51,13 @@ export interface PersistedUsageAttempt {
   sendCount: number;
   recoveryKinds: AttemptRecoveryKind[];
   usageStatus: UsageStatus;
+  /**
+   * True when the proxy answered this turn locally and issued no upstream request. It travels on
+   * the attempt itself rather than as a `finishRequestAttempt` argument because that function is
+   * called from six places, and a new parameter would silently default to the wrong answer at any
+   * one of them that was missed. Absent on ordinary attempts so old rows keep their exact shape.
+   */
+  locallyAnswered?: boolean;
   /** Stable non-PII identity for the Codex pool account that served this attempt. */
   accountLogLabel?: CodexUsageAccountLogLabel;
   inputTokenEstimate?: number;

--- a/tests/cursor-exec-empty-result.test.ts
+++ b/tests/cursor-exec-empty-result.test.ts
@@ -29,6 +29,16 @@ describe("codex exec bridge empty-result normalization (devlog 260826 gap-7)", (
     }
   });
 
+  // A failed wrapper is empty but not a success: reporting it as an empty success would erase the
+  // only failure signal. Reachable with isError: false through Responses history.
+  test("a failed exec wrapper keeps failure guidance, not empty-success text", () => {
+    const out = normalizeCursorToolResultText("Script failed\nWall time 0.1 seconds\nOutput:\n", { toolName: "exec", isError: false });
+    expect(out.changed).toBe(true);
+    expect(out.text).toContain("exec failed");
+    expect(out.text).not.toContain("NOT lost context");
+    expect(out.text).not.toContain("Do not re-run");
+  });
+
   test("non-empty exec output passes through byte-identical", () => {
     const out = normalizeCursorToolResultText("Output:\nhello", { toolName: "exec" });
     expect(out.changed).toBe(false);

--- a/tests/kiro-adapter.test.ts
+++ b/tests/kiro-adapter.test.ts
@@ -7,11 +7,12 @@ import { createKiroAdapter } from "../src/adapters/kiro";
 import {
   KIRO_ANSWER_DELIVERED_MESSAGE,
   KIRO_COMPLETION_RETRY_MESSAGE,
+  KIRO_COMPLETION_TOOL_NAME,
   KIRO_CONTINUATION_MESSAGE,
   KIRO_EMPTY_TOOL_RESULT_MESSAGE,
   KIRO_TOOL_RESULT_CARRIER_MESSAGE,
 } from "../src/adapters/kiro-constants";
-import { EMPTY_EXEC_OUTPUT_MESSAGE } from "../src/adapters/exec-tool-result-normalize";
+import { EMPTY_EXEC_OUTPUT_MESSAGE, FAILED_EXEC_OUTPUT_MESSAGE } from "../src/adapters/exec-tool-result-normalize";
 import { MAX_KIRO_TOOL_CATALOG_BYTES, MAX_KIRO_TOOL_COUNT } from "../src/adapters/kiro-tools";
 import { applyProviderConfigHints, buildCatalogEntries } from "../src/codex/catalog";
 import { getValidAccessTokenSnapshot } from "../src/oauth";
@@ -337,6 +338,21 @@ describe("kiro adapter — buildRequest", () => {
   });
 
   test("real exec output and empty non-exec results are left alone", async () => {
+    // Review finding (Codex P2): a failed cell with no output is empty but NOT a success. The
+    // success guidance would erase the only failure signal — reachable via Responses history,
+    // where function_call_output is parsed with isError: false.
+    const execTool0 = { name: "exec", description: "Run JavaScript", parameters: { type: "object" } };
+    const failed = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-f", name: "exec", arguments: {} }] },
+      { role: "toolResult", toolCallId: "call-f", toolName: "exec", content: "Script failed\nWall time 0.1 seconds\nOutput:\n", isError: false },
+    ];
+    const failedBody = await createKiroAdapter(provider).buildRequest(parsedWith(failed, [execTool0]));
+    const failedText = JSON.parse(failedBody.body).conversationState.currentMessage.userInputMessage
+      .userInputMessageContext.toolResults[0].content[0].text;
+    expect(failedText).toBe(FAILED_EXEC_OUTPUT_MESSAGE);
+    expect(failedText).not.toBe(EMPTY_EXEC_OUTPUT_MESSAGE);
+
     const execTool = { name: "exec", description: "Run JavaScript", parameters: { type: "object" } };
     const withExecOutput = [
       { role: "user", content: "run it" },
@@ -386,6 +402,54 @@ describe("kiro adapter — buildRequest", () => {
 
     expect(current.content).toContain(KIRO_CONTINUATION_MESSAGE);
     expect(current.content).not.toBe(KIRO_ANSWER_DELIVERED_MESSAGE);
+  });
+
+  // Review finding (Codex P2): suppressing the resume wording is not enough. While completion
+  // stays "required" the request keeps advertising the completion tool, so the model answers again
+  // or trips the text_fallback retry, which reopens the finished task.
+  test("a delivered final answer stops advertising the completion tool", async () => {
+    const delivered = [
+      { role: "user", content: "do it" },
+      { role: "assistant", phase: "final_answer", content: [{ type: "text", text: "Done." }] },
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(delivered, [bashTool]));
+    const current = JSON.parse(body).conversationState.currentMessage.userInputMessage;
+    const toolNames = (current.userInputMessageContext?.tools ?? [])
+      .map((t: { toolSpecification?: { name?: string } }) => t.toolSpecification?.name);
+
+    expect(toolNames).toContain("bash");
+    expect(toolNames).not.toContain(KIRO_COMPLETION_TOOL_NAME);
+    // The instructions must go too: they tell the model to call a tool that is no longer offered.
+    expect(current.content).not.toContain(KIRO_COMPLETION_TOOL_NAME);
+
+    // Control: an unfinished turn still gets the completion contract.
+    const unfinished = [
+      { role: "user", content: "do it" },
+      { role: "assistant", content: [{ type: "text", text: "Working..." }] },
+    ];
+    const open = await createKiroAdapter(provider).buildRequest(parsedWith(unfinished, [bashTool]));
+    const openNames = (JSON.parse(open.body).conversationState.currentMessage.userInputMessage
+      .userInputMessageContext?.tools ?? [])
+      .map((t: { toolSpecification?: { name?: string } }) => t.toolSpecification?.name);
+    expect(openNames).toContain(KIRO_COMPLETION_TOOL_NAME);
+  });
+
+  // Review finding (CodeRabbit): the acknowledgement was detected by comparing user content, so a
+  // real user message quoting that sentence lost its thinking tags and completion retry.
+  test("a user message quoting the acknowledgement is still treated as user content", async () => {
+    const messages = [
+      { role: "user", content: "do it" },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      { role: "user", content: KIRO_ANSWER_DELIVERED_MESSAGE },
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest({
+      ...parsedWith(messages, [bashTool]),
+      options: { reasoning: "xhigh" },
+    } as never);
+    const current = JSON.parse(body).conversationState.currentMessage.userInputMessage;
+
+    // Real user text keeps its reasoning injection; internal state must not be inferred from it.
+    expect(current.content).toContain("<thinking_mode>");
   });
 
   test("commentary after a final answer reopens continuation", async () => {

--- a/tests/kiro-adapter.test.ts
+++ b/tests/kiro-adapter.test.ts
@@ -4,7 +4,14 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createKiroAdapter } from "../src/adapters/kiro";
-import { KIRO_TOOL_RESULT_CARRIER_MESSAGE } from "../src/adapters/kiro-constants";
+import {
+  KIRO_ANSWER_DELIVERED_MESSAGE,
+  KIRO_COMPLETION_RETRY_MESSAGE,
+  KIRO_CONTINUATION_MESSAGE,
+  KIRO_EMPTY_TOOL_RESULT_MESSAGE,
+  KIRO_TOOL_RESULT_CARRIER_MESSAGE,
+} from "../src/adapters/kiro-constants";
+import { EMPTY_EXEC_OUTPUT_MESSAGE } from "../src/adapters/exec-tool-result-normalize";
 import { MAX_KIRO_TOOL_CATALOG_BYTES, MAX_KIRO_TOOL_COUNT } from "../src/adapters/kiro-tools";
 import { applyProviderConfigHints, buildCatalogEntries } from "../src/codex/catalog";
 import { getValidAccessTokenSnapshot } from "../src/oauth";
@@ -307,6 +314,92 @@ describe("kiro adapter — buildRequest", () => {
 
     expect(current.content.trim()).not.toBe("");
     expect(current.userInputMessageContext.toolResults[0].content[0].text.trim()).not.toBe("");
+  });
+
+  // An empty code-mode exec result must say WHY it is empty. Without this the model reads a blank
+  // result, concludes earlier context was lost, and restarts finished work.
+  test("an empty code-mode exec result carries the actionable reason, not the generic fallback", async () => {
+    const execTool = { name: "exec", description: "Run JavaScript", parameters: { type: "object" } };
+    for (const raw of ["", "Script completed\nWall time 0.1 seconds\nOutput:\n", "<empty>"]) {
+      const messages = [
+        { role: "user", content: "run it" },
+        { role: "assistant", content: [{ type: "toolCall", id: "call-x", name: "exec", arguments: {} }] },
+        { role: "toolResult", toolCallId: "call-x", toolName: "exec", content: raw, isError: false },
+      ];
+      const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [execTool]));
+      const resultText = JSON.parse(body).conversationState.currentMessage.userInputMessage
+        .userInputMessageContext.toolResults[0].content[0].text;
+
+      expect(resultText).toBe(EMPTY_EXEC_OUTPUT_MESSAGE);
+      // The generic fallback would leave the model to guess; assert it is NOT what shipped.
+      expect(resultText).not.toBe(KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+    }
+  });
+
+  test("real exec output and empty non-exec results are left alone", async () => {
+    const execTool = { name: "exec", description: "Run JavaScript", parameters: { type: "object" } };
+    const withExecOutput = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-x", name: "exec", arguments: {} }] },
+      { role: "toolResult", toolCallId: "call-x", toolName: "exec", content: "Output:\nhello", isError: false },
+    ];
+    const execBody = await createKiroAdapter(provider).buildRequest(parsedWith(withExecOutput, [execTool]));
+    expect(JSON.parse(execBody.body).conversationState.currentMessage.userInputMessage
+      .userInputMessageContext.toolResults[0].content[0].text).toBe("Output:\nhello");
+
+    // A non-exec tool keeps the generic message: asserting code-mode semantics for arbitrary
+    // tools would tell the model to call text()/notify() in a runtime that has neither.
+    const nonExec = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-y", name: "bash", arguments: {} }] },
+      { role: "toolResult", toolCallId: "call-y", toolName: "bash", content: "", isError: false },
+    ];
+    const bashBody = await createKiroAdapter(provider).buildRequest(parsedWith(nonExec, [bashTool]));
+    expect(JSON.parse(bashBody.body).conversationState.currentMessage.userInputMessage
+      .userInputMessageContext.toolResults[0].content[0].text).toBe(KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+  });
+
+  // A delivered final answer already ended its turn. Asking it to continue reopens closed work,
+  // which is what made a finished task behave like a still-open goal.
+  test("a delivered final answer is not told to continue or to complete again", async () => {
+    const messages = [
+      { role: "user", content: "do it" },
+      { role: "assistant", phase: "final_answer", content: [{ type: "text", text: "Done: the answer." }] },
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [bashTool]));
+    const current = JSON.parse(body).conversationState.currentMessage.userInputMessage;
+
+    expect(current.content).toBe(KIRO_ANSWER_DELIVERED_MESSAGE);
+    expect(current.content).not.toContain(KIRO_CONTINUATION_MESSAGE);
+    expect(current.content).not.toContain(KIRO_COMPLETION_RETRY_MESSAGE);
+  });
+
+  test("an unfinished trailing assistant turn still gets the continuation prompt", async () => {
+    // Same shape minus `phase`: proves the new branch keys off the delivered final answer and did
+    // not simply disable continuation for every trailing assistant turn.
+    const messages = [
+      { role: "user", content: "do it" },
+      { role: "assistant", content: [{ type: "text", text: "Working on it..." }] },
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [bashTool]));
+    const current = JSON.parse(body).conversationState.currentMessage.userInputMessage;
+
+    expect(current.content).toContain(KIRO_CONTINUATION_MESSAGE);
+    expect(current.content).not.toBe(KIRO_ANSWER_DELIVERED_MESSAGE);
+  });
+
+  test("commentary after a final answer reopens continuation", async () => {
+    // A merged assistant turn is terminal only if its LAST component was the final answer.
+    const messages = [
+      { role: "user", content: "do it" },
+      { role: "assistant", phase: "final_answer", content: [{ type: "text", text: "Done." }] },
+      { role: "assistant", content: [{ type: "text", text: "Actually, one more check." }] },
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [bashTool]));
+    const current = JSON.parse(body).conversationState.currentMessage.userInputMessage;
+
+    expect(current.content).toContain(KIRO_CONTINUATION_MESSAGE);
+    expect(current.content).not.toBe(KIRO_ANSWER_DELIVERED_MESSAGE);
   });
 
   test("tool result images are attached to Kiro carrier user messages", async () => {

--- a/tests/kiro-adapter.test.ts
+++ b/tests/kiro-adapter.test.ts
@@ -1413,6 +1413,9 @@ describe("kiro code-mode catalog nudge", () => {
 
     expect(content).toContain("ALL_TOOLS");
     expect(content).toContain("Codex code mode");
+    // Reaches the ACTUAL Kiro wire prompt, not just the builder: the live 2026-08-28 session that
+    // misread a blank result was a routed Kiro turn.
+    expect(content).toContain("Nothing in the isolate is echoed automatically");
     // The generic fallback must be gone, not merely accompanied.
     expect(content).not.toContain("If a listed tool exposes nested helpers such as a tools.* API");
   });

--- a/tests/server-kiro-completion-e2e.test.ts
+++ b/tests/server-kiro-completion-e2e.test.ts
@@ -6,6 +6,7 @@ import { KIRO_COMPLETION_TOOL_NAME } from "../src/adapters/kiro-constants";
 import { saveConfig } from "../src/config";
 import { encodeMessage } from "../src/lib/eventstream-decoder";
 import { startServer } from "../src/server";
+import { clearRequestLogsForTests, getRequestLogEntries } from "../src/server/request-log";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
 
@@ -347,4 +348,58 @@ describe("Kiro completion through public server endpoints", () => {
       upstream.server.stop(true);
     }
   });
+});
+
+// The behavioural tests above prove nothing was SENT. This one proves the request log says so.
+// The C-phase verifier caught exactly this gap: the first implementation logged the local terminal
+// with `estimated: true`, because Kiro usage is marked estimated provider-wide. Zero counts from a
+// turn that made no inference are exact, and a row that claims otherwise is indistinguishable from
+// a real turn whose usage frame never arrived.
+describe("Kiro local terminal accounting", () => {
+  for (const stream of [true, false]) {
+    test(`a delivered final answer logs exact zero usage and no send (stream=${stream})`, async () => {
+      const upstream = scriptedKiroUpstream([]);
+      saveConfig(kiroConfig(upstream.server.url.toString()));
+      clearRequestLogsForTests();
+      const proxy = startServer(0);
+      try {
+        const response = await originalFetch(new URL("/v1/responses", proxy.url), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            model: "kiro-test/gpt-5.6-sol",
+            stream,
+            input: [
+              { type: "message", role: "user", content: [{ type: "input_text", text: "what is code mode" }] },
+              {
+                type: "message",
+                role: "assistant",
+                phase: "final_answer",
+                content: [{ type: "output_text", text: "Code mode runs JavaScript that calls tools." }],
+              },
+            ],
+            tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+          }),
+        });
+        expect(response.status).toBe(200);
+        // The streaming log is written when the body finishes, so drain it before reading.
+        await response.text();
+        expect(upstream.requests).toHaveLength(0);
+
+        const entry = getRequestLogEntries().find(row => row.provider === "kiro-test");
+        expect(entry).toBeDefined();
+        expect(entry!.localTerminalReason).toBe("kiro_final_answer_already_delivered");
+        // Exact, not estimated: this is the assertion the first implementation failed.
+        expect(entry!.usageStatus).toBe("reported");
+        expect(entry!.usage?.estimated).toBeUndefined();
+        expect(entry!.usage?.inputTokens).toBe(0);
+        expect(entry!.usage?.outputTokens).toBe(0);
+        expect(entry!.attempts?.every(attempt => attempt.sendCount === 0) ?? true).toBe(true);
+        expect(entry!.attempts?.every(attempt => attempt.inputTokenEstimate === undefined) ?? true).toBe(true);
+      } finally {
+        await proxy.stop(true);
+        upstream.server.stop(true);
+      }
+    });
+  }
 });

--- a/tests/server-kiro-completion-e2e.test.ts
+++ b/tests/server-kiro-completion-e2e.test.ts
@@ -396,6 +396,13 @@ describe("Kiro local terminal accounting", () => {
         expect(entry!.usage?.outputTokens).toBe(0);
         expect(entry!.attempts?.every(attempt => attempt.sendCount === 0) ?? true).toBe(true);
         expect(entry!.attempts?.every(attempt => attempt.inputTokenEstimate === undefined) ?? true).toBe(true);
+        // The EMBEDDED attempt must agree with its parent row. The re-verification caught this
+        // exact gap: the row read exact while its own attempt still said "estimated", and the
+        // attempt is the detailed accounting a maintainer reads for a zero-send turn.
+        for (const attempt of entry!.attempts ?? []) {
+          expect(attempt.usageStatus).toBe("reported");
+          expect(attempt.usage?.estimated).toBeUndefined();
+        }
       } finally {
         await proxy.stop(true);
         upstream.server.stop(true);

--- a/tests/server-kiro-completion-e2e.test.ts
+++ b/tests/server-kiro-completion-e2e.test.ts
@@ -313,6 +313,181 @@ describe("Kiro completion through public server endpoints", () => {
     }
   }
 
+  test("a proxy-recorded final answer suppresses replay when the client drops phase", async () => {
+    const deliveredAnswer = "Code mode runs JavaScript that calls tools.";
+    const upstream = scriptedKiroUpstream([completionFrames(deliveredAnswer)]);
+    saveConfig(kiroConfig(upstream.server.url.toString()));
+    const proxy = startServer(0);
+    try {
+      const first = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", session_id: "kiro-recorded-final-thread" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: "what is code mode",
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+      expect(first.status).toBe(200);
+      await first.text();
+      expect(upstream.requests).toHaveLength(1);
+
+      const replay = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", session_id: "kiro-recorded-final-thread" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: [
+            { type: "message", role: "user", content: [{ type: "input_text", text: "what is code mode" }] },
+            {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: deliveredAnswer }],
+            },
+          ],
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+
+      expect(replay.status).toBe(200);
+      expect((await replay.json() as { output?: unknown[] }).output ?? []).toHaveLength(0);
+      // The second turn is byte-for-byte replay history except for the client-dropped phase. A
+      // send here means the proxy forgot its own delivered answer and restarted finished work.
+      expect(upstream.requests).toHaveLength(1);
+
+      // Suppression must SURVIVE being used. A local terminal emits no output, so it writes no new
+      // record; if the read consumed or overwrote the original one, the second identical replay
+      // would send upstream and the loop this fix exists to end would return one turn later. The
+      // observed live failure was exactly a repeated identical history, not a single stray turn.
+      const replayAgain = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", session_id: "kiro-recorded-final-thread" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: [
+            { type: "message", role: "user", content: [{ type: "input_text", text: "what is code mode" }] },
+            {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: deliveredAnswer }],
+            },
+          ],
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+      expect(replayAgain.status).toBe(200);
+      expect((await replayAgain.json() as { output?: unknown[] }).output ?? []).toHaveLength(0);
+      expect(upstream.requests).toHaveLength(1);
+    } finally {
+      await proxy.stop(true);
+      upstream.server.stop(true);
+    }
+  });
+
+  test("a new user request after a proxy-recorded final answer is not suppressed", async () => {
+    const deliveredAnswer = "Code mode runs JavaScript that calls tools.";
+    const upstream = scriptedKiroUpstream([
+      completionFrames(deliveredAnswer),
+      completionFrames("Yes — one JavaScript cell can make several tool calls."),
+    ]);
+    saveConfig(kiroConfig(upstream.server.url.toString()));
+    const proxy = startServer(0);
+    try {
+      const first = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", session_id: "kiro-recorded-follow-up-thread" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: "what is code mode",
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+      expect(first.status).toBe(200);
+      await first.text();
+
+      const followUp = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", session_id: "kiro-recorded-follow-up-thread" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: [
+            { type: "message", role: "user", content: [{ type: "input_text", text: "what is code mode" }] },
+            {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: deliveredAnswer }],
+            },
+            { type: "message", role: "user", content: [{ type: "input_text", text: "so it batches calls?" }] },
+          ],
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+
+      expect(followUp.status).toBe(200);
+      await followUp.text();
+      // A later user message is the new work. The remembered answer may suppress only when that
+      // same assistant answer is still the trailing content-bearing message.
+      expect(upstream.requests).toHaveLength(2);
+    } finally {
+      await proxy.stop(true);
+      upstream.server.stop(true);
+    }
+  });
+
+  test("a recorded final answer is isolated to its conversation scope", async () => {
+    const deliveredAnswer = "Code mode runs JavaScript that calls tools.";
+    const upstream = scriptedKiroUpstream([
+      completionFrames(deliveredAnswer),
+      completionFrames("This is a separate thread, so I answered independently."),
+    ]);
+    saveConfig(kiroConfig(upstream.server.url.toString()));
+    const proxy = startServer(0);
+    try {
+      const first = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", session_id: "kiro-record-owner-thread" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: "what is code mode",
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+      expect(first.status).toBe(200);
+      await first.text();
+
+      const otherThread = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json", session_id: "kiro-record-other-thread" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: [
+            { type: "message", role: "user", content: [{ type: "input_text", text: "what is code mode" }] },
+            {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: deliveredAnswer }],
+            },
+          ],
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+
+      expect(otherThread.status).toBe(200);
+      await otherThread.text();
+      expect(upstream.requests).toHaveLength(2);
+    } finally {
+      await proxy.stop(true);
+      upstream.server.stop(true);
+    }
+  });
+
   // Control for the above: the predicate keys off the trailing turn, so a genuine follow-up
   // question after a delivered answer is an ordinary turn and MUST still reach Kiro. Without this,
   // a short-circuit that swallowed every turn would pass the tests above.

--- a/tests/server-kiro-completion-e2e.test.ts
+++ b/tests/server-kiro-completion-e2e.test.ts
@@ -250,4 +250,101 @@ describe("Kiro completion through public server endpoints", () => {
       upstream.server.stop(true);
     }
   });
+
+  // A turn whose replayed history already ENDS with a delivered final answer has nothing to ask
+  // Kiro. Before the local terminal, the adapter appended a trailing user turn — neutral wording,
+  // but structurally still a prompt — and performed a real inference, so the model answered the
+  // closed task again and a finished turn behaved like a still-open goal.
+  //
+  // `emptyCompletionRetry` is exercised BOTH ways on purpose. A local terminal produces no content,
+  // which is exactly the shape that guard re-invokes: if the short-circuit were routed through the
+  // ordinary event path, the enabled case would send the request the fix exists to prevent, and a
+  // guard-off-only test would pass while the user's own config still looped.
+  for (const emptyCompletionRetry of [false, true]) {
+    for (const stream of [true, false]) {
+      test(`a delivered final answer sends nothing upstream (emptyCompletionRetry=${emptyCompletionRetry}, stream=${stream})`, async () => {
+        const upstream = scriptedKiroUpstream([]);
+        saveConfig({ ...kiroConfig(upstream.server.url.toString()), emptyCompletionRetry } as OcxConfig);
+        const proxy = startServer(0);
+        try {
+          const response = await originalFetch(new URL("/v1/responses", proxy.url), {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              model: "kiro-test/gpt-5.6-sol",
+              stream,
+              input: [
+                { type: "message", role: "user", content: [{ type: "input_text", text: "what is code mode" }] },
+                {
+                  type: "message",
+                  role: "assistant",
+                  phase: "final_answer",
+                  content: [{ type: "output_text", text: "Code mode runs JavaScript that calls tools." }],
+                },
+              ],
+              tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+            }),
+          });
+
+          expect(response.status).toBe(200);
+          const body = await response.text();
+          // The load-bearing assertion: zero upstream requests. The scripted upstream has no
+          // attempts queued, so any send would also answer 500 and fail the status check above.
+          expect(upstream.requests).toHaveLength(0);
+
+          if (stream) {
+            const events = responseEvents(body);
+            expect(events.filter(event => event.name === "response.completed")).toHaveLength(1);
+            expect(events.some(event => event.name === "response.output_text.delta")).toBe(false);
+            // The empty-completion guard's failure event must not appear: a local terminal is a
+            // deliberate no-inference turn, not an upstream empty completion.
+            expect(body).not.toContain("empty_completion_retry_failed");
+          } else {
+            const json = JSON.parse(body) as { status?: string; output?: unknown[] };
+            expect(json.status).toBe("completed");
+            expect(json.output ?? []).toHaveLength(0);
+          }
+        } finally {
+          await proxy.stop(true);
+          upstream.server.stop(true);
+        }
+      });
+    }
+  }
+
+  // Control for the above: the predicate keys off the trailing turn, so a genuine follow-up
+  // question after a delivered answer is an ordinary turn and MUST still reach Kiro. Without this,
+  // a short-circuit that swallowed every turn would pass the tests above.
+  test("a real user follow-up after a delivered final answer still reaches Kiro", async () => {
+    const upstream = scriptedKiroUpstream([completionFrames("Yes — one JavaScript cell, many tool calls.")]);
+    saveConfig(kiroConfig(upstream.server.url.toString()));
+    const proxy = startServer(0);
+    try {
+      const response = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          stream: false,
+          input: [
+            { type: "message", role: "user", content: [{ type: "input_text", text: "what is code mode" }] },
+            {
+              type: "message",
+              role: "assistant",
+              phase: "final_answer",
+              content: [{ type: "output_text", text: "Code mode runs JavaScript that calls tools." }],
+            },
+            { type: "message", role: "user", content: [{ type: "input_text", text: "so it batches calls?" }] },
+          ],
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(upstream.requests).toHaveLength(1);
+    } finally {
+      await proxy.stop(true);
+      upstream.server.stop(true);
+    }
+  });
 });

--- a/tests/tool-catalog-nudge.test.ts
+++ b/tests/tool-catalog-nudge.test.ts
@@ -4,6 +4,7 @@ import {
   buildNonOpenAIToolCatalogNudgeFromNames,
   shouldInjectNonOpenAIToolCatalogNudge,
 } from "../src/adapters/tool-catalog-nudge";
+import { CODE_MODE_RESULT_ECHO_SENTENCE, EMPTY_EXEC_OUTPUT_MESSAGE } from "../src/adapters/exec-tool-result-normalize";
 import type { OcxTool } from "../src/types";
 
 describe("non-OpenAI tool catalog nudge", () => {
@@ -216,5 +217,39 @@ describe("non-OpenAI tool catalog nudge", () => {
     expect(shouldInjectNonOpenAIToolCatalogNudge({ baseUrl: "https://api.openai.com/v1" })).toBe(false);
     expect(shouldInjectNonOpenAIToolCatalogNudge({ baseUrl: "https://chatgpt.com/backend-api/codex" })).toBe(false);
     expect(shouldInjectNonOpenAIToolCatalogNudge({ baseUrl: "https://api.kimi.com/coding/v1" })).toBe(true);
+  });
+
+  // The empty-result guidance in exec-tool-result-normalize only fires AFTER a wasted call. Live
+  // 2026-08-28: a routed Kiro session read a blank result, reported it as possible context loss,
+  // and learned the echo rule only from the repair text. Stating it up front is the prevention.
+  describe("code-mode result echo rule", () => {
+    test("states the echo rule before the first call when code mode is advertised", () => {
+      const note = buildNonOpenAIToolCatalogNudgeFromNames(["exec"], name => name, "exec");
+
+      if (!note) throw new Error("Expected a nudge for a code-mode catalog");
+      expect(note).toContain("Nothing in the isolate is echoed automatically");
+      expect(note).toContain("is DISCARDED");
+      expect(note).toContain("text(...)");
+      // Names the wrong conclusions, so a blank result is not read as a failed command.
+      expect(note).toContain("rather than a failed command or lost context");
+    });
+
+    test("omits the echo rule when the turn has no code-mode exec", () => {
+      const note = buildNonOpenAIToolCatalogNudgeFromNames(["exec_command", "mcp__fs__read_file"]);
+
+      if (!note) throw new Error("Expected a nudge for a flat catalog");
+      // A flat shell bridge echoes stdout on its own; this guidance would be a lie there.
+      expect(note).not.toContain("Nothing in the isolate is echoed automatically");
+    });
+
+    test("shares one wording with the post-hoc empty-result guidance", () => {
+      const note = buildNonOpenAIToolCatalogNudgeFromNames(["exec"], name => name, "exec");
+
+      if (!note) throw new Error("Expected a nudge for a code-mode catalog");
+      // Both surfaces must describe the same isolate. Drift here is how a model gets told two
+      // different things about whether its output survived.
+      expect(note).toContain(CODE_MODE_RESULT_ECHO_SENTENCE);
+      expect(EMPTY_EXEC_OUTPUT_MESSAGE).toContain("text(...)");
+    });
   });
 });

--- a/tests/usage-log.test.ts
+++ b/tests/usage-log.test.ts
@@ -784,6 +784,24 @@ describe("usage log", () => {
     expect(usageForFinalLog("openai", { ...usage, estimated: true })).toEqual({ ...usage, estimated: true });
   });
 
+  // A turn the proxy answered locally issued no upstream request, so its zero counts are exact.
+  // The provider-wide estimated marking exists because the Kiro/Cursor adapters can only guess a
+  // real inference's usage; there is nothing to guess when there was no inference, and marking it
+  // estimated makes a no-send turn indistinguishable from one whose usage frame never arrived.
+  test("a locally answered turn keeps exact usage instead of the provider estimated marking", () => {
+    const zero = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    expect(usageForFinalLog("kiro", zero, true)).toEqual(zero);
+    expect(usageForFinalLog("kiro-p9d8524", zero, true)).toEqual(zero);
+    // Default and explicit-false keep the existing behavior: this is opt-in per turn, so an
+    // ordinary Kiro turn cannot lose its estimated marking by omission.
+    expect(usageForFinalLog("kiro", zero)).toEqual({ ...zero, estimated: true });
+    expect(usageForFinalLog("kiro", zero, false)).toEqual({ ...zero, estimated: true });
+    // The flag reports a fact about the turn, not about the numbers: an adapter that genuinely
+    // estimated something still says so.
+    const guessed = { inputTokens: 4, outputTokens: 6, estimated: true };
+    expect(usageForFinalLog("kiro", guessed, true)).toEqual(guessed);
+  });
+
   test("preserves cached token counts alongside estimated status", () => {
     appendUsageEntry({
       requestId: "ocx-cache",


### PR DESCRIPTION
## Summary

Three defects made a Kiro code-mode session unable to see its own tool output and unable to end its turn.

**1. Empty exec output was unexplained.** A code-mode `exec` cell that never calls `text()`/`notify()` returns nothing — the last expression value is not echoed. Kiro received the generic `"The tool completed without textual output."`, so the model concluded its earlier context was lost and restarted finished work. Cursor already had actionable wording for exactly this state; Kiro had no equivalent.

Detection now lives in `src/adapters/exec-tool-result-normalize.ts` and both adapters share one message, so the wording cannot drift. Cursor keeps `normalizeCursorToolResultText` as a wrapper because it owns Computer Use precedence and `isError` policy, which are not Kiro's — that also preserves its existing public test seam.

Checked before `text.trim()` deliberately: the wrapper form (`"Script completed\nWall time ...\nOutput:\n"`) is non-blank and would otherwise pass through as if it were real output. Non-exec tools keep the generic message — asserting code-mode semantics for arbitrary tools would tell a model to call `text()` in a runtime that has neither.

The same rule is now also stated **before** the first call, in the code-mode catalog nudge. The recovery message above only fires after a model has already spent a call and read a blank result; that recovers the turn but cannot prevent the wasted round trip, and the model still has to guess whether its command failed or its output was merely dropped. Both strings live beside each other so the up-front rule and the repair cannot drift apart.

**2. A delivered final answer was told to continue.** The trailing-turn predicate was `turns.at(-1)?.kind === "assistant"`, which cannot distinguish "stopped mid-task" from "already answered". Both received a continuation or completion-retry prompt, so a closed task read as a still-open goal and looped.

The turn now carries whether it was the delivered final answer, keyed off Responses `phase: "final_answer"` (preserved through the parser) rather than guessed from turn position. Kiro still requires a trailing user turn, so it is still appended — only its text changes, to a neutral acknowledgement that withholds any instruction to resume. Removing the append instead would throw at the `currentTurn` pop. The `text_fallback` and thinking-tag paths are both excluded, since either would re-append the resume instruction and reinstate the loop.

A merged assistant turn counts as final only when its last component was, so commentary after an answer correctly reopens continuation. The adapter now answers such a turn **locally**: suppressing the completion contract removed the instruction to complete but could not remove the inference itself, so the turn is short-circuited with no build, no send, and no token estimate. That path is kept out of the ordinary event flow on purpose — the empty-completion guard treats an outputless terminal as a failed turn and re-invokes the identical request, which would reinstate the very loop being fixed. A locally answered turn is logged as exact zero usage rather than an estimate, on both the parent row and its own attempt.

**3. The suppression above never fired in production.** Detection keyed off the inbound `phase: "final_answer"` alone — a field this proxy emits but no client is obliged to send back. Measured against the running proxy: the same history **with** phase sent nothing upstream (`output: []`, `end_turn: true`), and **without** it spent 7,686 input tokens redoing the closed task. `localTerminalReason` appeared **0 times across 1,534 logged Kiro turns** with the code deployed and loaded, so fix 2 had never once taken effect for a real client. The existing e2e test passed only because its fixture supplied `phase` by hand.

The proxy now records the final answer it actually emitted, keyed by the normalized conversation digest already computed for logging, and consults that record when the inbound phase is absent. An explicit phase still wins; the record is an additional source, not a replacement.

Scope is the load-bearing constraint. Only the 32-hex normalized digest may key the map, so no raw header or account identifier can be retained there, and an unresolvable scope means "no record" rather than a global fallback. The store is bounded by both a 1h TTL and an entry cap.

Invalidation needed care: every legitimate next turn contains a new user message somewhere in its history, so "a later user message exists" would suppress nothing at all. Matching therefore requires the remembered answer to still be the **trailing content-bearing message**, which is what separates a re-sent closed history from a genuine follow-up. And because a local terminal emits no output, it writes no new record — that is what keeps suppression alive across the repeated identical histories the live loop actually produced, rather than lapsing one turn later.

## Verification

- `bun x tsc --noEmit` — clean (exit 0).
- `bun test tests/server-kiro-completion-e2e.test.ts` — **14 pass, 0 fail, 89 expect()**.
- `bun test tests/kiro-adapter.test.ts tests/core-lab-boundary.test.ts` — **92 pass, 0 fail**.
- `bun test` on `kiro-adapter`, `kiro-stream`, `cursor-exec-empty-result`, `cursor-toolresult-normalize`, `server-kiro-completion-e2e`, `tool-catalog-nudge`, `cursor-tool-definitions` — all green.
- `bun run privacy:scan` — passed.
- `bun test tests/core-lab-boundary.test.ts tests/repo-hygiene.test.ts` — green (no lab import, no gitlink).
- **Non-vacuity proven:** each fix was reverted individually and the matching new assertion went red, then restored to green. For fix 3 specifically, the phase-absent replay test reached upstream and returned 500 before the implementation existed.
- **Live measurement on the running proxy** (port 10100, this exact worktree) is what identified fix 3: two otherwise byte-identical histories differing only in `phase` produced zero-send versus a 7,686-token re-inference.

Disclosure: the full repository-wide `bun run test` was **not** run, at the maintainer's explicit instruction; the suites above were selected to cover every changed file plus the shared-boundary guards. CI on this PR is the remaining signal. Commit and push used `--no-verify` as instructed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing config or API surface changed; the messages are internal prompt text and the new store is proxy-private in-memory state.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No auth, credential, workflow, or release-automation code touched. The new store accepts only the already-normalized 32-hex digest as a key, refuses raw headers by construction, is bounded by TTL and entry cap, and logs nothing; `privacy:scan` green.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty command-execution results with clearer, actionable guidance.
  * Added specific guidance for failed executions that produce no output.
  * Preserved normal output and generic handling for unrelated tools.
  * Prevented completed Kiro responses from being incorrectly reopened, duplicated, or followed by continuation prompts.
  * Ensured completion options are not shown after a final answer.
  * Avoided unnecessary processing when a final answer has already been delivered.

* **Tests**
  * Added coverage for execution results, final answers, follow-up turns, and local completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->