### PR TITLE
fix(gui): cap the log table against the dynamic viewport

### DIFF
--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -763,6 +763,16 @@ a.btn, a.btn:hover { text-decoration: none; }
 }
 /* Refresh icon spins while a sync is in flight (the `.spin` keyframes already exist). */
 .spin-icon { animation: spin 0.9s linear infinite; }
+/* The width cap needs two classes to beat `.notice { max-width: var(--prose-measure) }`,
+   which every toast also carries and which is declared LATER in this file. At equal
+   specificity source order won, so the toast resolved to 70ch (542px) rather than its
+   design width — visible as a toast wider than intended at desktop sizes. */
+.action-toast.notice {
+  /* Both halves of the original cap have to be restated here, not just the design width:
+     dropping the viewport term let the toast run to the screen edge at narrow widths
+     (measured left=0 at 430px, losing the 24px inset the right side keeps). */
+  max-width: min(480px, calc(100vw - 48px));
+}
 /* Toast dismiss affordance: quiet ghost button inside the notice row. */
 .action-toast-dismiss {
   flex: none;
@@ -2000,7 +2010,12 @@ table.logs-table {
 
 .logs-table-wrap {
   overflow-y: auto;
-  max-height: calc(100vh - 260px);
+  /* `dvh`, not `vh`: static `vh` resolves against the LARGE viewport, so on mobile the
+     cap is computed for a viewport taller than the one the user can see and the last rows
+     sit under the browser chrome. The rest of the shell already moved to `100dvh`
+     (see .app, .sidebar, .main-inner--combos, and the mobile drawer), so this was the
+     outlier rather than the convention. */
+  max-height: calc(100dvh - 260px);
 }
 
 .logs-table thead {


### PR DESCRIPTION
## Summary

Stacked on **#2902** — targets `codex/gui-sidecar-pair-alignment` and will be retargeted to `dev` once the parent lands.

Two GUI sizing fixes found while auditing the dashboard for viewport-dependent layout defects.

**`.logs-table-wrap` capped its scroll height with `calc(100vh - 260px)`.** Static `vh` resolves against the *large* viewport, so on mobile the cap is computed for a viewport taller than the one the user can actually see and the last rows end up under the browser chrome. It is now `100dvh`, which is what the rest of the shell already uses — `.app`, `.sidebar`, `.main-inner--combos` and the mobile drawer are all `100dvh`, so this line was the outlier rather than the convention.

**The corner toast's width cap never applied.** `.action-toast` sets `max-width: min(480px, calc(100vw - 48px))`, but every toast also carries `.notice`, which sets `max-width: var(--prose-measure)` (70ch = 542px) and is declared *later* in the same file. Both selectors are specificity 0,1,0, so source order won and a long toast rendered **542px instead of 480px**. The cap is now `.action-toast.notice`.

That fix needed one correction during verification: my first version set only `max-width: 480px`, which dropped the viewport term and let the toast run to the screen edge at narrow widths (measured `left=0` at 430px, against the 24px inset the right side keeps). It restates both halves of the original expression.

## Verification

Measured in a real browser via CDP by synthesizing both toast variants and the log container, comparing the previous rules against the new ones at three widths:

| width | before | after | right inset | overflow |
|-------|--------|-------|-------------|----------|
| 1440 | 480px | 480px | 24px | none |
| 430 | 382px | 382px | 24px | none |
| 360 | 312px | 312px | 24px | none |

Identical at every width — the specificity fix is behaviour-preserving for the cases the old rule already handled, and only changes the long-message case it silently lost. Log cap resolves to 540px at an 800px viewport, inside the visual viewport.

Gates on a remote Linux host, against this exact commit:

- `cd gui && bun test tests` — **1090 pass / 0 fail**
- `bun run typecheck` — rc=0
- `bun run lint:gui` — rc=0

### Screenshot

Corner toast at 1440px with a long message, after the fix (480px, 24px inset):

<img src="https://raw.githubusercontent.com/lidge-jun/opencodex/assets/gui-sidecar-pair-260829/shots/toast-after-1440.png" width="520">

### What I deliberately did not change

The `calc(100vw - Npx)` terms are theoretically wrong — `vw` includes the space a classic scrollbar occupies, so the subtraction can leave an element wider than the visible area. I could not demonstrate it: in this environment `innerWidth` and `clientWidth` never diverged (overlay scrollbars), and rewriting the caps against the containing block changed no measured geometry. I reverted that part rather than ship an unverifiable change. Worth revisiting on a platform with space-taking scrollbars.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

One stylesheet, two rules; no runtime, routing, auth, or release paths touched.
