### PR TITLE
fix(claude): detect Windows Desktop policy conflicts

### DIFF
--- a/docs-site/src/content/docs/guides/claude-code.md
+++ b/docs-site/src/content/docs/guides/claude-code.md
@@ -108,6 +108,7 @@ You can also manage the same profile from the command line:
 ```bash
 ocx claude desktop [apply]
 ocx claude desktop show [--json]
+ocx claude desktop status [--json]
 ocx claude desktop move <route> <opus|fable|sonnet|haiku> [--default]
 ocx claude desktop default <opus|fable|sonnet|haiku> <route|none>
 ocx claude desktop export <path|->
@@ -115,10 +116,18 @@ ocx claude desktop import <path> [--apply]
 ```
 
 `ocx claude desktop` and `apply` both write the current profile to Claude Desktop. `show` gives a
-readable summary; add `--json` for scripts. `export -` writes versioned JSON to standard output.
+readable summary; `status` reports the applied profile, drift, request activity, and Windows
+managed-policy health. Add `--json` for scripts. `export -` writes versioned JSON to standard output.
 Import validates the complete file before saving, so an invalid file leaves the current profile
 unchanged. Add `--apply` to write a valid imported profile to Desktop immediately. Use `none` only
 for an empty family; every non-empty family must keep one default.
+
+On Windows, a machine-managed Claude policy can make Desktop ignore the local third-party profile.
+OpenCodex reports this as `present`; a policy it cannot read is `unknown`, which is also a warning
+rather than a clean result. The diagnostic reports only that state—it does not expose policy value
+names or data, and it never removes or bypasses policy. Resolve the policy with your administrator,
+then fully quit and reopen Claude Desktop. Applying again also preserves profile keys that OpenCodex
+does not own while refreshing its gateway and model fields.
 
 Apply writes to Claude Desktop's real Electron user-data `configLibrary`: `~/Library/Application
 Support/Claude/configLibrary` on macOS, `%APPDATA%\Claude\configLibrary` on Windows, and

--- a/docs-site/src/content/docs/reference/cli/agents.md
+++ b/docs-site/src/content/docs/reference/cli/agents.md
@@ -180,6 +180,7 @@ Claude Desktop profile commands are:
 ```text
 ocx claude desktop [apply]                         Save and apply the four-family profile
 ocx claude desktop show [--json]                   Show routes, families, and defaults
+ocx claude desktop status [--json]                 Show applied state, drift, and health
 ocx claude desktop move <route> <family> [--default]
 ocx claude desktop default <family> <route|none>
 ocx claude desktop export <path|->                 Export versioned JSON (`-` = stdout)

