### PR TITLE
test(codex): prove replay 402 closes compact recovery

### DIFF
--- a/tests/responses-pool-401-refresh.test.ts
+++ b/tests/responses-pool-401-refresh.test.ts
@@ -375,72 +375,76 @@ describe("ordinary pool 401 refresh and replay (#2887)", () => {
     expect(harness.refreshes).toEqual(["refresh-grant"]);
   });
 
-  test("compact does not compose a stored-account replay 429 with a remembered model", async () => {
-    const headers = { "x-codex-parent-thread-id": "compact-refresh-budget" };
-    writeStoredAccount({
-      [OTHER_ACCOUNT_ID]: storedRecord({
-        accessToken: "other-access",
-        refreshToken: "other-grant",
-        generation: 1,
-        chatgptAccountId: "acc-other",
-      }),
+  for (const replayStatus of [429, 402] as const) {
+    test(`compact does not compose a stored-account replay ${replayStatus} with another account or remembered model`, async () => {
+      const headers = { "x-codex-parent-thread-id": `compact-refresh-budget-${replayStatus}` };
+      writeStoredAccount({
+        [OTHER_ACCOUNT_ID]: storedRecord({
+          accessToken: "other-access",
+          refreshToken: "other-grant",
+          generation: 1,
+          chatgptAccountId: "acc-other",
+        }),
+      });
+      const cfg = config({ secondAccount: true });
+      cfg.accountPoolStrategy = "fill-first";
+      cfg.providers.seed = {
+        adapter: "openai-responses",
+        baseUrl: "https://seed.example/v1",
+        authMode: "key",
+        apiKey: "seed-test-key",
+      };
+      let seedModelSends = 0;
+      let alternateAccountSends = 0;
+      const harness = installHarness({
+        responseForSend: (authorization, _sendNumber, url) => {
+          if (url.hostname === "seed.example") {
+            seedModelSends += 1;
+            return Response.json({
+              id: "seed",
+              object: "response",
+              status: "completed",
+              output: [{
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: "seed summary", annotations: [] }],
+              }],
+            });
+          }
+          if (authorization === "Bearer rejected-access") {
+            return Response.json({ error: { message: "rejected bearer" } }, { status: 401 });
+          }
+          if (authorization === "Bearer refreshed-access") {
+            return Response.json({ error: { message: "pool exhausted" } }, { status: replayStatus });
+          }
+          if (authorization === "Bearer other-access") {
+            alternateAccountSends += 1;
+            return Response.json({ id: "must-not-run", object: "response", status: "completed", output: [] });
+          }
+          return undefined;
+        },
+      });
+
+      const seed = await handleResponsesCompact(
+        request("/v1/responses/compact", { model: "seed/seed-model", headers }),
+        cfg,
+        { model: "", provider: "" } as RequestLogContext,
+      );
+      expect(seed.status).toBe(200);
+
+      const response = await handleResponsesCompact(
+        request("/v1/responses/compact", { headers }),
+        cfg,
+        { model: "", provider: "" } as RequestLogContext,
+      );
+
+      expect(response.status).toBe(replayStatus);
+      expect(harness.sends).toHaveLength(3);
+      expect(alternateAccountSends).toBe(0);
+      expect(seedModelSends).toBe(1);
+      expect(harness.refreshes).toHaveLength(1);
     });
-    const cfg = config({ secondAccount: true });
-    cfg.accountPoolStrategy = "fill-first";
-    cfg.providers.seed = {
-      adapter: "openai-responses",
-      baseUrl: "https://seed.example/v1",
-      authMode: "key",
-      apiKey: "seed-test-key",
-    };
-    const harness = installHarness({
-      responseForSend: (authorization, _sendNumber, url) => {
-        if (url.hostname === "seed.example") {
-          return Response.json({
-            id: "seed",
-            object: "response",
-            status: "completed",
-            output: [{
-              type: "message",
-              role: "assistant",
-              content: [{ type: "output_text", text: "seed summary", annotations: [] }],
-            }],
-          });
-        }
-        if (authorization === "Bearer rejected-access") {
-          return Response.json({ error: { message: "rejected bearer" } }, { status: 401 });
-        }
-        if (authorization === "Bearer refreshed-access") {
-          return Response.json({ error: { message: "pool exhausted" } }, { status: 429 });
-        }
-        if (authorization === "Bearer other-access") {
-          return Response.json({ id: "must-not-run", object: "response", status: "completed", output: [] });
-        }
-        return undefined;
-      },
-    });
-
-    const seed = await handleResponsesCompact(
-      request("/v1/responses/compact", { model: "seed/seed-model", headers }),
-      cfg,
-      { model: "", provider: "" } as RequestLogContext,
-    );
-    expect(seed.status).toBe(200);
-
-    const response = await handleResponsesCompact(
-      request("/v1/responses/compact", { headers }),
-      cfg,
-      { model: "", provider: "" } as RequestLogContext,
-    );
-
-    expect(response.status).toBe(429);
-    expect(harness.sends).toEqual([
-      "Bearer seed-test-key",
-      "Bearer rejected-access",
-      "Bearer refreshed-access",
-    ]);
-    expect(harness.refreshes).toEqual(["refresh-grant"]);
-  });
+  }
 
   test("the replayed account is still selectable on the NEXT request, not just this one", async () => {
     // The affinity entry is bound under generation G; the forced refresh CAS-writes G+1 and
@@ -641,7 +645,7 @@ describe("ordinary pool 401 refresh and replay (#2887)", () => {
     expect(harness.refreshes).toEqual(["refresh-grant"]);
   });
 
-  test("a stored-account replay 429 cannot reach another account even when one is eligible", async () => {
+  test("a stored-account replay 402 cannot reach another account even when one is eligible", async () => {
     // The mirror of the case above: a quota failure has no same-account move left, so it is
     // terminal. Asserted with a healthy alternate present, so passing means the budget stopped
     // it rather than there being nowhere to go.

--- a/tests/responses-pool-401-refresh.test.ts
+++ b/tests/responses-pool-401-refresh.test.ts
@@ -439,10 +439,14 @@ describe("ordinary pool 401 refresh and replay (#2887)", () => {
       );
 
       expect(response.status).toBe(replayStatus);
-      expect(harness.sends).toHaveLength(3);
+      expect(harness.sends).toEqual([
+        "Bearer seed-test-key",
+        "Bearer rejected-access",
+        "Bearer refreshed-access",
+      ]);
       expect(alternateAccountSends).toBe(0);
       expect(seedModelSends).toBe(1);
-      expect(harness.refreshes).toHaveLength(1);
+      expect(harness.refreshes).toEqual(["refresh-grant"]);
     });
   }
 


### PR DESCRIPTION
## Summary

- `origin/dev` already contains the gap-5 production fix from #2897 (`4fa981fb8`), so this is the missing focused regression follow-up rather than a duplicate control-flow rewrite.
- Exercise compact stored-Pool replay failures as separate 429 and 402 cases. Each case counts all upstream sends and proves zero later sends to either an alternate Pool account or the remembered compact model.
- Correct the existing regular Responses 402 regression title, which previously said 429. This is a title-only correction: the fixture and assertion were already 402, so no coverage moved.
- No production source, credential-store state machine, forced-refresh provenance, rejected-bearer exclusion, or affinity handoff is changed. PR #2920 remains separate and untouched.

Refs #2892.

This is a credential/auth path and requires explicit security review before merge. The tests add no logging and do not serialize tokens or account identifiers.

## Verification

- `bun test tests/responses-pool-401-refresh.test.ts tests/codex-account-store.test.ts` — **55 pass / 0 fail** on head `f06e8ca83`.
- `bun x tsc --noEmit` — exit 0.
- `bun run privacy:scan` — **Privacy scan passed**.
- The existing one-refresh/one-replay and next-request-availability regressions remain green.

### Mutation evidence

Regular Responses 402: setting `sameAccountOnly: false` allowed the alternate account send and turned the existing corrected-title test RED:

```text
bun test v1.4.0 (34cbb9a40)

tests/responses-pool-401-refresh.test.ts:
683 |     expect(response.status).toBe(402);
                                  ^
error: expect(received).toBe(expected)

Expected: 402
Received: 200

(fail) ordinary pool 401 refresh and replay (#2887) > a stored-account replay 402 cannot reach another account even when one is eligible

0 pass
19 filtered out
1 fail
```

New compact 402 case, alternate-account mutation: removed the exact `&& !storedPool401ReplayAttempted` guard at `src/server/responses/compact.ts:846` from the 429/402 alternate-account `if`; this turned it RED:

```text
bun test v1.4.0 (34cbb9a40)

tests/responses-pool-401-refresh.test.ts:
446 |       expect(response.status).toBe(replayStatus);
                                    ^
error: expect(received).toBe(expected)

Expected: 402
Received: 200

(fail) ordinary pool 401 refresh and replay (#2887) > compact does not compose a stored-account replay 402 with another account or remembered model

0 pass
20 filtered out
1 fail
```

Remembered-model mutation: removed the exact `&& !storedPool401ReplayAttempted` guard at `src/server/responses/compact.ts:957` from `else if (quotaFailure && !storedPool401ReplayAttempted)`; it independently produced the same RED failure (`Expected: 402`, `Received: 200`). Both source mutations were restored before the green run and are absent from this PR.

I also tried adding separate combo-402 and policy-402 cases. Disabling their stored-replay dispatch gates did **not** turn those tests red (`1 pass / 0 fail` in each case), because their independent general failure classifiers already stop 402. I removed those vacuous cases and do not claim them as gap-5 mutation coverage.

### Could not verify

- Repository-wide `bun run test` was not run because this delegation explicitly prohibited it.
- GitHub CI had not completed when this PR was opened.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No docs change is needed for this regression-only follow-up.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Explicit maintainer security review is still required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for stored-account replay handling across rate-limit and quota-exhaustion responses.
  - Added assertions verifying refresh behavior, seed-model sends, and prevention of unintended alternate-account usage.
  - Updated test naming to accurately reflect quota-exhaustion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->