### PR TITLE
fix(responses): bind a rotated OAuth bearer to its own Copilot origin

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -62,10 +62,9 @@ export interface OAuthAccessSnapshot {
   /**
    * Allowlisted GitHub Copilot API origin belonging to THIS account.
    *
-   * Copilot pins its bearer to an account-scoped regional host, and the initial route already
-   * pairs the two (`core.ts` resolves transport with `getOAuthCredentialApiBaseUrl`). Account
-   * failover must carry the pairing across the rotation; without it, account B's token is sent to
-   * account A's origin (#2568d).
+   * Copilot pins its bearer to an account-scoped regional host. Initial routing, 401 refresh, and
+   * account failover must resolve transport from this same snapshot; rereading the active account
+   * can pair account A's token with account B's origin during a concurrent switch (#2568d).
    */
   apiBaseUrl?: string;
 }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -100,7 +100,6 @@ import type {
 } from "../../types";
 import {
   forceRefreshOAuthAccessSnapshot,
-  getOAuthCredentialApiBaseUrl,
   getValidAccessTokenForAccount,
   getValidAccessTokenSnapshot,
   publicOAuthAuthenticationErrorMessage,
@@ -2836,9 +2835,8 @@ async function handleResponsesInner(
    *   snapshot value is RESOLVED first: `rotatedProvider` is a clone of the FAILED account's
    *   provider, so passing a bare `undefined` origin let the transport resolver fall through its
    *   own `?? validateCopilotApiBaseUrl(provider.baseUrl)` step to the previous account's host —
-   *   pairing B's bearer with A's accepted origin. An account legitimately has no stored origin
-   *   whenever its login response carried no `endpoints.api`, so this was reachable with
-   *   ordinary credentials, and both values were individually valid: the defect was the pairing.
+   *   pairing B's bearer with A's accepted origin. Login and refresh always persist a resolved
+   *   origin, so this fallback protects malformed or manually seeded credentials.
    * - A Cloud Code Assist provider needs an account-matched project. Antigravity's refresh path
    *   tolerates project discovery failing, so a stored account can legitimately have no project;
    *   sending that account's bearer with the FAILED account's project is worse than not rotating.
@@ -2940,7 +2938,9 @@ async function handleResponsesInner(
     route.providerName,
     route.provider,
     parsed.options.promptCacheKey,
-    route.providerName === "github-copilot" ? getOAuthCredentialApiBaseUrl(route.providerName) : undefined,
+    route.providerName === "github-copilot" && route.provider.authMode === "oauth"
+      ? resolveCopilotApiBaseUrl(sentOAuthSnapshot?.apiBaseUrl)
+      : undefined,
   );
   let adapterProvider = resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire);
   const stripClaudeMainAuth = options.stripClaudeMainAuthForNoncanonicalForward === true
@@ -3562,7 +3562,9 @@ async function handleResponsesInner(
         route.providerName,
         { ...route.provider, apiKey: refreshed.accessToken },
         parsed.options.promptCacheKey,
-        route.providerName === "github-copilot" ? getOAuthCredentialApiBaseUrl(route.providerName) : undefined,
+        route.providerName === "github-copilot"
+          ? resolveCopilotApiBaseUrl(refreshed.apiBaseUrl)
+          : undefined,
       );
       route.provider = refreshedProvider;
       const refreshedAdapter = resolveAdapter(
@@ -5149,7 +5151,9 @@ async function handleResponsesInner(
           route.providerName,
           { ...route.provider, apiKey: refreshed.accessToken },
           parsed.options.promptCacheKey,
-          route.providerName === "github-copilot" ? getOAuthCredentialApiBaseUrl(route.providerName) : undefined,
+          route.providerName === "github-copilot"
+            ? resolveCopilotApiBaseUrl(refreshed.apiBaseUrl)
+            : undefined,
         );
         route.provider = refreshedProvider;
         invalidateSameTargetRequest();

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -127,6 +127,7 @@ import {
   isGenericOAuthFailoverEnabled,
   rotateGenericOAuthAccountOn429,
 } from "../../oauth/generic-account-failover";
+import { resolveCopilotApiBaseUrl } from "../../oauth/github-copilot";
 import { buildWebSearchTool, planWebSearch, runWithWebSearch, shouldResolveOpenAiWebSearchSidecar } from "../../web-search";
 import { buildImageTool, buildVideoTool, planImageBridge, planVideoBridge, runWithImageBridge, clampImageMaxRounds, IMAGE_GEN_TOOL_NAME, VIDEO_GEN_TOOL_NAME } from "../../images";
 import { describeImagesInPlace, isModelTextOnly, planVisionSidecar, resolveOpenAiVisionModel, shouldResolveOpenAiVisionSidecar, stripImagesInPlace } from "../../vision";
@@ -2831,7 +2832,13 @@ async function handleResponsesInner(
    * rotation rather than send a half-applied identity:
    *
    * - Copilot pins its bearer to an account-scoped regional origin, so transport is re-resolved
-   *   with the new account's `apiBaseUrl` instead of inheriting the previous account's host.
+   *   with the new account's `apiBaseUrl` instead of inheriting the previous account's host. The
+   *   snapshot value is RESOLVED first: `rotatedProvider` is a clone of the FAILED account's
+   *   provider, so passing a bare `undefined` origin let the transport resolver fall through its
+   *   own `?? validateCopilotApiBaseUrl(provider.baseUrl)` step to the previous account's host —
+   *   pairing B's bearer with A's accepted origin. An account legitimately has no stored origin
+   *   whenever its login response carried no `endpoints.api`, so this was reachable with
+   *   ordinary credentials, and both values were individually valid: the defect was the pairing.
    * - A Cloud Code Assist provider needs an account-matched project. Antigravity's refresh path
    *   tolerates project discovery failing, so a stored account can legitimately have no project;
    *   sending that account's bearer with the FAILED account's project is worse than not rotating.
@@ -2844,7 +2851,7 @@ async function handleResponsesInner(
         route.providerName,
         rotatedProvider,
         parsed.options.promptCacheKey,
-        snapshot.apiBaseUrl,
+        resolveCopilotApiBaseUrl(snapshot.apiBaseUrl),
       ) as OcxProviderConfig;
     }
     if (snapshot.projectId) rotatedProvider = { ...rotatedProvider, project: snapshot.projectId };

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -267,16 +267,15 @@ describe("sidecar on429 wiring", () => {
  *
  * `applyFailoverSnapshot` clones the FAILED account's provider (`{ ...route.provider }`) and then
  * re-resolves Copilot transport with the rotated account's `snapshot.apiBaseUrl`. When the
- * rotated account has no stored origin — an ordinary state, since `apiBaseUrl` is only recorded
- * when the login response carried `endpoints.api` — the resolver's own fallback chain is
+ * rotated account has no stored origin — a malformed or manually seeded state, because login and
+ * refresh always persist a resolved origin — the resolver's own fallback chain is
  *
  *     validateCopilotApiBaseUrl(apiBaseUrl)          // undefined for account B
  *  ?? validateCopilotApiBaseUrl(provider.baseUrl)    // still account A's regional origin
  *  ?? GITHUB_COPILOT_DEFAULT_API_BASE
  *
- * so B's bearer is sent to A's accepted origin. Both values are individually legitimate, which
- * is why every existing test passed: the defect is in the PAIRING, and only a test that supplies
- * one account WITH an origin and one WITHOUT can observe it.
+ * so B's bearer is sent to A's accepted origin. The defense-in-depth defect is in the PAIRING,
+ * and only a test that supplies one account WITH an origin and one WITHOUT can observe it.
  */
 describe("#2807 a 429 rotation pairs the bearer with its OWN origin", () => {
   const REGIONAL = "https://proxy.githubcopilot.com";

--- a/tests/generic-oauth-failover.test.ts
+++ b/tests/generic-oauth-failover.test.ts
@@ -12,6 +12,8 @@ import {
   rotateGenericOAuthAccountOn429,
 } from "../src/oauth/generic-account-failover";
 import { getAccountSet, markAccountNeedsReauth, saveCredential } from "../src/oauth/store";
+import { resolveCopilotApiBaseUrl } from "../src/oauth/github-copilot";
+import { resolveProviderTransport } from "../src/providers/xai-transport";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
 const originalHome = process.env.OPENCODEX_HOME;
@@ -249,9 +251,92 @@ describe("sidecar on429 wiring", () => {
     // re-resolved with the rotated account's own apiBaseUrl.
     expect(body).toContain("github-copilot");
     expect(body).toContain("snapshot.apiBaseUrl");
+    // ...and RESOLVED before it is handed over, so a rotated account with no stored origin
+    // cannot fall through to the previous account's inherited baseUrl. See the behavioral
+    // test below for why asserting the bare expression was not enough.
+    expect(body).toContain("resolveCopilotApiBaseUrl(snapshot.apiBaseUrl)");
     expect(body).toContain("resolveProviderTransport(");
 
     // Kiro routing metadata still travels with its own token.
     expect(body).toContain("_kiroAuthContext");
+  });
+});
+
+/**
+ * The rotation pairing bug that source-text guards could not see.
+ *
+ * `applyFailoverSnapshot` clones the FAILED account's provider (`{ ...route.provider }`) and then
+ * re-resolves Copilot transport with the rotated account's `snapshot.apiBaseUrl`. When the
+ * rotated account has no stored origin — an ordinary state, since `apiBaseUrl` is only recorded
+ * when the login response carried `endpoints.api` — the resolver's own fallback chain is
+ *
+ *     validateCopilotApiBaseUrl(apiBaseUrl)          // undefined for account B
+ *  ?? validateCopilotApiBaseUrl(provider.baseUrl)    // still account A's regional origin
+ *  ?? GITHUB_COPILOT_DEFAULT_API_BASE
+ *
+ * so B's bearer is sent to A's accepted origin. Both values are individually legitimate, which
+ * is why every existing test passed: the defect is in the PAIRING, and only a test that supplies
+ * one account WITH an origin and one WITHOUT can observe it.
+ */
+describe("#2807 a 429 rotation pairs the bearer with its OWN origin", () => {
+  const REGIONAL = "https://proxy.githubcopilot.com";
+  const CANONICAL = "https://api.githubcopilot.com";
+
+  /** The failed account's provider as `applyFailoverSnapshot` receives it: already resolved. */
+  function providerAfterAccountA(): OcxProviderConfig {
+    return {
+      adapter: "openai-chat",
+      authMode: "oauth",
+      baseUrl: REGIONAL,
+      apiKey: "bearer-account-a",
+    } as unknown as OcxProviderConfig;
+  }
+
+  test("an account with its own regional origin keeps it", () => {
+    const rotated = resolveProviderTransport(
+      "github-copilot",
+      { ...providerAfterAccountA(), apiKey: "bearer-account-b" },
+      undefined,
+      resolveCopilotApiBaseUrl("https://other.githubcopilot.com"),
+    ) as OcxProviderConfig;
+    expect(rotated.baseUrl).toBe("https://other.githubcopilot.com");
+    expect(rotated.apiKey).toBe("bearer-account-b");
+  });
+
+  test("an account with NO stored origin falls back to canonical, never to the failed account's", () => {
+    // This is the regression. Before the fix, `undefined` reached the transport resolver and its
+    // second fallback returned the cloned REGIONAL origin — account A's — paired with B's bearer.
+    const rotated = resolveProviderTransport(
+      "github-copilot",
+      { ...providerAfterAccountA(), apiKey: "bearer-account-b" },
+      undefined,
+      resolveCopilotApiBaseUrl(undefined),
+    ) as OcxProviderConfig;
+    expect(rotated.baseUrl).toBe(CANONICAL);
+    expect(rotated.baseUrl).not.toBe(REGIONAL);
+    expect(rotated.apiKey).toBe("bearer-account-b");
+  });
+
+  test("the unresolved form is what made the pairing possible", () => {
+    // Proves the assertion above is not vacuous: hand the resolver the raw snapshot value the
+    // way the code used to, and account A's origin comes back with account B's bearer.
+    const leaked = resolveProviderTransport(
+      "github-copilot",
+      { ...providerAfterAccountA(), apiKey: "bearer-account-b" },
+      undefined,
+      undefined,
+    ) as OcxProviderConfig;
+    expect(leaked.baseUrl).toBe(REGIONAL);
+    expect(leaked.apiKey).toBe("bearer-account-b");
+  });
+
+  test("a crafted non-Copilot origin on the rotated account is refused, not forwarded", () => {
+    const rotated = resolveProviderTransport(
+      "github-copilot",
+      { ...providerAfterAccountA(), apiKey: "bearer-account-b" },
+      undefined,
+      resolveCopilotApiBaseUrl("https://attacker.example.com"),
+    ) as OcxProviderConfig;
+    expect(rotated.baseUrl).toBe(CANONICAL);
   });
 });

--- a/tests/github-copilot-account-origin.test.ts
+++ b/tests/github-copilot-account-origin.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { clearGenericFailoverHealth } from "../src/oauth/generic-account-failover";
+import { getAccountSet, saveCredential, setActiveAccount } from "../src/oauth/store";
+import { handleResponses } from "../src/server/responses";
+import type { OcxConfig } from "../src/types";
+
+const ACCOUNT_A_ORIGIN = "https://a.githubcopilot.com";
+const ACCOUNT_B_ORIGIN = "https://b.githubcopilot.com";
+const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
+const GITHUB_USER_URL = "https://api.github.com/user";
+
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.OPENCODEX_HOME;
+let home = "";
+
+type Wire = "chat" | "responses";
+
+function config(wire: Wire): OcxConfig {
+  const model = wire === "chat" ? "gpt-4o" : "gpt-5.4";
+  return {
+    port: 0,
+    defaultProvider: "github-copilot",
+    providers: {
+      "github-copilot": {
+        adapter: "openai-chat",
+        authMode: "oauth",
+        baseUrl: "https://api.githubcopilot.com",
+        models: [model],
+        ...(wire === "responses" ? { modelAdapters: { [model]: "openai-responses" } } : {}),
+      },
+    },
+  } as OcxConfig;
+}
+
+function request(wire: Wire): Request {
+  const model = wire === "chat" ? "gpt-4o" : "gpt-5.4";
+  return new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: `github-copilot/${model}`, input: "hello", stream: false }),
+  });
+}
+
+function successResponse(wire: Wire): Response {
+  if (wire === "responses") {
+    return Response.json({
+      id: "resp-copilot-origin",
+      object: "response",
+      status: "completed",
+      model: "gpt-5.4",
+      output: [{
+        id: "msg-copilot-origin",
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [{ type: "output_text", text: "ok", annotations: [] }],
+      }],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    });
+  }
+  return Response.json({
+    id: "chatcmpl-copilot-origin",
+    object: "chat.completion",
+    choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  });
+}
+
+async function seedAccounts(aExpires = Date.now() + 3_600_000): Promise<{ a: string; b: string }> {
+  await saveCredential("github-copilot", {
+    access: "copilot-access-a",
+    refresh: "gho-account-a",
+    expires: aExpires,
+    accountId: "101",
+    apiBaseUrl: ACCOUNT_A_ORIGIN,
+    source: "oauth",
+  });
+  await saveCredential("github-copilot", {
+    access: "copilot-access-b",
+    refresh: "gho-account-b",
+    expires: Date.now() + 3_600_000,
+    accountId: "202",
+    apiBaseUrl: ACCOUNT_B_ORIGIN,
+    source: "oauth",
+  });
+  const set = getAccountSet("github-copilot");
+  const a = set?.accounts.find(account => account.credential.accountId === "101")?.id;
+  const b = set?.accounts.find(account => account.credential.accountId === "202")?.id;
+  if (!a || !b) throw new Error("failed to seed Copilot account fixtures");
+  await setActiveAccount("github-copilot", a);
+  return { a, b };
+}
+
+function installFetch(options: {
+  wire: Wire;
+  statuses: number[];
+  switchToAccountId?: string;
+  switchOn: "refresh" | "first-dispatch" | "never";
+}): { dispatches: { origin: string; authorization: string }[] } {
+  const dispatches: { origin: string; authorization: string }[] = [];
+  let refreshSwitched = false;
+  globalThis.fetch = (async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url === COPILOT_TOKEN_URL) {
+      if (options.switchOn === "refresh" && options.switchToAccountId && !refreshSwitched) {
+        refreshSwitched = true;
+        await setActiveAccount("github-copilot", options.switchToAccountId);
+      }
+      return Response.json({
+        token: "copilot-access-a-refreshed",
+        refresh_in: 1500,
+        endpoints: { api: ACCOUNT_A_ORIGIN },
+      });
+    }
+    if (url === GITHUB_USER_URL) return Response.json({ id: 101 });
+
+    const parsed = new URL(url);
+    if (parsed.hostname.endsWith(".githubcopilot.com") || parsed.hostname === "api.githubcopilot.com") {
+      dispatches.push({
+        origin: parsed.origin,
+        authorization: new Headers(init?.headers).get("authorization") ?? "",
+      });
+      if (options.switchOn === "first-dispatch" && options.switchToAccountId && dispatches.length === 1) {
+        await setActiveAccount("github-copilot", options.switchToAccountId);
+      }
+      const status = options.statuses.shift() ?? 200;
+      if (status !== 200) {
+        return Response.json({ error: { message: status === 401 ? "rejected" : "limited" } }, {
+          status,
+          headers: status === 429 ? { "retry-after": "1" } : undefined,
+        });
+      }
+      return successResponse(options.wire);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  return { dispatches };
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ocx-copilot-origin-"));
+  process.env.OPENCODEX_HOME = home;
+  clearGenericFailoverHealth();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearGenericFailoverHealth();
+  if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = originalHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("GitHub Copilot bearer/origin snapshot atomicity", () => {
+  for (const wire of ["chat", "responses"] as const) {
+    test(`${wire} initial refresh keeps account A's origin after B becomes active`, async () => {
+      const accounts = await seedAccounts(0);
+      const observed = installFetch({
+        wire,
+        statuses: [200],
+        switchToAccountId: accounts.b,
+        switchOn: "refresh",
+      });
+
+      const response = await handleResponses(request(wire), config(wire), { model: "", provider: "" });
+      await response.text();
+
+      expect(response.status).toBe(200);
+      expect(observed.dispatches).toEqual([{
+        origin: ACCOUNT_A_ORIGIN,
+        authorization: "Bearer copilot-access-a-refreshed",
+      }]);
+    });
+
+    test(`${wire} 401 replay keeps refreshed account A's origin after B becomes active`, async () => {
+      const accounts = await seedAccounts();
+      const observed = installFetch({
+        wire,
+        statuses: [401, 200],
+        switchToAccountId: accounts.b,
+        switchOn: "first-dispatch",
+      });
+
+      const response = await handleResponses(request(wire), config(wire), { model: "", provider: "" });
+      await response.text();
+
+      expect(response.status).toBe(200);
+      expect(observed.dispatches).toEqual([
+        { origin: ACCOUNT_A_ORIGIN, authorization: "Bearer copilot-access-a" },
+        { origin: ACCOUNT_A_ORIGIN, authorization: "Bearer copilot-access-a-refreshed" },
+      ]);
+    });
+  }
+
+  test("chat 429 failover moves bearer and origin together to account B", async () => {
+    await seedAccounts();
+    const observed = installFetch({ wire: "chat", statuses: [429, 200], switchOn: "never" });
+
+    const response = await handleResponses(request("chat"), config("chat"), { model: "", provider: "" });
+    await response.text();
+
+    expect(response.status).toBe(200);
+    expect(observed.dispatches).toEqual([
+      { origin: ACCOUNT_A_ORIGIN, authorization: "Bearer copilot-access-a" },
+      { origin: ACCOUNT_B_ORIGIN, authorization: "Bearer copilot-access-b" },
+    ]);
+  });
+});

--- a/tests/github-copilot-account-origin.test.ts
+++ b/tests/github-copilot-account-origin.test.ts
@@ -18,6 +18,10 @@ let home = "";
 
 type Wire = "chat" | "responses";
 
+function bearer(accessToken: string): string {
+  return ["Bearer", accessToken].join(" ");
+}
+
 function config(wire: Wire): OcxConfig {
   const model = wire === "chat" ? "gpt-4o" : "gpt-5.4";
   return {
@@ -171,7 +175,7 @@ describe("GitHub Copilot bearer/origin snapshot atomicity", () => {
       expect(response.status).toBe(200);
       expect(observed.dispatches).toEqual([{
         origin: ACCOUNT_A_ORIGIN,
-        authorization: "Bearer copilot-access-a-refreshed",
+        authorization: bearer("copilot-access-a-refreshed"),
       }]);
     });
 
@@ -189,8 +193,8 @@ describe("GitHub Copilot bearer/origin snapshot atomicity", () => {
 
       expect(response.status).toBe(200);
       expect(observed.dispatches).toEqual([
-        { origin: ACCOUNT_A_ORIGIN, authorization: "Bearer copilot-access-a" },
-        { origin: ACCOUNT_A_ORIGIN, authorization: "Bearer copilot-access-a-refreshed" },
+        { origin: ACCOUNT_A_ORIGIN, authorization: bearer("copilot-access-a") },
+        { origin: ACCOUNT_A_ORIGIN, authorization: bearer("copilot-access-a-refreshed") },
       ]);
     });
   }
@@ -204,8 +208,8 @@ describe("GitHub Copilot bearer/origin snapshot atomicity", () => {
 
     expect(response.status).toBe(200);
     expect(observed.dispatches).toEqual([
-      { origin: ACCOUNT_A_ORIGIN, authorization: "Bearer copilot-access-a" },
-      { origin: ACCOUNT_B_ORIGIN, authorization: "Bearer copilot-access-b" },
+      { origin: ACCOUNT_A_ORIGIN, authorization: bearer("copilot-access-a") },
+      { origin: ACCOUNT_B_ORIGIN, authorization: bearer("copilot-access-b") },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Reimplements **#2807** on current `dev` and closes the additional credential/destination race found by independent security review.

There are two distinct defects:

1. **Defense in depth for malformed credentials.** During generic-OAuth 429 rotation, `applyFailoverSnapshot` clones the failed account's provider and replaces its bearer. If the rotated snapshot has no `apiBaseUrl`, passing bare `undefined` lets the Copilot transport resolver fall through to the cloned provider origin. Resolving `snapshot.apiBaseUrl` first prevents that stale-origin inheritance.

   A missing origin is **not an ordinary production credential state**. `exchangeCopilotToken` resolves `endpoints.api` through `resolveCopilotApiBaseUrl`, and `credentialsFromGithubAccess` persists that resolved value. The tests without an origin deliberately manufacture a malformed or manually seeded credential. Keeping the fix is still correct because it fails closed instead of pairing a new bearer with a stale destination.

2. **Ordinarily reachable concurrent account switch.** Initial OAuth resolution and both 401 replay branches captured/refreshed account A's `OAuthAccessSnapshot`, then independently called `getOAuthCredentialApiBaseUrl`. That getter reads whichever account is active at that later instant. If a login or account switch makes B active while A's refresh or upstream 401 is in flight, A's bearer is dispatched to B's Copilot origin.

The fix now resolves every Copilot destination from the same snapshot that supplied the bearer:

- initial Chat and Responses binding: `sentOAuthSnapshot.apiBaseUrl`
- native Responses 401 replay: `refreshed.apiBaseUrl`
- translated-adapter 401 replay: `refreshed.apiBaseUrl`
- 429 account failover: the existing shared helper continues to use `snapshot.apiBaseUrl`

All values pass through `resolveCopilotApiBaseUrl` before transport, so malformed, empty, or hostile origins fail closed to the canonical Copilot API origin.

## Verification

RED proof at reviewed head `b5743143a4a2b3708ff5878aca583c03e7bcdcf4`:

```
bun test tests/github-copilot-account-origin.test.ts
1 pass / 4 fail / 10 expect calls
```

All four failures reproduced the same invariant violation: the dispatched bearer belonged to account A while the observed origin was `https://b.githubcopilot.com` instead of A's `https://a.githubcopilot.com`. The passing case was the already-fixed Chat 429 snapshot rotation.

GREEN at `a0c0cc5f628de5823fc17fedbff8256e44e3373f`:

```
bun test tests/github-copilot-account-origin.test.ts
5 pass / 0 fail / 10 expect calls

bun test tests/generic-oauth-failover.test.ts tests/adapter-event-oauth-failover.test.ts tests/github-copilot-oauth.test.ts tests/core-lab-boundary.test.ts tests/github-copilot-account-origin.test.ts
65 pass / 0 fail / 193 expect calls

bun x tsc --noEmit
exit 0

bun run privacy:scan
Privacy scan passed / exit 0
```

The new regression uses the production OAuth store, refresh/snapshot logic, request handler, and Copilot transport. It gives A and B distinct allowlisted origins, switches the active account while A's request is in flight, and asserts the actual outbound origin and bearer together for initial Chat/Responses requests, both 401 replay branches, and supported Chat 429 account failover.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup: three production/comment adjustments plus one focused regression file; no package version change.
- [x] Docs or release notes were updated when needed. No public configuration or user-facing contract changed; stale reachability claims in source/test comments were corrected.
- [ ] **Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.** This commit addresses the independent review blocker and has local security/privacy evidence, but the updated head still requires non-author security re-review under `MAINTAINERS.md` before merge.

Do not merge until that re-review clears the snapshot-atomicity fix at the exact head above.
