### PR TITLE
docs(devlog): back 020's withdrawal with the horizontal measurement

### DIFF
--- a/devlog/_plan/260829_gui_dashboard_slop/020_phantom_grid_track.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/020_phantom_grid_track.md
@@ -21,28 +21,41 @@ container is wide enough to nominally fit it. With only two children the track
 collapses to 0 and the trailing gap measures 0, so nothing shifts today. It
 becomes a real phantom gap the moment a third card is added.
 
-## Change
+## Why this was withdrawn — measured
 
-Both grids hold a *known* number of cards, so express that instead of asking
-`auto-fit` to guess:
+The claim above ("the trailing gap measures 0, so nothing shifts today") was the
+reason to withdraw, but it went unmeasured on the axis the request named first —
+the horizontal one. It has now been measured, by auditing the rendered edges of
+each grid's direct children rather than reading the computed track list.
 
-```css
-grid-template-columns: repeat(auto-fit, minmax(min(100%, 21rem), 1fr));
-```
+`.dash-sidecar-grid` and `.dash-overview-tools`, two-up regime:
 
-becomes an explicit two-up that collapses to one column by container width:
+| vw | card widths | top spread | bottom spread | gutters |
+|----|-------------|-----------|---------------|---------|
+| 1600 | 556 / 556 | 0.0px | 0.0px | one 16px |
+| 1440 | 555 / 555 | 0.0px | 0.0px | one 16px |
+| 1280 | 475 / 475 | 0.0px | 0.0px | one 16px |
+| 1100 | 385 / 385 | 0.0px | 0.0px | one 16px |
+| 1024 | 347 / 347 | 0.0px | 0.0px | one 16px |
 
-```css
-grid-template-columns: 1fr;                 /* narrow: stack */
-@container / min-width: two-up → 1fr 1fr    /* wide: matched pair */
-```
+Identical widths, shared top and bottom edges, and exactly one gutter — no
+trailing gap after the second card at any width. The collapsed third track
+consumes no space and displaces nothing, in either grid, on both axes. So there
+is no horizontal misalignment to fix here, and the generated-but-collapsed track
+is not a defect.
 
-Applies to `.dash-sidecar-grid` and `.dash-overview-tools`. The wrap width stays
-`21rem` per card so the responsive behaviour is unchanged — verified by the same
-sweep, which must keep reporting STACKED at 900/430 and PAIRED at 1024+.
+## The rewrite that was considered and rejected
 
-## Acceptance
+Recorded so it is not mistaken for a pending plan: **none of this shipped, and
+applying it is not recommended.**
 
-- No `0px` track in either grid's computed columns at any swept width.
-- The PAIRED/STACKED pattern per width matches the baseline exactly (no
-  behavioural change, only the phantom track removed).
+The option was to stop asking `auto-fit` to guess and state the known card count
+— `grid-template-columns: 1fr` with a container query promoting to `1fr 1fr` —
+for both grids. It was rejected on cost against benefit: it fixes nothing
+measurable today (see the table above), and it trades `auto-fit`'s automatic
+behaviour for a hard-coded count, so a third card would then need a stylesheet
+change instead of just appearing. The phantom track only becomes real if a third
+card is added, and at that point `auto-fit` is what handles it correctly.
+
+If a future change does add a third card to either grid, re-measure the trailing
+gap first; the audit above is the procedure.

--- a/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
@@ -1,13 +1,17 @@
 # 030 — Dynamic viewport units in scroll surfaces (wp3)
 
-> **Implemented by this pull request**, separately from the sidecar alignment fix
-> that the rest of this unit records. It is a different change to a different
-> file (`gui/src/styles.css`), kept in the same unit because one audit pass found
-> both.
+> **Shipped in #2906** (`4d646c494`), separately from the sidecar alignment fix in
+> #2905 that the rest of this unit records. It is a different change to a
+> different file (`gui/src/styles.css`), kept in the same unit because one audit
+> pass found both.
+>
+> Rules below are named by selector, not line number: the fix this document
+> describes inserted lines above the very rules it cites, so the original
+> citations (`styles.css:2003`, `:755`, `:1222`) now land on unrelated CSS.
 
 ## Defect
 
