### PR TITLE
fix(gui): correct the record and lock the test constants

### DIFF
--- a/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
@@ -104,9 +104,12 @@ and `.toast-notice` cap toast width with `calc(100vw - Npx)`, which ignores clas
 scrollbar width.
 
 Rules are named by selector rather than line number on purpose: the fix itself
-inserted lines above them, so every original citation (`styles.css:2003`,
-`:755`, `:1222`, `:2198`) now lands on unrelated CSS. Current locations are in
-`030` and the Outcome section below.
+inserted lines above them, so most of the original citations no longer describe
+what they pointed at. `:2003` is now `min-width: 220px`, `:1222` is the toast
+host's `z-index`, and `:2198` is `background: var(--glass-rail)`. `:755` still
+happens to land on `.action-toast`'s `max-width`, which is the point rather than a
+reprieve: one of four survived by coincidence, and nothing marks which. Current
+locations are in `030` and the Outcome section below.
 
 The probe measures this behaviourally — comparing each scroll container's
 computed cap against `visualViewport.height` — rather than grepping for the

--- a/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/000_baseline_and_roadmap.md
@@ -51,10 +51,16 @@ stretches them to equal height. Below ~`36rem` of *card* width the container
 query gives copy and controls `flex-basis: 100%`, so each card becomes two
 wrapped flex lines. The two cards then have **equal outer height but different
 content height** — vision's control column is taller (select row + advanced
-disclosure). Flexbox distributes the leftover space of each card independently
-and `align-items: center` centres each line within its own leftover, so the
-shorter card's control row sinks by half the difference. Nothing ties one card's
-second line to the other's.
+disclosure). Flexbox distributes the leftover space of each card independently,
+so the shorter card's control row sinks. Nothing ties one card's second line to
+the other's.
+
+> **Corrected during implementation.** This paragraph originally blamed
+> `align-items: center`. That is the wrong property: `align-items` centres each item
+> *within* its line, while the mis-distributed thing is the **lines**, which is
+> `align-content` — defaulting to `stretch` on a multi-line flex container. The fix
+> is `align-content: start`; `align-items: center` stays and is what keeps the
+> single-line (one-column) regime centred. See `013`.
 
 The shipped mitigation is a hard-coded reserved band:
 
@@ -89,12 +95,18 @@ third card is added to either grid.
 
 ## Defect 3 — static viewport units in scroll surfaces
 
-`gui/src/styles.css:2003` caps `.logs-table-wrap` with
+**As measured before the fix.** `.logs-table-wrap` capped with
 `max-height: calc(100vh - 260px)`. Static `vh` resolves against the *large*
 viewport, ignoring mobile browser chrome, while the rest of the shell already
-uses `100dvh` (styles.css:244, 247, 411, 412, 2198). The log table is therefore
-sized for a viewport the user cannot see. `styles.css:755` and `1222` cap toast
-width with `calc(100vw - Npx)`, which ignores classic scrollbar width.
+used `100dvh` (`.app`, the sidebar, `.main-inner--combos`, the mobile drawer). The
+log table was therefore sized for a viewport the user cannot see. `.action-toast`
+and `.toast-notice` cap toast width with `calc(100vw - Npx)`, which ignores classic
+scrollbar width.
+
+Rules are named by selector rather than line number on purpose: the fix itself
+inserted lines above them, so every original citation (`styles.css:2003`,
+`:755`, `:1222`, `:2198`) now lands on unrelated CSS. Current locations are in
+`030` and the Outcome section below.
 
 The probe measures this behaviourally — comparing each scroll container's
 computed cap against `visualViewport.height` — rather than grepping for the

--- a/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
@@ -14,7 +14,8 @@
 
 ## Defect
 
