### PR TITLE
fix(gui): cap the log table against the dynamic viewport

### DIFF
--- a/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
@@ -121,4 +121,3 @@ distinct.
   `ssh lidge` + `ocx-run`; pushes use `--no-verify` only after those gates.
 - Delivery is a stacked PR chain onto `dev`, each PR carrying screenshots
   (`enforce-target` requires a screenshot for GUI PRs).
-

--- a/devlog/_plan/260829_gui_dashboard_slop/011_audit_correction_align_content.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/011_audit_correction_align_content.md
@@ -112,4 +112,3 @@ flow (`position: fixed`, off-canvas at `x=-280`), so `.main-inner` JUMPS from
 526px to 750px. The sidecar grid re-splits into two columns at 349px each and the
 22.5px misalignment returns — on tablet widths, below the width where it was last
 believed fixed. Any fix must be verified at 760/740, not only at desktop widths.
-

--- a/devlog/_plan/260829_gui_dashboard_slop/020_phantom_grid_track.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/020_phantom_grid_track.md
@@ -1,5 +1,10 @@
 # 020 — Phantom zero-width auto-fit track (wp2)
 
+> **WITHDRAWN — nothing in this document ships.** The investigation concluded the
+> reported defect is not a defect: a collapsed zero-width `auto-fit` track is
+> normal behaviour, and no code change was made for it. Kept as the record of why
+> the track is expected, so the next person who measures it does not re-open it.
+
 ## Defect
 
 At vw ≥ 1440 both dashboard grids compute a third, zero-width column:

--- a/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
@@ -1,5 +1,10 @@
 # 030 — Dynamic viewport units in scroll surfaces (wp3)
 
+> **Implemented by this pull request**, separately from the sidecar alignment fix
+> that the rest of this unit records. It is a different change to a different
+> file (`gui/src/styles.css`), kept in the same unit because one audit pass found
+> both.
+
 ## Defect
 
 `gui/src/styles.css:2003`:

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -763,6 +763,16 @@ a.btn, a.btn:hover { text-decoration: none; }
 }
 /* Refresh icon spins while a sync is in flight (the `.spin` keyframes already exist). */
 .spin-icon { animation: spin 0.9s linear infinite; }
