### PR TITLE
[WRONG BRANCH] release: v2.36.0-preview.20260829

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.35.0",
+  "version": "2.36.0-preview.20260829",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Version bump only: `package.json` 2.35.0 → `2.36.0-preview.20260829`, so the preview channel can publish the content already promoted onto `preview` in #2825.

The diff is one line. No source, test, workflow, or dependency change.

### Why 2.36.0 and not 2.35.0

This release train ran in the reverse of the usual order. Every prior cycle published the preview channel first and the stable channel second (`v2.34.0-preview.20260827` at 21:33, `v2.34.0` at 22:06; same shape for 2.33.0 and 2.32.x), so the preview version was always a prerelease of a version that did not yet have a stable tag.

Here `v2.35.0` shipped first — npm `latest` is 2.35.0, gitHead `fc4de772b`. A `2.35.0-preview.*` version now orders **behind** that published tag, which is a channel regression. `tests/release-version-line.test.ts` caught exactly this on the first attempt (#2829, closed): `compareReleaseTags` returned -1 where the test requires > 0. Its sibling assertion documents the correct shape — a prerelease of a *future* version is ahead, not behind.

So the preview channel moves to the next train. `2.36.0-preview.20260829` orders ahead of `v2.35.0`, and the version-line test passes locally on this commit.

### Why this bump travels as a PR

`scripts/release.ts` normally commits and pushes the bump directly. The `refs/heads/preview` ruleset requires a pull request, and the release deploy key that bypasses it (`OCX_RELEASE_SSH_KEY` → `~/.ssh/opencodex_release_ed25519`) is not present on this machine. The PR path is the documented fallback.

`enforce-target` will fail `wrong_base` — `ALLOWED_BASES` is `["dev"]`, so every release-branch PR trips it by construction. Precedent: #2825, #2826, #2757, #2760.

## Verification

- `bun test tests/release-version-line.test.ts` on this exact commit: 3 pass / 0 fail — including the assertion that rejected the 2.35.0-preview attempt.
- Full release preflight passed on this content before the version correction: `bun audit --audit-level=high` (root + gui, no vulnerabilities), `tsc --noEmit`, the CI-matching test grouping with 0 failures, and `privacy:scan`.
- Promoted content identity: the parent commit `e0e323420` is #2825, whose tree is `origin/dev` verbatim. `origin/preview` and `origin/dev` differ in 0 files.
- The same tree already published successfully on the stable channel: npm `latest` = 2.35.0, tag `v2.35.0`, gitHead matching the main promotion commit `fc4de772b`.

## Checklist

- [x] Local CI green for this content
- [x] One-line version bump, no functional change
- [x] Version orders ahead of every published tag
- [x] Ready for maintainer merge



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to preview version 2.36.0-preview.20260829.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->