### PR TITLE
fix(kiro): render one answer when prose and the completion tool share an inference

### DIFF
--- a/devlog/_plan/260828_kiro_turn_termination/021_audit_round3.md
+++ b/devlog/_plan/260828_kiro_turn_termination/021_audit_round3.md
@@ -1,0 +1,71 @@
+# wp2 audit round 3 — the outer drain must not learn about completions
+
+Reviewer: independent explorer lane, read-only, HEAD `a43e4cda`.
+Verdict: **FAIL** on the plan as written in `020_wp2_duplicate_answer.md`.
+This document records the finding and the corrected design.
+
+## What the reviewer accepted
+
+- Consuming the retained collection on a valid completion IS sufficient to remove
+  the user-visible duplicate. Required-mode text is held only in `deferred`
+  (`src/adapters/kiro.ts:1174-1179`, `:1207`), fallback text only in
+  `fallbackEvents` (`:1202-1205`), and a valid completion never live-flushes that
+  run because a completion alongside a real tool call is already a protocol error
+  (`:1260-1261`). With the commentary `text_delta` gone, `src/bridge.ts` never
+  splits the message.
+- There is **no third emitter**. `:1523` builds a new event from
+  `completionAnswer`; it does not read `deferred`. The early-loop yields at
+  `:1398` and `:1418` only flush `deferred` when a real tool starts (`:1175`).
+- Dropping `text_delta` while keeping non-text retained events loses nothing
+  load-bearing on this path. Tool events never sit in the collection — they splice
+  live and forbid a valid completion.
+- `releaseEvent` is idempotent via its `eventBytes` map guard (`:808-810`), so a
+  double release cannot double-credit the budget.
+
+## The blocker
+
+`020`'s option 1 says to consume the collection at BOTH readers — the inner flush
+and the outer drain in `parseKiroAttempt` (`:996-1001`). The reviewer showed the
+second half is wrong:
+
+> `996-1001` is also the leftover flush for early `terminal` returns that never
+> hit `1468` (`1405-1413`). Dropping `text_delta` there without a completion flag
+> hides the only commentary.
+
+That outer drain is the release path for stream, protocol, and provider failures —
+the row `020`'s own table requires to stay intact. A turn that fails after emitting
+progress prose would lose that prose entirely, which is a worse defect than the
+duplicate: the user would see an error with no indication of what the model had
+been doing.
+
+## Corrected design
+
+The inner site is the only consumer, and it leaves the collection **empty**:
+
+1. `src/adapters/kiro.ts:1468`, `mode === "required"`: when
+   `completionAnswer !== undefined`, splice the collection and consume it — drop
+   each `text_delta` after releasing its retention, yield every non-text event and
+   release it. When there is no completion answer, flush exactly as today.
+2. `:1474`, `mode === "text_fallback"`: this branch is **already** gated on
+   `completionAnswer !== undefined`, so the same consume applies there and nowhere
+   else in that mode.
+3. `:996-1001`, the outer drain: **unchanged**. Because step 1 splices, there is
+   nothing left for it to emit on the completion path, and it keeps its full
+   flush behaviour for every early-terminal path.
+
+The correction is that suppression is expressed by emptying the collection at the
+one site that knows a completion arrived — not by teaching a second,
+failure-serving reader to discard text.
+
+Untouched, per `020`'s release table: the `sawRealTool` flush (`:1483`), the
+plain-text promotion (`:1490-1498`), and the empty/reasoning-only fallback
+(`:1505`).
+
+## Budget note
+
+The reviewer's condition for a leak is "splice, skip `releaseEvent`, and skip
+`releaseAll`". The consume path releases every event it drops, and
+`releaseRetained`/`releaseAll` still runs for the `trackReplacement` remainder
+(`:801-803`), which is not tracked in `eventBytes`. A test asserts the budget
+returns to baseline.
+

