### PR TITLE
fix(gui): harden dashboard asset serving and log retries

### DIFF
--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -250,7 +250,9 @@ function formatTokPerSecond(result: TokPerSecondResult | undefined, localeTag?: 
   return `${result.estimated ? "~" : ""}${value}`;
 }
 
-/** Consecutive failed polls before a stale table is called out. Two seconds each, so ~6s. */
+const LOGS_POLL_INTERVAL_MS = 2000;
+const LOGS_POLL_BACKOFF_MAX_EXPONENT = 4;
+/** Consecutive failed polls before a stale table is called out. */
 const STALE_POLL_FAILURE_LIMIT = 3;
 
 const METRIC_REASON_KEYS = {
@@ -363,12 +365,18 @@ export default function Logs({ apiBase }: { apiBase: string }) {
   const resourceKey = logsCacheKey(apiBase);
   const cachedLogs = validCachedLogs(readSessionListCache<LogEntry[]>(resourceKey));
   const [autoRefresh, setAutoRefresh] = useState(true);
+  const [failureStreak, setFailureStreak] = useState<{ error: unknown; count: number }>(
+    { error: null, count: 0 },
+  );
   const [detail, setDetail] = useState<LogEntry | null>(null);
   const [surfaceFilter, setSurfaceFilter] = useState<LogSurfaceFilter>("all");
   const [interceptedHelpersOnly, setInterceptedHelpersOnly] = useState(false);
   const [conversationFilter, setConversationFilter] = useState("");
   const [conversationQueryHash, setConversationQueryHash] = useState<string | undefined>();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const logRetryRef = useRef<{ key: string; failures: number; nextAttemptAt: number; error: unknown }>(
+    { key: resourceKey, failures: 0, nextAttemptAt: 0, error: null },
+  );
   const localeTag = LOCALES.find(l => l.code === locale)?.htmlLang;
   // The proxy's own zone, so timestamps read the same as the server's logs rather than being
   // silently shifted into the viewer's zone (#725). Fetched once: it cannot change while the
@@ -417,18 +425,36 @@ export default function Logs({ apiBase }: { apiBase: string }) {
   const selectTab = selectLogsTab;
 
   const loadLogs = useCallback(async (signal: AbortSignal): Promise<LogEntry[]> => {
-    const res = await fetch(`${apiBase}/api/logs?limit=2000`, { signal });
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`.trim());
-    const body = await res.json() as LogEntry[] | { logs?: LogEntry[] };
-    const raw = Array.isArray(body) ? body : (body.logs ?? []);
-    const next = raw.map(sanitizeLogEntryRouteDecision);
-    writeSessionListCache(resourceKey, next);
-    return next;
+    let retry = logRetryRef.current;
+    if (retry.key !== resourceKey) {
+      retry = { key: resourceKey, failures: 0, nextAttemptAt: 0, error: null };
+      logRetryRef.current = retry;
+    }
+    if (retry.failures > 0 && Date.now() < retry.nextAttemptAt) throw retry.error;
+    try {
+      const res = await fetch(`${apiBase}/api/logs?limit=2000`, { signal });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`.trim());
+      const body = await res.json() as LogEntry[] | { logs?: LogEntry[] };
+      const raw = Array.isArray(body) ? body : (body.logs ?? []);
+      const next = raw.map(sanitizeLogEntryRouteDecision);
+      logRetryRef.current = { key: resourceKey, failures: 0, nextAttemptAt: 0, error: null };
+      writeSessionListCache(resourceKey, next);
+      return next;
+    } catch (error) {
+      if (signal.aborted) throw error;
+      const normalized = error ?? new Error("log request failed");
+      const failures = retry.failures + 1;
+      const backoffMs = LOGS_POLL_INTERVAL_MS * (2 ** Math.min(
+        failures,
+        LOGS_POLL_BACKOFF_MAX_EXPONENT,
+      ));
+      logRetryRef.current = { key: resourceKey, failures, nextAttemptAt: Date.now() + backoffMs, error: normalized };
+      throw normalized;
+    }
   }, [apiBase, resourceKey]);
 
-  // The resource layer owns the request and the 2s poll. It keeps held rows through a quiet
-  // poll on its own, which is what the old silent/non-silent split was hand-rolling — and an
-  // empty successful response is now a real empty result rather than a cold load.
+  // The resource layer owns the request and the 2s base poll. loadLogs backs off actual network
+  // attempts after failures while preserving those shared scheduler ticks and held rows.
   const logsResource = useDataSurface<LogEntry[]>(
     resourceKey,
     [apiBase],
@@ -436,13 +462,17 @@ export default function Logs({ apiBase }: { apiBase: string }) {
     {
       isEmpty: rows => rows.length === 0,
       enabled: tab === "logs",
-      pollMs: autoRefresh ? 2000 : undefined,
+      pollMs: autoRefresh ? LOGS_POLL_INTERVAL_MS : undefined,
       initialData: cachedLogs ?? undefined,
     },
   );
   const logsState = logsResource.state;
   const logs = logsState.data ?? cachedLogs ?? [];
   const fetchLogs = logsResource.refresh;
+  const retryLogs = useCallback(() => {
+    logRetryRef.current = { key: resourceKey, failures: 0, nextAttemptAt: 0, error: null };
+    fetchLogs({ forceLoading: true });
+  }, [fetchLogs, resourceKey]);
 
   // A single failed tick on a two-second poll is noise, but an outage that never recovers must not
   // leave the user reading stale rows as if they were current. Count consecutive failures and speak
@@ -453,9 +483,6 @@ export default function Logs({ apiBase }: { apiBase: string }) {
   // in sync and no frame painted with a stale banner. `streak` counts CONSECUTIVE failed
   // settlements: it is stored keyed by the error identity that produced it, so repeated
   // renders of the same failure do not inflate the count and a success clears it.
-  const [failureStreak, setFailureStreak] = useState<{ error: unknown; count: number }>(
-    { error: null, count: 0 },
-  );
   if (settledSuccess && failureStreak.count !== 0) {
     setFailureStreak({ error: null, count: 0 });
   } else if (settledFailure && failureStreak.error !== logsState.error) {
@@ -646,7 +673,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
       {logsState.kind === "failed-cold" && (
         <Notice tone="err">
           {logsState.error instanceof Error ? `${t("logs.loadError")} ${logsState.error.message}` : t("logs.loadError")}{" "}
-          <button type="button" className="btn btn-ghost btn-sm" onClick={() => fetchLogs({ forceLoading: true })} disabled={logsState.refreshing}>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={retryLogs} disabled={logsState.refreshing}>
             {t("common.retry")}
           </button>
         </Notice>
@@ -656,7 +683,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
       {pollFailing && logs.length > 0 && (
         <Notice tone="err">
           {t("logs.loadError")}{" "}
-          <button type="button" className="btn btn-ghost btn-sm" onClick={() => fetchLogs({ forceLoading: true })} disabled={logsResource.refreshing}>
+          <button type="button" className="btn btn-ghost btn-sm" onClick={retryLogs} disabled={logsResource.refreshing}>
             {t("common.retry")}
           </button>
         </Notice>

--- a/gui/tests/logs-auto-refresh.test.tsx
+++ b/gui/tests/logs-auto-refresh.test.tsx
@@ -136,15 +136,17 @@ async function flushMicrotasks(): Promise<void> {
   });
 }
 
-async function advanceSilentRefresh(): Promise<void> {
-  await act(async () => {
-    jest.advanceTimersByTime(2000);
-  });
-  await flushMicrotasks();
-  await act(async () => {
-    jest.advanceTimersByTime(0);
-    await Promise.resolve();
-  });
+async function advanceSilentRefresh(ms = 2000): Promise<void> {
+  for (let elapsed = 0; elapsed < ms; elapsed += 2000) {
+    await act(async () => {
+      jest.advanceTimersByTime(Math.min(2000, ms - elapsed));
+    });
+    await flushMicrotasks();
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+  }
 }
 
 function clickRetry(container: HTMLElement): void {
@@ -181,7 +183,7 @@ test("Logs: initial failure shows error; silent failure keeps it; retry then rec
   const initialCalls = calls.filter(u => u.includes("/api/logs")).length;
   expect(initialCalls).toBeGreaterThanOrEqual(1);
 
-  await advanceSilentRefresh();
+  await advanceSilentRefresh(6000);
   expect(container.textContent).toContain("Could not load request logs.");
   expect(container.textContent).not.toContain("No requests yet.");
   expect(calls.filter(u => u.includes("/api/logs")).length).toBeGreaterThan(initialCalls);
@@ -228,7 +230,7 @@ test("Logs: silent failure after successful load keeps the table and does not to
   expect(/\bLoading\b/.test(container.textContent ?? "")).toBe(false);
 
   mode = "updated";
-  await advanceSilentRefresh();
+  await advanceSilentRefresh(6000);
   expectTableLoaded(container, "gpt-updated");
 
   await act(async () => { root.unmount(); });
@@ -249,7 +251,7 @@ test("Logs: silent success clears a previous error; later silent failure keeps t
   expect(container.textContent).toContain("Could not load request logs.");
 
   mode = "ok";
-  await advanceSilentRefresh();
+  await advanceSilentRefresh(6000);
   expectTableLoaded(container, "gpt-test");
 
   mode = "fail-again";
@@ -263,10 +265,12 @@ test("Logs: silent success clears a previous error; later silent failure keeps t
 // recovers must not leave stale rows reading as current forever. Three consecutive failures
 // is the point where silence becomes a lie.
 test("Logs: a sustained poll outage says the rows are stale, and a recovery clears it", async () => {
+  const calls: string[] = [];
   let mode: "ok" | "fail" = "ok";
 
   globalThis.fetch = (async (input) => {
     const url = String(input);
+    calls.push(url);
     if (!url.includes("/api/logs")) return new Response(null, { status: 404 });
     if (mode === "fail") return jsonResponse({ error: "down" }, 503);
     return jsonResponse([sampleLog]);
@@ -280,11 +284,14 @@ test("Logs: a sustained poll outage says the rows are stale, and a recovery clea
   // Below the limit the rows stay quiet: a single dropped tick is not worth an alarm.
   await advanceSilentRefresh();
   expect(container.textContent).not.toContain("Could not load request logs.");
+  const afterFirstFailure = calls.filter(u => u.includes("/api/logs")).length;
   await advanceSilentRefresh();
+  expect(calls.filter(u => u.includes("/api/logs"))).toHaveLength(afterFirstFailure);
+  await advanceSilentRefresh(4000);
   expect(container.textContent).not.toContain("Could not load request logs.");
 
   // Third consecutive failure: the outage is not transient, so say so while keeping the rows.
-  await advanceSilentRefresh();
+  await advanceSilentRefresh(10000);
   expect(container.textContent).toContain("Could not load request logs.");
   expect(container.querySelector(".logs-table")).not.toBeNull();
   expect(container.textContent).toContain("gpt-test");
@@ -292,7 +299,7 @@ test("Logs: a sustained poll outage says the rows are stale, and a recovery clea
 
   // A recovered poll must retract the notice rather than leaving a permanent scar.
   mode = "ok";
-  await advanceSilentRefresh();
+  await advanceSilentRefresh(20000);
   expectTableLoaded(container, "gpt-test");
 
   await act(async () => { root.unmount(); });
@@ -533,4 +540,3 @@ test("Logs: an intercepted helper row is badged and filterable", async () => {
 
   await act(async () => { root.unmount(); });
 });
-

--- a/src/server/gui-static.ts
+++ b/src/server/gui-static.ts
@@ -127,7 +127,10 @@ export function serveGuiFile(
   const ext = extname(filePath);
   const contentType = MIME_TYPES[ext] || "application/octet-stream";
   if (ext === ".html") return htmlResponse(filePath, session);
-  return new Response(Bun.file(filePath), {
+  // Snapshot bytes before returning the response. Bun.file is lazy: if gui/dist is replaced
+  // after Bun frames the response but before the stream finishes, its Content-Length can
+  // describe the old file while the body comes from the new one (#2792).
+  return new Response(readFileSync(filePath), {
     headers: { "Content-Type": contentType, ...browserSecurityHeaders() },
   });
 }

--- a/tests/gui-static.test.ts
+++ b/tests/gui-static.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { serveGuiFile } from "../src/server/gui-static";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("#2792 snapshots a static asset before server framing can outlive the file", async () => {
+  const guiDist = mkdtempSync(join(tmpdir(), "ocx-gui-static-"));
+  temporaryDirectories.push(guiDist);
+  writeFileSync(join(guiDist, "index.html"), "<!doctype html>");
+  const assetPath = join(guiDist, "index.js");
+  const originalAsset = "console.log('complete dashboard asset');";
+  writeFileSync(assetPath, originalAsset);
+
+  const response = serveGuiFile("/index.js", guiDist);
+  expect(response).not.toBeNull();
+
+  // A package update may replace gui/dist after the response is constructed. The response
+  // body must retain the same byte snapshot the HTTP server uses for Content-Length.
+  writeFileSync(assetPath, "truncated");
+  expect(await response!.text()).toBe(originalAsset);
+});


### PR DESCRIPTION
## Summary

- Related to #2792: snapshot packaged GUI asset bytes before returning a response so a `gui/dist` replacement cannot make Bun frame one file length and stream another file body.
- Related to #2791: keep the shared two-second Logs scheduler, but exponentially back off actual `/api/logs` network retries after failures; manual Retry bypasses the gate and a successful fetch resets it.
- Add focused regressions for the static-body snapshot and sustained Logs polling failure/recovery behavior.

## Verification

- RED: `bun test tests/gui-static.test.ts` — failed because the response read `"truncated"` after the backing file changed instead of retaining the original asset.
- RED: `cd gui && bun test tests/logs-auto-refresh.test.tsx` — failed because another `/api/logs` request fired at the next two-second tick after a failure.
- GREEN: `bun test tests/gui-static.test.ts` — 1 pass, 0 fail.
- GREEN: `cd gui && bun test tests/logs-auto-refresh.test.tsx` — 9 pass, 0 fail.
- `bun x tsc --noEmit` — exit 0.
- `bun run lint:gui` — exit 0.
- `bun run build:gui` — exit 0; packaged bundle `index-CuQMOt5l.js` built successfully.
- `bun run privacy:scan` — passed.
- Isolated live proxy (`HOME`, `OPENCODEX_HOME`, and `CODEX_HOME` all set to a temporary directory): final JavaScript response declared 2,482,833 bytes and delivered exactly 2,482,833 bytes, both with and without `Accept-Encoding: gzip`.
- Isolated `/api/logs?limit=2000` probe: an empty ring returned in 3.14 ms; a full 2,000-entry, 1,288,853-byte response returned in 1.97–2.69 ms across three runs. The route does not long-poll or hold the connection open.
- Full repository tests were not run per the delegated machine-lock constraint; only focused test files were executed.

### Screenshot

![Patched OpenCodex Logs dashboard](https://gist.githubusercontent.com/lidge-jun/657a3657aa8835a491e950f33e407ffd/raw/0aff5f2057811bc5200676bb951ce31347ff49b3/opencodex-dashboard-2791-2792.png)

[Screenshot gist](https://gist.github.com/lidge-jun/657a3657aa8835a491e950f33e407ffd)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No user-facing configuration or contract changed, so no docs update is required.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This PR does not change authentication or credential handling; the privacy scan passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic log refresh reliability with exponential backoff after repeated failures.
  * Preserved cached log entries during polling issues and improved stale-data notifications.
  * Retry actions now immediately reset failure tracking.
  * Ensured static files are served consistently even when files change during delivery.

* **Tests**
  * Added coverage for log polling outages, recovery, retries, and backoff behavior.
  * Added coverage confirming static assets return their original content during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->