-`.logs-table-wrap` in `gui/src/styles.css` (line 2011 as shipped):
+`.logs-table-wrap` in `gui/src/styles.css` — **as it was before the fix**; the
+rule now sits at line 2011 and carries `100dvh`:
 
 ```css
 .logs-table-wrap { max-height: calc(100vh - 260px); }

--- a/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
@@ -6,8 +6,11 @@
 > pass found both.
 >
 > Rules below are named by selector, not line number: the fix this document
-> describes inserted lines above the very rules it cites, so the original
-> citations (`styles.css:2003`, `:755`, `:1222`) now land on unrelated CSS.
+> describes inserted lines above the very rules it cites, so most of its original
+> citations stopped describing what they pointed at — `styles.css:2003` is now
+> `min-width: 220px` and `:1222` is a `z-index`. `:755` still lands on
+> `.action-toast`'s `max-width` by coincidence, which is why the selector is the
+> reference and the line is only a hint.
 
 ## Defect
 

--- a/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
+++ b/devlog/_plan/260829_gui_dashboard_slop/030_dynamic_viewport_units.md
@@ -23,10 +23,12 @@ rows under the browser UI. The rest of the shell already moved to `100dvh` —
 `.app` (244), the sidebar (247), `.main-inner--combos` (411-412) and the mobile
 drawer (2213) — so this line is an outlier, not a convention.
 
-`.action-toast` (749) and `.notice` (1215) cap toast width with `calc(100vw - Npx)`. Per CSS
-Values and Units 4, `100vw` includes the classic scrollbar gutter, so a
-scrollbar-reserving platform can in principle render a cap wider than the visible
-area.
+`.action-toast` (749) and `.toast-notice` (1229) cap toast width with
+`calc(100vw - Npx)`. Per CSS Values and Units 4, `100vw` includes the classic
+scrollbar gutter, so a scrollbar-reserving platform can in principle render a cap
+wider than the visible area. (`.notice` at 1215 is a different rule: it caps with
+`var(--prose-measure)`, which is what makes it win the cascade below — it does not
+use a viewport unit at all.)
 
 A separate, *reproduced* toast defect turned up while measuring that one: the
 cap on `.action-toast` never applied at all. Every toast also carries `.notice`,

--- a/gui/src/styles-dashboard-workspace.css
+++ b/gui/src/styles-dashboard-workspace.css
@@ -231,8 +231,12 @@
    boxes of the hint's own computed line-height. It covers the longest shipped hint, so the
    shorter hint reserves the same three lines and both control rows start together. Because
    it scales with font metrics rather than a hard-coded 19.5px, a font or line-height change
-   cannot invalidate it, and a longer translation only matters if it exceeds three lines —
-   which the regression test asserts by measuring rendered line counts, not string length.
+   cannot invalidate it, and a longer translation only matters if it exceeds three lines.
+
+   The committed regression is source-text only (happy-dom performs no layout): it asserts
+   the floor is expressed in `lh` with at least 3 lines and that the old `rem` band is gone.
+   The three-line number itself came from rendered measurement in a real browser, which is
+   recorded in devlog/_plan/260829_gui_dashboard_slop/013, not re-derived by the test.
 
    Verified across all eight shipped locales at every two-up width (1600-740): worst offset
    0.0px, no hint truncated, no card collapsed. */

--- a/gui/tests/viewport-scroll-caps.test.ts
+++ b/gui/tests/viewport-scroll-caps.test.ts
@@ -60,10 +60,15 @@ function effectiveDeclaration(css: string, selector: string, property: string): 
   const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp("(?:^|[;{\\n])\\s*" + escaped + "\\s*:\\s*([^;}]+)", "gi");
   let winner: string | null = null;
+  // Only an escape in PROPERTY-NAME position defeats this reader. Scanning the whole body
+  // would also reject an escape in a value - `content: "\\2014"` is ordinary CSS - so the
+  // guard is anchored the same way the matcher is: body start or after `;`/newline, then a
+  // name containing a hex escape, then a colon.
+  const escapedName = /(?:^|[;{\n])\s*[-\w]*\\[0-9a-fA-F]/;
   for (const body of ruleBodies(css, selector)) {
-    // An escaped identifier would need CSS unescaping to compare; refuse rather than
-    // report a value this reader cannot prove is the winner.
-    if (/\\[0-9a-fA-F]/.test(body)) {
+    // An escaped identifier would need CSS unescaping to compare; refuse rather than report
+    // a value this reader cannot prove is the winner.
+    if (escapedName.test(body)) {
       throw new Error("escaped property identifier in " + selector + "; this reader cannot resolve it");
     }
     for (const m of body.matchAll(pattern)) winner = m[1].trim();
@@ -171,4 +176,17 @@ test("the cap reader survives case variants and refuses escaped identifiers", ()
   // reader fails loudly - nothing in this stylesheet writes one.
   const escapedIdent = ".logs-table-wrap { max-height: calc(100dvh - 260px); max\\2d height: calc(100dvh - 261px); }";
   expect(() => effectiveDeclaration(escapedIdent, ".logs-table-wrap", "max-height")).toThrow(/escaped/);
+});
+
+test("an escape in a VALUE is ordinary CSS and must not trip the guard", () => {
+  // The escape guard exists for property NAMES. Scanning the whole rule body would also
+  // reject `content: "\\2014"`, which is ordinary CSS and says nothing about which
+  // declaration wins - a false failure is as much a broken oracle as a false pass.
+  const valueEscape = [
+    ".logs-table-wrap {",
+    "  content: \"\\\\2014\";",
+    "  max-height: calc(100dvh - 260px);",
+    "}",
+  ].join("\n");
+  expect(effectiveDeclaration(valueEscape, ".logs-table-wrap", "max-height")).toBe("calc(100dvh - 260px)");
 });

--- a/gui/tests/viewport-scroll-caps.test.ts
+++ b/gui/tests/viewport-scroll-caps.test.ts
@@ -33,7 +33,11 @@ test("the log table caps its scroll height against the dynamic viewport", async 
   // last rows sit underneath the address bar. The rest of the shell (.app, .sidebar,
   // .main-inner--combos, the mobile drawer) already uses 100dvh, so this rule was the
   // outlier rather than the convention.
-  expect(wrap).toMatch(/max-height:\s*calc\(\s*100dvh\s*-/);
+  // The subtrahend is locked, not just the unit: a `calc(100dvh - <anything>)` would
+  // satisfy a unit-only assertion while silently resizing the table.
+  const cap = wrap.match(/max-height:\s*calc\(\s*100dvh\s*-\s*([\d.]+)px\s*\)/);
+  expect(cap).not.toBeNull();
+  expect(Number(cap![1])).toBe(260);
   expect(wrap).not.toMatch(/max-height:\s*calc\(\s*100vh\s*-/);
 });
 
@@ -51,9 +55,12 @@ test("the toast width cap outranks the later .notice rule", async () => {
   // Both halves are asserted on purpose. An earlier revision kept only the design width,
   // which dropped the viewport term and let the toast reach the screen edge at narrow
   // widths (measured left = 0 at 430px, losing the 24px inset the right side keeps).
+  // Exact values, not merely positive ones: a 1px design width or a 1px inset would pass
+  // a `> 0` check while destroying the layout. 480px is the design width and 48px is the
+  // 24px inset doubled, both measured on the rendered toast.
   expect(cap).not.toBeNull();
-  expect(Number(cap![1])).toBeGreaterThan(0);
-  expect(Number(cap![2])).toBeGreaterThan(0);
+  expect(Number(cap![1])).toBe(480);
+  expect(Number(cap![2])).toBe(48);
 
   // Guard the ordering premise itself: if `.notice` ever moved ABOVE this rule, a
   // single-class cap would start working and someone could "simplify" the compound

--- a/gui/tests/viewport-scroll-caps.test.ts
+++ b/gui/tests/viewport-scroll-caps.test.ts
@@ -30,7 +30,8 @@ function ruleBodies(css: string, selector: string): string[] {
 }
 
 /**
- * The last declaration of a property across all bodies of an exact selector.
+ * The last *textual* declaration of a property across all bodies of an exact selector,
+ * matched on the property's canonical lowercase spelling.
  *
  * Two false negatives, both found by review and both reproduced before being closed:
  *
@@ -42,17 +43,29 @@ function ruleBodies(css: string, selector: string): string[] {
  *    the rendered cap wrong. Hence the boundary below: the property must start the body
  *    or follow `;`/newline, and must not be preceded by `-`.
  *
- * Scope, stated because the previous comment overclaimed: this is source-order within one
- * exact selector string. It does not model `!important`, competing selectors of different
- * specificity, or @-rule nesting. For these two rules that is enough - each is declared
- * once, and the cascade question that matters (`.notice` beating `.action-toast`) is
- * asserted separately below.
+ * CSS property names are case-insensitive, and an identifier may be written with escapes
+ * (`max\\2d height` is `max-height`). A case-sensitive literal match therefore reported the
+ * wrong winner when the real declaration used `MAX-HEIGHT`. Matching is now case-insensitive,
+ * and an escape in the property name is rejected outright rather than silently skipped:
+ * nothing in this stylesheet writes one, so its appearance means the oracle no longer
+ * understands the file and should fail loudly instead of guessing.
+ *
+ * Scope, stated because an earlier version of this comment overclaimed: this is source
+ * order within one exact selector string. It does not model `!important`, competing
+ * selectors of different specificity, or @-rule nesting. For these two rules that is
+ * enough - each is declared once, and the cascade question that matters (`.notice` beating
+ * a single-class `.action-toast`) is asserted separately below.
  */
 function effectiveDeclaration(css: string, selector: string, property: string): string {
   const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp("(?:^|[;{\\n])\\s*" + escaped + "\\s*:\\s*([^;}]+)", "g");
+  const pattern = new RegExp("(?:^|[;{\\n])\\s*" + escaped + "\\s*:\\s*([^;}]+)", "gi");
   let winner: string | null = null;
   for (const body of ruleBodies(css, selector)) {
+    // An escaped identifier would need CSS unescaping to compare; refuse rather than
+    // report a value this reader cannot prove is the winner.
+    if (/\\[0-9a-fA-F]/.test(body)) {
+      throw new Error("escaped property identifier in " + selector + "; this reader cannot resolve it");
+    }
     for (const m of body.matchAll(pattern)) winner = m[1].trim();
   }
   if (winner === null) throw new Error("property not found: " + selector + " { " + property + " }");
@@ -139,4 +152,23 @@ test("the cap reader is not fooled by a custom property or an earlier duplicate"
   // A property that genuinely is not there must throw rather than silently report a
   // neighbouring declaration.
   expect(() => effectiveDeclaration(".logs-table-wrap { overflow-y: auto; }", ".logs-table-wrap", "max-height")).toThrow();
+});
+
+test("the cap reader survives case variants and refuses escaped identifiers", () => {
+  // CSS property names are case-insensitive, so `MAX-HEIGHT` is a real declaration and won
+  // the cascade while a case-sensitive reader reported the earlier lowercase value. Both of
+  // these were demonstrated in a browser before being closed here.
+  const shouted = [
+    ".logs-table-wrap {",
+    "  max-height: calc(100dvh - 260px);",
+    "  MAX-HEIGHT: calc(100dvh - 261px);",
+    "}",
+  ].join("\n");
+  expect(effectiveDeclaration(shouted, ".logs-table-wrap", "max-height")).toBe("calc(100dvh - 261px)");
+
+  // An escaped identifier (`max\\2d height` is `max-height`) would need CSS unescaping to
+  // compare. Rather than skip it and report a value it cannot prove is the winner, the
+  // reader fails loudly - nothing in this stylesheet writes one.
+  const escapedIdent = ".logs-table-wrap { max-height: calc(100dvh - 260px); max\\2d height: calc(100dvh - 261px); }";
+  expect(() => effectiveDeclaration(escapedIdent, ".logs-table-wrap", "max-height")).toThrow(/escaped/);
 });

--- a/gui/tests/viewport-scroll-caps.test.ts
+++ b/gui/tests/viewport-scroll-caps.test.ts
@@ -18,10 +18,34 @@ function withoutComments(css: string): string {
 
 /** All bodies for a selector, which may be declared more than once. */
 function allRuleBodies(css: string, selector: string): string {
+  return ruleBodies(css, selector).join("\n");
+}
+
+/** Every body for a selector, in source order. */
+function ruleBodies(css: string, selector: string): string[] {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const matches = [...css.matchAll(new RegExp("(^|\\n)\\s*" + escaped + "\\s*\\{([^}]*)\\}", "g"))];
   if (matches.length === 0) throw new Error("rule not found: " + selector);
-  return matches.map((m) => m[2]).join("\n");
+  return matches.map((m) => m[2]);
+}
+
+/**
+ * The declaration that actually wins for a property: the LAST one across all bodies of
+ * the selector.
+ *
+ * Concatenating bodies and taking the first match is what a reviewer correctly called a
+ * false negative: a second rule for the same selector, added later with a wrong value,
+ * wins the cascade while the first (correct) declaration still satisfies the assertion.
+ * Reading the last occurrence is what makes these tests describe the rendered result.
+ */
+function effectiveDeclaration(css: string, selector: string, property: string): string {
+  const pattern = new RegExp(property + "\\s*:\\s*([^;}]+)", "g");
+  let winner: string | null = null;
+  for (const body of ruleBodies(css, selector)) {
+    for (const m of body.matchAll(pattern)) winner = m[1].trim();
+  }
+  if (winner === null) throw new Error("property not found: " + selector + " { " + property + " }");
+  return winner;
 }
 
 test("the log table caps its scroll height against the dynamic viewport", async () => {
@@ -34,8 +58,10 @@ test("the log table caps its scroll height against the dynamic viewport", async 
   // .main-inner--combos, the mobile drawer) already uses 100dvh, so this rule was the
   // outlier rather than the convention.
   // The subtrahend is locked, not just the unit: a `calc(100dvh - <anything>)` would
-  // satisfy a unit-only assertion while silently resizing the table.
-  const cap = wrap.match(/max-height:\s*calc\(\s*100dvh\s*-\s*([\d.]+)px\s*\)/);
+  // satisfy a unit-only assertion while silently resizing the table. Read from the
+  // EFFECTIVE declaration so a later duplicate rule cannot hide behind this one.
+  const effective = effectiveDeclaration(css, ".logs-table-wrap", "max-height");
+  const cap = effective.match(/^calc\(\s*100dvh\s*-\s*([\d.]+)px\s*\)$/);
   expect(cap).not.toBeNull();
   expect(Number(cap![1])).toBe(260);
   expect(wrap).not.toMatch(/max-height:\s*calc\(\s*100vh\s*-/);
@@ -49,8 +75,11 @@ test("the toast width cap outranks the later .notice rule", async () => {
   // order therefore won and a single-class `.action-toast` cap never applied - the toast
   // rendered 542px instead of its design width. Two classes is what wins the cascade, so
   // the cap must stay on the compound selector.
-  const compound = allRuleBodies(css, ".action-toast.notice");
-  const cap = compound.match(/max-width:\s*min\(\s*([\d.]+)px\s*,\s*calc\(\s*100vw\s*-\s*([\d.]+)px\s*\)\s*\)/);
+  // Again the EFFECTIVE declaration, for the same reason: a second `.action-toast.notice`
+  // rule added later with a wrong width would win the cascade while the first one still
+  // matched a first-occurrence assertion.
+  const effective = effectiveDeclaration(css, ".action-toast.notice", "max-width");
+  const cap = effective.match(/^min\(\s*([\d.]+)px\s*,\s*calc\(\s*100vw\s*-\s*([\d.]+)px\s*\)\s*\)$/);
 
   // Both halves are asserted on purpose. An earlier revision kept only the design width,
   // which dropped the viewport term and let the toast reach the screen edge at narrow

--- a/gui/tests/viewport-scroll-caps.test.ts
+++ b/gui/tests/viewport-scroll-caps.test.ts
@@ -30,16 +30,27 @@ function ruleBodies(css: string, selector: string): string[] {
 }
 
 /**
- * The declaration that actually wins for a property: the LAST one across all bodies of
- * the selector.
+ * The last declaration of a property across all bodies of an exact selector.
  *
- * Concatenating bodies and taking the first match is what a reviewer correctly called a
- * false negative: a second rule for the same selector, added later with a wrong value,
- * wins the cascade while the first (correct) declaration still satisfies the assertion.
- * Reading the last occurrence is what makes these tests describe the rendered result.
+ * Two false negatives, both found by review and both reproduced before being closed:
+ *
+ * 1. Concatenating bodies and taking the FIRST match let a second rule for the same
+ *    selector, added later with a wrong value, win the cascade while the earlier correct
+ *    declaration still satisfied the assertion. Hence reading the last occurrence.
+ * 2. An unanchored property name matched inside a CUSTOM PROPERTY, so
+ *    `max-height: calc(100dvh - 261px); --max-height: calc(100dvh - 260px)` passed with
+ *    the rendered cap wrong. Hence the boundary below: the property must start the body
+ *    or follow `;`/newline, and must not be preceded by `-`.
+ *
+ * Scope, stated because the previous comment overclaimed: this is source-order within one
+ * exact selector string. It does not model `!important`, competing selectors of different
+ * specificity, or @-rule nesting. For these two rules that is enough - each is declared
+ * once, and the cascade question that matters (`.notice` beating `.action-toast`) is
+ * asserted separately below.
  */
 function effectiveDeclaration(css: string, selector: string, property: string): string {
-  const pattern = new RegExp(property + "\\s*:\\s*([^;}]+)", "g");
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp("(?:^|[;{\\n])\\s*" + escaped + "\\s*:\\s*([^;}]+)", "g");
   let winner: string | null = null;
   for (const body of ruleBodies(css, selector)) {
     for (const m of body.matchAll(pattern)) winner = m[1].trim();
@@ -98,4 +109,34 @@ test("the toast width cap outranks the later .notice rule", async () => {
   const compoundIndex = css.search(/(^|\n)\s*\.action-toast\.notice\s*\{/);
   expect(compoundIndex).toBeGreaterThanOrEqual(0);
   expect(noticeIndex).toBeGreaterThan(compoundIndex);
+});
+
+test("the cap reader is not fooled by a custom property or an earlier duplicate", () => {
+  // Both of these are regressions, not hypotheticals: each passed a previous revision of
+  // this file while the rendered cap was wrong, and each was reproduced against the real
+  // stylesheet before being closed. The fixture is inline so the guard is testable without
+  // touching gui/src/styles.css.
+
+  // A custom property whose NAME contains the property being read. Reading `max-height`
+  // without a declaration boundary matched `--max-height` and reported the good value
+  // while the real declaration was 261px.
+  const masked = [
+    ".logs-table-wrap {",
+    "  max-height: calc(100dvh - 261px);",
+    "  --max-height: calc(100dvh - 260px);",
+    "}",
+  ].join("\n");
+  expect(effectiveDeclaration(masked, ".logs-table-wrap", "max-height")).toBe("calc(100dvh - 261px)");
+
+  // A later duplicate rule for the same selector wins the cascade. Taking the FIRST match
+  // reported the earlier correct value.
+  const duplicated = [
+    ".action-toast.notice { max-width: min(480px, calc(100vw - 48px)); }",
+    ".action-toast.notice { max-width: min(200px, calc(100vw - 8px)); }",
+  ].join("\n");
+  expect(effectiveDeclaration(duplicated, ".action-toast.notice", "max-width")).toBe("min(200px, calc(100vw - 8px))");
+
+  // A property that genuinely is not there must throw rather than silently report a
+  // neighbouring declaration.
+  expect(() => effectiveDeclaration(".logs-table-wrap { overflow-y: auto; }", ".logs-table-wrap", "max-height")).toThrow();
 });


### PR DESCRIPTION
## Summary

An independent final-gate audit of the merged `260829_gui_dashboard_slop` unit returned **NEAR-PASS** with five findings. Four were correct and are fixed here; each was re-verified against `origin/dev` before being accepted.

**My own citation fix in #2911 introduced an error.** Replacing the drifted line numbers, I wrote that `.action-toast` (749) and `.notice` (1215) both cap toast width with `calc(100vw - Npx)`. `.notice` does not use a viewport unit at all — it caps with `var(--prose-measure)`, which is exactly why it wins the cascade and why the compound selector is necessary. The second `calc(100vw - Npx)` belongs to `.toast-notice` at 1229. Naming the wrong rule undercut the explanation two paragraphs below it.

**A stylesheet comment overstated the test.** It claimed the three-line floor is something *"the regression test asserts by measuring rendered line counts"*. The committed test is source-text only and says so in its own header; the line count came from browser measurement recorded in `013`. The comment now separates what the test checks from where the number came from.

**`000` blamed the wrong property.** Its root-cause paragraph attributed the mis-distributed wrapped lines to `align-items: center`. `align-items` centres each item *within* its line; the lines themselves are `align-content`, which defaults to `stretch`. That distinction is the whole reason `align-content: start` ships while `align-items: center` stays. Corrected in place with a note, because the original wording is part of how the investigation went wrong.

**`000` still carried the drifted citations** that #2911 fixed only in `030` — `styles.css:2003`, `:755`, `:1222`, `:2198`, none of which point at the cited rule any more (2003 is now `min-width: 220px`). Now named by selector, with the reason stated.

## Test constants are now locked

The fifth finding was that the toast assertions accept any positive number:

```ts
expect(Number(cap![1])).toBeGreaterThan(0);   // a 1px design width passes
expect(Number(cap![2])).toBeGreaterThan(0);   // a 1px inset passes
```

The reviewer was right — those would survive a change that destroys the layout. Both toast constants and the log-cap subtrahend are now asserted exactly (480, 48, 260).

**Proved non-vacuous by mutation.** Rewriting the stylesheet to `min(479px, calc(100vw - 47px))` and `calc(100dvh - 261px)` turns both tests **red** (`Expected: 480, Received: 479`), where the previous assertions passed. The stylesheet was then restored byte-identical to `origin/dev`, verified by sha256, and the suites are back to 10 pass / 0 fail.

## Deliberately not changed

The reviewer also flagged that several *secondary* sidecar assertions can pass on an empty match — a `@container` loop that asserts nothing if no rule reaches it. That is a real weakness, but it is pre-existing and unrelated to this unit's fixes, and tightening it requires deciding what those queries must contain. That belongs in its own change rather than in a correction to this record.

## Verification

- `gui/tests/sidecar-layout.test.ts` + `gui/tests/viewport-scroll-caps.test.ts` — **10 pass / 0 fail** (29 expect calls, up from 28).
- Mutation check as described above: 2 fail on drifted constants, then green again after restore.
- `gui/src/styles.css` byte-identical to `origin/dev` after the mutation experiment (sha256 compared).
- `git diff --check` clean; MD040 clean across the unit.

No screenshot: the only `gui/src` change is a comment, and the CSS declarations are untouched — verified by the byte-identical hash above. Rendered evidence for the unit is in #2905, #2906 and #2911.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Two devlog files, one stylesheet comment, one test file; no runtime, routing, auth, or release paths are touched.


---

## Round 2 findings, also fixed

A second independent round returned NEAR-PASS: five claims verified, two partial. Both partials were correct.

**The overstated claim was mine.** Fixing the drifted citations I wrote that *"every original citation now lands on unrelated CSS"*. Three of four do — `:2003` is now `min-width: 220px`, `:1222` is a `z-index`, `:2198` is a `background` — but `:755` still lands exactly on `.action-toast`'s `max-width`. One of four survived by coincidence and nothing marked which, so the note now says that rather than claiming all four rotted.

**The remaining test gap was worse than the one locking constants closed.** `allRuleBodies()` concatenates every body for a selector and `.match()` takes the *first* hit — so a second rule for the same selector, added later with a wrong value, wins the cascade while the original correct declaration still satisfies the assertion. Green test, broken toast.

Both assertions now read the **effective** declaration (the last one across all bodies) and anchor the regex to the whole value. Proved against the reviewer's exact scenario — appending

```css
.action-toast.notice { max-width: min(200px, calc(100vw - 8px)); }
.logs-table-wrap { max-height: calc(100dvh - 900px); }
```

turns both tests **red** (`Expected: 480, Received: 200`) where the first-match logic passed. The 479/47/261 value mutation is still caught too. `gui/src/styles.css` restored byte-identical to `origin/dev` after each experiment (sha256 `39425844a41cba50`), suites at 10 pass / 0 fail.


---

## Round 3 finding, also fixed

Round 3 **refuted** my round-2 fix, and it was right — the bug was mine. Reading a property with an unanchored name also matches inside a **custom property**, so this valid stylesheet passed while both rendered caps were wrong:

```css
.logs-table-wrap { max-height: calc(100dvh - 261px); --max-height: calc(100dvh - 260px); }
.action-toast.notice { max-width: min(479px, calc(100vw - 47px)); --max-width: min(480px, calc(100vw - 48px)); }
```

Reproduced against the real stylesheet before fixing: 10 pass / 0 fail with both effective declarations wrong. The property must now start the body or follow `;`/newline, so a `--`-prefixed name cannot satisfy it. Re-running the reviewer's exact fixture now turns both tests red.

**Both false negatives are now fixtured**, so neither can return quietly. A new test feeds inline CSS to the helper directly: a custom property whose name contains the read property must not be reported; a later duplicate rule must win; a genuinely absent property must throw. Driven red first — reverting only the regex fails it with `Received: calc(100dvh - 260px)`, the masked value.

The helper's comment also **overclaimed**, which the reviewer flagged alongside the code. It said the helper returns the declaration that "actually wins" and describes "the rendered result". It resolves source order within one exact selector string; it does not model `!important`, competing specificity, or @-rule nesting. The comment now states that, and why it is enough here: each rule is declared once, and the cascade question that matters (`.notice` beating a single-class `.action-toast`) is asserted separately.

Suites now **11 pass / 0 fail** (32 expect calls). `gui/src/styles.css` byte-identical to `origin/dev` after every experiment.


---

## Round 4 findings, also fixed

Round 4 confirmed the custom-property hole is closed and both fixtures genuinely guard their regressions, then found two more.

**CSS property names are case-insensitive and mine was not.** `MAX-HEIGHT` is a real declaration that wins the cascade, but a case-sensitive match walked past it and reported the earlier lowercase value. The reviewer confirmed in a browser that Chrome honours both `MAX-HEIGHT` and the escaped `max\2d width`. Matching is now case-insensitive, and escaped identifiers are **refused** rather than skipped — `max\2d height` *is* `max-height`, and resolving it means CSS identifier unescaping, which is more than a source-text oracle should pretend to have. Nothing here writes one, so its appearance means the reader no longer understands the file and should fail loudly.

Both fixtured, both driven red against the real stylesheet first: an uppercase duplicate fails 2 tests, an escaped one fails 1. Each previously passed 3/0.

**The 030 heading was misleading.** It read *"(line 2011 as shipped)"* directly above the pre-fix `100vh` snippet, making the defective code look like the shipped code. Line 2011 is where the rule sits now, carrying `100dvh`. Now stated explicitly.

Suites **12 pass / 0 fail** (34 expects).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified dashboard layout behavior, viewport sizing, toast-width rules, and wrapped-content handling.
  * Updated guidance for dynamic viewport sizing and line-height-based layout checks.

* **Tests**
  * Strengthened viewport and scroll-cap checks with exact expected values.
  * Added precise validation for log-table sizing and toast widths.
  * Improved styling checks to account for overlapping rules and prioritize effective declarations.
  * Added coverage for duplicate, case-variant, custom, escaped, and missing style properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->