--- a/devlog/_plan/260828_kiro_turn_termination/030_wp1_live_measurement.md
+++ b/devlog/_plan/260828_kiro_turn_termination/030_wp1_live_measurement.md
@@ -1,0 +1,94 @@
+# wp1 — live measurement: what is stale, what is a real defect
+
+Measured 2026-08-29 by direct probe of three hosts plus the current tree.
+This phase changed no production code.
+
+## Host attribution
+
+| host | opencodex | process | age at measurement | verdict |
+|------|-----------|---------|--------------------|---------|
+| jun's mac (local) | 2.35.0, run from the checkout via `bun src/cli/index.ts start --port 10100` | PID 62773 | started 2026-08-28 22:12:11 | **STALE by 3 commits** |
+| `suji` (sujis-MacBook-Pro, 100.65.106.2) | 2.24.2, installed binary `~/.local/bin/ocx` | PID 98048 | uptime 941472s ≈ **10.9 days** | **GROSSLY STALE** — predates every Kiro fix in this unit |
+| `macmini-cf` (juniui-Macmini) | checkout `~/opencodex` at `d7a82a8fc` (dev, includes all of #2819) | none | `ocx` not installed, no proxy running | current source, not serving |
+
+Commands: `ps -o lstart=,etime= -p 62773`, `curl -s localhost:10100/healthz` on each
+host, `git log --oneline -3` in `~/opencodex` on macmini-cf.
+
+## Finding 1 — part of the non-termination report is a stale process
+
+The local proxy the user was routed through started at **22:12:11**. Three commits
+of #2819 landed *after* that:
+
+| commit | time | content |
+|--------|------|---------|
+| `b0740840d` | 22:14 | mark the physical attempt as locally answered too |
+| `d9d26552f` | 22:15 | state the code-mode echo rule before the first call |
+| `68eaf45d8` | 22:30 | remember a delivered final answer instead of trusting the client to echo phase |
+
+`68eaf45d8` is the one that matters: it stops the terminal boundary from depending
+on the client echoing `phase`. A proxy started before it cannot have the completed
+form of the wp1 terminal-boundary fix. So the user's "still doesn't finish" report
+is measured against a binary that never contained the finished fix.
+
+`suji` is worse and is worth stating plainly: at 2.24.2 with 10.9 days of uptime it
+predates the entire unit, so any Kiro turn routed there reproduces every symptom
+regardless of what `dev` contains.
+
+**This does not close the report.** It explains part of it. Finding 2 is a real
+defect in current source.
+
+## Finding 2 — the duplicate answer is live in current `dev`
+
+Live probes against the running proxy (`/v1/responses`, streaming,
+`kiro/claude-opus-5`):
+
+- plain question, no tools -> 1 visible assistant message, `phase: "final_answer"`, `end_turn: true`
+- question with a tool available, answered directly -> 1 visible message
+- tool-result round trip -> normal `function_call`
+
+Those turns are clean, which is consistent with finding 1's fix having landed in
+source. But the duplicate needs a specific shape: **one inference that emits
+ordinary prose AND then calls the private completion tool**. The model does not
+take that shape on every turn, so a live probe is not a reliable trigger.
+
+It does not need to be. The shape is pinned deterministically by the suite in the
+current tree — `tests/kiro-stream.test.ts` asserts the duplicate as expected
+behaviour in three places:
+
+| test | asserted events |
+|------|-----------------|
+| "tool-enabled commentary can finish only through a fragmented private completion call" (:267) | `"Checking the result."` commentary, then `"Task complete."` final_answer |
+| "STOP_SEQUENCE text also enters bounded completion validation" (:659) | `"Done."` commentary, then `"Done."` final_answer — **byte-identical** |
+| "END_TURN does not promote a private completion answer's commentary" (:746) | `"Checking the result."` commentary, then `"Task complete."` final_answer |
+
+Verified green at HEAD: `bun test tests/kiro-stream.test.ts -t "STOP_SEQUENCE text
+also enters bounded completion validation"` -> 1 pass, 3 expect() calls.
+
+The `:659` case is the user's symptom exactly: the same text delivered twice, once
+as commentary and once as the final answer. `src/bridge.ts` splits on the phase
+change, so the client renders two assistant messages.
+
+Mechanism in source, unchanged from `000_research.md`:
+`src/adapters/kiro.ts:1468` flushes the whole `deferred` collection
+unconditionally when `mode === "required"`, immediately before the completion
+answer is emitted as `final_answer`. Nothing consumes the retained prose when a
+valid completion answer supersedes it.
+
+## Finding 3 — the outer drain is a second, independent emitter
+
+`parseKiroAttempt` drains `deferred` again at `src/adapters/kiro.ts:996-999` after
+the inner generator returns. Skipping only the inner flush at `:1468` therefore
+does not remove the duplicate — it reverses its order. Any fix must CONSUME the
+collection, not skip one of its two readers. This confirms the audit round-2
+correction in `020_wp2_duplicate_answer.md` against current source.
+
+## Conclusion
+
+- The non-termination report: **partly stale process** (local proxy predates
+  `68eaf45d8`; `suji` predates the entire unit). Restart is the remedy, not a code
+  change.
+- The duplicate answer: **a real, currently-pinned defect in `dev`**. It is wp2.
+
+Both hosts need a restart onto current `dev` before any further live judgement of
+turn termination is meaningful.
+

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -1062,6 +1062,27 @@ async function* parseKiroAttemptEvents(
       try { yield event; } finally { retention.releaseEvent(event); }
     }
   };
