### PR TITLE
fix(providers): give the live GLM-5.3-Flash route its own effort ladder

### DIFF
--- a/src/providers/command-code-efforts.ts
+++ b/src/providers/command-code-efforts.ts
@@ -73,6 +73,30 @@ const COMMAND_CODE_MODEL_EFFORTS = {
     efforts: ["low", "high", "max"],
     profileUrl: "https://commandcode.ai/models/glm-5-3",
   },
+  /*
+   * GLM-5.3-Flash (#2883). Reported as advertising NO efforts at all: the live
+   * route is `z-ai/glm-5.3-flash`, which shares neither vendor prefix nor model
+   * id with `zai-org/GLM-5.3` above, so `modelRecordValue` cannot bridge them
+   * (exact / colon-family / case-folded only — by design; a substring match here
+   * would merge two genuinely different models across two vendor namespaces).
+   *
+   * PROVENANCE: unlike the #2647 rows above, this ladder is MEASURED, not
+   * reported. commandcode.ai renders the profile client-side, but the delivered
+   * HTML ships a serialized React payload whose string table can be read
+   * directly: in the 2026-08-29 fetch of /models/glm-5-3-flash (HTTP 200,
+   * 228749 bytes) the indices resolve as 224=low, 225=medium, 226=high,
+   * 227=xhigh, 569=max, and this model's array is [224,226,569].
+   *
+   * The index map was cross-validated against every row in this table that the
+   * same page carries: deepseek-v4-pro and -flash [226,569], gpt-5.6-luna
+   * [224,225,226,227,569], gemini-3.7-flash [224,225,226], GLM-5.2 [226,569],
+   * GLM-5.3 [224,226,569] — six for six against the values already committed
+   * here. No authenticated upstream generate probe was performed.
+   */
+  "z-ai/glm-5.3-flash": {
+    efforts: ["low", "high", "max"],
+    profileUrl: "https://commandcode.ai/models/glm-5-3-flash",
+  },
   // Muse Spark: CLI currently prints "has no adjustable reasoning effort" and
   // blocks --effort locally, but the upstream /alpha/generate endpoint accepts
   // reasoning_effort low..max for meta/muse-spark-1.2-contributor (verified

--- a/tests/command-code-provider.test.ts
+++ b/tests/command-code-provider.test.ts
@@ -87,6 +87,31 @@ describe("Command Code provider", () => {
     });
   });
 
