### PR TITLE
fix(doctor): diagnose the broken Codex env_key launch path

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -10,7 +10,7 @@
 import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { getConfigDir, getConfigPath, readConfigDiagnostics, resolveEnvValue } from "../config";
+import { getConfigDir, getConfigPath, readConfigDiagnostics } from "../config";
 import { readPid } from "../config/process-state";
 import { findLiveProxy, type LiveProxy } from "../server/proxy-liveness";
 import { BUN_RUNTIME_SOURCES } from "../lib/bun-runtime";
@@ -404,6 +404,10 @@ export function collectWslDualInstall(deps: WslDualInstallDeps = {}): WslDualIns
 export type ProxyEnvRow = { key: string; present: boolean };
 export type EnvMap = Record<string, string | undefined>;
 
+function ownEnvValue(env: EnvMap, name: string): string | undefined {
+  return Object.hasOwn(env, name) ? env[name] : undefined;
+}
+
 /** Report only presence/absence of proxy env vars - never the value (it may
  * embed credentials). Checks both upper- and lower-case forms. */
 export function collectProxyEnv(env: EnvMap = process.env): ProxyEnvRow[] {
@@ -439,11 +443,6 @@ export function collectProviderApiKeyDiagnostics(
   providers: Record<string, { authMode?: string; apiKey?: string }> = readConfigDiagnostics().config.providers ?? {},
   env: EnvMap = process.env,
 ): ProviderApiKeyDiagnostic[] {
-  const resolveInEnv = (value: string): string | undefined => {
-    const name = envReferenceName(value);
-    if (!name) return value;
-    return env[name];
-  };
   const rows: ProviderApiKeyDiagnostic[] = [];
   for (const [provider, config] of Object.entries(providers)) {
     if (config.authMode !== "key") continue;
@@ -451,7 +450,7 @@ export function collectProviderApiKeyDiagnostics(
     if (!raw) continue;
     const envName = envReferenceName(raw);
     if (!envName) continue;
-    const resolved = resolveInEnv(raw);
+    const resolved = ownEnvValue(env, envName);
     if (resolved?.trim()) continue;
     rows.push({
       provider,
@@ -478,7 +477,7 @@ export function collectCodexEnvKeyReadiness(
 ): CodexEnvKeyReadinessDiagnostic | null {
   if (!configText || rootTomlString(configText, "model_provider") !== "opencodex") return null;
   const envName = providerTableString(configText, "opencodex", "env_key")?.trim();
-  const envValue = envName && Object.hasOwn(env, envName) ? env[envName] : undefined;
+  const envValue = envName ? ownEnvValue(env, envName) : undefined;
   if (!envName || envValue?.trim() || shim.healthy || !serviceTokenPresent) return null;
   const shimState = shim.installed ? "unhealthy" : "missing";
   return {
@@ -512,7 +511,9 @@ export function collectConfiguredProxy(): ConfiguredProxyDiagnostic {
   }
 
   const envName = envReferenceName(rawProxy);
-  const resolved = resolveEnvValue(rawProxy);
+  const resolved = rawProxy.startsWith("$")
+    ? ownEnvValue(process.env, envName ?? rawProxy.slice(1))
+    : rawProxy;
   if (resolved?.trim()) {
     return {
       key: "config.proxy",
@@ -533,7 +534,7 @@ export function collectConfiguredProxy(): ConfiguredProxyDiagnostic {
 }
 
 export function parseProcessEnvBlock(content: string): EnvMap {
-  const env: EnvMap = {};
+  const env: EnvMap = Object.create(null);
   for (const entry of content.split("\0")) {
     if (!entry) continue;
     const separator = entry.indexOf("=");

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -26,7 +26,8 @@ import { probeNativeProfileRecoveryState, resolveNativeProfileContext } from "..
 import { NativeProfileError } from "../codex/native-profile-types";
 import { collectOrcaCodexHomeDiagnostic, resolveCodexHomeDir as resolveCodexHomeDirImpl, isWslRuntime, listWslWindowsCodexHomes, wslAutomountRoot, type CodexHomeDeps } from "../codex/home";
 import { scanCodexAgentRolesWithTomlModelFallback } from "../codex/subagent-model-fallback";
-import { findCodexOnPath, isWindowsInteropDir } from "../codex/shim";
+import { diagnoseCodexShim, findCodexOnPath, isWindowsInteropDir, type CodexShimDiagnostic } from "../codex/shim";
+import { providerTableString, rootTomlString } from "../codex/injected-marker";
 import { countPendingOpencodexHistory } from "../codex/history-provider";
 import {
   inspectCodexCoordinator,
@@ -459,6 +460,33 @@ export function collectProviderApiKeyDiagnostics(
     });
   }
   return rows;
+}
+
+export type CodexEnvKeyReadinessDiagnostic = {
+  envName: string;
+  shimState: "missing" | "unhealthy";
+  detail: string;
+  action: string;
+};
+
+/** Warn when routed Codex cannot obtain its configured admission token at launch. */
+export function collectCodexEnvKeyReadiness(
+  configText: string | null,
+  env: EnvMap,
+  shim: CodexShimDiagnostic,
+  serviceTokenPresent: boolean,
+): CodexEnvKeyReadinessDiagnostic | null {
+  if (!configText || rootTomlString(configText, "model_provider") !== "opencodex") return null;
+  const envName = providerTableString(configText, "opencodex", "env_key")?.trim();
+  const envValue = envName && Object.hasOwn(env, envName) ? env[envName] : undefined;
+  if (!envName || envValue?.trim() || shim.healthy || !serviceTokenPresent) return null;
+  const shimState = shim.installed ? "unhealthy" : "missing";
+  return {
+    envName,
+    shimState,
+    detail: `Codex uses env_key ${envName}, but that variable is unset and the OpenCodex shim is ${shimState}; the service token file exists but plain Codex does not load it`,
+    action: `Run 'ocx codex-shim install' to repair launch-time token injection, or export ${envName} in the process that starts Codex`,
+  };
 }
 
 export function collectConfiguredProxy(): ConfiguredProxyDiagnostic {
@@ -1059,6 +1087,17 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   }
 
   const doctorConfig = readConfigDiagnostics().config;
+  const codexConfigPath = join(resolveCodexHomeDirImpl(), "config.toml");
+  const codexConfigText = (() => {
+    try { return readFileSync(codexConfigPath, "utf8"); } catch { return null; }
+  })();
+  const serviceTokenPresent = Boolean(readInstalledServiceToken()?.trim());
+  const codexEnvKeyReadiness = collectCodexEnvKeyReadiness(
+    codexConfigText,
+    process.env,
+    diagnoseCodexShim(),
+    serviceTokenPresent,
+  );
   const startup = collectStartupHealth(doctorConfig);
   console.log("\nCodex restart safety");
   console.log(`  ${startup.rebootSafe ? "ok " : "!! "} ${startupHealthSummary(startup)}`);
@@ -1135,6 +1174,14 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     for (const row of providerApiKeys) {
       console.log(`  !!     ${row.detail}`);
     }
+  }
+
+  console.log("\nCodex env_key launch readiness");
+  if (codexEnvKeyReadiness) {
+    console.log(`  !!     ${codexEnvKeyReadiness.detail}`);
+    console.log(`         Action: ${codexEnvKeyReadiness.action}`);
+  } else {
+    console.log("  ok     no broken OpenCodex env_key launch path detected");
   }
 
   console.log("\nRunning proxy process proxy env (presence only)");
@@ -1274,6 +1321,7 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   for (const row of providerApiKeys) {
     hints.push(`${row.detail}. Set ${row.envName} in the shell that starts the proxy, or store a literal key in config (value hidden here).`);
   }
+  if (codexEnvKeyReadiness) hints.push(`${codexEnvKeyReadiness.detail}. ${codexEnvKeyReadiness.action}.`);
   const anyDrvfs = paths.some(p => detectFsType(p.path, mounts).isDrvfs || detectFsType(p.path, mounts).isMntDrive);
   const noProxy = currentProxyEnv.every(p => !p.present) && !configuredProxy.present;
   if (!startup.rebootSafe) {

--- a/tests/doctor-codex-envkey-readiness.test.ts
+++ b/tests/doctor-codex-envkey-readiness.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { collectCodexEnvKeyReadiness } from "../src/cli/doctor";
+import type { CodexShimDiagnostic } from "../src/codex/shim";
+
+const config = `
+model_provider = "opencodex"
+
+[model_providers.opencodex]
+base_url = "http://127.0.0.1:10100/v1"
+env_key = "OPENCODEX_API_AUTH_TOKEN"
+`;
+
+const missingShim: CodexShimDiagnostic = {
+  installed: false,
+  healthy: false,
+  summary: "Codex autostart shim is not installed.",
+};
+
+const healthyShim: CodexShimDiagnostic = {
+  installed: true,
+  healthy: true,
+  summary: "healthy",
+};
+
+describe("doctor Codex env_key launch readiness", () => {
+  test("warns when env_key is unset, the shim is missing, and a service token exists", () => {
+    expect(collectCodexEnvKeyReadiness(config, {}, missingShim, true)).toEqual({
+      envName: "OPENCODEX_API_AUTH_TOKEN",
+      shimState: "missing",
+      detail: "Codex uses env_key OPENCODEX_API_AUTH_TOKEN, but that variable is unset and the OpenCodex shim is missing; the service token file exists but plain Codex does not load it",
+      action: "Run 'ocx codex-shim install' to repair launch-time token injection, or export OPENCODEX_API_AUTH_TOKEN in the process that starts Codex",
+    });
+  });
+
+  test("distinguishes an installed but unhealthy shim", () => {
+    const row = collectCodexEnvKeyReadiness(config, {}, { ...missingShim, installed: true }, true);
+    expect(row?.shimState).toBe("unhealthy");
+  });
+
+  test("does not warn when the configured environment variable is set", () => {
+    expect(collectCodexEnvKeyReadiness(config, { OPENCODEX_API_AUTH_TOKEN: "secret" }, missingShim, true)).toBeNull();
+  });
+
+  test("treats prototype names as unset unless they are own environment properties", () => {
+    const prototypeNameConfig = config.replace("OPENCODEX_API_AUTH_TOKEN", "toString");
+    expect(() => collectCodexEnvKeyReadiness(prototypeNameConfig, {}, missingShim, true)).not.toThrow();
+    expect(collectCodexEnvKeyReadiness(prototypeNameConfig, {}, missingShim, true)?.envName).toBe("toString");
+    expect(collectCodexEnvKeyReadiness(prototypeNameConfig, { toString: "set" }, missingShim, true)).toBeNull();
+  });
+
+  test("does not warn when the shim is healthy", () => {
+    expect(collectCodexEnvKeyReadiness(config, {}, healthyShim, true)).toBeNull();
+  });
+
+  test("does not warn when no usable service token exists", () => {
+    expect(collectCodexEnvKeyReadiness(config, {}, missingShim, false)).toBeNull();
+  });
+
+  test("ignores another active provider and env_key text outside the active table", () => {
+    const other = `${config.replace('model_provider = "opencodex"', 'model_provider = "openai"')}\n# env_key = "SHOULD_NOT_MATCH"`;
+    expect(collectCodexEnvKeyReadiness(other, {}, missingShim, true)).toBeNull();
+  });
+
+  test("never includes token material in output", () => {
+    const token = "super-secret-fixture-token";
+    const row = collectCodexEnvKeyReadiness(config, {}, missingShim, Boolean(token));
+    expect(JSON.stringify(row)).not.toContain(token);
+  });
+});

--- a/tests/doctor-provider-apikey.test.ts
+++ b/tests/doctor-provider-apikey.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { collectProviderApiKeyDiagnostics } from "../src/cli/doctor";
 
+const prototypePropertyNames = [
+  "toString",
+  "valueOf",
+  "constructor",
+  "hasOwnProperty",
+  "__proto__",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+] as const;
+
 describe("doctor provider apiKey env diagnostics (#762)", () => {
   test("warns when a key-auth env reference resolves empty without printing secrets", () => {
     const rows = collectProviderApiKeyDiagnostics({
@@ -24,6 +35,21 @@ describe("doctor provider apiKey env diagnostics (#762)", () => {
       },
     }, { OPENROUTER_API_KEY: "secret-value" });
     expect(rows).toEqual([]);
+  });
+
+  test.each(prototypePropertyNames)("diagnoses inherited env reference $%s instead of throwing", (envName) => {
+    const rows = collectProviderApiKeyDiagnostics({
+      openrouter: {
+        authMode: "key",
+        apiKey: `$${envName}`,
+      },
+    }, {});
+
+    expect(rows).toEqual([{
+      provider: "openrouter",
+      envName,
+      detail: `provider openrouter: env reference ${envName} is unset or empty in this process`,
+    }]);
   });
 
   test("ignores literal keys and non-key providers", () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -274,6 +274,26 @@ describe("doctor", () => {
     expect(JSON.stringify(rows)).not.toContain("secret");
   });
 
+  test("parseProcessEnvBlock stores prototype-like names as own keys", () => {
+    const names = [
+      "toString",
+      "valueOf",
+      "constructor",
+      "hasOwnProperty",
+      "__proto__",
+      "isPrototypeOf",
+      "propertyIsEnumerable",
+      "toLocaleString",
+    ];
+    const env = parseProcessEnvBlock(names.map(name => `${name}=set-${name}`).join("\0"));
+
+    expect(Object.getPrototypeOf(env)).toBeNull();
+    for (const name of names) {
+      expect(Object.hasOwn(env, name)).toBe(true);
+      expect(env[name]).toBe(`set-${name}`);
+    }
+  });
+
   test("collectRunningProxyEnv separates no pid, unreadable pid env, and pid env presence", () => {
     const none = collectRunningProxyEnv({ readPidFn: () => null });
     expect(none.status).toBe("not_running");
@@ -311,6 +331,18 @@ describe("doctor", () => {
     expect(diagnostic.configured).toBe(true);
     expect(diagnostic.present).toBe(true);
     expect(JSON.stringify(diagnostic)).not.toContain("secret");
+  });
+
+  test("collectConfiguredProxy diagnoses an inherited env reference instead of throwing", () => {
+    writeFileSync(join(TEST_OPENCODEX_HOME, "config.json"), JSON.stringify({ proxy: "$toString" }));
+
+    expect(collectConfiguredProxy()).toEqual({
+      key: "config.proxy",
+      present: false,
+      configured: true,
+      source: "file",
+      detail: "env reference toString is unset",
+    });
   });
 
   test("probeWham classifies ok, http error, timeout, and connect failures", async () => {


### PR DESCRIPTION
## Summary

- Diagnose the broken Codex `env_key` launch path in `ocx doctor`, and fix the prototype-chain defect in that readiness check: a Codex config setting `env_key = "toString"` (or any `Object.prototype` member name) made the lookup return an inherited function instead of a missing value, and `doctor` threw a `TypeError` instead of reporting a diagnosis. Now guarded with `Object.hasOwn`.

Reimplements #2797 by @rrmlima on current `dev` — that fork branch's review checklist would reset on a rebase.

**This does not close #2713.** It only diagnoses the broken `env_key` plus missing/unhealthy shim path. It does not provide shim-independent or systemd credential injection, and it does not make credentials survive a Codex launcher replacement. #2713 stays open for that remaining work.

## Verification

- `bun test tests/doctor-codex-envkey-readiness.test.ts` — driven **RED 7 pass / 1 fail** with the expected `TypeError`, then **GREEN 8 pass / 0 fail**.
- `bun test tests/doctor.test.ts` — 46 pass, 0 fail.
- `bun x tsc --noEmit` — exit 0.
- `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed — `doctor` output only.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. `doctor` reads credential-adjacent config, so it needs non-author security review; the diagnosis reports presence and health, never a key value.

Refs #2713 (partial).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added launch-readiness diagnostics for Codex configurations using the OpenCodex provider.
  * Reports missing or unhealthy shims, unavailable environment variables, and missing service tokens.
  * Includes actionable guidance for resolving detected configuration issues.
  * Protects service-token values from being exposed in diagnostic output.

* **Bug Fixes**
  * Improved environment-variable and proxy diagnostics for names that overlap with built-in properties.
  * Prevented inherited environment values from causing errors or misleading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->