+  // A valid private completion answer supersedes the progress prose staged during the SAME
+  // inference: Kiro emits answer-like text and then calls the completion tool, so releasing both
+  // makes the bridge close the commentary message and open a second one with near-identical text
+  // (#2819 follow-up). Consume the collection instead — drop the redundant text, keep every
+  // non-text event, and release retention either way.
+  //
+  // This is deliberately the ONLY suppression site. The outer drain in `parseKiroAttempt` is also
+  // the leftover flush for early terminal returns (stream, protocol, and provider failures), so
+  // teaching it to discard text would hide the only commentary a failed turn ever produced.
+  // Splicing here leaves that drain empty on the completion path and untouched everywhere else.
+  const consumeSupersededByCompletion = async function* (
+    events: AdapterEvent[],
+  ): AsyncGenerator<AdapterEvent> {
+    for (const event of events.splice(0)) {
+      try {
+        if (event.type !== "text_delta") yield event;
+      } finally {
+        retention.releaseEvent(event);
+      }
+    }
+  };
 
   const providerState = (): { kiro: { conversationId: string } } | undefined =>
     returnedConversationId ? { kiro: { conversationId: returnedConversationId } } : undefined;
@@ -1466,12 +1487,15 @@ async function* parseKiroAttemptEvents(
     });
 
     if (mode === "required") {
-      yield* emitRetained(deferred.splice(0));
+      // A valid completion answer makes this inference's staged prose redundant; anything else
+      // still flushes exactly as before (bounded fallback, explicit stops, real tool calls).
+      if (completionAnswer !== undefined) yield* consumeSupersededByCompletion(deferred);
+      else yield* emitRetained(deferred.splice(0));
     }
 
     if (mode === "text_fallback") {
       if (completionAnswer !== undefined) {
-        yield* emitRetained(fallbackEvents);
+        yield* consumeSupersededByCompletion(fallbackEvents);
         yield { type: "text_delta", text: completionAnswer, phase: "final_answer" };
         return {
           assistantText,

--- a/tests/kiro-stream.test.ts
+++ b/tests/kiro-stream.test.ts
@@ -267,8 +267,9 @@ describe("kiro adapter — parseStream", () => {
       ...completionFrames("Task complete."),
     ))));
 
+    // The completion answer supersedes prose staged in the SAME inference. Releasing both made the
+    // bridge split one turn into two near-identical assistant messages, which is what the user saw.
     expect(events.filter(event => event.type === "text_delta")).toEqual([
-      { type: "text_delta", text: "Checking the result.", phase: "commentary" },
       { type: "text_delta", text: "Task complete.", phase: "final_answer" },
     ]);
     expect(events.some(event => event.type === "tool_call_start" || event.type === "tool_call_delta")).toBe(false);
@@ -742,8 +743,9 @@ describe("kiro adapter — parseStream", () => {
       eventFrame({ stopReason: "END_TURN" }, "metadataEvent"),
     ))));
 
+    // END_TURN still does not promote the prose to a final answer — but the prose is now consumed
+    // rather than released, so the turn renders as one answer instead of two.
     expect(events.filter(event => event.type === "text_delta")).toEqual([
-      { type: "text_delta", text: "Checking the result.", phase: "commentary" },
       { type: "text_delta", text: "Task complete.", phase: "final_answer" },
     ]);
     expect(events.at(-1)).toMatchObject({ type: "done", endTurn: true });

--- a/tests/server-kiro-completion-e2e.test.ts
+++ b/tests/server-kiro-completion-e2e.test.ts
@@ -218,6 +218,58 @@ describe("Kiro completion through public server endpoints", () => {
     }
   });
 