--- a/src/claude/desktop-3p.ts
+++ b/src/claude/desktop-3p.ts
@@ -585,7 +585,9 @@ export function writeDesktop3pConfig(
       ? metadata.entries.map(current => current === existing ? entry : current)
       : [...metadata.entries, entry];
 
-    const configJson = JSON.stringify(generateDesktop3pConfig(port, nativeSlugs, routedModels, apiKey, mode, profile, nativeContextCap), null, 2) + "\n";
+    const generated = generateDesktop3pConfig(port, nativeSlugs, routedModels, apiKey, mode, profile, nativeContextCap);
+    const preserved = readDesktopProfileForeignKeys(configPath);
+    const configJson = JSON.stringify({ ...preserved, ...generated }, null, 2) + "\n";
     const fingerprint = createHash("sha256").update(configJson).digest("hex").slice(0, 16);
     const { backupPath } = atomicReplaceDesktopConfig(configPath, configJson);
     try {
@@ -600,6 +602,24 @@ export function writeDesktop3pConfig(
     const reason = error instanceof Error ? error.message : String(error);
     return { written: false, path: configPath, reason };
   }
+}
+
+const OPENCODEX_DESKTOP_PROFILE_KEYS = new Set([
+  "inferenceProvider",
+  "inferenceCredentialKind",
+  "inferenceGatewayBaseUrl",
+  "inferenceGatewayApiKey",
+  "modelDiscoveryEnabled",
+  "inferenceModels",
+]);
+
+function readDesktopProfileForeignKeys(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (!isRecord(parsed)) throw new Error("Claude Desktop 3P profile is not a JSON object");
+  return Object.fromEntries(
+    Object.entries(parsed).filter(([key]) => !OPENCODEX_DESKTOP_PROFILE_KEYS.has(key)),
+  );
 }
 
 /** Backup an existing owned config then atomically replace it. Exported for failure-path tests. */

--- a/src/claude/desktop-policy.ts
+++ b/src/claude/desktop-policy.ts
@@ -1,0 +1,149 @@
+/** Read-only, privacy-safe Windows policy diagnosis for Claude Desktop 3P. */
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { resolveTrustedWindowsSystemDirectory } from "../lib/windows-elevation";
+import { decodeWindowsTextBytes } from "../lib/windows-text";
+
+const CLAUDE_POLICY_KEY = "HKLM\\SOFTWARE\\Policies\\Claude";
+const CLAUDE_POLICY_PARENT_KEY = "HKLM\\SOFTWARE\\Policies";
+const POLICY_PROBE_TIMEOUT_MS = 2_000;
+
+export type ClaudeDesktopPolicyState = "present" | "absent" | "unknown" | "not_applicable";
+
+export interface ClaudeDesktopPolicyProbeResult {
+  readonly status: number | null;
+  /** Kept inside the probe boundary; diagnostics never return or log it. */
+  readonly stdout: string;
+  readonly timedOut: boolean;
+  readonly spawnFailed: boolean;
+}
+
+export type ClaudeDesktopPolicyProbeRunner = (
+  file: string,
+  args: readonly string[],
+) => ClaudeDesktopPolicyProbeResult;
+
+export interface ClaudeDesktopPolicyProbeOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly run?: ClaudeDesktopPolicyProbeRunner;
+  readonly resolveSystemDirectory?: () => string;
+}
+
+export interface ClaudeDesktopPolicyHealth {
+  readonly ok: boolean;
+  readonly status: "ok" | "warning";
+  readonly state: ClaudeDesktopPolicyState;
+  readonly message: string;
+  readonly action: string;
+}
+
+const defaultPolicyProbeRunner: ClaudeDesktopPolicyProbeRunner = (file, args) => {
+  const result = spawnSync(file, [...args], {
+    encoding: "buffer",
+    maxBuffer: 64 * 1024,
+    timeout: POLICY_PROBE_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+  return {
+    status: result.status,
+    // Decoded only to prove key absence. This never crosses the probe boundary.
+    stdout: result.stdout ? decodeWindowsTextBytes(result.stdout) : "",
+    timedOut: errorCode === "ETIMEDOUT" || result.signal !== null,
+    spawnFailed: result.error !== undefined && errorCode !== "ETIMEDOUT",
+  };
+};
+
+function usable(result: ClaudeDesktopPolicyProbeResult): boolean {
+  return !result.timedOut && !result.spawnFailed && result.status !== null;
+}
+
+function parentListsPolicyKey(output: string): boolean {
+  const expected = CLAUDE_POLICY_KEY.toLowerCase();
+  return output.split(/\r?\n/).some(line => line.trim().toLowerCase()
+    .replace(/^hkey_local_machine\\/, "hklm\\") === expected);
+}
+
+/**
+ * Detect machine-level Claude managed policy without reading or exposing its contents.
+ *
+ * `reg.exe` returns exit 1 for both a missing key and query/access failures. As in the
+ * Windows tray registry reader, absence is therefore accepted only when the immediate
+ * parent can be queried successfully. Every other failure stays unknown.
+ */
+export function probeClaudeDesktopPolicy(
+  options: ClaudeDesktopPolicyProbeOptions = {},
+): ClaudeDesktopPolicyState {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") return "not_applicable";
+
+  let regExe: string;
+  try {
+    const systemDirectory = (options.resolveSystemDirectory ?? resolveTrustedWindowsSystemDirectory)();
+    regExe = join(systemDirectory, "reg.exe");
+  } catch {
+    return "unknown";
+  }
+
+  const run = options.run ?? defaultPolicyProbeRunner;
+  let policy: ClaudeDesktopPolicyProbeResult;
+  try {
+    policy = run(regExe, ["query", CLAUDE_POLICY_KEY, "/reg:64"]);
+  } catch {
+    return "unknown";
+  }
+  if (!usable(policy)) return "unknown";
+  if (policy.status === 0) return "present";
+  if (policy.status !== 1) return "unknown";
+
+  let parent: ClaudeDesktopPolicyProbeResult;
+  try {
+    parent = run(regExe, ["query", CLAUDE_POLICY_PARENT_KEY, "/reg:64"]);
+  } catch {
+    return "unknown";
+  }
+  if (!usable(parent) || parent.status !== 0) return "unknown";
+  // The child can be listed by a readable parent while its own ACL blocks the
+  // query. That is unreadable, not absent.
+  return parentListsPolicyKey(parent.stdout) ? "unknown" : "absent";
+}
+
+/** State-only health projection shared by CLI, apply, and management status. */
+export function claudeDesktopPolicyHealth(
+  state: ClaudeDesktopPolicyState,
+): ClaudeDesktopPolicyHealth {
+  if (state === "present") {
+    return {
+      ok: false,
+      status: "warning",
+      state,
+      message: "Windows managed Claude policy is active, so Claude Desktop will ignore the local third-party profile.",
+      action: "Ask your administrator to remove or revise the managed Claude policy, then fully quit and reopen Claude Desktop.",
+    };
+  }
+  if (state === "unknown") {
+    return {
+      ok: false,
+      status: "warning",
+      state,
+      message: "OpenCodex could not verify Windows managed Claude policy; Desktop third-party profile health is unverified.",
+      action: "Check access to Windows machine policy and run the status check again before relying on Claude Desktop 3P.",
+    };
+  }
+  return {
+    ok: true,
+    status: "ok",
+    state,
+    message: state === "absent"
+      ? "No Windows managed Claude policy was detected."
+      : "Windows managed Claude policy is not applicable on this platform.",
+    action: "No action required.",
+  };
+}
+
+export function claudeDesktopPolicyWarning(
+  state: ClaudeDesktopPolicyState,
+): string | undefined {
+  const health = claudeDesktopPolicyHealth(state);
+  return health.ok ? undefined : `${health.message} Action: ${health.action}`;
+}

--- a/src/cli/claude-desktop.ts
+++ b/src/cli/claude-desktop.ts
@@ -37,7 +37,8 @@ export interface ApplyProfileDeps {
   postApplyImpl?: (
     mode: Desktop3pConfigMode,
     profile: DesktopProfile,
-  ) => Promise<{ ok?: boolean; path?: string; error?: string }>;
+  ) => Promise<{ ok?: boolean; path?: string; error?: string; warning?: string }>;
+  probeClaudeDesktopPolicy?: typeof import("../claude/desktop-policy").probeClaudeDesktopPolicy;
 }
 
 export async function applyProfile(
@@ -71,10 +72,11 @@ export async function applyProfile(
       // Partial success: Desktop was written but the applied marker was not
       // persisted. Pass the degradation up instead of reporting a clean apply.
       const partial = (applied as { saved?: boolean; warning?: string }).saved === false;
+      const warning = (applied as { warning?: string }).warning;
       return {
         ok: true,
         path: applied.path ?? "",
-        ...(partial ? { warning: (applied as { warning?: string }).warning ?? "applied marker was not saved" } : {}),
+        ...(warning ? { warning } : partial ? { warning: "applied marker was not saved" } : {}),
       };
     } catch (error) {
       return { ok: false, path: "", reason: error instanceof Error ? error.message : String(error) };
@@ -102,7 +104,15 @@ export async function applyProfile(
     state.profile,
     nativeContextLimits(config),
   );
-  return { ok: result.written, path: result.path, reason: result.reason };
+  const { claudeDesktopPolicyWarning, probeClaudeDesktopPolicy } = await import("../claude/desktop-policy");
+  const policyState = (deps.probeClaudeDesktopPolicy ?? probeClaudeDesktopPolicy)();
+  const warning = result.written ? claudeDesktopPolicyWarning(policyState) : undefined;
+  return {
+    ok: result.written,
+    path: result.path,
+    reason: result.reason,
+    ...(warning ? { warning } : {}),
+  };
 }
 
 export async function handleClaudeDesktopCommand(argv: string[], deps: ApplyProfileDeps = {}): Promise<number> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -858,6 +858,11 @@ async function handleStatus() {
     console.log(`❌ Proxy: ${status.proxyLabel}`);
   }
   console.log(`   Health: ${status.healthLabel}`);
+  if (status.json.claudeDesktop.desiredEnabled && !status.json.claudeDesktop.policy.ok) {
+    console.log(`   ⚠️  Claude Desktop 3P health: ${status.json.claudeDesktop.policy.status}`);
+    console.log(`      ${status.json.claudeDesktop.policy.message}`);
+    console.log(`      Action: ${status.json.claudeDesktop.policy.action}`);
+  }
   // Printed here, not only in --json: a stale ocx on PATH is exactly the situation where
   // the operator is reading human output and wondering why the CLI disagrees with the
   // dashboard. Adding the JSON field alone would satisfy a test and help nobody (#2701).

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -291,6 +291,7 @@ export const CLI_COMMANDS: CliCommandEntry[] = [
       "Claude Desktop profile:",
       "  ocx claude desktop [apply]                         Save and apply the four-family profile",
       "  ocx claude desktop show [--json]                   Show routes, families, and defaults",
+      "  ocx claude desktop status [--json]                 Show applied state, drift, and health",
       "  ocx claude desktop move <route> <family> [--default]",
       "  ocx claude desktop default <family> <route|none>",
       "  ocx claude desktop export <path|->                 Export versioned JSON (`-` = stdout)",

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -16,6 +16,8 @@ import { computeVersionSkew, type VersionSkew } from "./version-skew";
 import { redactSecretString, redactUserPath } from "../lib/redact";
 import { collectOrcaCodexHomeDiagnostic, type OrcaCodexHomeDiagnostic } from "../codex/home";
 import { grokFenceEndpointDrift, readGrokStatus } from "../grok/status";
+import { claudeDesktopIntegrationEnabled } from "../codex/desired-state";
+import { claudeDesktopPolicyHealth, probeClaudeDesktopPolicy, type ClaudeDesktopPolicyHealth } from "../claude/desktop-policy";
 
 type HealthCheck = {
   ok: boolean;
@@ -77,6 +79,10 @@ export type CliStatusJson = {
     };
   };
   codexHome: OrcaCodexHomeDiagnostic;
+  claudeDesktop: {
+    desiredEnabled: boolean;
+    policy: ClaudeDesktopPolicyHealth;
+  };
   /**
    * This CLI's version against the running proxy's (#2701).
    *
@@ -299,6 +305,10 @@ export async function probeUncleanExitState(input: {
 export async function collectStatus(): Promise<CliStatusView> {
   const configDiagnostics = readConfigDiagnostics();
   const config = configDiagnostics.config;
+  const claudeDesktop = {
+    desiredEnabled: claudeDesktopIntegrationEnabled(config),
+    policy: claudeDesktopPolicyHealth(probeClaudeDesktopPolicy()),
+  };
   // Prefer identity-verified liveness (runtime-port + /healthz) over ocx.pid alone (#618).
   // Pass the already-resolved diagnostics config so findLiveProxy does not re-load and
   // warn on malformed config.json (status --json must stay stderr-clean).
@@ -486,6 +496,7 @@ export async function collectStatus(): Promise<CliStatusView> {
       codexPlugins,
       codexRuntime,
       codexHome,
+      claudeDesktop,
       // Own field rather than a line in `codexRuntime.warning`: a stale ocx on PATH is a
       // fact about this install, not about the Codex runtime, and filing it there would
       // print it under the wrong heading (#2701).

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -925,6 +925,11 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
         nativeContextLimits(latest),
       );
       if (!result.written) return jsonResponse({ error: result.reason ?? "Claude Desktop apply failed", saved: true, path: result.path }, 500);
+      const { claudeDesktopPolicyWarning, probeClaudeDesktopPolicy } = await import("../../claude/desktop-policy");
+      const policyState = (deps.probeClaudeDesktopPolicy ?? probeClaudeDesktopPolicy)({
+        platform: deps.platform ?? process.platform,
+      });
+      const policyWarning = claudeDesktopPolicyWarning(policyState);
       // Persist applied fingerprint + timestamp so GUI can show saved-vs-applied state.
       if (result.fingerprint) {
         // The Desktop write already landed, so a failed bookkeeping save is not
@@ -941,11 +946,22 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
             saved: false,
             path: result.path,
             fingerprint: result.fingerprint,
-            warning: `Claude Desktop was applied, but the applied marker was not saved (${marked.reason}).`,
+            warning: [
+              `Claude Desktop was applied, but the applied marker was not saved (${marked.reason}).`,
+              policyWarning,
+            ].filter(Boolean).join(" "),
           });
         }
       }
-      return jsonResponse({ ok: true, saved: true, applied: true, path: result.path, fingerprint: result.fingerprint });
+      return jsonResponse({
+        ok: true,
+        saved: true,
+        applied: true,
+        path: result.path,
+        fingerprint: result.fingerprint,
+        policyState,
+        ...(policyWarning ? { warning: policyWarning } : {}),
+      });
     } catch (error) {
       rethrowManagementBodyTooLarge(error);
       return jsonResponse({ error: error instanceof Error ? error.message : String(error) }, 400);
@@ -967,7 +983,24 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
       // a stale apply the operator should refresh.
       const stale = desiredEnabled && observed.kind === "gateway_drifted";
       const { getDesktopHealth } = await import("../../claude/desktop-health");
-      const health = getDesktopHealth();
+      const { claudeDesktopPolicyHealth, probeClaudeDesktopPolicy } = await import("../../claude/desktop-policy");
+      const policyState = (deps.probeClaudeDesktopPolicy ?? probeClaudeDesktopPolicy)({
+        platform: deps.platform ?? process.platform,
+      });
+      const policy = claudeDesktopPolicyHealth(policyState);
+      const health = {
+        ...getDesktopHealth(),
+        ok: policy.ok,
+        status: policy.status,
+        policy,
+      };
+      const policyConflict = desiredEnabled && !policy.ok;
+      const baseDrift = desiredEnabled ? !applied || stale : applied || observed.kind === "unsafe";
+      const driftReason = policyConflict
+        ? policy.state === "present" ? "managed_policy_present" : "managed_policy_unknown"
+        : desiredEnabled
+          ? !applied ? "desired_on_not_current" : stale ? "profile_drift" : null
+          : applied ? "desired_off_gateway_selected" : null;
       return jsonResponse({
         desiredEnabled,
         installed: observed.kind !== "not_installed",
@@ -982,8 +1015,8 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
         // undeterminable (no/unreadable metadata or no appliedId); a readable
         // appliedId with no owned entry is a KNOWN false. Predates the inspector.
         activeProfile: observed.ownedProfileActive,
-        drift: desiredEnabled ? !applied || stale : applied || observed.kind === "unsafe",
-        driftReason: desiredEnabled ? (!applied ? "desired_on_not_current" : stale ? "profile_drift" : null) : (applied ? "desired_off_gateway_selected" : null),
+        drift: baseDrift || policyConflict,
+        driftReason,
         health,
       });
     } catch (error) {

--- a/src/server/management/context.ts
+++ b/src/server/management/context.ts
@@ -9,6 +9,7 @@ import type { CatalogModel } from "../../codex/catalog";
 import type { Paths as CodexPromptPaths } from "../../codex/prompt-layers";
 import type { injectGrokConfig } from "../../grok/inject";
 import type { removeDesktop3pStandardPivot, writeDesktop3pConfig } from "../../claude/desktop-3p";
+import type { probeClaudeDesktopPolicy } from "../../claude/desktop-policy";
 import type { RuntimePortState } from "../../config/process-state";
 import type { CatalogDisposition, ConvergeCodex } from "../../codex/convergence-types";
 import type {
@@ -49,6 +50,8 @@ export interface ManagementApiDeps {
   /** Desktop mutation seams keep route tests inside temporary config libraries. */
   removeDesktop3pStandardPivot?: typeof removeDesktop3pStandardPivot;
   writeDesktop3pConfig?: typeof writeDesktop3pConfig;
+  /** Read-only Windows MDM policy seam for status/apply tests. */
+  probeClaudeDesktopPolicy?: typeof probeClaudeDesktopPolicy;
   /**
    * Runtime-state seam: the fence must name the host/port the RUNNING process
    * bound (agent-settings-routes.ts:99-103 pattern), and a test must not depend

--- a/tests/claude-desktop-policy.test.ts
+++ b/tests/claude-desktop-policy.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import {
+  claudeDesktopPolicyHealth,
+  probeClaudeDesktopPolicy,
+  type ClaudeDesktopPolicyProbeRunner,
+} from "../src/claude/desktop-policy";
+
+function result(overrides: Partial<ReturnType<ClaudeDesktopPolicyProbeRunner>> = {}) {
+  return {
+    status: 0,
+    stdout: "",
+    timedOut: false,
+    spawnFailed: false,
+    ...overrides,
+  };
+}
+
+test("a present Windows Claude policy degrades Desktop 3P health", () => {
+  const calls: Array<{ file: string; args: readonly string[] }> = [];
+  const state = probeClaudeDesktopPolicy({
+    platform: "win32",
+    resolveSystemDirectory: () => "/trusted/System32",
+    run: (file, args) => {
+      calls.push({ file, args });
+      return result({ status: 0, stdout: "registry output stays private" });
+    },
+  });
+
+  expect(state).toBe("present");
+  expect(claudeDesktopPolicyHealth(state)).toMatchObject({
+    ok: false,
+    status: "warning",
+    state: "present",
+  });
+  expect(calls).toEqual([{
+    file: "/trusted/System32/reg.exe",
+    args: ["query", "HKLM\\SOFTWARE\\Policies\\Claude", "/reg:64"],
+  }]);
+});
+
+test("an unreadable Windows Claude policy stays unknown and degrades health", () => {
+  let calls = 0;
+  const state = probeClaudeDesktopPolicy({
+    platform: "win32",
+    resolveSystemDirectory: () => "/trusted/System32",
+    run: (_file, args) => {
+      calls += 1;
+      return result({
+        status: 1,
+        ...(args[1] === "HKLM\\SOFTWARE\\Policies"
+          ? {
+              status: 0,
+              stdout: [
+                "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies",
+                "    privatePolicyName REG_SZ private-value",
+                "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Claude",
+              ].join("\r\n"),
+            }
+          : {}),
+      });
+    },
+  });
+  const health = claudeDesktopPolicyHealth(state);
+
+  expect(calls).toBe(2);
+  expect(state).toBe("unknown");
+  expect(state).not.toBe("absent");
+  expect(health).toMatchObject({ ok: false, status: "warning", state: "unknown" });
+  expect(JSON.stringify(health)).not.toContain("privatePolicyName");
+  expect(JSON.stringify(health)).not.toContain("private-value");
+});
+
+test("a missing policy is absent only after its parent is readable", () => {
+  let calls = 0;
+  const state = probeClaudeDesktopPolicy({
+    platform: "win32",
+    resolveSystemDirectory: () => "/trusted/System32",
+    run: () => {
+      calls += 1;
+      return calls === 1
+        ? result({ status: 1 })
+        : result({ status: 0, stdout: "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies" });
+    },
+  });
+
+  expect(calls).toBe(2);
+  expect(state).toBe("absent");
+  expect(claudeDesktopPolicyHealth(state)).toMatchObject({ ok: true, status: "ok" });
+});
+
+test("non-Windows policy probing is not applicable and never spawns", () => {
+  let spawned = false;
+  let resolved = false;
+  const state = probeClaudeDesktopPolicy({
+    platform: "darwin",
+    resolveSystemDirectory: () => {
+      resolved = true;
+      return "/unused";
+    },
+    run: () => {
+      spawned = true;
+      return result();
+    },
+  });
+
+  expect(state).toBe("not_applicable");
+  expect(claudeDesktopPolicyHealth(state)).toMatchObject({ ok: true, status: "ok" });
+  expect(spawned).toBe(false);
+  expect(resolved).toBe(false);
+});

--- a/tests/desktop-3p.test.ts
+++ b/tests/desktop-3p.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, posix, win32 } from "node:path";
 import {
@@ -13,6 +13,7 @@ import {
   parseDesktop3pModeArgs,
   resolveDesktop3pConfigLibraryPath,
   resolveDesktop3pAlias,
+  writeDesktop3pConfig,
 } from "../src/claude/desktop-3p";
 import { moveDesktopRoute, reconcileDesktopProfile, setDesktopFamilyDefault } from "../src/claude/desktop-profile";
 import { resolveInboundModel } from "../src/claude/inbound";
@@ -270,6 +271,40 @@ describe("Claude Desktop 3P models", () => {
       expect(readFileSync(path, "utf8")).toBe("stable bytes\n");
       expect(readFileSync(`${path}.bak`, "utf8")).toBe("stable bytes\n");
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("re-applying an owned profile preserves foreign profile keys", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-desktop-merge-"));
+    const previous = process.env.OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR;
+    process.env.OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR = dir;
+    try {
+      const id = "owned-profile";
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "_meta.json"), JSON.stringify({
+        appliedId: id,
+        entries: [{ id, name: "opencodex" }],
+      }));
+      writeFileSync(join(dir, `${id}.json`), JSON.stringify({
+        inferenceProvider: "gateway",
+        inferenceCredentialKind: "static",
+        inferenceGatewayBaseUrl: "http://127.0.0.1:1",
+        inferenceGatewayApiKey: "old-key",
+        modelDiscoveryEnabled: false,
+        inferenceModels: [],
+        foreignDeploymentSetting: { allowed: true },
+      }));
+
+      const written = writeDesktop3pConfig(4096, ["gpt-5.6-sol"], [], "new-key");
+      expect(written.written).toBe(true);
+      const profile = JSON.parse(readFileSync(join(dir, `${id}.json`), "utf8"));
+      expect(profile.foreignDeploymentSetting).toEqual({ allowed: true });
+      expect(profile.inferenceGatewayBaseUrl).toBe("http://127.0.0.1:4096");
+      expect(profile.inferenceGatewayApiKey).toBe("new-key");
+    } finally {
+      if (previous === undefined) delete process.env.OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR;
+      else process.env.OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR = previous;
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/tests/native-claude-desktop-toggle.test.ts
+++ b/tests/native-claude-desktop-toggle.test.ts
@@ -181,6 +181,26 @@ test("status reports leftover owned drift as not stale when the durable switch i
   });
 });
 
+test("status reports a managed policy conflict as warning health and drift", async () => {
+  const response = await dispatch("/api/claude-desktop/status", undefined, {
+    probeClaudeDesktopPolicy: () => "present",
+  });
+  const body = await response!.json() as {
+    drift: boolean;
+    driftReason: string | null;
+    health: { ok: boolean; status: string; policy: { state: string; action: string } };
+  };
+
+  expect(body.health).toMatchObject({
+    ok: false,
+    status: "warning",
+    policy: { state: "present" },
+  });
+  expect(body.health.policy.action.length).toBeGreaterThan(0);
+  expect(body.drift).toBe(true);
+  expect(body.driftReason).toBe("managed_policy_present");
+});
+
 test("post-commit unsafe and incomplete refusals disclose desired OFF without contents", async () => {
   writeFileSync(join(root, "config.json"), JSON.stringify(config()));
   writeFileSync(join(root, "metadata-marker"), "");


### PR DESCRIPTION
## Summary

- Fixes #2893 by probing `HKLM\\SOFTWARE\\Policies\\Claude` with a bounded, read-only `reg.exe` query resolved from the trusted Windows System32 directory.
- Reports policy state as `present | absent | unknown | not_applicable`. `present` and `unknown` make Claude Desktop 3P health non-green and provide an actionable warning in apply, Desktop status, and `ocx status`; registry value names/data never leave the probe.
- Preserves non-OpenCodex keys in an existing owned Desktop profile while replacing only the OpenCodex-owned gateway/model subtree.
- Documents `ocx claude desktop status`, policy warnings, and merge preservation.

Closes #2893

## Verification

- `bun test tests/claude-desktop-policy.test.ts tests/desktop-3p.test.ts tests/native-claude-desktop-toggle.test.ts tests/claude-desktop-cli.test.ts tests/cli-status-json.test.ts tests/cli-help.test.ts tests/skill-ocx.test.ts` — 91 pass, 0 fail.
- `bun x tsc --noEmit` — passed.
- `bun run privacy:scan` — passed.
- `(cd docs-site && bun install --frozen-lockfile && bun run build)` — 401 pages built; passed with the existing large-chunk advisory.
- Rebased onto `origin/dev` at `64b994c0f6330c4bc56e85138037935859de48e4`; post-rebase verification above passed.

Mutation proof (each source mutation was restored immediately after the named RED run):

1. Policy present -> health warning: changed the successful query result from `present` to `absent`.

```text
$ bun test tests/claude-desktop-policy.test.ts -t "a present Windows Claude policy degrades Desktop 3P health"
Expected: "present"
Received: "absent"
(fail) a present Windows Claude policy degrades Desktop 3P health
0 pass, 1 fail
```

2. Unreadable policy -> `unknown`, never `absent`: changed the readable-parent/blocked-child result to `absent`.

```text
$ bun test tests/claude-desktop-policy.test.ts -t "an unreadable Windows Claude policy stays unknown and degrades health"
Expected: "unknown"
Received: "absent"
(fail) an unreadable Windows Claude policy stays unknown and degrades health
0 pass, 1 fail
```

3. Proven missing policy -> `absent`: changed the readable-parent/missing-child result to `unknown`.

```text
$ bun test tests/claude-desktop-policy.test.ts -t "a missing policy is absent only after its parent is readable"
Expected: "absent"
Received: "unknown"
(fail) a missing policy is absent only after its parent is readable
0 pass, 1 fail
```

4. Non-Windows -> `not_applicable` without spawn: changed the platform short-circuit to `unknown`.

```text
$ bun test tests/claude-desktop-policy.test.ts -t "non-Windows policy probing is not applicable and never spawns"
Expected: "not_applicable"
Received: "unknown"
(fail) non-Windows policy probing is not applicable and never spawns
0 pass, 1 fail
```

5. Profile merge preserves a foreign key: removed the preserved-key spread from the writer.

```text
$ bun test tests/desktop-3p.test.ts -t "re-applying an owned profile preserves foreign profile keys"
Expected: { "allowed": true }
Received: undefined
(fail) Claude Desktop 3P models > re-applying an owned profile preserves foreign profile keys
0 pass, 1 fail
```

6. Policy conflict makes management status non-green: forced the composed health `ok` field to `true`.

```text
$ bun test tests/native-claude-desktop-toggle.test.ts -t "status reports a managed policy conflict as warning health and drift"
Expected health.ok: false
Received health.ok: true
(fail) status reports a managed policy conflict as warning health and drift
0 pass, 1 fail
```

Could not verify on this macOS host:

- A real Windows `reg.exe` invocation, Windows registry ACL behavior, or an actual Claude Desktop MSIX policy conflict. Those paths are covered with injected Windows runner/system-directory seams, not claimed as live Windows validation.
- Repository-wide `bun run test` and `bun run typecheck` were intentionally not run under the delegated task constraints. The allowed `bun x tsc --noEmit` and focused test files passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
