### PR TITLE
fix(codex): coalesce prompt probes and cancel abandoned probes

### DIFF
--- a/src/codex/prompt-text-probe.ts
+++ b/src/codex/prompt-text-probe.ts
@@ -105,6 +105,7 @@ interface ProbeCommand {
   args: string[];
   cwd: string;
   timeoutMs: number;
+  promptRevision: string | null;
 }
 
 interface PromptProbeFlight {
@@ -129,7 +130,13 @@ let probeSpawnAttemptsForTests = 0;
 let probeCloseBarrierForTests: Promise<void> | null = null;
 
 function commandKey(command: ProbeCommand): string {
-  return JSON.stringify([command.binary, command.args, command.cwd, command.timeoutMs]);
+  return JSON.stringify([
+    command.binary,
+    command.args,
+    command.cwd,
+    command.timeoutMs,
+    command.promptRevision,
+  ]);
 }
 
 function completedExecution(value: string | null): PromptProbeExecution {
@@ -358,7 +365,11 @@ export const extractSectionsForTests = extractSections;
  * `cwd` matters: AGENTS.md and environment context are directory-dependent, so a
  * probe from the wrong place would describe a prompt the user never sees.
  */
-export async function probePromptText(timeoutMs = 15_000, signal?: AbortSignal): Promise<PromptTextProbe> {
+export async function probePromptText(
+  timeoutMs = 15_000,
+  signal?: AbortSignal,
+  promptRevision: string | null = null,
+): Promise<PromptTextProbe> {
   // The probe runs in CODEX_HOME, never in a caller-supplied directory. A `cwd`
   // parameter let an authenticated request read any readable folder's AGENTS.md,
   // and it also described a prompt that depends on where Codex happened to run.
@@ -376,6 +387,7 @@ export async function probePromptText(timeoutMs = 15_000, signal?: AbortSignal):
     args: probeCommandForTests?.args ?? ["debug", "prompt-input"],
     cwd: codexHome,
     timeoutMs,
+    promptRevision,
   };
   const raw = await runSharedPromptProbe(command, signal);
   if (raw === null) {

--- a/src/codex/prompt-text-probe.ts
+++ b/src/codex/prompt-text-probe.ts
@@ -100,41 +100,217 @@ function resolveCodexBinary(): string | null {
 /** 8 MiB is far above any real prompt and far below anything that hurts the server. */
 const MAX_PROBE_OUTPUT_BYTES = 8 * 1024 * 1024;
 
-function runProbe(binary: string, cwd: string, timeoutMs: number): Promise<string | null> {
-  return new Promise(resolve => {
+interface ProbeCommand {
+  binary: string;
+  args: string[];
+  cwd: string;
+  timeoutMs: number;
+}
+
+interface PromptProbeFlight {
+  key: string;
+  controller: AbortController;
+  result: Promise<string | null>;
+  closed: Promise<void>;
+  waiters: number;
+  joinable: boolean;
+  resultSettled: boolean;
+  settled: boolean;
+}
+
+interface PromptProbeExecution {
+  result: Promise<string | null>;
+  closed: Promise<void>;
+}
+
+let activePromptProbe: PromptProbeFlight | null = null;
+let probeCommandForTests: { binary: string; args: string[] } | null = null;
+let probeSpawnAttemptsForTests = 0;
+let probeCloseBarrierForTests: Promise<void> | null = null;
+
+function commandKey(command: ProbeCommand): string {
+  return JSON.stringify([command.binary, command.args, command.cwd, command.timeoutMs]);
+}
+
+function completedExecution(value: string | null): PromptProbeExecution {
+  return { result: Promise.resolve(value), closed: Promise.resolve() };
+}
+
+function runProbe(
+  command: ProbeCommand,
+  signal: AbortSignal,
+  onStopping: () => void,
+): PromptProbeExecution {
+  if (signal.aborted) return completedExecution(null);
+  let resolveResult!: (value: string | null) => void;
+  let resolveClosed!: () => void;
+  const result = new Promise<string | null>(resolve => { resolveResult = resolve; });
+  const closed = new Promise<void>(resolve => { resolveClosed = resolve; });
+  let resultSettled = false;
+  let closeSettled = false;
+
+  const finishResult = (value: string | null) => {
+    if (resultSettled) return;
+    resultSettled = true;
+    resolveResult(value);
+  };
+  const finishClosed = () => {
+    if (closeSettled) return;
+    closeSettled = true;
+    resolveClosed();
+  };
+
+  try {
     // A probe must never hang OR balloon the management API: it is bounded in
     // time AND in bytes, and every failure degrades to "unavailable" rather than
     // an error page.
-    const child = spawn(binary, ["debug", "prompt-input"], {
-      cwd,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    let child: ReturnType<typeof spawn>;
+    try {
+      if (probeCommandForTests) probeSpawnAttemptsForTests += 1;
+      child = spawn(command.binary, command.args, {
+        cwd: command.cwd,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      finishResult(null);
+      finishClosed();
+      return { result, closed };
+    }
     const chunks: Buffer[] = [];
     let size = 0;
     let settled = false;
-    // One settlement path: a timeout that resolved before `close` used to leave
-    // the child streaming into a buffer nobody would ever read.
-    const settle = (value: string | null) => {
+    let stopping = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (value: string | null) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
-      child.stdout?.destroy();
-      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
-      resolve(value);
+      if (timer) clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      finishResult(value);
+      finishClosed();
     };
-    const timer = setTimeout(() => settle(null), timeoutMs);
+
+    // Keep the flight admitted until `close`: kill() only requests termination
+    // and does not prove the exact child has released its process and stdio.
+    const terminate = () => {
+      if (settled || stopping) return;
+      stopping = true;
+      onStopping();
+      if (timer) clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      child.stdout?.destroy();
+      // The caller is bounded even if OS termination later fails. Admission is
+      // retained separately by `closed`, and later probes fail soft while this
+      // exact child remains unproven terminal.
+      finishResult(null);
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Exact child state is ambiguous. Keep admission non-joinable until its
+        // own `close` proves terminal instead of targeting a reusable numeric PID.
+      }
+    };
+    const onAbort = () => terminate();
+
+    timer = setTimeout(terminate, command.timeoutMs);
+    signal.addEventListener("abort", onAbort, { once: true });
     child.stdout?.on("data", (chunk: Buffer) => {
       size += chunk.length;
-      if (size > MAX_PROBE_OUTPUT_BYTES) { settle(null); return; }
+      if (size > MAX_PROBE_OUTPUT_BYTES) { terminate(); return; }
       chunks.push(chunk);
     });
-    child.on("error", () => settle(null));
+    child.on("error", () => {
+      // No PID means spawn itself failed, so there is no live child to drain.
+      if (child.pid === undefined) {
+        finish(null);
+      }
+      else terminate();
+    });
     child.on("close", code => {
       // Decode once, at the end: `String(chunk)` per chunk corrupts any UTF-8
       // character that straddles a chunk boundary.
-      settle(code === 0 ? Buffer.concat(chunks).toString("utf8") : null);
+      const recordClose = () => {
+        finish(!stopping && code === 0 ? Buffer.concat(chunks).toString("utf8") : null);
+      };
+      const barrier = probeCloseBarrierForTests;
+      if (barrier) void barrier.then(recordClose, recordClose);
+      else recordClose();
     });
+    // Close the race between the pre-spawn check and listener registration.
+    if (signal.aborted) terminate();
+  } catch {
+    finishResult(null);
+    finishClosed();
+  }
+  return { result, closed };
+}
+
+function startPromptProbeFlight(command: ProbeCommand): PromptProbeFlight {
+  const controller = new AbortController();
+  const flight: PromptProbeFlight = {
+    key: commandKey(command),
+    controller,
+    result: Promise.resolve(null),
+    closed: Promise.resolve(),
+    waiters: 0,
+    joinable: true,
+    resultSettled: false,
+    settled: false,
+  };
+  const execution = runProbe(command, controller.signal, () => {
+    flight.joinable = false;
   });
+  flight.result = execution.result
+    .catch(() => null)
+    .finally(() => {
+      flight.resultSettled = true;
+    });
+  flight.closed = execution.closed
+    .finally(() => {
+      flight.settled = true;
+      if (activePromptProbe === flight) activePromptProbe = null;
+    });
+  activePromptProbe = flight;
+  return flight;
+}
+
+async function runSharedPromptProbe(command: ProbeCommand, signal?: AbortSignal): Promise<string | null> {
+  const key = commandKey(command);
+  if (signal?.aborted) return null;
+  const active = activePromptProbe;
+  if (!active) return waitForPromptProbeFlight(startPromptProbeFlight(command), signal);
+  if (active.key === key && active.joinable && !active.controller.signal.aborted) {
+    return waitForPromptProbeFlight(active, signal);
+  }
+  // A different or terminating flight still owns the sole process slot. Never
+  // wait unboundedly for an unproven close and never launch beside it.
+  return null;
+}
+
+async function waitForPromptProbeFlight(flight: PromptProbeFlight, signal?: AbortSignal): Promise<string | null> {
+  if (signal?.aborted) {
+    if (flight.waiters === 0 && !flight.settled) flight.controller.abort();
+    return null;
+  }
+  flight.waiters += 1;
+  let onAbort: (() => void) | undefined;
+  try {
+    if (!signal) return await flight.result;
+    const aborted = new Promise<null>(resolve => {
+      onAbort = () => resolve(null);
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) onAbort();
+    });
+    return await Promise.race([flight.result, aborted]);
+  } finally {
+    if (onAbort) signal?.removeEventListener("abort", onAbort);
+    flight.waiters = Math.max(0, flight.waiters - 1);
+    if (flight.waiters === 0 && !flight.resultSettled) {
+      flight.controller.abort(new DOMException("All prompt probe callers cancelled", "AbortError"));
+    }
+  }
 }
 
 /** Pull every `<tag>...</tag>` section out of the rendered developer messages. */
@@ -182,19 +358,33 @@ export const extractSectionsForTests = extractSections;
  * `cwd` matters: AGENTS.md and environment context are directory-dependent, so a
  * probe from the wrong place would describe a prompt the user never sees.
  */
-export async function probePromptText(timeoutMs = 15_000): Promise<PromptTextProbe> {
+export async function probePromptText(timeoutMs = 15_000, signal?: AbortSignal): Promise<PromptTextProbe> {
   // The probe runs in CODEX_HOME, never in a caller-supplied directory. A `cwd`
   // parameter let an authenticated request read any readable folder's AGENTS.md,
   // and it also described a prompt that depends on where Codex happened to run.
   // The global home is the one context this page can honestly report on.
   const codexHome = resolveCodexHomeDir();
-  const binary = resolveCodexBinary();
+  if (signal?.aborted) {
+    return { ok: false, codexHome, layers: {}, detail: "prompt probe cancelled" };
+  }
+  const binary = probeCommandForTests?.binary ?? resolveCodexBinary();
   if (!binary) {
     return { ok: false, codexHome, layers: {}, detail: "codex binary not found" };
   }
-  const raw = await runProbe(binary, codexHome, timeoutMs);
+  const command: ProbeCommand = {
+    binary,
+    args: probeCommandForTests?.args ?? ["debug", "prompt-input"],
+    cwd: codexHome,
+    timeoutMs,
+  };
+  const raw = await runSharedPromptProbe(command, signal);
   if (raw === null) {
-    return { ok: false, codexHome, layers: {}, detail: "codex debug prompt-input failed" };
+    return {
+      ok: false,
+      codexHome,
+      layers: {},
+      detail: signal?.aborted ? "prompt probe cancelled" : "codex debug prompt-input failed",
+    };
   }
   const sections = extractSections(raw);
   if (sections.size === 0) {
@@ -235,4 +425,36 @@ export async function probePromptText(timeoutMs = 15_000): Promise<PromptTextPro
     layers[id] ??= { text: null, reason: "not-exposed", bytes: 0 };
   }
   return { ok: true, codexHome, layers };
+}
+
+/** Test-only command seam; production always resolves the installed Codex binary. */
+export function setPromptTextProbeCommandForTests(command: { binary: string; args: string[] } | null): void {
+  probeCommandForTests = command ? { binary: command.binary, args: [...command.args] } : null;
+}
+
+/** Test-only process-start counter for proving admission without timing guesses. */
+export function promptTextProbeSpawnAttemptsForTests(): number {
+  return probeSpawnAttemptsForTests;
+}
+
+/** Test-only close barrier for proving admission is not released at process exit. */
+export function setPromptTextProbeCloseBarrierForTests(barrier: Promise<void> | null): void {
+  probeCloseBarrierForTests = barrier;
+}
+
+/** Test-only fail-closed drain so one failed lifecycle case cannot poison another. */
+export async function resetPromptTextProbeForTests(): Promise<void> {
+  const active = activePromptProbe;
+  if (active && !active.settled) {
+    active.controller.abort(new DOMException("Prompt probe test reset", "AbortError"));
+    const drained = await Promise.race([
+      active.closed.then(() => true),
+      Bun.sleep(2_000).then(() => false),
+    ]);
+    if (!drained) throw new Error("prompt probe child did not close during test reset");
+  }
+  if (activePromptProbe === active) activePromptProbe = null;
+  probeCommandForTests = null;
+  probeSpawnAttemptsForTests = 0;
+  probeCloseBarrierForTests = null;
 }

--- a/src/codex/prompt-text-probe.ts
+++ b/src/codex/prompt-text-probe.ts
@@ -124,6 +124,11 @@ interface PromptProbeExecution {
   closed: Promise<void>;
 }
 
+type SharedPromptProbeOutcome =
+  | { kind: "output"; raw: string }
+  | { kind: "failed" }
+  | { kind: "busy" };
+
 let activePromptProbe: PromptProbeFlight | null = null;
 let probeCommandForTests: { binary: string; args: string[] } | null = null;
 let probeSpawnAttemptsForTests = 0;
@@ -283,17 +288,24 @@ function startPromptProbeFlight(command: ProbeCommand): PromptProbeFlight {
   return flight;
 }
 
-async function runSharedPromptProbe(command: ProbeCommand, signal?: AbortSignal): Promise<string | null> {
+async function runSharedPromptProbe(
+  command: ProbeCommand,
+  signal?: AbortSignal,
+): Promise<SharedPromptProbeOutcome> {
   const key = commandKey(command);
-  if (signal?.aborted) return null;
+  if (signal?.aborted) return { kind: "failed" };
   const active = activePromptProbe;
-  if (!active) return waitForPromptProbeFlight(startPromptProbeFlight(command), signal);
+  if (!active) {
+    const raw = await waitForPromptProbeFlight(startPromptProbeFlight(command), signal);
+    return raw === null ? { kind: "failed" } : { kind: "output", raw };
+  }
   if (active.key === key && active.joinable && !active.controller.signal.aborted) {
-    return waitForPromptProbeFlight(active, signal);
+    const raw = await waitForPromptProbeFlight(active, signal);
+    return raw === null ? { kind: "failed" } : { kind: "output", raw };
   }
   // A different or terminating flight still owns the sole process slot. Never
   // wait unboundedly for an unproven close and never launch beside it.
-  return null;
+  return { kind: "busy" };
 }
 
 async function waitForPromptProbeFlight(flight: PromptProbeFlight, signal?: AbortSignal): Promise<string | null> {
@@ -389,15 +401,20 @@ export async function probePromptText(
     timeoutMs,
     promptRevision,
   };
-  const raw = await runSharedPromptProbe(command, signal);
-  if (raw === null) {
+  const outcome = await runSharedPromptProbe(command, signal);
+  if (outcome.kind !== "output") {
     return {
       ok: false,
       codexHome,
       layers: {},
-      detail: signal?.aborted ? "prompt probe cancelled" : "codex debug prompt-input failed",
+      detail: signal?.aborted
+        ? "prompt probe cancelled"
+        : outcome.kind === "busy"
+          ? "another prompt probe is still finishing; retry shortly"
+          : "codex debug prompt-input failed",
     };
   }
+  const raw = outcome.raw;
   const sections = extractSections(raw);
   if (sections.size === 0) {
     // Zero sections from a zero-exit probe means the output did not parse, which

--- a/src/server/management/codex-prompt-routes.ts
+++ b/src/server/management/codex-prompt-routes.ts
@@ -320,7 +320,7 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
     // A `cwd` parameter would have let any authenticated request read an arbitrary
     // folder's AGENTS.md through this endpoint.
     const { probePromptText } = await import("../../codex/prompt-text-probe");
-    return jsonResponse(await probePromptText(), 200, req, ctx.config);
+    return jsonResponse(await probePromptText(15_000, req.signal), 200, req, ctx.config);
   }
 
   if (url.pathname === "/api/codex-prompt/toggle" && req.method === "PUT") {

--- a/src/server/management/codex-prompt-routes.ts
+++ b/src/server/management/codex-prompt-routes.ts
@@ -320,7 +320,11 @@ export async function handleCodexPromptRoutes(ctx: ManagementContext): Promise<R
     // A `cwd` parameter would have let any authenticated request read an arbitrary
     // folder's AGENTS.md through this endpoint.
     const { probePromptText } = await import("../../codex/prompt-text-probe");
-    return jsonResponse(await probePromptText(15_000, req.signal), 200, req, ctx.config);
+    // A write can complete while an older probe is still running. Include the
+    // exact prompt-file revision in single-flight admission so a post-write read
+    // fails soft instead of joining and returning the pre-write result.
+    const promptRevision = readPromptLayers(paths(ctx)).revision;
+    return jsonResponse(await probePromptText(15_000, req.signal, promptRevision), 200, req, ctx.config);
   }
 
   if (url.pathname === "/api/codex-prompt/toggle" && req.method === "PUT") {

--- a/tests/codex-prompt-route.test.ts
+++ b/tests/codex-prompt-route.test.ts
@@ -884,7 +884,10 @@ describe("020 coverage completions", () => {
     writeFileSync(fx.configPath, "include_apps_instructions = true\n", "utf8");
 
     const afterWrite = await call("GET", "/api/codex-prompt/text", fx);
-    expect(afterWrite.body).toMatchObject({ ok: false, detail: "codex debug prompt-input failed" });
+    expect(afterWrite.body).toMatchObject({
+      ok: false,
+      detail: "another prompt probe is still finishing; retry shortly",
+    });
     expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
     expect((await beforeWrite).body.ok).toBe(true);
 

--- a/tests/codex-prompt-route.test.ts
+++ b/tests/codex-prompt-route.test.ts
@@ -12,6 +12,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleManagementAPI } from "../src/server/management-api";
 import { LAYER_INVENTORY, readPromptLayers } from "../src/codex/prompt-layers";
+import {
+  promptTextProbeSpawnAttemptsForTests,
+  resetPromptTextProbeForTests,
+  setPromptTextProbeCommandForTests,
+} from "../src/codex/prompt-text-probe";
 import type { ManagementPrincipal } from "../src/server/management-auth";
 import type { OcxConfig } from "../src/types";
 
@@ -62,6 +67,23 @@ function ownedConfig(projection: string): string {
 
 function read(path: string): string | null {
   return existsSync(path) ? readFileSync(path, "utf8") : null;
+}
+
+async function waitUntil(predicate: () => boolean, detail: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${detail}`);
+    await Bun.sleep(10);
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -117,7 +139,8 @@ async function revision(fx: Fixture): Promise<string> {
   return res.body.revision as string;
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await resetPromptTextProbeForTests();
   while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
 });
 
@@ -798,6 +821,46 @@ describe("020 coverage completions", () => {
     expect(probe).toContain("if (settled) return;");
     // Decoding per chunk corrupts UTF-8 that straddles a chunk boundary.
     expect(probe).toContain("Buffer.concat(chunks).toString(\"utf8\")");
+  });
+
+  test("27. the text route forwards live request cancellation to its exact child", async () => {
+    const fx = fixture("");
+    const pidPath = join(fx.decoyHome, "probe-pid.txt");
+    setPromptTextProbeCommandForTests({
+      binary: process.execPath,
+      args: ["-e", [
+        `require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+        "setInterval(() => {}, 1_000);",
+      ].join("")],
+    });
+    const controller = new AbortController();
+    const url = new URL("http://127.0.0.1:10100/api/codex-prompt/text");
+    const req = new Request(url, {
+      method: "GET",
+      headers: { host: "127.0.0.1:10100" },
+      signal: controller.signal,
+    });
+    const previousHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = fx.decoyHome;
+    let res: Response | null = null;
+    try {
+      const pending = handleManagementAPI(req, url, config, {
+        codexPromptPaths: { configPath: fx.configPath, storePath: fx.storePath, baseVariantDir: fx.baseVariantDir },
+      }, "gui-session");
+      await waitUntil(() => existsSync(pidPath), "route probe child pid");
+      controller.abort();
+      res = await pending;
+    } finally {
+      if (previousHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousHome;
+    }
+
+    expect(res?.status).toBe(200);
+    expect(await res?.json()).toMatchObject({ ok: false, detail: "prompt probe cancelled" });
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
+    const pid = Number(readFileSync(pidPath, "utf8"));
+    await waitUntil(() => !isProcessAlive(pid), "route probe child exit");
+    expectDecoyUntouched(fx);
   });
   test("24. every ownership state is named, not collapsed into a boolean", async () => {
     // developerInstructionsOwned:false covers an ABSENT key and an EXTERNAL one, and

--- a/tests/codex-prompt-route.test.ts
+++ b/tests/codex-prompt-route.test.ts
@@ -810,7 +810,7 @@ describe("020 coverage completions", () => {
     const probe = await Bun.file(new URL("../src/codex/prompt-text-probe.ts", import.meta.url)).text();
     // The probe resolves CODEX_HOME itself; it must not accept a directory.
     expect(probe).toContain("resolveCodexHomeDir()");
-    expect(probe).toMatch(/export async function probePromptText\(timeoutMs/);
+    expect(probe).toMatch(/export async function probePromptText\(\s*timeoutMs/);
   });
 
   test("26. the probe is bounded in bytes as well as in time", async () => {
@@ -862,6 +862,37 @@ describe("020 coverage completions", () => {
     await waitUntil(() => !isProcessAlive(pid), "route probe child exit");
     expectDecoyUntouched(fx);
   });
+
+  test("28. a post-write text read never joins a pre-write probe", async () => {
+    const fx = fixture("include_apps_instructions = false\n");
+    const startedPath = join(fx.decoyHome, "revision-probe-started.txt");
+    const probeOutput = JSON.stringify([{
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "<skills_instructions>Skill text.</skills_instructions>" }],
+    }]);
+    setPromptTextProbeCommandForTests({
+      binary: process.execPath,
+      args: ["-e", [
+        `require("node:fs").writeFileSync(${JSON.stringify(startedPath)}, "started");`,
+        `setTimeout(() => process.stdout.write(${JSON.stringify(probeOutput)}), 200);`,
+      ].join("")],
+    });
+
+    const beforeWrite = call("GET", "/api/codex-prompt/text", fx);
+    await waitUntil(() => existsSync(startedPath), "pre-write probe start");
+    writeFileSync(fx.configPath, "include_apps_instructions = true\n", "utf8");
+
+    const afterWrite = await call("GET", "/api/codex-prompt/text", fx);
+    expect(afterWrite.body).toMatchObject({ ok: false, detail: "codex debug prompt-input failed" });
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
+    expect((await beforeWrite).body.ok).toBe(true);
+
+    const fresh = await call("GET", "/api/codex-prompt/text", fx);
+    expect(fresh.body.ok).toBe(true);
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(2);
+  });
+
   test("24. every ownership state is named, not collapsed into a boolean", async () => {
     // developerInstructionsOwned:false covers an ABSENT key and an EXTERNAL one, and
     // a GUI that cannot tell them apart hides its own create affordance from every

--- a/tests/codex-prompt-text-probe.test.ts
+++ b/tests/codex-prompt-text-probe.test.ts
@@ -180,6 +180,7 @@ describe("prompt probe process lifecycle", () => {
     const blockedDuringDrain = await probePromptText(2_000);
 
     expect(blockedDuringDrain.ok).toBe(false);
+    expect(blockedDuringDrain.detail).toBe("another prompt probe is still finishing; retry shortly");
     expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
     await resetPromptTextProbeForTests();
     setPromptTextProbeCommandForTests({ binary: process.execPath, args: ["-e", replacementSource] });
@@ -213,6 +214,7 @@ describe("prompt probe process lifecycle", () => {
     const blockedBeforeClose = await probePromptText(2_000);
 
     expect(blockedBeforeClose.ok).toBe(false);
+    expect(blockedBeforeClose.detail).toBe("another prompt probe is still finishing; retry shortly");
     expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
     releaseClose();
     expect((await first).ok).toBe(true);

--- a/tests/codex-prompt-text-probe.test.ts
+++ b/tests/codex-prompt-text-probe.test.ts
@@ -6,12 +6,57 @@
  * that a missing body is attributed to the right cause, because the dialog shows
  * that attribution to a user as an explanation.
  */
-import { describe, expect, test } from "bun:test";
-import { extractSectionsForTests } from "../src/codex/prompt-text-probe";
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  extractSectionsForTests,
+  probePromptText,
+  promptTextProbeSpawnAttemptsForTests,
+  resetPromptTextProbeForTests,
+  setPromptTextProbeCloseBarrierForTests,
+  setPromptTextProbeCommandForTests,
+} from "../src/codex/prompt-text-probe";
+
+const lifecycleRoots: string[] = [];
+const VALID_PROBE_OUTPUT = JSON.stringify([{
+  type: "message",
+  role: "developer",
+  content: [{ type: "input_text", text: "<skills_instructions>Skill text.</skills_instructions>" }],
+}]);
 
 function message(text: string): string {
   return JSON.stringify([{ type: "message", role: "developer", content: [{ type: "input_text", text }] }]);
 }
+
+async function waitUntil(predicate: () => boolean, detail: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${detail}`);
+    await Bun.sleep(10);
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function root(): string {
+  const path = mkdtempSync(join(tmpdir(), "ocx-prompt-probe-"));
+  lifecycleRoots.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await resetPromptTextProbeForTests();
+  while (lifecycleRoots.length) rmSync(lifecycleRoots.pop()!, { recursive: true, force: true });
+});
 
 describe("section extraction", () => {
   test("a tag name containing a space is still matched", () => {
@@ -66,5 +111,111 @@ describe("section extraction", () => {
     const sections = extractSectionsForTests(raw);
     expect(sections.has("div")).toBe(false);
     expect(sections.get("__agents_md")).toContain("<div>");
+  });
+});
+
+describe("prompt probe process lifecycle", () => {
+  test("a pre-aborted caller starts no child", async () => {
+    const marker = join(root(), "started.txt");
+    setPromptTextProbeCommandForTests({
+      binary: process.execPath,
+      args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "started")`],
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await probePromptText(2_000, controller.signal);
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBe("prompt probe cancelled");
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("concurrent callers share one child and one caller may cancel", async () => {
+    const started = join(root(), "started.txt");
+    const source = [
+      `require("node:fs").appendFileSync(${JSON.stringify(started)}, "1\\n");`,
+      `setTimeout(() => process.stdout.write(${JSON.stringify(VALID_PROBE_OUTPUT)}), 150);`,
+    ].join("");
+    setPromptTextProbeCommandForTests({ binary: process.execPath, args: ["-e", source] });
+    const controller = new AbortController();
+
+    const first = probePromptText(2_000, controller.signal);
+    const second = probePromptText(2_000);
+    controller.abort();
+
+    expect((await first).detail).toBe("prompt probe cancelled");
+    expect((await second).ok).toBe(true);
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
+    expect(readFileSync(started, "utf8").trim().split(/\r?\n/)).toHaveLength(1);
+  });
+
+  test("the last cancellation drains the exact child before another command starts", async () => {
+    const dir = root();
+    const pidPath = join(dir, "pid.txt");
+    const overlapPath = join(dir, "overlap.txt");
+    const hangingSource = [
+      `require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+      "setInterval(() => {}, 1_000);",
+    ].join("");
+    setPromptTextProbeCommandForTests({ binary: process.execPath, args: ["-e", hangingSource] });
+    const controller = new AbortController();
+    const hanging = probePromptText(5_000, controller.signal);
+    await waitUntil(() => existsSync(pidPath), "hanging child pid");
+    const pid = Number(readFileSync(pidPath, "utf8"));
+    expect(isProcessAlive(pid)).toBe(true);
+
+    controller.abort();
+    expect((await hanging).detail).toBe("prompt probe cancelled");
+
+    const replacementSource = [
+      `const fs = require("node:fs"); const pid = Number(fs.readFileSync(${JSON.stringify(pidPath)}, "utf8"));`,
+      `try { process.kill(pid, 0); fs.writeFileSync(${JSON.stringify(overlapPath)}, "overlap"); } catch {}`,
+      `process.stdout.write(${JSON.stringify(VALID_PROBE_OUTPUT)});`,
+    ].join("");
+    setPromptTextProbeCommandForTests({ binary: process.execPath, args: ["-e", replacementSource] });
+    const blockedDuringDrain = await probePromptText(2_000);
+
+    expect(blockedDuringDrain.ok).toBe(false);
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
+    await resetPromptTextProbeForTests();
+    setPromptTextProbeCommandForTests({ binary: process.execPath, args: ["-e", replacementSource] });
+    const replacement = await probePromptText(2_000);
+
+    expect(replacement.ok).toBe(true);
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
+    expect(existsSync(overlapPath)).toBe(false);
+    await waitUntil(() => !isProcessAlive(pid), "cancelled child exit");
+  });
+
+  test("admission stays occupied between child exit and close handling", async () => {
+    const pidPath = join(root(), "exited-parent-pid.txt");
+    let releaseClose!: () => void;
+    setPromptTextProbeCloseBarrierForTests(new Promise<void>(resolve => { releaseClose = resolve; }));
+    const delayedCloseSource = [
+      `const fs = require("node:fs");`,
+      `fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+      `process.stdout.write(${JSON.stringify(VALID_PROBE_OUTPUT)});`,
+    ].join("");
+    setPromptTextProbeCommandForTests({ binary: process.execPath, args: ["-e", delayedCloseSource] });
+    const first = probePromptText(2_000);
+    await waitUntil(() => existsSync(pidPath), "exit-close parent pid");
+    const pid = Number(readFileSync(pidPath, "utf8"));
+    await waitUntil(() => !isProcessAlive(pid), "probe parent exit");
+
+    setPromptTextProbeCommandForTests({
+      binary: process.execPath,
+      args: ["-e", `process.stdout.write(${JSON.stringify(VALID_PROBE_OUTPUT)})`],
+    });
+    const blockedBeforeClose = await probePromptText(2_000);
+
+    expect(blockedBeforeClose.ok).toBe(false);
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(1);
+    releaseClose();
+    expect((await first).ok).toBe(true);
+    const afterClose = await probePromptText(2_000);
+    expect(afterClose.ok).toBe(true);
+    expect(promptTextProbeSpawnAttemptsForTests()).toBe(2);
   });
 });

--- a/tests/codex-prompt-text-probe.test.ts
+++ b/tests/codex-prompt-text-probe.test.ts
@@ -171,7 +171,9 @@ describe("prompt probe process lifecycle", () => {
 
     const replacementSource = [
       `const fs = require("node:fs"); const pid = Number(fs.readFileSync(${JSON.stringify(pidPath)}, "utf8"));`,
-      `try { process.kill(pid, 0); fs.writeFileSync(${JSON.stringify(overlapPath)}, "overlap"); } catch {}`,
+      "let priorProbeAlive = true;",
+      "try { process.kill(pid, 0); } catch { priorProbeAlive = false; }",
+      `if (priorProbeAlive) fs.writeFileSync(${JSON.stringify(overlapPath)}, "overlap");`,
       `process.stdout.write(${JSON.stringify(VALID_PROBE_OUTPUT)});`,
     ].join("");
     setPromptTextProbeCommandForTests({ binary: process.execPath, args: ["-e", replacementSource] });


### PR DESCRIPTION
## Summary

- Coalesce concurrent prompt-text probes into one shared Codex child instead of launching a duplicate process for every management request.
- Let one caller cancel without interrupting surviving callers, while canceling the exact direct child when the last waiter leaves.
- Keep the single-flight slot occupied until that child emits `close`, and key admission by the current prompt revision so post-write reads never join a stale probe.
- Forward HTTP request cancellation into the probe lifecycle.

## Verification

- `bun test tests/codex-prompt-text-probe.test.ts tests/codex-prompt-route.test.ts` — 62 pass, 0 fail on Bun `1.4.0+34cbb9a40` at the current head.
- `bun run typecheck`
- `bun run privacy:scan`
- `git diff origin/dev..HEAD --check`
- Independent concurrency, process-lifecycle, and test-scope audits found no actionable P0–P2 issue before publication; the subsequent Codex stale-revision finding was fixed and regression-tested.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prompt text checks now support cancellation and stop promptly when a request is aborted.
  - Concurrent requests can safely share an in-progress check, while changes to prompt settings trigger a fresh check.
  - Improved handling of failed or interrupted prompt checks for more reliable results.

- **Tests**
  - Added coverage for cancellation, concurrent requests, process cleanup, and prompt updates during active checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->