+  /*
+   * #2883. `z-ai/glm-5.3-flash` is a live-discovered route whose id shares
+   * neither the vendor prefix nor the model of `zai-org/GLM-5.3`, so no
+   * `modelRecordValue` relaxation reaches it — only an explicit row does. Both
+   * presets must carry it, because the picker is empty on whichever one the
+   * user configured, and the two entries are separately constructed.
+   */
+  test("the live GLM-5.3-Flash route carries its own effort ladder on both presets", () => {
+    const oauth = PROVIDER_REGISTRY.find(row => row.id === "command-code");
+    const apiKey = PROVIDER_REGISTRY.find(row => row.id === "commandcode");
+    for (const [label, entry] of [["oauth", oauth], ["api-key", apiKey]] as const) {
+      expect(entry?.modelReasoningEfforts?.["z-ai/glm-5.3-flash"], `${label} preset ladder`)
+        .toEqual(["low", "high", "max"]);
+    }
+    // Distinct rows for distinct upstream models: GLM-5.3 and GLM-5.3-Flash happen to
+    // share a ladder today, but neither may be derived from the other.
+    expect(commandCodeReasoningEfforts("z-ai/glm-5.3-flash")).toEqual(["low", "high", "max"]);
+    expect(commandCodeReasoningEfforts("zai-org/GLM-5.3")).toEqual(["low", "high", "max"]);
+    // The reported id arrives lowercase from live discovery; a caller may still fold case.
+    expect(commandCodeReasoningEfforts("Z-AI/GLM-5.3-Flash")).toEqual(["low", "high", "max"]);
+    // Nothing widened into a substring match: a sibling that upstream does not list
+    // must stay unknown rather than inheriting the Flash ladder.
+    expect(commandCodeReasoningEfforts("z-ai/glm-5.3-flash-vision")).toBeUndefined();
+  });
+
   test("OAuth and API-key presets share only verified image capabilities", () => {
     const oauth = PROVIDER_REGISTRY.find(row => row.id === "command-code");
     const apiKey = PROVIDER_REGISTRY.find(row => row.id === "commandcode");

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -1003,6 +1003,34 @@ describe("provider registry parity", () => {
     // so the request still reaches Command Code as `deepseek/deepseek-v4-flash`.
     expect(entries.find(e => e.slug === "commandcode/deepseek-deepseek-v4-flash")).toBeTruthy();
   });
+
+  /*
+   * #2883, at the surface the reporter actually saw. A live-discovered model with no
+   * row in the effort table falls through `configuredReasoningEfforts` to the
+   * provider-level `reasoningEfforts: []`, which `applyProviderConfigHints` then
+   * writes onto the model — so the Codex App picker renders empty and the request
+   * carries `requestedEffort: "none"`. Asserting the catalog entry rather than just
+   * the table is what makes this a regression test for the symptom.
+   */
+  test("the Command Code GLM-5.3-Flash route reaches the catalog with a selectable ladder", () => {
+    const commandcode = PROVIDER_REGISTRY.find(entry => entry.id === "commandcode");
+    const seed = providerConfigSeed(commandcode!);
+    const model = applyProviderConfigHints("commandcode", seed, {
+      id: "z-ai/glm-5.3-flash",
+      provider: "commandcode",
+    });
+    expect(model.id).toBe("z-ai/glm-5.3-flash");
+    expect(model.reasoningEfforts).toEqual(["low", "high", "max"]);
+
+    const entries = buildCatalogEntries(nativeTemplate() as never, [], [model]);
+    const entry = entries.find(e => e.slug === "commandcode/z-ai-glm-5.3-flash");
+    expect(entry).toBeTruthy();
+    // The empty ladder is exactly the reported symptom: an empty picker in the app.
+    expect(entry?.supported_reasoning_levels).not.toEqual([]);
+    // Routed catalogs append the synthetic top rung, as every other routed row above does.
+    expect((entry?.supported_reasoning_levels as { effort: string }[]).map(l => l.effort))
+      .toEqual(["low", "high", "max", "ultra"]);
+  });
   /*
    * #1043. Zen publishes no modality metadata, so the classification below is an
    * empirical list measured against the live endpoint on 2026-08-05, not something


### PR DESCRIPTION
## Summary

A live-discovered Command Code model advertised **no reasoning efforts at all**: the Codex App picker for `z-ai/glm-5.3-flash` was empty, and requests went out with `requestedEffort: "none"` (#2883).

The chain, end to end. `COMMAND_CODE_MODEL_EFFORTS` carries `zai-org/GLM-5.3`, but the live route is `z-ai/glm-5.3-flash` — a different vendor prefix *and* a different model. `modelRecordValue` matches exact, colon-family, or case-folded ids only, so it cannot bridge those two, `configuredReasoningEfforts` falls through to the provider-level `reasoningEfforts: []`, and `applyProviderConfigHints` writes that empty ladder onto the model. An empty `supported_reasoning_levels` is what the app renders as no picker.

The fix is one explicit table row. **`modelRecordValue` is deliberately left alone**: relaxing it to a substring or stem match would merge `zai-org/GLM-5.3` with `z-ai/glm-5.3-flash` — two genuinely different upstream models in two vendor namespaces — and would do it for every provider at once. The row also widens `knownModelIdsForProvider`, so the Codex-facing slug decodes back to the native id instead of passing through undecoded.

## The ladder is measured, not reported

The three #2647 rows above it in the same file are the reporter's, recorded as reported and explicitly not verified, because the profile pages render client-side and the file's comment says the delivered `reasoningEfforts` array is empty. That is true of the *array*, but not of the payload: the serialized React blob ships a string table that can be read directly.

From the 2026-08-29 fetch of `https://commandcode.ai/models/glm-5-3-flash` (HTTP 200, 228 749 bytes), the indices resolve as **224=low, 225=medium, 226=high, 227=xhigh, 569=max**, and this model's array is **`[224,226,569]` → `low, high, max`**.

The index map was cross-validated against every row already committed in this table that the same page carries — six for six, no adjustment:

| model | payload array | decoded | committed value |
| --- | --- | --- | --- |
| `deepseek/deepseek-v4-pro` | `[226,569]` | high, max | high, max |
| `deepseek/deepseek-v4-flash` | `[226,569]` | high, max | high, max |
| `gpt-5.6-luna` | `[224,225,226,227,569]` | low…max | low…max |
| `google/gemini-3.7-flash` | `[224,225,226]` | low, medium, high | low, medium, high |
| `zai-org/GLM-5.2` | `[226,569]` | high, max | high, max |
| `zai-org/GLM-5.3` | `[224,226,569]` | low, high, max | low, high, max |

To be exact about what this is and is not: it is a decode of the public page's own payload, checked against six known-good rows. **No authenticated upstream `generate` probe was performed** — I hold no Command Code credential — so the ladder is not confirmed by a live 200/400 from the API.

## Two things I looked at and deliberately did not change

**Slug decoding is already exact.** The linked symptom suggested a decode gap, but `decodeRoutedModelId` in `src/providers/slug-codec.ts` is bijective and uses no `includes()`, and the reporter's own log shows `resolvedModel: "z-ai/glm-5.3-flash"` resolving correctly with the request returning 200. The defect was only ever the missing ladder.

**`refreshCommandCodeReasoningEfforts` is dead for every row in the table**, not just this one. `parsedProfileEfforts` matches prose of the form "Reasoning efforts … are supported;", and `grep -c -i 'reasoning efforts'` against the live page returns 0. So a wrong ladder here stays wrong until a human changes it. That is pre-existing, documented in the file's own comment, and now fixable — the decode recipe above is exactly what the parser would need — but it is a separate change with its own failure modes, and folding it in here would hide this one-line fix inside a parser rewrite.

## Verification

- `bun test tests/command-code-provider.test.ts tests/provider-registry-parity.test.ts` — **72 pass / 0 fail**, 898 expect calls.
- **Mutation-proven.** Deleting the new table row turns **both** new tests red (`Expected - 5 / Received + 1`, ladder → `undefined`); 70 pass / 2 fail. The source was then restored and verified byte-identical by sha256 (`41b349d7…`), suite back to 72/0.
- `bun x tsc --noEmit` — clean.
- `bun run privacy:scan` — passed.

The catalog-level test is the one that matters: it asserts the built entry's `supported_reasoning_levels` is not `[]`, which is the reporter's exact symptom, rather than only asserting the table contains a key. It also pins the routed `ultra` rung the other routed rows in that file already expect. The provider test additionally asserts a sibling id (`z-ai/glm-5.3-flash-vision`) stays `undefined`, so a future substring-matching "fix" fails here.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

One table row plus two regression tests. No auth, routing, release, or credential path is touched; the ladder values are public model metadata.

Closes #2883


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `z-ai/glm-5.3-flash` model.
  - Model reasoning effort options now include **Low**, **High**, and **Max**.
  - Support is available across both OAuth and API-key connection methods.
  - The model’s catalog entry now exposes the available reasoning levels, including the highest routed option, **Ultra**.

- **Bug Fixes**
  - Prevented similarly named models from incorrectly inheriting these reasoning options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->