### PR TITLE
fix(service): support systemd 219 install cleanup

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -2689,7 +2689,11 @@ export function systemdInstallCleanupStatus(
   deps: { show?: () => string } = {},
 ): string | null {
   const output = (deps.show ?? (() => sh(`systemctl --user show ${TASK} -p LoadState`)))();
-  const match = /^LoadState=(.*)$/m.exec(output.replace(/\r/g, ""));
+  const lines = output.replace(/\r/g, "").split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  const match = lines.length === 1
+    ? /^LoadState=(.+)$/.exec(lines[0] ?? "")
+    : null;
   const loadState = match?.[1]?.trim().toLowerCase() ?? "";
   if (!loadState) throw new Error("systemd service status could not be verified.");
   return loadState === "not-found" ? null : loadState;

--- a/src/service.ts
+++ b/src/service.ts
@@ -2676,6 +2676,25 @@ type ServiceInstallCleanupOps = {
   stop: () => void;
 };
 
+/**
+ * Query whether systemd already knows the user service before install cleanup.
+ *
+ * Keep the property name in the output instead of using `systemctl --value`:
+ * CentOS 7's systemd 219 supports `-p LoadState` but not the later `--value`
+ * switch (#2866). Requiring the explicit `LoadState=` key also preserves the
+ * fail-closed boundary — empty, truncated, or unrelated output must not be
+ * mistaken for a confirmed absent unit.
+ */
+export function systemdInstallCleanupStatus(
+  deps: { show?: () => string } = {},
+): string | null {
+  const output = (deps.show ?? (() => sh(`systemctl --user show ${TASK} -p LoadState`)))();
+  const match = /^LoadState=(.*)$/m.exec(output.replace(/\r/g, ""));
+  const loadState = match?.[1]?.trim().toLowerCase() ?? "";
+  if (!loadState) throw new Error("systemd service status could not be verified.");
+  return loadState === "not-found" ? null : loadState;
+}
+
 function platformOps(backend: ServiceBackend = "scheduler"): ServiceOps | null {
   if (process.platform === "darwin")
     return { install: installLaunchd, start: startLaunchd, stop: stopLaunchd, status: statusLaunchd, uninstall: uninstallLaunchd };
@@ -2745,17 +2764,12 @@ function platformServiceInstallCleanupOps(backend: ServiceBackend): ServiceInsta
   }
   if (process.platform === "linux") {
     return {
-      status: () => {
-        // `list-unit-files <name>` exits non-zero when the unit has never been
-        // installed, which made a clean first install look like an unknown manager
-        // failure. `show LoadState` gives us the tri-state we actually need: a
-        // healthy user manager returns `not-found` for a missing unit, while an
-        // unreachable/permission-denied manager still makes `sh()` throw and the
-        // caller therefore fails closed.
-        const loadState = sh(`systemctl --user show ${TASK} --property=LoadState --value`).trim().toLowerCase();
-        if (!loadState) throw new Error("systemd service status could not be verified.");
-        return loadState === "not-found" ? null : loadState;
-      },
+      // `list-unit-files <name>` exits non-zero when the unit has never been
+      // installed, which made a clean first install look like an unknown manager
+      // failure. `show LoadState` gives us the tri-state we actually need; the helper
+      // also keeps this compatible with systemd 219 without weakening fail-closed
+      // manager errors (#2866).
+      status: systemdInstallCleanupStatus,
       stop: () => { sh(`systemctl --user stop ${TASK}`); },
     };
   }

--- a/tests/systemd-install-cleanup-hardening.test.ts
+++ b/tests/systemd-install-cleanup-hardening.test.ts
@@ -14,17 +14,26 @@ describe("systemd install cleanup status hardening", () => {
   });
 
   test("uses the key/value output supported by systemd 219", () => {
-    const helper = source.slice(
-      source.indexOf("export function systemdInstallCleanupStatus"),
-      source.indexOf("function platformOps"),
-    );
+    const start = source.indexOf("export function systemdInstallCleanupStatus");
+    const end = source.indexOf("function platformOps", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const helper = source.slice(start, end);
 
     expect(helper).toContain("systemctl --user show ${TASK} -p LoadState");
     expect(helper).not.toContain("--value");
   });
 
   test("fails closed on missing, empty, or legacy bare-value output", () => {
-    for (const output of ["", "LoadState=\n", "not-found\n", "ActiveState=inactive\n"]) {
+    for (const output of [
+      "",
+      "LoadState=\n",
+      "not-found\n",
+      "ActiveState=inactive\n",
+      "ActiveState=inactive\nLoadState=loaded\n",
+      "LoadState=loaded\nunexpected\n",
+      "LoadState=loaded\n\n",
+    ]) {
       expect(() => systemdInstallCleanupStatus({ show: () => output }))
         .toThrow("systemd service status could not be verified");
     }

--- a/tests/systemd-install-cleanup-hardening.test.ts
+++ b/tests/systemd-install-cleanup-hardening.test.ts
@@ -1,13 +1,32 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { systemdInstallCleanupStatus } from "../src/service";
 
 const source = readFileSync(join(import.meta.dir, "../src/service.ts"), "utf8");
 
 describe("systemd install cleanup status hardening", () => {
   test("only treats literal not-found as confirmed unit absence", () => {
-    expect(source).toContain('if (!loadState) throw new Error("systemd service status could not be verified.");');
+    expect(systemdInstallCleanupStatus({ show: () => "LoadState=not-found\n" })).toBeNull();
+    expect(systemdInstallCleanupStatus({ show: () => "LoadState=loaded\n" })).toBe("loaded");
     expect(source).toContain('return loadState === "not-found" ? null : loadState;');
     expect(source).not.toContain('return !loadState || loadState === "not-found" ? null : loadState;');
+  });
+
+  test("uses the key/value output supported by systemd 219", () => {
+    const helper = source.slice(
+      source.indexOf("export function systemdInstallCleanupStatus"),
+      source.indexOf("function platformOps"),
+    );
+
+    expect(helper).toContain("systemctl --user show ${TASK} -p LoadState");
+    expect(helper).not.toContain("--value");
+  });
+
+  test("fails closed on missing, empty, or legacy bare-value output", () => {
+    for (const output of ["", "LoadState=\n", "not-found\n", "ActiveState=inactive\n"]) {
+      expect(() => systemdInstallCleanupStatus({ show: () => output }))
+        .toThrow("systemd service status could not be verified");
+    }
   });
 });


### PR DESCRIPTION
## Summary

- replace the Linux install-cleanup probe use of unsupported `systemctl --value` with the systemd-219-compatible `-p LoadState` form
- parse the explicit `LoadState=` key so only literal `not-found` proves absence
- keep empty, malformed, unrelated, and manager-failure output fail-closed
- add focused coverage for CentOS 7 style output and the unsafe malformed cases

Closes #2866.

## Why

CentOS 7.6 ships systemd 219. It supports property selection but not the later `--value` switch, so `ocx service install` failed during cleanup before it could install the unit. The existing service-manager probe already relies on key/value property output; this aligns the install path without weakening the cleanup ownership boundary.

## Verification

- `bun test tests/systemd-install-cleanup-hardening.test.ts tests/service.test.ts tests/codex-service-manager-probe.test.ts` — 200 pass, 0 fail on exact head `46a7a56bb`
- `git diff --check` — clean
- protected local OpenCodex/Codex/Paseo config hashes unchanged before and after tests
- `bun run typecheck` reports the same three pre-existing Bun fetch `timeout` typing errors on this head and exact base `e546c160b`; no new type error is introduced by this patch

## Scope

No user-facing command syntax or config changes. No Go counterpart is required: this is the TypeScript OS service-manager install path, which the current Go native runtime does not own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux service status detection for compatibility with older systemd versions.
  * Correctly distinguishes missing services from loaded services.
  * Prevents cleanup operations from proceeding when service status cannot be verified.

* **Tests**
  * Added coverage for loaded, missing, empty, legacy, and unsupported service status responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->