### PR TITLE
docs(devlog): correct the red-test arithmetic and name two enumeration gaps

### DIFF
--- a/devlog/_plan/260829_cursor_tool_continuation_pairing/040_phase5_checkpoint_suffix_gap.md
+++ b/devlog/_plan/260829_cursor_tool_continuation_pairing/040_phase5_checkpoint_suffix_gap.md
@@ -62,7 +62,7 @@ the fix was restored:
 | covered history is not replayed a second time | no — double-replay guard |
 | an id reused in covered history yields no invocation line | no — ambiguity guard |
 | native composer keeps checkpoint results off the root prompt | no — native-path guard |
-| an ambiguous id resolved from full history is not re-resolved from the suffix | yes — but against `size > 0`, not against the threading |
+| an ambiguous id resolved from full history is not re-resolved from the suffix | yes — against the threading *and* against `size > 0` |
 
 ### Why the lookup uses `??` and not a `size > 0` check
 
@@ -89,8 +89,19 @@ covered history yields no invocation line" passes under *both* variants, because
 is ambiguous within the suffix too. The distinction only shows up when the ambiguity is visible in
 full history but not in the suffix, which is what the added case constructs.
 
-Two assertions fail without the threading and pass with it; the other three are guards that
-must hold either way, and they document what the widened lookup must *not* break.
+**Three** of the six assertions fail without the threading and pass with it; the other three are
+guards that must hold either way, and they document what the widened lookup must *not* break.
+
+An independent final-gate review corrected this count. The original text said two of five, which was
+wrong on both numbers: the sixth test was added after the table was written, and it fails against a
+missing threading too, not only against a `size > 0` fallback. Without the threading `knownCalls` is
+`undefined`, so the suffix-only index sees one candidate and names `echo SECOND` for a result whose
+output is `FIRST` — the same wrong label, reached by a different route. Measured at `1241a8d5c`:
+reverting only the call-site threading gives **16 pass / 3 fail**.
+
+The fix is therefore better covered than the first version of this record claimed. Recorded because a
+reader who reverts the threading expecting two failures would not know whether they were looking at a
+stale doc or a real drift.
 
 Two shapes needed care while writing them:
 
@@ -129,6 +140,37 @@ callers select on role first.
 So the `toolResult` branch inside `contentText` is dead for these paths, and the two patched sites are
 the complete set. `request-builder.ts` has its own `toolResultToText` for the text `messages` channel;
 it is a different channel with no invocation line by design and is out of scope here.
+
+### Two gaps that enumeration missed
+
+The final-gate review found the argument above correct about `contentText` but the surrounding claim
+overstated: "only two functions attach an invocation line" is true, yet it is not the same statement as
+"every site that emits a result envelope has been accounted for". Both items below are **pre-existing**
+and neither is induced by the checkpoint cut.
+
+**A fourth emission site, line ~1025.** The `conversationTurns` native branch resolves its call from
+suffix-local `pendingToolCalls` and, on a miss, falls through to a bare `toolResultToText(message)`
+with no invocation line. It never consults `knownCalls`. Measured: full replay and checkpoint produce
+byte-identical bare output on the same interleaved input, so the cut does not induce it.
+
+**The two builders gate on different predicates.** `rootPromptMessages` uses
+`cursorNeedsExternalToolContinuation`; `conversationTurns` uses `isCursorExternalWireModel`. These
+disagree for exactly one model:
+
+| Model | `cursorNeedsExternalToolContinuation` | `isCursorExternalWireModel` |
+|-------|--------------------------------------|------------------------------|
+| `composer-2.5` | true | **false** |
+| `grok-4.6-high` | true | true |
+| `composer-2.5-fast` | false | false |
+
+So for `composer-2.5` the map is threaded in and then ignored by the turn builder. Measured on an
+interleaved history: `ROOT invoked=true`, `TURN_STEP invoked=false`.
+
+The asymmetry was inherited from #2900, where the root gate was deliberately widened to
+`cursorNeedsExternalToolContinuation` (audit 001 F2) while the turn gate was left alone. Whether
+`composer-2.5` turn steps should also name the invocation is a behaviour question about a native
+model's replay, not a checkpoint-indexing bug, so it is not folded in here — it belongs to a unit that
+can verify the native path end to end rather than being changed on inference.
 - `bun x tsc --noEmit` — exit 0.
 - Full suite on `ssh lidge`; no local full-suite run was used as a gate.
 