-`gui/src/styles.css:2003`:
+`.logs-table-wrap` in `gui/src/styles.css` (line 2011 as shipped):
 
 ```css
 .logs-table-wrap { max-height: calc(100vh - 260px); }
@@ -15,11 +19,11 @@
 
 `vh` is the *large* viewport: it ignores mobile browser chrome, so the log table
 is capped for a viewport taller than the one the user can see, pushing the last
-rows under the browser UI. The rest of the shell already moved to `100dvh`
-(styles.css:244, 247, 411, 412, 2198), so this line is an outlier, not a
-convention.
+rows under the browser UI. The rest of the shell already moved to `100dvh` —
+`.app` (244), the sidebar (247), `.main-inner--combos` (411-412) and the mobile
+drawer (2213) — so this line is an outlier, not a convention.
 
-`styles.css:755` and `1222` cap toast width with `calc(100vw - Npx)`. Per CSS
+`.action-toast` (749) and `.notice` (1215) cap toast width with `calc(100vw - Npx)`. Per CSS
 Values and Units 4, `100vw` includes the classic scrollbar gutter, so a
 scrollbar-reserving platform can in principle render a cap wider than the visible
 area.
@@ -37,7 +41,7 @@ file at equal specificity, so source order won and the toast resolved to 70ch
   classes so it beats the later `.notice` rule. Both halves of the cap are
   restated: dropping the viewport term let the toast reach the screen edge at
   430px (measured `left = 0`, losing the 24px inset the right side keeps).
-- `styles.css:2003` is the only static `vh` in a scroll surface; the `12vh`
+- `.logs-table-wrap` was the only static `vh` in a scroll surface; the `12vh`
   padding on the toast wrapper is decorative offset, not a size cap, and stays.
 
 ### Not changed: the `vw` → containing-block rewrite


### PR DESCRIPTION
## Summary

Follow-up to #2905 and #2906. `devlog/_plan/260829_gui_dashboard_slop/020_phantom_grid_track.md` landed with a **WITHDRAWN** banner at the top and then, three lines later, a full `## Change` section prescribing a rewrite of both dashboard grids from `repeat(auto-fit, ...)` to a hard-coded two-up, plus an `## Acceptance` section demanding no `0px` track. Read top-down it says "nothing here ships" and then hands you a diff to apply.

The withdrawal also rested on an unmeasured claim. *"The trailing gap measures 0, so nothing shifts today"* was the entire reason to withdraw, and the axis it concerns is the horizontal one the original request named first (*"컴포넌트 좌우정렬도 안맞고"*). Nothing in the landed record backed it — a grep for width/spread evidence in that file on `dev` returns nothing.

## What changed

Measured it, by auditing the **rendered edges of each grid's direct children** rather than reading the computed track list — a collapsed track is invisible to the track list but would show up as a trailing gap or unequal widths:

| vw | card widths | top spread | bottom spread | gutters |
|----|-------------|-----------|---------------|---------|
| 1600 | 556 / 556 | 0.0px | 0.0px | one 16px |
| 1440 | 555 / 555 | 0.0px | 0.0px | one 16px |
| 1280 | 475 / 475 | 0.0px | 0.0px | one 16px |
| 1100 | 385 / 385 | 0.0px | 0.0px | one 16px |
| 1024 | 347 / 347 | 0.0px | 0.0px | one 16px |

Both `.dash-sidecar-grid` and `.dash-overview-tools`, at every two-up width: identical card widths, shared top and bottom edges, exactly one gutter, and no trailing gap after the second card. The collapsed third track consumes no space and displaces nothing on either axis, so there is no horizontal misalignment here and the generated-but-collapsed track is not a defect.

The `## Change` and `## Acceptance` sections are replaced by that measurement. The rewrite is **kept as a named rejected option** rather than deleted, with the reasoning: it fixes nothing measurable today, and it would trade `auto-fit`'s automatic behaviour for a hard-coded card count that a third card would have to come back and change. The note says plainly that it did not ship and is not recommended, and points at the audit as the procedure to re-run if a third card ever lands.

## Verification

Documentation only — no stylesheet, component, or test behaviour is touched, so there is no new regression surface.

- Horizontal edge audit run against the current `dev` stylesheets in a real browser via CDP (local `gui/src` files byte-identical to `origin/dev` `4d646c494`: sha256 `052ff29aa02ef486` / `39425844a41cba50`).
- `gui/tests/sidecar-layout.test.ts` + `gui/tests/viewport-scroll-caps.test.ts` — **10 pass / 0 fail**, confirming the documentation change moved no behaviour.
- `git diff --check` clean; no untagged code fences (MD040 clean across the whole unit).

No screenshot: this PR changes a Markdown file and no UI. The rendered evidence behind the table is the same harness whose screenshots are in #2905 and #2906.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

One devlog file; no runtime, routing, auth, or release paths are touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile log-table sizing so the final rows remain visible above browser controls.
  * Corrected notification width limits so notices no longer appear unnecessarily wide.
  * Documented dashboard layout findings and confirmed no changes were needed for the reported grid behavior.

* **Tests**
  * Added coverage to verify responsive log-table and notification sizing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->