### PR TITLE
docs(devlog): close the dashboard slop unit with its outcome

### DIFF
--- a/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
@@ -121,3 +121,44 @@ distinct.
   `ssh lidge` + `ocx-run`; pushes use `--no-verify` only after those gates.
 - Delivery is a stacked PR chain onto `dev`, each PR carrying screenshots
   (`enforce-target` requires a screenshot for GUI PRs).
+
+## Outcome — closed
+
+All three PRs are squash-merged into `dev`. Two defects were fixed; one reported
+defect was withdrawn because measurement said it was not one.
+
+| PR | commit | what shipped |
+|----|--------|--------------|
+| #2905 | `fc74e2026` | sidecar pair alignment: `align-content: start` on the card plus `min-height: 3lh` on the hint, replacing the `3.9375rem` copy band |
+| #2906 | `4d646c494` | `.logs-table-wrap` `100vh` → `100dvh`, and the toast width cap moved onto `.action-toast.notice` so it wins the cascade |
+| #2911 | `e1becb7f9` | record corrections: `020`'s withdrawal backed by the horizontal measurement, `030`'s citations anchored to selectors |
+
+**wp1 (sidecar pair).** The two shipped declarations are both load-bearing, each
+confirmed by removing it from the shipped stylesheet and re-measuring: `3lh` alone
+leaves 27.8px, `align-content: start` alone leaves 19.5px, together 0.0px. The first
+governs how the wrapped flex lines distribute; the second governs the height of
+the copy row they pack against. Subgrid, which `010` proposed, is unavailable here:
+Chrome rejects a child's `grid-template-rows: subgrid` under the `container-type`
+ancestors this surface needs.
+
+**wp2 (phantom track) — withdrawn, not implemented.** The zero-width `auto-fit`
+track is normal collapsed-track behaviour. Measured on the rendered edges rather
+than the computed track list: identical card widths and 0.0px top/bottom spread
+with one 16px gutter and no trailing gap, at 1600/1440/1280/1100/1024. Nothing to
+fix, and the rewrite would have traded `auto-fit` for a hard-coded card count.
+
+**wp3 (dynamic viewport).** Static `vh` resolves against the large viewport, so the
+log cap described more space than a mobile user can see. The toast defect found
+alongside it was a cascade problem, not a unit problem — `.notice` won on source
+order at equal specificity and the toast rendered 542.1px instead of 480px. The
+`vw` → containing-block rewrite was deliberately not shipped: the scrollbar
+divergence could not be reproduced here (`innerWidth == clientWidth`).
+
+Regressions: `gui/tests/sidecar-layout.test.ts` and `gui/tests/viewport-scroll-caps.test.ts`,
+both driven red against the pre-fix stylesheets before being accepted.
+
+Two measurement traps are worth carrying forward, both of which produced a
+confident wrong answer during this unit: a **symmetric** break passes a relative
+alignment gate (the subgrid collapse reported 0.0px while cards rendered 54px
+instead of 215px), and a **leftover injected probe stylesheet** makes a candidate
+look correct on a page that is not the shipped page. `013` records both.


### PR DESCRIPTION
## Summary

Closes the `260829_gui_dashboard_slop` devlog unit. Its roadmap (`000_baseline_and_roadmap.md`) still described the work in the future tense and recorded no landing, so a reader arriving at the unit's entry point could not tell that all three PRs had merged — nor that one of the three reported defects turned out not to be a defect at all.

Adds a terminal `## Outcome — closed` section.

| PR | commit | what shipped |
|----|--------|--------------|
| #2905 | `fc74e2026` | sidecar pair alignment: `align-content: start` + `min-height: 3lh`, replacing the `3.9375rem` copy band |
| #2906 | `4d646c494` | `.logs-table-wrap` `100vh` → `100dvh`, and the toast cap moved onto `.action-toast.notice` so it wins the cascade |
| #2911 | `e1becb7f9` | record corrections: `020`'s withdrawal backed by measurement, `030`'s citations anchored to selectors |

## What the record now says

The findings a future maintainer would otherwise have to rediscover:

- **Both sidecar declarations are load-bearing**, each confirmed by removing it from the shipped stylesheet and re-measuring: `3lh` alone leaves 27.8px, `align-content: start` alone leaves 19.5px, together 0.0px. They fix different halves — how the wrapped flex lines distribute, and the height of the copy row those lines pack against. Deleting either one re-opens the defect.
- **Subgrid is unavailable on this surface**, not merely awkward: `container-type` ancestors make Chrome reject a child's `grid-template-rows: subgrid` outright. `010` proposed it and an independent auditor recommended it; measurement disproved it.
- **wp2 was withdrawn on measurement, not implemented**, and the outcome says so explicitly rather than leaving it inferable.
- **The toast defect was a cascade problem**, not a unit problem — `.notice` won on source order at equal specificity, so the toast rendered 542.1px instead of 480px.
- **Two measurement traps**, each of which produced a confident wrong answer during this unit: a *symmetric* break passes a relative alignment gate (the subgrid collapse reported 0.0px while cards rendered 54px instead of 215px), and a *leftover injected probe stylesheet* makes a candidate look correct on a page that is not the shipped page.

## Verification

Documentation only — no stylesheet, component, or test is touched, so there is no new regression surface.

- Every claim in the new section was re-read off `origin/dev` before being written: `align-content: start` at `styles-dashboard-workspace.css:199`, `min-height: 3lh` at `:240`, `calc(100dvh - 260px)` at `styles.css:2018`, `.action-toast.notice` at `:770`, and both test files tracked.
- `gui/tests/sidecar-layout.test.ts` + `gui/tests/viewport-scroll-caps.test.ts` — **10 pass / 0 fail**, confirming the documentation change moved no behaviour.
- `git diff --check` clean; MD040 clean across the unit.

No screenshot: this PR changes one Markdown file and no UI. The rendered evidence behind its numbers is in #2905, #2906 and #2911.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

One devlog file; no runtime, routing, auth, or release paths are touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented completed dashboard layout improvements for better side-panel alignment.
  * Recorded improved log-area sizing on mobile and more appropriate notification width handling.
  * Added regression findings and validation notes for the completed fixes.
  * Clarified which proposed layout adjustments were intentionally not included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->