### PR DESCRIPTION
## Summary

An independent final-gate review of #2910 found the recorded arithmetic wrong. This corrects it and
records two gaps the completeness enumeration in #2913 missed. **Devlog only — no `src/` change.**

**The red-test count was wrong on both numbers.** #2910 claimed "2 of 5 assertions fail without the
threading". Reverting only the call-site threading and running the focused file gives **16 pass / 3
fail**, and the block has **6** tests. The sixth was added late, after the table was written, and it
fails against a missing threading as well as against a `size > 0` fallback: with `knownCalls`
undefined the suffix-only index names `echo SECOND` for a result whose output is `FIRST` — the same
wrong label reached by a different route. The fix is better covered than the record claimed, which is
still worth correcting: a reader who reverts the threading expecting two failures cannot tell a stale
doc from a real drift.

**Two pre-existing gaps, neither induced by the checkpoint cut.**

1. A fourth emission site at `protobuf-request.ts` line ~1025. The `conversationTurns` native branch
   resolves its call from suffix-local `pendingToolCalls` and falls through to a bare
   `toolResultToText(message)` on a miss, never consulting `knownCalls`. Full replay and checkpoint
   produce byte-identical bare output on the same input, so the cut does not cause it.
2. The two builders gate on different predicates — `cursorNeedsExternalToolContinuation` for the root,
   `isCursorExternalWireModel` for turns. They disagree for exactly one model:

   | Model | `cursorNeedsExternalToolContinuation` | `isCursorExternalWireModel` |
   |-------|--------------------------------------|------------------------------|
   | `composer-2.5` | true | **false** |
   | `grok-4.6-high` | true | true |
   | `composer-2.5-fast` | false | false |

   So `composer-2.5` gets the map threaded in and then ignored by the turn builder: measured
   `ROOT invoked=true`, `TURN_STEP invoked=false`. Inherited from #2900, where the root gate was
   deliberately widened (audit 001 F2) while the turn gate was left alone.

Whether `composer-2.5` turn steps should also name the invocation is a behaviour question about a
native model's replay, not a checkpoint-indexing bug, so it is **not** changed here. Fixing it on
inference is how this unit produced three partial fixes already.

The review also flagged the `turnCalls` lookup sitting at column 0 inside a nested block since #2900.
That fix is **not** in this PR: a whitespace-only edit under `src/` reads as behaviour to the hygiene
gate (`isCommentOnlyChange` compares trimmed lines), which failed `missing_regression_test` on the
first push. Rather than attach a `test-exception-approved` label to a cosmetic change, the edit is
deferred to a PR that touches that file for a real reason.

## Verification

- No source change, so behaviour is unchanged by construction.
- `bun run privacy:scan` — passed.
- Corrected count reproduced directly: revert the threading, 16 pass / 3 fail; restore, 19 pass / 0 fail.
- Predicate asymmetry reproduced with a decode probe on an interleaved history
  (`ROOT invoked=true`, `TURN_STEP invoked=false` for `composer-2.5`).
- `bun test tests/cursor-tool-result-invocation.test.ts tests/cursor-tool-continuation.test.ts tests/cursor-blob.test.ts` — 124 pass, 0 fail, and `bun x tsc --noEmit` exit 0, both taken while the deferred whitespace fix was still applied locally.
- Full suite and typecheck on `ssh lidge`: TSC=0, TEST=0, 0 failures.

No GUI change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the phase 5 test results and clarified assertion failures.
  * Added completeness details covering invocation-line handling and known limitations.
  * Documented additional pre-existing gaps and differing conditions affecting `composer-2.5`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->