+
+  test("answer-like prose plus a completion answer in ONE inference renders exactly one answer", async () => {
+    // The user-visible defect: Kiro emits answer-shaped prose and then calls the private completion
+    // tool in the SAME inference. Releasing both made bridge.ts close the commentary message and
+    // open a second one with near-identical text, so the client rendered the answer twice.
+    // Adapter-event coverage cannot prove this is gone — the split happens in the bridge.
+    const upstream = scriptedKiroUpstream([
+      [textFrame("The workspace is ready."), ...completionFrames("The workspace is ready.")],
+    ]);
+    saveConfig(kiroConfig(upstream.server.url.toString()));
+    const proxy = startServer(0);
+    try {
+      const response = await originalFetch(new URL("/v1/responses", proxy.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "kiro-test/gpt-5.6-sol",
+          input: "Inspect the workspace",
+          stream: true,
+          tools: [{ type: "function", name: "bash", description: "Run a command", parameters: { type: "object" } }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const wire = await response.text();
+      const events = responseEvents(wire);
+
+      // One inference only: the completion answer resolves the turn, so no bounded fallback runs.
+      expect(upstream.requests).toHaveLength(1);
+
+      // Exactly one visible assistant answer, and the prose is not repeated as its own message.
+      const completed = events.filter(event => event.name === "response.completed");
+      expect(completed).toHaveLength(1);
+      const messages = completed[0].data.response.output.filter((item: { type: string }) => item.type === "message");
+      expect(messages).toHaveLength(1);
+      expect(messages[0].phase).toBe("final_answer");
+      expect(messages[0].content.map((part: { text: string }) => part.text).join("")).toBe("The workspace is ready.");
+
+      // And the duplicate is gone at the delta level too, not merely coalesced into one message.
+      const deltas = events
+        .filter(event => event.name === "response.output_text.delta")
+        .map(event => event.data.delta);
+      expect(deltas.join("")).toBe("The workspace is ready.");
+
+      expect(events.at(-1)?.name).toBe("response.completed");
+      expect(wire).not.toContain(KIRO_COMPLETION_TOOL_NAME);
+    } finally {
+      await proxy.stop(true);
+      upstream.server.stop(true);
+    }
+  });
+
   test("routed compaction with text.format summarizes instead of tripping the capability guard", async () => {
     const upstream = scriptedKiroUpstream([
       [textFrame("Compaction summary of the earlier turns.")],


### PR DESCRIPTION
## Summary

- Kiro emits answer-shaped prose and then calls the private completion tool in the **same** inference. The adapter released the prose as `phase: "commentary"` and the completion answer as `phase: "final_answer"`, and `src/bridge.ts` closes the commentary message on the phase change — so the client rendered **two assistant messages with near-identical text**. That is the duplicate answer still reported after #2819.
- A valid completion answer supersedes prose staged during the same inference, so that collection is now **consumed** instead of released: the redundant `text_delta` is dropped, every non-text event is kept, and retention is released either way. Applied to `deferred` in `required` mode and to `fallbackEvents` in `text_fallback`, which is already gated on a valid completion answer.
- The outer drain in `parseKiroAttempt` (`src/adapters/kiro.ts:996-1001`) is deliberately **left untouched**. An independent audit caught that it is also the leftover flush for early terminal returns, so teaching it to discard text would hide the only commentary a failed turn ever produces. Splicing at the inner site leaves that drain empty on the completion path and unchanged on every failure path.

Every release path from the design doc is preserved: the `sawRealTool` flush, the clean no-completion fallback, the stream/protocol/provider failure drain, explicit non-completion stops, plain-text promotion, and the empty/reasoning-only fallback.

### Note on the other half of the report

The same report also said turns "keep going after the answer." Measurement across three hosts found that part is largely a **stale process**, not current code: the reporting proxy started at 22:12:11, before `b0740840d`, `d9d26552f`, and `68eaf45d8` landed, and a second host was still on 2.24.2 with 10.9 days of uptime. Live `/v1/responses` probes against current source return exactly one `final_answer` with `end_turn: true`. Details in `devlog/_plan/260828_kiro_turn_termination/030_wp1_live_measurement.md`. No code change is proposed for that half — restarting onto current `dev` is the remedy.

## Verification

- `bun test tests/kiro-adapter.test.ts tests/kiro-stream.test.ts tests/server-kiro-completion-e2e.test.ts` — 191 pass, 0 fail
- `bun run typecheck` — clean
- `bun run test` — full suite green (receipt bound to `0dc8704`, not dirty, exit 0)
- `bun run privacy:scan` — passed
- **Both new assertions driven red against the unpatched adapter**, not written green:
  - `tests/server-kiro-completion-e2e.test.ts`: `expect(messages).toHaveLength(1)` failed with `Received length: 2` — the user-visible duplicate, proven at the Responses-protocol level rather than only in adapter events, because the split happens in the bridge.
  - `tests/kiro-stream.test.ts`: the updated expectation failed with the extra `{ phase: "commentary", text: "Checking the result." }` event present.
- The two existing expectations that pinned the duplicate as intended behaviour were **updated to state the new contract**, not deleted.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No auth, credential, workflow, or release surface is touched; the change is confined to adapter event-release ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate assistant responses when a completion answer follows intermediate commentary.
  * Preserved non-text events while suppressing redundant commentary.
  * Ensured completed turns report the correct final answer and termination status.

* **Tests**
  * Added regression coverage for streaming and end-to-end response scenarios.
  * Verified single-request handling, no duplicated deltas, and private tool suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->