### PR TITLE
fix(release): move dev's version line past the published preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

- `dev`'s `package.json` said `2.35.0` while the repository had already published
  `v2.36.0-preview.20260829`. npm dist-tags at the time of this PR:
  `latest=2.35.0`, `preview=2.36.0-preview.20260829`.
- `tests/release-version-line.test.ts` therefore fails on **every** commit that
  descends from `dev`, with the assertion it was written to catch:
  `package.json version 2.35.0 is BEHIND the highest release tag v2.36.0-preview.20260829`.
- That inherited failure is currently red on `test 2/4`, `test 3/4`, `test 4/4`, and
  `macos` across six open bug PRs whose own diffs never touch release tooling:
  #2835, #2822, #2821, #2796, #2797, #2785. Rebasing them onto an unrepaired `dev`
  cannot turn them green, so this one-line repair unblocks all of them.
- `2.36.0` rather than a preview suffix follows this repository's own precedent:
  `e4a85d134` moved `dev` to `2.34.0` when it trailed a published `2.33.0`, and
  `076ad3036` moved `dev` to `2.35.0` right after `v2.34.0` shipped. `dev` carries the
  next stable version; the preview train adds its suffix at release time.

No source, test, or workflow file changes — one line of `package.json`.

## Verification

The version string was chosen by running the repository's own comparator, not by reading
it (`scripts/release-notes.ts` `compareReleaseTags`, compared against the highest tag
`v2.36.0-preview.20260829`; positive means ahead):

```
2.35.0                           -1
2.35.1                           -1
2.36.0                            1
2.36.0-preview.20260829           0
2.36.0-preview.20260829.1         1
```

`2.36.0-preview.20260829` returns `0`, and the test's equality branch is legal only on
the commit that tag names (`tagPointsAtHead`) — a `dev` merge commit is not that commit,
so equality would fail as a duplicate claim. `2.36.0` is unused: `npm view
@bitkyc08/opencodex@2.36.0` returns `E404 No match found for version 2.36.0`, and
`git tag --list v2.36.0` is empty.

Commands run on this branch:

```
bun test tests/release-version-line.test.ts    3 pass 0 fail   (before: 2 pass 1 fail)
bun test tests/release-helper.test.ts          5 pass 0 fail
bun test tests/compatibility-version.test.ts   1 pass 0 fail
```

The before/after pair is the activation evidence: the assertion is the trigger, it fails
on `2.35.0` with the quoted BEHIND message and passes on `2.36.0`.

`tests/release-helper.test.ts` is included because it exercises
`assertChannelVersionMovesForward`, the release-time guard that reads the same version
line; it stays green, so release behavior is unchanged.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing behavior change; the
      reasoning lives in the commit message and `devlog/_plan/260829_bugpr_zero_remaining/`.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No
      auth, credential, workflow, or dependency surface is touched; the diff is one version
      string.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 2.35.0 to 2.36.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->