### PR TITLE
fix(windows): scope scheduler ownership by OpenCodex home

### DIFF
--- a/src/service-manager-probe.ts
+++ b/src/service-manager-probe.ts
@@ -681,7 +681,19 @@ function inspectWindows(
   }
 
   if (task === "absent") {
-    return schedulerRegistered
+    if (!schedulerRegistered) return { kind: "absent" };
+    if (!registration.registeredXml.trim()) {
+      return unknown("Task Scheduler is registered but its definition XML could not be read");
+    }
+    const launcherArg = windowsTaskArguments(registration.registeredXml);
+    if (!launcherArg) {
+      return unknown("Task Scheduler holds opencodex-proxy but its task XML is missing");
+    }
+    const launcherPath = /"([^"]+)"/.exec(launcherArg)?.[1];
+    if (!launcherPath) {
+      return unknown("Task Scheduler holds opencodex-proxy but its task XML is missing");
+    }
+    return windowsPathInsideConfigDir(launcherPath, configDir)
       ? unknown("Task Scheduler holds opencodex-proxy but its task XML is missing")
       : { kind: "absent" };
   }

--- a/tests/codex-service-manager-probe-hardening.test.ts
+++ b/tests/codex-service-manager-probe-hardening.test.ts
@@ -138,6 +138,61 @@ function taskAbsentRunner(calls: Array<{ file: string; args: readonly string[] }
 }
 
 describe("Windows ownership probe hardening regressions", () => {
+  test("a scheduler registered for another OpenCodex home does not claim the current home (#2800)", () => {
+    const foreignConfigDir = join(home, "foreign-opencodex");
+    const foreignLauncher = join(foreignConfigDir, "opencodex-service-launcher.vbs");
+    const runRaw: RawProbeRunner = (file, args) => {
+      if (file.toLowerCase().endsWith("sc.exe")) return raw(1, "", "1060");
+      if (args.includes("/xml")) return raw(0, schedulerXml(foreignLauncher));
+      return raw(1, "", "unexpected query");
+    };
+
+    const result = inspectNativeCodexOwnership({
+      platform: "win32",
+      home,
+      configDir,
+      runRaw,
+      winswStatus: () => "nonexistent",
+      statePaths: [],
+      currentHomes: {
+        codexHome: join(home, "current-codex"),
+        opencodexHome: configDir,
+      },
+    });
+
+    expect(result).toEqual({
+      ownership: "owned",
+      reason: "no service state and no service manager claim",
+    });
+  });
+
+  test("a current-home scheduler with missing local task XML remains unproven", () => {
+    const localLauncher = join(configDir, "opencodex-service-launcher.vbs");
+    const runRaw: RawProbeRunner = (file, args) => {
+      if (file.toLowerCase().endsWith("sc.exe")) return raw(1, "", "1060");
+      if (args.includes("/xml")) return raw(0, schedulerXml(localLauncher));
+      return raw(1, "", "unexpected query");
+    };
+
+    const result = inspectNativeCodexOwnership({
+      platform: "win32",
+      home,
+      configDir,
+      runRaw,
+      winswStatus: () => "nonexistent",
+      statePaths: [],
+      currentHomes: {
+        codexHome: join(home, "current-codex"),
+        opencodexHome: configDir,
+      },
+    });
+
+    expect(result).toEqual({
+      ownership: "unknown",
+      reason: "Task Scheduler holds opencodex-proxy but its task XML is missing",
+    });
+  });
+
   test("registered CP949 task XML preserves a Korean profile path", () => {
     const koreanConfigDir = join(home, "한글", ".opencodex");
     const codexHome = join(home, "한글", ".codex");


### PR DESCRIPTION
## Summary

- Scope the machine-global `opencodex-proxy` Task Scheduler registration to the effective `OPENCODEX_HOME` before it participates in write ownership.
- Treat a registered launcher outside the current config directory as another home's manager claim, allowing the current home to reach the existing Codex write coordinator.
- Keep current-home missing XML, malformed launcher arguments, unreadable registration XML, WinSW overlap, and manager-query failures fail-closed.

Closes #2800

## Verification

- RED: `bun test tests/codex-service-manager-probe-hardening.test.ts` returned `ownership: unknown` with `Task Scheduler holds opencodex-proxy but its task XML is missing` for the second-home fixture.
- Mutation RED: restoring the previous machine-global `unknown` decision failed only the new #2800 ownership regression while the current-home negative remained green.
- GREEN: `bun test tests/codex-service-manager-probe-hardening.test.ts tests/codex-service-manager-probe.test.ts tests/codex-admission.test.ts` — 83 pass, 0 fail, 201 assertions.
- `bun x tsc --noEmit` — exit 0.
- `bun run privacy:scan` — passed.
- Real Windows Task Scheduler execution was not available on this macOS host. The focused tests inject scheduler and service-state evidence and verify the exact ownership decisions; they do not claim a Windows 11 end-to-end `ocx sync` run.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No user-facing contract changed; this restores per-home behavior for an existing supported setup.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The probe parses only the registered launcher path, never reads a foreign path, and retains fail-closed behavior for current-home or malformed evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows scheduled-task detection to verify that a registered task belongs to the current installation.
  * Reports an indeterminate status when task details are missing, malformed, or point outside the configured installation directory.
  * Prevents tasks belonging to another installation from being incorrectly recognized.

* **Tests**
  * Added coverage for task ownership validation and missing local task definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->