### PR TITLE
docs(devlog): enumerate every invocation-line site to bound the cursor fix

### DIFF
--- a/devlog/_plan/260829_cursor_tool_continuation_pairing/040_phase5_checkpoint_suffix_gap.md
+++ b/devlog/_plan/260829_cursor_tool_continuation_pairing/040_phase5_checkpoint_suffix_gap.md
@@ -104,6 +104,31 @@ Two shapes needed care while writing them:
 ## Verification
 
 - `bun test tests/cursor-tool-result-invocation.test.ts tests/cursor-tool-continuation.test.ts tests/cursor-blob.test.ts` — 123 pass, 0 fail.
+
+## Completeness: are the two patched sites the whole set?
+
+The obvious residual risk is a *third* replay site with the same suffix-indexing bug, which would
+make this unit's third partial fix. Enumerated against the source rather than assumed.
+
+Only two functions attach an invocation line, and both now take `knownCalls`:
+
+| Site | Line | Emits | Indexed from |
+|------|------|-------|--------------|
+| `rootPromptMessages` | 240 | root `[Tool Result]` blob | `knownCalls ?? toolCallsByCallId(messages)` |
+| `conversationTurns` | 953 | turn step `[Tool Result]` | `knownCalls ?? toolCallsByCallId(messages)` |
+
+`toolResultToText` has a third caller, `contentText` at line 498, which passes no call and therefore
+can never name an invocation. It is not a gap, because no tool result reaches it: all three of its
+callers select on role first.
+
+- line 285 — `historyContentText`, guarded by `message.role === "user" || message.role === "developer"`.
+- line 1034 — the turn's `userMessage`, reached only in the loop's final `else` after the `assistant`
+  and `toolResult` branches have both `continue`d.
+- line 1052 — `activePromptText`, which scans backwards for a `user`/`developer` message.
+
+So the `toolResult` branch inside `contentText` is dead for these paths, and the two patched sites are
+the complete set. `request-builder.ts` has its own `toolResultToText` for the text `messages` channel;
+it is a different channel with no invocation line by design and is out of scope here.
 - `bun x tsc --noEmit` — exit 0.
 - Full suite on `ssh lidge`; no local full-suite run was used as a gate.
 


### PR DESCRIPTION
## Summary

Devlog only. Follow-up to #2910, which fixed the checkpoint replay path.

That was the **third** partial fix for one defect: #2900 named the invocation inside a replayed tool
result, #2903 bounded and identity-checked it, and #2910 covered the checkpoint continuation path
that the first two missed. The obvious residual risk was a fourth site with the same shape, so this
enumerates them against the source instead of assuming the set is closed.

Only two functions attach an invocation line, and both take `knownCalls` after #2910:

| Site | Line | Emits | Indexed from |
|------|------|-------|--------------|
| `rootPromptMessages` | 240 | root `[Tool Result]` blob | `knownCalls ?? toolCallsByCallId(messages)` |
| `conversationTurns` | 953 | turn step `[Tool Result]` | `knownCalls ?? toolCallsByCallId(messages)` |

`toolResultToText` has a third caller, `contentText` (line 498), which passes no call and so can never
name an invocation. It is not a gap: no tool result reaches it, because all three of its callers
select on role first — line 285 guards on `user`/`developer`, line 1034 is the turn `userMessage`
reached only after the `assistant` and `toolResult` branches both `continue`, and line 1052
(`activePromptText`) scans backwards for a `user`/`developer` message.

`request-builder.ts` has its own `toolResultToText` for the text `messages` channel; different
channel, no invocation line by design, out of scope.

## Verification

- No source change, so behaviour is unchanged by construction.
- `bun run privacy:scan` — passed.
- `bun test tests/cursor-tool-result-invocation.test.ts tests/cursor-tool-continuation.test.ts tests/cursor-blob.test.ts` — 124 pass, 0 fail.
- Full suite and `bun x tsc --noEmit` on `ssh lidge` at the head SHA.

No GUI change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added analysis documenting how invocation lines and tool results are handled during replay.
  * Clarified the supported replay paths and distinguished them from unrelated text-processing channels.
  * Confirmed that no public interfaces or externally visible behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->