### PR TITLE
fix(cli): unblock dest CI after the agentic-control stack

### DIFF
--- a/skills/ocx/references/01_management_surface.md
+++ b/skills/ocx/references/01_management_surface.md
@@ -44,7 +44,7 @@ JSON mode: `envelope`.
 
 ### `ocx capabilities`
 
-Enumerate every CLI capability with the management routes it drives.
+List the declared CLI capabilities and the management routes they drive.
 
 Drives no management route.
 
@@ -56,21 +56,21 @@ Drives no management route.
 
 JSON mode: `envelope`.
 
-- Start here when driving ocx programmatically: it is the surface index.
+- Start here when driving ocx programmatically: it is the declared surface index, not a complete verb list.
 
 ### `ocx provider list`
 
 Configured providers with connectivity and selected models.
 
-| Method | Route |
-|---|---|
-| GET | `/api/providers` |
+Drives no management route.
 
 | Flag | Value | Meaning |
 |---|---|---|
 | `--json` | boolean | Emit the provider list as JSON. |
 
-JSON mode: `payload`.
+JSON mode: `envelope`.
+
+- Reads local config; drives no management API route.
 
 ### `ocx account list`
 
@@ -87,7 +87,7 @@ Codex OAuth accounts with pool priority and pause state.
 JSON mode: `payload`.
 
 - STATUS names `paused` alongside `selected`: a paused-but-selected account still receives requests.
-- Quota is only fetched under `--quota` (a deliberate cost decision), so 5h and weekly percentages appear in `account list --quota`, not bare `account list`.
+- `--quota` shows cached Codex windows (including 5h); `--refresh` bypasses the server TTL.
 
 ### `ocx usage`
 
@@ -365,7 +365,7 @@ Pause every Codex account whose quota is spent.
 
 JSON mode: `envelope`.
 
-- The route refreshes quota per account and can partially fail; a non-zero failed count is reported, because silence would read as `none were exhausted`.
+- The route refreshes quota per account and can partially fail; a non-zero failed count exits 1 and sets ok:false, because silence would read as `none were exhausted`.
 
 ### `ocx account strategy`
 

--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -179,7 +179,7 @@ export interface FamilyRows {
   activeId: string | null;
   autoSwitchThreshold?: number;
   /** HTTP status for a completed family read, including failures. */
-  status?: number;
+  status: number;
   /** Set when the family endpoint returned an error. */
   errorJson?: Record<string, unknown>;
   networkDown?: boolean;

--- a/src/cli/account-extended.ts
+++ b/src/cli/account-extended.ts
@@ -238,7 +238,7 @@ function configAndType(deps: AccountDeps, name: string) {
 
 function familyFailure(result: FamilyRows, fallback: string): number | null {
   if (result.networkDown) return proxyUnreachable(result.transportError);
-  if (result.errorJson) return apiError(result.errorJson, fallback, result.status ?? 1);
+  if (result.errorJson) return apiError(result.errorJson, fallback, result.status);
   return null;
 }
 

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -188,7 +188,8 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
     const r = await fetchRows(deps, baseUrl, t.name, t.type, wantsQuota ? { refresh: refreshQuota } : undefined);
     if (r.networkDown) return proxyUnreachable(r.transportError);
     if (r.errorJson) {
-      if (name) return apiError(r.errorJson, `failed to list ${t.name}`, r.status ?? 1);
+      if (name) return apiError(r.errorJson, `failed to list ${t.name}`, r.status);
+
       const errorText = typeof r.errorJson.error === "string" ? r.errorJson.error : "";
       const skipUnknownKey = t.type === "api-key"
         && r.status === 404
@@ -198,7 +199,7 @@ async function cmdList(rest: string[], deps: AccountDeps): Promise<number> {
         && r.status === 400
         && errorText.includes("unknown oauth provider");
       if (skipUnknownKey || skipConfigOAuth) continue;
-      return apiError(r.errorJson, `failed to list ${t.name}`, r.status ?? 1);
+      return apiError(r.errorJson, `failed to list ${t.name}`, r.status);
     }
     if (r.rows.length === 0) {
       if (showAll) notes.push(`${t.name}: no stored accounts or keys`);
@@ -245,7 +246,7 @@ async function cmdCurrent(rest: string[], deps: AccountDeps): Promise<number> {
   if (!baseUrl) return proxyUnreachable();
   const r = await fetchRows(deps, baseUrl, name, c.type);
   if (r.networkDown) return proxyUnreachable(r.transportError);
-  if (r.errorJson) return apiError(r.errorJson, `failed to read ${name}`, r.status ?? 1);
+  if (r.errorJson) return apiError(r.errorJson, `failed to read ${name}`, r.status);
 
   const activeRow = r.rows.find(row => row.active) ?? null;
   if (wantsJson) {

--- a/tests/cli-capabilities.test.ts
+++ b/tests/cli-capabilities.test.ts
@@ -222,6 +222,7 @@ const UNDECLARED_ROUTES_2026_08_28: readonly string[] = [
   "GET /api/provider-context-caps",
   "GET /api/provider-presets",
   "GET /api/provider-quotas",
+  "GET /api/providers",
   "GET /api/providers/keys",
   "GET /api/request-history",
   "GET /api/request-history/{id}",

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -647,7 +647,7 @@ describe("CLI /api sync wiring for stale app-servers (#476)", () => {
       // restartCodex, quitting the user's app would ride along on a flag whose
       // documented contract is app-server-only.
       expect(handler).toContain('includes("--restart-desktop-app")');
-      expect(handler).toContain("if (restartDesktopApp) await handleDesktopAppRestart(console)");
+      expect(handler).toMatch(/if \(restartDesktopApp\) await handleDesktopAppRestart\((console|jsonSafeLog)\)/);
       expect(handler).not.toContain("restartDesktopApp = restartCodex");
       // Gated behind the same real-write condition as the app-server handling.
       const desktopAt = handler.indexOf("restartDesktopApp) await handleDesktopAppRestart");


### PR DESCRIPTION
## Summary

- Dest Cross-platform CI on the #2790 merge failed four honesty-stack leftovers: `GET /api/providers` was missing from the undeclared-route ratchet, `apiError` call sites coalesced status with `?? 1` (so the 404→4 mapping scan failed), `sync-cache` now restarts Desktop with `jsonSafeLog` rather than `console`, and the generated skill surface still claimed `provider list` drives `GET /api/providers`.

## Verification

- Matched against dest run 33172494686 annotations (`gates`, `test 1/4`, `test 2/4`, `test 4/4`). Did not rerun the suite locally.
- Regenerated `skills/ocx/references/01_management_surface.md` from the capability table.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI capability listings and provider discovery behavior.
  * Updated account quota and pause-exhausted command guidance, including refresh behavior and failure outcomes.

* **Bug Fixes**
  * Improved account API error handling and status reporting.
  * Preserved correct behavior when querying specific providers or discovering available providers.

* **Tests**
  * Updated capability and desktop restart checks to reflect supported route and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->