### PR TITLE
fix(responses): fold only message-shaped system items

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -1202,6 +1202,13 @@ function canonicalForwardSystemText(item: Record<string, unknown>): string | nul
   return text;
 }
 
+/** Only message items may carry privileged system instructions. */
+function isCanonicalForwardSystemMessage(item: unknown): item is Record<string, unknown> {
+  return isPlainObject(item)
+    && (item.type === undefined || item.type === "message")
+    && item.role === "system";
+}
+
 /**
  * The public Responses API accepts input system messages and `truncation`, but the canonical
  * ChatGPT Codex forward endpoint rejects both. Fold only fully textual system messages into the
@@ -1225,7 +1232,7 @@ function normalizeCanonicalForwardPromptEnvelope(body: unknown): unknown {
   let sawSystemMessage = false;
   let canFoldAllSystemMessages = true;
   for (const item of input) {
-    if (!isPlainObject(item) || item.role !== "system") continue;
+    if (!isCanonicalForwardSystemMessage(item)) continue;
     sawSystemMessage = true;
     const text = canonicalForwardSystemText(item);
     if (text === null) {
@@ -1239,7 +1246,7 @@ function normalizeCanonicalForwardPromptEnvelope(body: unknown): unknown {
   const next: Record<string, unknown> = { ...body };
   if (stripTruncation) delete next.truncation;
   if (sawSystemMessage && canFoldAllSystemMessages) {
-    next.input = input.filter(item => !isPlainObject(item) || item.role !== "system");
+    next.input = input.filter(item => !isCanonicalForwardSystemMessage(item));
     const folded = foldedText.join("\n\n");
     if (folded !== "") {
       const existing = typeof body.instructions === "string" ? body.instructions : "";

--- a/tests/responses-forward-prompt-envelope.test.ts
+++ b/tests/responses-forward-prompt-envelope.test.ts
@@ -86,6 +86,28 @@ describe("canonical ChatGPT forward prompt envelope", () => {
     expect(body.input).toEqual(input);
   });
 
+  test("folds only message-shaped system items", () => {
+    const externalAgentMessage = {
+      type: "agent_message",
+      role: "system",
+      content: [{ type: "input_text", text: "external agent content" }],
+    };
+    const body = outboundBody(canonicalForward, {
+      model: "gpt-5.6-luna",
+      instructions: "Existing instructions",
+      input: [
+        { type: "message", role: "system", content: "Typed system instruction" },
+        { role: "system", content: "Easy input system instruction" },
+        externalAgentMessage,
+      ],
+    });
+
+    expect(body.instructions).toBe(
+      "Existing instructions\n\nTyped system instruction\n\nEasy input system instruction",
+    );
+    expect(body.input).toEqual([externalAgentMessage]);
+  });
+
   test.each([
     {
       name: "key-auth public Responses provider",


### PR DESCRIPTION
## Summary

- Treat only Responses message items as canonical-forward system messages: `type: "message"` or an EasyInputMessage with the optional type omitted.
- Preserve explicitly typed non-message items even when an extension object also carries `role: "system"`, instead of removing it from `input` and promoting its content into top-level instructions.
- Keep the existing atomic multimodal behavior and leave public Responses providers and noncanonical forward gateways unchanged.

## Verification

- Stable Bun 1.4.0: `bun test tests/responses-forward-prompt-envelope.test.ts` — 5 passed, 0 failed.
- Stable Bun 1.4.0: `bun run typecheck`.
- Stable Bun 1.4.0: `bun run privacy:scan`.
- `git diff --check`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt handling so only valid system message items are folded into instructions.
  * Preserved other system-role item types in the input instead of incorrectly removing or reclassifying them.

* **Tests**
  * Added coverage for typed, untyped, and non-message system items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->