### PR TITLE
[WRONG BRANCH] release: v2.35.0-preview.20260829

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.35.0",
+  "version": "2.35.0-preview.20260829",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Version bump only: `package.json` 2.35.0 → `2.35.0-preview.20260829` for the preview-channel publish of the content already promoted in #2825.

`scripts/release.ts` produced this commit on `preview` and then could not push it: the `refs/heads/preview` ruleset requires a pull request, and the release deploy key that normally bypasses it is not present on this machine. The bump therefore travels as a PR, which is the documented fallback for protected release branches.

The diff is one line. No source, test, workflow, or dependency change.

`enforce-target` will fail `wrong_base` — `ALLOWED_BASES` is `["dev"]`, so every release-branch PR trips it by construction. Precedent: #2825, #2826, #2757, #2760.

## Verification

- Full release preflight already passed on this exact content before the bump: `bun audit --audit-level=high` (root + gui, no vulnerabilities), `tsc --noEmit`, the CI-matching test grouping with 0 failures, and `privacy:scan`.
- Promoted content identity: the parent commit `e0e323420` is #2825, whose tree is `origin/dev` verbatim.
- The stable channel for the same content already published successfully: npm `latest` = 2.35.0, tag `v2.35.0`, gitHead `fc4de772b` matching the main promotion commit.

## Checklist

- [x] Local CI green for this content
- [x] One-line version bump, no functional change
- [x] Stable channel for the same tree already published
- [x] Ready for maintainer merge



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to preview version 2.35.0-preview.20260829.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->