### PR TITLE
fix(responses): recover encrypted combo agent tasks safely

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1339,6 +1339,7 @@ export interface HandleResponsesOptions {
     sourceBody: unknown;
     previousResponseInputExpanded: boolean;
     providerContinuation: OcxProviderContinuationState | undefined;
+    recoveredPlaintext: boolean;
   };
   /** Internal combo handoff: allow a later same-provider model after a reset-derived 429/402. */
   deferCodexResetDerivedCooldown?: boolean;
@@ -1894,6 +1895,7 @@ export async function handleComboResponses(
     providerContinuation: !scopeMismatch && body !== rawBody && requestedPreviousId
       ? previousResponseProviderState(requestedPreviousId)
       : undefined,
+    recoveredPlaintext: false,
   };
   const adoptFailedChildLog = (childLog: RequestLogContext): void => {
     // Attempts remain the complete physical history; the logical row mirrors the most recent
@@ -1923,11 +1925,40 @@ export async function handleComboResponses(
       return false;
     }
   };
+  let comboPayloadReadable = false;
   const payloadEligible = (target: (typeof combo.targets)[number]): boolean =>
-    !unreadableEncryptedAgentTask || canDecryptUnreadableAgentTask(target);
+    comboPayloadReadable || !unreadableEncryptedAgentTask || canDecryptUnreadableAgentTask(target);
 
   if (unreadableEncryptedAgentTask && !combo.targets.some(canDecryptUnreadableAgentTask)) {
-    return unreadableEncryptedAgentTaskResponse();
+    const recovery = agentTaskRecoveryConfig(config);
+    let recovered = false;
+    if (
+      (options.inboundWire ?? "responses") === "responses"
+      && isThreadSpawnRequest(req.headers)
+      && recovery
+      && !options.comboAttempt
+    ) {
+      try {
+        recovered = await recoverEncryptedAgentTask(
+          req,
+          (body as { input?: unknown } | undefined)?.input,
+          recovery,
+          config,
+          { parentThreadId: inboundClientThreadId, abortSignal: options.abortSignal },
+        );
+      } catch {
+        recovered = false;
+      }
+    }
+    // Recovery has the same in-place input mutation contract as the direct routed path.
+    if (
+      !recovered
+      || hasUnreadableEncryptedAgentTask((body as { input?: unknown } | undefined)?.input)
+    ) {
+      return unreadableEncryptedAgentTaskResponse();
+    }
+    comboPayloadReadable = true;
+    comboReplaySnapshot.recoveredPlaintext = true;
   }
 
   const initialNow = Date.now();