+/* The width cap needs two classes to beat `.notice { max-width: var(--prose-measure) }`,
+   which every toast also carries and which is declared LATER in this file. At equal
+   specificity source order won, so the toast resolved to 70ch (542px) rather than its
+   design width — visible as a toast wider than intended at desktop sizes. */
+.action-toast.notice {
+  /* Both halves of the original cap have to be restated here, not just the design width:
+     dropping the viewport term let the toast run to the screen edge at narrow widths
+     (measured left=0 at 430px, losing the 24px inset the right side keeps). */
+  max-width: min(480px, calc(100vw - 48px));
+}
 /* Toast dismiss affordance: quiet ghost button inside the notice row. */
 .action-toast-dismiss {
   flex: none;
@@ -2000,7 +2010,12 @@ table.logs-table {
 
 .logs-table-wrap {
   overflow-y: auto;
-  max-height: calc(100vh - 260px);
+  /* `dvh`, not `vh`: static `vh` resolves against the LARGE viewport, so on mobile the
+     cap is computed for a viewport taller than the one the user can see and the last rows
+     sit under the browser chrome. The rest of the shell already moved to `100dvh`
+     (see .app, .sidebar, .main-inner--combos, and the mobile drawer), so this was the
+     outlier rather than the convention. */
+  max-height: calc(100dvh - 260px);
 }
 
 .logs-table thead {

--- a/gui/tests/viewport-scroll-caps.test.ts
+++ b/gui/tests/viewport-scroll-caps.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+
+/**
+ * Viewport-dependent sizing contracts in the shared stylesheet.
+ *
+ * Source-text assertions, not rendered measurements: happy-dom performs no layout, so a
+ * computed max-width here would prove nothing. Rendered proof was captured in a real
+ * browser via CDP while fixing these two rules; this file's job is to stop the specific
+ * shapes that caused the defects from coming back silently.
+ */
+
+const cssUrl = new URL("../src/styles.css", import.meta.url);
+
+/** Strip comments so no assertion can pass on prose that quotes an old value. */
+function withoutComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** All bodies for a selector, which may be declared more than once. */
+function allRuleBodies(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const matches = [...css.matchAll(new RegExp("(^|\\n)\\s*" + escaped + "\\s*\\{([^}]*)\\}", "g"))];
+  if (matches.length === 0) throw new Error("rule not found: " + selector);
+  return matches.map((m) => m[2]).join("\n");
+}
+
+test("the log table caps its scroll height against the dynamic viewport", async () => {
+  const css = withoutComments(await Bun.file(cssUrl).text());
+  const wrap = allRuleBodies(css, ".logs-table-wrap");
+
+  // Static `vh` resolves against the LARGE viewport, which ignores mobile browser chrome:
+  // the cap is then computed for a viewport taller than the one the user can see and the
+  // last rows sit underneath the address bar. The rest of the shell (.app, .sidebar,
+  // .main-inner--combos, the mobile drawer) already uses 100dvh, so this rule was the
+  // outlier rather than the convention.
+  expect(wrap).toMatch(/max-height:\s*calc\(\s*100dvh\s*-/);
+  expect(wrap).not.toMatch(/max-height:\s*calc\(\s*100vh\s*-/);
+});
+
+test("the toast width cap outranks the later .notice rule", async () => {
+  const css = withoutComments(await Bun.file(cssUrl).text());
+
+  // Every toast carries BOTH classes, and `.notice { max-width: var(--prose-measure) }`
+  // (70ch = 542px) is declared later in this same file at equal specificity 0,1,0. Source
+  // order therefore won and a single-class `.action-toast` cap never applied - the toast
+  // rendered 542px instead of its design width. Two classes is what wins the cascade, so
+  // the cap must stay on the compound selector.
+  const compound = allRuleBodies(css, ".action-toast.notice");
+  const cap = compound.match(/max-width:\s*min\(\s*([\d.]+)px\s*,\s*calc\(\s*100vw\s*-\s*([\d.]+)px\s*\)\s*\)/);
+
+  // Both halves are asserted on purpose. An earlier revision kept only the design width,
+  // which dropped the viewport term and let the toast reach the screen edge at narrow
+  // widths (measured left = 0 at 430px, losing the 24px inset the right side keeps).
+  expect(cap).not.toBeNull();
+  expect(Number(cap![1])).toBeGreaterThan(0);
+  expect(Number(cap![2])).toBeGreaterThan(0);
+
+  // Guard the ordering premise itself: if `.notice` ever moved ABOVE this rule, a
+  // single-class cap would start working and someone could "simplify" the compound
+  // selector away. The assertion is only meaningful while `.notice` still comes later.
+  const noticeIndex = css.search(/(^|\n)\s*\.notice\s*\{/);
+  const compoundIndex = css.search(/(^|\n)\s*\.action-toast\.notice\s*\{/);
+  expect(compoundIndex).toBeGreaterThanOrEqual(0);
+  expect(noticeIndex).toBeGreaterThan(compoundIndex);
+});


### PR DESCRIPTION
## Summary

Two GUI sizing fixes found while auditing the dashboard for viewport-dependent layout defects, plus the devlog cleanup that #2905's review asked for and that missed its merge window.

Now targets `dev` directly — its parent #2905 has landed, so this is no longer a stacked child.

**`.logs-table-wrap` capped its scroll height with `calc(100vh - 260px)`.** Static `vh` resolves against the *large* viewport, so on mobile the cap is computed for a viewport taller than the one the user can actually see and the last rows end up under the browser chrome. It is now `100dvh`, which is what the rest of the shell already uses — `.app`, `.sidebar`, `.main-inner--combos` and the mobile drawer are all `100dvh`, so this line was the outlier rather than the convention.

**The corner toast's width cap never applied.** `.action-toast` sets `max-width: min(480px, calc(100vw - 48px))`, but every toast also carries `.notice`, which sets `max-width: var(--prose-measure)` (70ch = 542px) and is declared *later* in the same file. Both selectors are specificity 0,1,0, so source order won and a long toast rendered **542px instead of 480px**. The cap is now on the two-class `.action-toast.notice`.

That fix needed one correction during verification: my first version set only `max-width: 480px`, which dropped the viewport term and let the toast run to the screen edge at narrow widths (measured `left = 0` at 430px, against the 24px inset the right side keeps). It restates both halves of the original expression.

### Not changed: the `vw` → containing-block rewrite

The original plan also swapped `vw` for containing-block insets, on the theory that `100vw` includes the classic scrollbar gutter. That was reverted before commit because it could not be reproduced on this surface — the probe measured `innerWidth == clientWidth`, gap 0 — and it would have been an unmeasured edit to a live width cap. The units stay `vw`. The reproduced defect was the specificity one, and that is what this PR fixes.

### Regression test

The hygiene gate flagged `missing_regression_test` on the first revision, and the reviewer asked for the same treatment #2905 gave the sidecar rules rather than a test exception. `gui/tests/viewport-scroll-caps.test.ts` pins both:

- `.logs-table-wrap` must cap against `100dvh` and must not return to static `100vh`.
- The toast cap must stay on the compound `.action-toast.notice` selector with **both** halves of `min(480px, calc(100vw - 48px))` intact.

The second test also guards its own premise: it asserts `.notice` still appears *after* the compound rule in source order, because that ordering is the entire reason the compound selector is required. If `.notice` ever moves above it, the test fails rather than quietly allowing a "simplification" back to a single class.

Source-text assertions, matching the existing `gui/tests` convention for CSS contracts — happy-dom performs no layout, so a computed `max-width` there would prove nothing. Driven **red first**: against the parent commit's stylesheet both tests fail (the `dvh` assertion, and `.action-toast.notice` not existing at all); both pass on this branch's.

### Devlog cleanup carried over from #2905's review

@Ingwannu's review of #2905 asked for two things beyond the record correction that landed in that PR. They are here because #2905 merged while they were being pushed:

- `git diff --check` reported "new blank line at EOF" on `000_baseline_and_roadmap.md` and `011_audit_correction_align_content.md`. Both had two newlines at EOF; now one. The review said all seven files, but the other five already ended with a single newline, so they are untouched.
- `020` and `030` now state their shipping status in the first line the reader sees, instead of leaving it inferable from a "Deferred" section at the bottom of `013`. `020` is **withdrawn** — the zero-width `auto-fit` track it reports is normal behaviour and no code change was made for it. `030` is **implemented by this PR**.

`git diff --check` is clean on this head.

## Verification

Measured in a real browser via CDP, not asserted from source alone:

- `.logs-table-wrap`: computed `max-height` compared against `visualViewport.height` at a 430-wide mobile profile where the visual viewport is smaller than the large viewport — no cap exceeds the visible height.
- Toast: computed `max-width` is **480px** at 1440 (was 542px), and at 430px it keeps its 24px inset on both sides rather than reaching `left = 0`.

Focused GUI gates on this exact head:

- `gui/tests/viewport-scroll-caps.test.ts` — 2 pass / 0 fail (red on the pre-fix stylesheet)
- `gui/tests/sidecar-layout.test.ts` — 8 pass / 0 fail (unchanged by this PR, run because it covers the same stylesheet family)

Remote Linux gates against this exact commit:

- `cd gui && bun test tests` — rc=0
- `bun run typecheck` — rc=0
- `bun run lint:gui` — rc=0
- `bun run test` (full repo suite) — rc=0

### Screenshots

The same long toast at 1440px, before and after. Before, the later `.notice` rule won and it rendered 542.1px; after, the compound selector applies its 480px cap:

| before - 542.1px | after - 480px |
|---|---|
| <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/assets/gui-sidecar-pair-260829/shots/toast-before-1440.png" width="420"> | <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/assets/gui-sidecar-pair-260829/shots/toast-after-1440.png" width="420"> |

At 430px the viewport term binds instead, giving 382px (= 430 - 48) and keeping the 24px inset on both sides - which is what the width-only version lost:

<img src="https://raw.githubusercontent.com/lidge-jun/opencodex/assets/gui-sidecar-pair-260829/shots/toast-after-430.png" width="330">

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Scope is one stylesheet, one new test file, and four devlog files; no runtime, routing, auth, or release paths are touched.
