### PR TITLE
fix(cli): scope model removal selectors to provider

### DIFF
--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -283,9 +283,12 @@ async function handleCustomRemove(args: string[]): Promise<void> {
   // that row while the dash form matched both — the two relations disagreed on the same
   // config. Removal stays exact-or-refuse: an ambiguous selector still aborts below, which is
   // the right default for a destructive command.
+  const separator = target.indexOf("/");
+  const selectedProvider = separator >= 0 ? target.slice(0, separator) : undefined;
   const matchingIndexes = existing.flatMap((model, index) => {
-    if (!target.includes("/")) return model.id === target ? [index] : [];
-    const resolved = resolveSlugSelection(model.provider, target, [model.modelId]);
+    if (selectedProvider === undefined) return model.id === target ? [index] : [];
+    if (model.provider !== selectedProvider) return [];
+    const resolved = resolveSlugSelection(selectedProvider, target, [model.modelId]);
     return resolved.matched.length > 0 ? [index] : [];
   });
   if (matchingIndexes.length === 0) fail(`custom model "${target}" not found`);

--- a/tests/cli-models.test.ts
+++ b/tests/cli-models.test.ts
@@ -478,5 +478,42 @@ describe("#2491 the removal selector uses the shared equivalence relation", () =
       rmSync(dir, { recursive: true, force: true });
     }
   });
-});
 
+  test("a provider-qualified selector does not match a native id under another provider", () => {
+    const { dir } = freshConfig({
+      customModels: [
+        { id: "11111111-1111-4111-8111-111111111111", provider: "openai", modelId: "gpt-5.5" },
+        { id: "22222222-2222-4222-8222-222222222222", provider: "test", modelId: "openai/gpt-5.5" },
+      ],
+    });
+    try {
+      const result = runCli(["models", "remove", "openai/gpt-5.5", "--yes"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(0);
+      const config = JSON.parse(readFileSync(join(dir, "config.json"), "utf8"));
+      expect(config.customModels).toEqual([
+        expect.objectContaining({ provider: "test", modelId: "openai/gpt-5.5" }),
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a provider-qualified selector cannot remove a sole row from another provider", () => {
+    const { dir } = freshConfig({
+      customModels: [
+        { id: "22222222-2222-4222-8222-222222222222", provider: "test", modelId: "openai/gpt-5.5" },
+      ],
+    });
+    try {
+      const result = runCli(["models", "remove", "openai/gpt-5.5", "--yes"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("not found");
+      const config = JSON.parse(readFileSync(join(dir, "config.json"), "utf8"));
+      expect(config.customModels).toEqual([
+        expect.objectContaining({ provider: "test", modelId: "openai/gpt-5.5" }),
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Parse the provider prefix in `ocx models remove provider/model` once and evaluate only custom-model rows owned by that provider.
- Prevent a selector for one provider from deleting a different provider's row merely because that row's native model id resembles the full selector.
- Preserve exact UUID removal, same-provider slash/dash equivalence, and fail-closed ambiguity handling introduced by #2596.

## Verification

- Stable Bun 1.4.0: `bun test tests/cli-models.test.ts` — 23 passed, 0 failed.
- Stable Bun 1.4.0: `bun run typecheck`.
- Stable Bun 1.4.0: `bun run privacy:scan`.
- `git diff --check`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom model removal for provider-qualified selectors.
  * Selectors such as `provider/model` now remove only the matching model from that provider.
  * Prevented models with the same ID under different providers from being removed accidentally.
  * Non-qualified selectors continue to match exact custom model IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->