### PR TITLE
fix(codex): match codex.opencodex-real launcher backups in app-server restarts

### DIFF
--- a/devlog/_plan/260829_restart_codex_shim_backup/000_repro_and_root_cause.md
+++ b/devlog/_plan/260829_restart_codex_shim_backup/000_repro_and_root_cause.md
@@ -9,7 +9,7 @@ reports zero app-server processes stopped, leaving long-lived app-servers holdin
 
 `ps -ef` on the affected host:
 
-```
+```text
 ubuntu  3600609  1  0 04:35 ?  /home/ubuntu/.local/bin/codex.opencodex-real -c features.code_mode_host=true app-server --listen unix://
 ```
 

--- a/devlog/_plan/260829_restart_codex_shim_backup/000_repro_and_root_cause.md
+++ b/devlog/_plan/260829_restart_codex_shim_backup/000_repro_and_root_cause.md
@@ -1,0 +1,26 @@
+# 000 — `--restart-codex` misses `codex.opencodex-real` shim backup binaries
+
+## The report
+
+On remote hosts where Codex autostart shim is installed (`~/.local/bin/codex`), running `ocx sync --restart-codex`
+reports zero app-server processes stopped, leaving long-lived app-servers holding stale in-memory model catalogs.
+
+## What is actually running there
+
+`ps -ef` on the affected host:
+
+```
+ubuntu  3600609  1  0 04:35 ?  /home/ubuntu/.local/bin/codex.opencodex-real -c features.code_mode_host=true app-server --listen unix://
+```
+
+## The defect
+
+`isCodexExecutableToken` in `src/codex/app-server-processes.ts` checked only `codex`, `codex.exe`, `codex.cmd`,
+and Rust target triples. When the autostart shim moves the original launcher to `codex.opencodex-real`,
+the process command line starts with `codex.opencodex-real` and fails `isCodexExecutableToken`, so `--restart-codex`
+ignores it entirely.
+
+## The fix
+
+Admit `codex.opencodex-real`, `codex.opencodex-real.exe`, and `codex.opencodex-real.cmd` in `isCodexExecutableToken`
+and in `WINDOWS_CODEX_BASENAME_CANDIDATE_RE`.

--- a/src/codex/app-server-processes.ts
+++ b/src/codex/app-server-processes.ts
@@ -46,7 +46,7 @@ const CODEX_TARGET_TRIPLE_BODY = "[a-z0-9_]+-[a-z0-9_]+-[a-z0-9_]+(?:-[a-z0-9_]+
  * `codex-x86_64-pc-windows-msvc.exe`.
  */
 export const WINDOWS_CODEX_BASENAME_CANDIDATE_RE = new RegExp(
-  `(^|[/\\\\\\s'"=])codex(-${CODEX_TARGET_TRIPLE_BODY})?([.]exe|[.]cmd)?['"]?(\\s|$)`,
+  `(^|[/\\\\\\s'"=])codex([.]opencodex-real)?(-${CODEX_TARGET_TRIPLE_BODY})?([.]exe|[.]cmd)?['"]?(\\s|$)`,
   "i",
 );
 
@@ -159,6 +159,8 @@ function tokenBasename(token: string): string {
 function isCodexExecutableToken(token: string): boolean {
   const base = tokenBasename(token);
   return base === "codex" || base === "codex.exe" || base === "codex.cmd"
+    || base === "codex.opencodex-real" || base === "codex.opencodex-real.exe"
+    || base === "codex.opencodex-real.cmd"
     || CODEX_TARGET_TRIPLE_BASENAME_RE.test(base);
 }
 

--- a/tests/codex-app-server-processes.test.ts
+++ b/tests/codex-app-server-processes.test.ts
@@ -398,6 +398,18 @@ describe("Codex app-server process matching (#476)", () => {
   });
 
 
+  test("matches codex.opencodex-real launcher backup binaries and wrappers", () => {
+    expect(isCodexAppServerCommandLine("/home/ubuntu/.local/bin/codex.opencodex-real app-server proxy")).toBe(true);
+    expect(isCodexAppServerCommandLine(
+      "/home/ubuntu/.local/bin/codex.opencodex-real -c features.code_mode_host=true app-server --listen unix://",
+    )).toBe(true);
+    expect(isCodexAppServerCommandLine("C:\\Users\\a\\AppData\\codex.opencodex-real.exe app-server --listen pipe")).toBe(true);
+    expect(isCodexAppServerCommandLine("\"C:\\Program Files\\nodejs\\codex.opencodex-real.cmd\" app-server")).toBe(true);
+    expect(isCodexAppServerCommandLine("node /usr/local/bin/codex.opencodex-real app-server proxy")).toBe(true);
+    expect(isCodexAppServerCommandLine("codex.opencodex-real exec 'hello'")).toBe(false);
+    expect(isCodexAppServerCommandLine("node worker.js codex.opencodex-real app-server")).toBe(false);
+  });
+
   test("matches the npm wrapper that supervises the native app-server", () => {
     // The shape that made `ocx sync --restart-codex` report a survivor on Linux. An
     // npm-installed Codex runs as a PAIR: `node /usr/local/bin/codex app-server` and
@@ -491,6 +503,12 @@ describe("Codex app-server process matching (#476)", () => {
     )).toBe(true);
     expect(isWindowsCodexCandidateCommandLine(
       "C:\\Users\\a\\.codex\\bin\\codex-aarch64-pc-windows-msvc.exe app-server",
+    )).toBe(true);
+    expect(isWindowsCodexCandidateCommandLine(
+      "C:\\Users\\a\\.local\\bin\\codex.opencodex-real.exe app-server",
+    )).toBe(true);
+    expect(isWindowsCodexCandidateCommandLine(
+      "\"C:\\Program Files\\Codex\\codex.opencodex-real.cmd\" app-server",
     )).toBe(true);
     // Stay narrow: incidental "opencodex" paths must not pay GetOwner.
     expect(isWindowsCodexCandidateCommandLine(


### PR DESCRIPTION
## Summary

- Fix `--restart-codex` process matcher overlooking `codex.opencodex-real` launcher backup binaries and wrappers.
- On remote hosts where the Codex autostart launcher shim is installed (`~/.local/bin/codex`), the original binary is renamed to `codex.opencodex-real`. When ChatGPT Desktop or SSH sessions launch `codex app-server`, the command line starts with `codex.opencodex-real`.
- `isCodexExecutableToken` previously matched only `codex`, `codex.exe`, `codex.cmd`, and target triples, causing `ocx sync --restart-codex` to miss running app-servers on shim-managed hosts and leaving stale in-memory model catalogs.
- Admitted `codex.opencodex-real`, `codex.opencodex-real.exe`, and `codex.opencodex-real.cmd` into `isCodexExecutableToken` and `WINDOWS_CODEX_BASENAME_CANDIDATE_RE`.

## Verification

- Added unit test assertions in `tests/codex-app-server-processes.test.ts` for Unix and Windows `codex.opencodex-real` command lines.
- `bun test tests/codex-app-server-processes.test.ts` (55 pass, 0 fail).
- `bun run typecheck` clean (0 errors).
- `bun test tests/core-lab-boundary.test.ts` (17 pass, 0 fail).

## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex process detection on Windows to recognize backup launcher variants, including `.exe` and `.cmd` forms.
  - `ocx sync --restart-codex` can now reliably find and stop app-server processes launched through these backup binaries.
  - Improved handling of quoted paths, command-line flags, and Node-based launcher invocations while avoiding unrelated processes.

- **Documentation**
  - Added root-cause analysis and remediation notes for the Codex restart issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->