@@ -2335,6 +2366,9 @@ async function handleResponsesInner(
   let toolBridgeMaps: ReturnType<typeof buildToolBridgeMaps>;
   try {
     parsed = parseRequest(body);
+    if (options.comboReplaySnapshot?.recoveredPlaintext) {
+      markBodyNonPersistable(parsed._rawBody);
+    }
     toolBridgeMaps = buildToolBridgeMaps(parsed, translatorBudget);
     if (previousResponseInputExpanded) parsed._previousResponseInputExpanded = true;
     const providerContinuationCandidate = options.comboReplaySnapshot

--- a/tests/agent-task-recovery-combo.test.ts
+++ b/tests/agent-task-recovery-combo.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearResponseStateForTests,
+  clearResponseStateMemoryForTests,
+  responseContinuationRetainedStoreSnapshot,
+  runPendingResponseStatePersistForTests,
+} from "../src/responses/state";
+import { resetAgentTaskRecoveryState } from "../src/server/responses/agent-task-recovery";
+import {
+  codexHeaders,
+  encryptedInput,
+  FERNET_TASK,
+  originalFetch,
+  post,
+  providerResponse,
+  recoverySse,
+  routedConfig,
+} from "./helpers/agent-task-recovery";
+
+function providerCompletion(): Response {
+  return Response.json({
+    id: "chatcmpl_combo_recovery",
+    object: "chat.completion",
+    choices: [{
+      index: 0,
+      message: { role: "assistant", content: "done" },
+      finish_reason: "stop",
+    }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  });
+}
+
+function comboConfig(targets: Array<{ provider: string; model: string }>) {
+  const config = routedConfig();
+  config.combos = {
+    routed: {
+      strategy: "failover",
+      targets,
+    },
+  };
+  return config;
+}
+
+describe("combo path encrypted agent task recovery", () => {
+  const priorHome = process.env["OPENCODEX_HOME"];
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ocx-agent-task-combo-"));
+    process.env["OPENCODEX_HOME"] = home;
+    clearResponseStateMemoryForTests();
+    resetAgentTaskRecoveryState();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    resetAgentTaskRecoveryState();
+    clearResponseStateForTests();
+    rmSync(home, { recursive: true, force: true });
+    if (priorHome === undefined) delete process.env["OPENCODEX_HOME"];
+    else process.env["OPENCODEX_HOME"] = priorHome;
+  });
+
+  test("recovers an all-third-party combo once without retaining plaintext continuation state", async () => {
+    const assignment = "RECOVERED-COMBO-PLAINTEXT-SENTINEL";
+    const fetchedUrls: string[] = [];
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      fetchedUrls.push(url);
+      if (url.includes("chatgpt.com")) {
+        return new Response(recoverySse(assignment), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return providerCompletion();
+    }) as typeof fetch;
+
+    const response = await post(
+      comboConfig([{ provider: "xai", model: "grok-4.5" }]),
+      "combo/routed",
+      encryptedInput(),
+      codexHeaders(),
+    );
+    await runPendingResponseStatePersistForTests();
+    const responsePayload = await response.clone().json() as { id?: string };
+
+    expect(response.status).toBe(200);
+    expect(typeof responsePayload.id).toBe("string");
+    expect(fetchedUrls).toHaveLength(2);
+    expect(fetchedUrls[0]).toContain("chatgpt.com/backend-api/codex/responses");
+    expect(responseContinuationRetainedStoreSnapshot().count).toBe(0);
+    const snapshotPath = join(home, "responses-state.json");
+    const snapshot = existsSync(snapshotPath) ? readFileSync(snapshotPath, "utf8") : "";
+    expect(snapshot).not.toContain(assignment);
+    expect(snapshot).not.toContain(responsePayload.id!);
+  });
+
+  test("keeps the canonical target bypass in a mixed combo without running recovery", async () => {
+    const forwardedBodies: string[] = [];
+    globalThis.fetch = (async (_input, init) => {
+      forwardedBodies.push(typeof init?.body === "string" ? init.body : "");
+      return providerResponse();
+    }) as typeof fetch;
+
+    const response = await post(
+      comboConfig([
+        { provider: "xai", model: "grok-4.5" },
+        { provider: "openai", model: "gpt-5.5" },
+      ]),
+      "combo/routed",
+      encryptedInput(),
+      codexHeaders(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwardedBodies).toHaveLength(1);
+    expect(forwardedBodies[0]).toContain(FERNET_TASK);
+    expect(forwardedBodies[0]).not.toContain("capture_assignment");
+  });
+});

--- a/tests/agent-task-recovery.test.ts
+++ b/tests/agent-task-recovery.test.ts
@@ -551,7 +551,7 @@ describe("agent task recovery (opt-in, default off)", () => {
     expect(forwardedBody).not.toContain("capture_assignment");
   });
 
-  test("does not enable recovery inside combo attempts", async () => {
+  test("fails closed after a single failed combo recovery pass", async () => {
     const config = routedConfig();
     config.combos = {
       routed: {
@@ -559,10 +559,10 @@ describe("agent task recovery (opt-in, default off)", () => {
         targets: [{ provider: "xai", model: "grok-4.5" }],
       },
     };
-    let fetchCalls = 0;
-    globalThis.fetch = (async () => {
-      fetchCalls += 1;
-      throw new Error("combo must fail before dispatch");
+    const fetchedUrls: string[] = [];
+    globalThis.fetch = (async (input) => {
+      fetchedUrls.push(String(input));
+      throw new Error("every upstream call must fail");
     }) as typeof fetch;
 
     const response = await post(
@@ -573,7 +573,8 @@ describe("agent task recovery (opt-in, default off)", () => {
     );
 
     expect(response.status).toBe(400);
-    expect(fetchCalls).toBe(0);
+    expect(fetchedUrls).toHaveLength(1);
+    expect(fetchedUrls[0]).toContain("chatgpt.com/backend-api/codex/responses");
     expect(await response.json()).toMatchObject({
       error: { code: "unreadable_encrypted_agent_task" },
     });


### PR DESCRIPTION
## Summary

- Recover ciphertext-only Responses thread-spawn tasks once before an all-third-party combo returns `unreadable_encrypted_agent_task`.
- Propagate an internal recovered-plaintext marker to each cloned combo child before any response-state recorder can persist the decrypted assignment.
- Preserve failed-recovery fail-closed behavior and the existing mixed canonical OpenAI plus third-party target bypass.
- Supersedes #2744 without changing or closing it. Credit to @yxr1995-maker for the original diagnosis and fix.
- Security boundary: this handles encrypted task payloads and forwarded recovery credentials. It requires non-author security review and must not merge without that approval.
- Deliberately contains zero `package.json` changes.

## Verification

- RED on current `origin/dev` `f7bb8932eeac05b1b842ff0359eb184d5be2e81c`: `bun test tests/agent-task-recovery-combo.test.ts` -> 1 pass, 2 fail; the all-third-party combo returned 400 before recovery and failed recovery made zero upstream calls.
- Persistence mutation proof: with child `markBodyNonPersistable` propagation temporarily removed, `bun test tests/agent-task-recovery-combo.test.ts` -> 1 pass, 1 fail; retained continuation count was 1 instead of 0.
- `bun test tests/agent-task-recovery*.test.ts` -> 39 pass, 0 fail, 179 assertions across 5 files.
- `bun test tests/server-combo-failover-e2e.test.ts tests/combo-stream-preflight.test.ts tests/combo-workspace-data.test.ts tests/responses-parser.test.ts` -> 150 pass, 0 fail, 12,970 assertions across 4 files.
- `bun x tsc --noEmit` -> exit 0, 0 errors.
- `bun run privacy:scan` -> exit 0, `Privacy scan passed`.
- `git diff origin/dev...HEAD -- package.json` -> empty.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No configuration or public API shape changed; the existing recovery documentation remains accurate.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Pending required non-author security review.
