### PR TITLE
Windows (zh-CN): pair zh/ja locales with their code pages, make the localized task-not-found probe decisive, share the 30s identity budget

### DIFF
--- a/src/codex/user-identity.ts
+++ b/src/codex/user-identity.ts
@@ -36,27 +36,21 @@ const SID_PATTERN = /^S-1-(?:\d+-)+\d+$/i;
  * Hard budget for the Windows identity-lookup PowerShell child. These lookups
  * run at startup and on config writes; a hung child must fail the lookup
  * (recoverable — the caller refuses) rather than wedge the proxy indefinitely.
- */
-const WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS = 8_000;
-
-/**
- * The same budget, widened for a contended CI runner.
  *
- * 8s is a generous ceiling for `powershell.exe -Command` on a real desktop and is not one
- * on a GitHub Windows runner executing a quarter of this suite: the composed-acceptance
- * cases fail there with "Windows effective-account lookup timed out" while the child is
- * still starting. That is runner contention, not a hung lookup, and the budget exists to
- * bound the latter.
- *
- * Gated on `CI` alone. A user's machine keeps the 8s ceiling exactly as before, so the
- * recoverable-refusal contract this budget protects is unchanged where it matters.
+ * 30s, shared by desktops and CI. On a healthy desktop the child needs well
+ * under a second, but contended desktops are real: antivirus real-time
+ * scanning, a loaded task scheduler, and per-spawn jitter stack up (measured
+ * 3-5s per `powershell.exe -Command` child on a zh-CN Windows 10 host with 401
+ * scheduled tasks), and the old 8s desktop ceiling was breached
+ * intermittently — "Windows effective-account lookup timed out" on an ordinary
+ * sync, the same failure the CI gate was widened for. The budget still bounds
+ * a genuinely hung child; it no longer assumes contention only happens on
+ * runners.
  */
-const WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_CI_MS = 30_000;
+const WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS = 30_000;
 
 function windowsIdentityLookupTimeoutMs(): number {
-  return process.env.CI === "true"
-    ? WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_CI_MS
-    : WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS;
+  return WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS;
 }
 
 /**

--- a/src/lib/windows-text.ts
+++ b/src/lib/windows-text.ts
@@ -10,10 +10,11 @@
  *   iconv dependency. The former can reinterpret valid text; the latter widens
  *   the install/security surface for two small, already-supported codecs.
  * - Choice: recognize UTF-16 first, accept only strict UTF-8 next, then use the
- *   locale-appropriate WHATWG decoder (CP949 through `euc-kr`, or Windows-1252
- *   only for locales that actually use that family). Unknown/unsupported
- *   locales fail back to the old replacement-preserving UTF-8 result instead
- *   of guessing another code page or throwing in diagnostics.
+ *   locale-appropriate WHATWG decoder (CP949 through `euc-kr`, GBK/Big5 for the
+ *   zh family, Shift_JIS for ja, or Windows-1252 only for locales that actually
+ *   use that family). Unknown/unsupported locales fail back to the old
+ *   replacement-preserving UTF-8 result instead of guessing another code page
+ *   or throwing in diagnostics.
  * - Impact: decoding stays dependency-free and bounded, but this deliberately
  *   does not guess arbitrary OEM code pages that the runtime cannot identify.
  */
@@ -49,14 +50,27 @@ function decodeUtf16Be(buffer: Uint8Array): string {
 }
 
 /**
- * CP949 is exposed by the Encoding Standard under the `euc-kr` label. Keep the
- * Western fallback deliberately narrow: treating CP932, CP1250, or CP1251
- * bytes as Windows-1252 can fabricate a different valid-looking filesystem
- * path, which is worse than the previous replacement-character refusal.
+ * CP949 is exposed by the Encoding Standard under the `euc-kr` label; the zh
+ * family maps to `gbk` (zh-Hans) or `big5` (zh-Hant), and ja maps to
+ * `shift_jis`. Each locale is paired with the exact code page its Windows host
+ * actually emits, never a cross-family guess. Keep the Western fallback
+ * deliberately narrow: treating CP1250 or CP1251 bytes as Windows-1252 can
+ * fabricate a different valid-looking filesystem path, which is worse than the
+ * previous replacement-character refusal.
  */
-function legacyEncodingForLocale(locale: string): "euc-kr" | "windows-1252" | null {
-  const language = locale.trim().split(/[-_]/, 1)[0]?.toLowerCase();
+function legacyEncodingForLocale(
+  locale: string,
+): "euc-kr" | "windows-1252" | "gbk" | "big5" | "shift_jis" | null {
+  const normalized = locale.trim().toLowerCase();
+  const language = normalized.split(/[-_]/, 1)[0]?.toLowerCase();
   if (language === "ko") return "euc-kr";
+  if (language === "ja") return "shift_jis";
+  if (language === "zh") {
+    // zh-Hant hosts (zh-TW / zh-HK / zh-MO, and any explicit -hant tag) emit
+    // Big5; the rest of the zh family (zh-CN and friends) emits GBK.
+    const traditional = normalized.includes("hant") || /[-_](tw|hk|mo)\b/.test(normalized);
+    return traditional ? "big5" : "gbk";
+  }
   if (language && WINDOWS_1252_LANGUAGES.has(language)) return "windows-1252";
   return null;
 }

--- a/src/service-manager-probe.ts
+++ b/src/service-manager-probe.ts
@@ -535,16 +535,21 @@ function windowsTaskListContains(body: string, taskName: string): boolean {
   });
 }
 
-/** English hosts provide a decisive fast path; other locales fall back to a full listing. */
-const SCHTASKS_TASK_NOT_FOUND_EN = /cannot find the file specified/i;
+/**
+ * English hosts provide a decisive fast path; zh/ja hosts emit localized
+ * task-not-found messages that decode through the same legacy codecs, so they
+ * are decisive too. Any other locale still falls back to a full listing.
+ */
+const SCHTASKS_TASK_NOT_FOUND = /cannot find the file specified|找不到指定的文件|指定されたファイルが見つかりません/i;
 
 /**
  * Registration state of the scheduled task.
  *
  * The `/xml` query gives the authoritative registered definition. A nonzero
- * result is locale-dependent. English's task-not-found message is decisive; all
- * other nonzero responses use a bounded full listing as the locale-neutral
- * fallback, and only a successful list without our task proves absence.
+ * result is locale-dependent. English and zh/ja task-not-found messages are
+ * decisive; all other nonzero responses use a bounded full listing as the
+ * locale-neutral fallback, and only a successful list without our task proves
+ * absence.
  */
 function probeWindowsTaskRegistration(
   deps: Required<Pick<ProbeDeps, "runRaw">> & Pick<ProbeDeps, "windowsLocale">,
@@ -570,7 +575,7 @@ function probeWindowsTaskRegistration(
   }
 
   const queryText = `${decodeWindowsTextBytes(queried.stdout, { locale: deps.windowsLocale })}\n${decodeWindowsTextBytes(queried.stderr, { locale: deps.windowsLocale })}`;
-  if (queried.status !== null && SCHTASKS_TASK_NOT_FOUND_EN.test(queryText)) {
+  if (queried.status !== null && SCHTASKS_TASK_NOT_FOUND.test(queryText)) {
     return { registered: "absent", registeredXml: "" };
   }
 

--- a/tests/codex-service-manager-probe-hardening.test.ts
+++ b/tests/codex-service-manager-probe-hardening.test.ts
@@ -338,6 +338,44 @@ describe("Windows ownership probe hardening regressions", () => {
     expect(calls.some(call => call.args.includes("/fo"))).toBe(true);
   });
 
+  test("zh-CN GBK schtasks task-not-found output is decisive without the full listing", () => {
+    const calls: Array<{ file: string; args: readonly string[] }> = [];
+    const runRaw: RawProbeRunner = (file, args) => {
+      calls.push({ file, args });
+      if (args.includes("/xml")) {
+        // Real zh-CN bytes: 错误: 系统找不到指定的文件。 (GBK/CP936)
+        return {
+          status: 1,
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from(
+            "B4EDCEF33A20CFB5CDB3D5D2B2BBB5BDD6B8B6A8B5C4CEC4BCFEA1A3",
+            "hex",
+          ),
+          timedOut: false,
+          spawnFailed: false,
+        };
+      }
+      if (args.includes("/fo")) {
+        return raw(0, '"\\SomeOtherTask","N/A","Ready"\r\n');
+      }
+      return raw(1, "", "unexpected query");
+    };
+
+    const result = inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      runRaw,
+      winswStatus: () => "nonexistent",
+      windowsLocale: "zh-CN",
+    });
+
+    // Decisive absence: the /fo full listing is the 2s-budget fallback that
+    // times out on hosts with many scheduled tasks, so it must not be reached.
+    expect(result.kind).toBe("absent");
+    expect(calls.some(call => call.args.includes("/fo"))).toBe(false);
+  });
+
   test("a staged but unregistered WinSW definition remains visible as a present claim", () => {
     const codexHome = "C:\\staged\\.codex";
     writeWinsw(configDir, codexHome, configDir);

--- a/tests/codex-user-identity.test.ts
+++ b/tests/codex-user-identity.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { join, parse } from "node:path";
 import { tmpdir } from "node:os";
@@ -11,6 +11,7 @@ import {
   resolveEffectiveUserIdentity,
   probeCodexCoordinatorNamespace,
   samePathIdentity,
+  windowsIdentityPowerShellSpawnOptionsForTests,
 } from "../src/codex/user-identity";
 
 let codexHome = "";
@@ -228,4 +229,23 @@ test("H is keyed by state database identity and is never N's or K's path", () =>
   // A relative state database is refused rather than silently keyed on its text.
   expect(() => resolveCodexHistorySerializationDatabasePath(identity, canonicalHome, "state_5.sqlite"))
     .toThrow();
+});
+
+describe("Windows identity-lookup budget", () => {
+  test("desktop and CI share the 30s budget — contended desktops breached the old 8s ceiling", () => {
+    // Regression: a zh-CN Windows 10 desktop with 401 scheduled tasks and AV
+    // real-time scanning measures 3-5s per powershell.exe child; spawn jitter
+    // pushed the old desktop-only 8s ceiling over intermittently, refusing
+    // every sync with "Windows effective-account lookup timed out" (#2914).
+    const previousCi = process.env.CI;
+    try {
+      delete process.env.CI;
+      expect(windowsIdentityPowerShellSpawnOptionsForTests().timeout).toBe(30_000);
+      process.env.CI = "true";
+      expect(windowsIdentityPowerShellSpawnOptionsForTests().timeout).toBe(30_000);
+    } finally {
+      if (previousCi === undefined) delete process.env.CI;
+      else process.env.CI = previousCi;
+    }
+  });
 });

--- a/tests/windows-text-decoding.test.ts
+++ b/tests/windows-text-decoding.test.ts
@@ -18,9 +18,46 @@ describe("Windows system text decoding (#1573)", () => {
     expect(decodeWindowsTextBytes(windows1252, { locale: "de-DE" })).toBe("C:\\Users\\Jörg");
   });
 
-  test("does not guess Windows-1252 for an unsupported legacy-codepage locale", () => {
-    const cp932 = Buffer.from([0x82, 0xa0]);
-    expect(decodeWindowsTextBytes(cp932, { locale: "ja-JP" })).toContain("\uFFFD");
+  test("decodes GBK zh-Hans schtasks task-not-found output under a Chinese Windows locale", () => {
+    // GBK hex of the real zh-CN message: 错误: 系统找不到指定的文件。
+    const gbk = Buffer.from("B4EDCEF33A20CFB5CDB3D5D2B2BBB5BDD6B8B6A8B5C4CEC4BCFEA1A3", "hex");
+    expect(decodeWindowsTextBytes(gbk, { locale: "zh-CN" })).toBe("错误: 系统找不到指定的文件。");
+  });
+
+  test("decodes GBK output for the bare zh and zh-Hans locale tags", () => {
+    const gbk = Buffer.from("B4EDCEF33A20CFB5CDB3D5D2B2BBB5BDD6B8B6A8B5C4CEC4BCFEA1A3", "hex");
+    expect(decodeWindowsTextBytes(gbk, { locale: "zh" })).toBe("错误: 系统找不到指定的文件。");
+    expect(decodeWindowsTextBytes(gbk, { locale: "zh-Hans-CN" })).toBe("错误: 系统找不到指定的文件。");
+  });
+
+  test("decodes Big5 zh-Hant schtasks-style output under a Traditional Chinese locale", () => {
+    // Big5 hex of: 系統找不到指定的檔案。
+    const big5 = Buffer.from("A874B2CEA7E4A4A3A8ECABFCA977AABAC0C9AED7A143", "hex");
+    expect(decodeWindowsTextBytes(big5, { locale: "zh-TW" })).toBe("系統找不到指定的檔案。");
+  });
+
+  test("decodes Shift_JIS Japanese schtasks task-not-found output under a Japanese locale", () => {
+    // Shift_JIS hex of: エラー: 指定されたファイルが見つかりません。
+    const shiftJis = Buffer.from(
+      "83478389815B3A208E7792E882B382EA82BD837483408343838B82AA8CA982C282A982E882DC82B982F18142",
+      "hex",
+    );
+    expect(decodeWindowsTextBytes(shiftJis, { locale: "ja-JP" })).toBe(
+      "エラー: 指定されたファイルが見つかりません。",
+    );
+  });
+
+  test("does not guess Windows-1252 for a legacy-codepage locale outside the paired table", () => {
+    // CP1251 bytes (Cyrillic) with no ru mapping: fail back to UTF-8 mojibake
+    // rather than fabricating a different valid-looking value.
+    const cp1251 = Buffer.from([0xd0, 0xd1]);
+    expect(decodeWindowsTextBytes(cp1251, { locale: "ru-RU" })).toContain("\uFFFD");
+  });
+
+  test("does not reinterpret zh-Hant bytes as GBK under a Traditional Chinese locale", () => {
+    const big5 = Buffer.from("A874B2CEA7E4A4A3A8ECABFCA977AABAC0C9AED7A143", "hex");
+    expect(decodeWindowsTextBytes(big5, { locale: "zh-TW" })).toBe("系統找不到指定的檔案。");
+    expect(decodeWindowsTextBytes(big5, { locale: "zh-CN" })).not.toBe("系統找不到指定的檔案。");
   });
 
   test("preserves UTF-16LE task XML", () => {


### PR DESCRIPTION
Fixes #2914.

## What happened on a zh-CN host

`ocx sync` on a Simplified Chinese Windows desktop (proxy running manually — no scheduled task, no WinSW service) deterministically refused every write:

```
Refusing to write because ownership could not be proven: Task Scheduler could not be asked whether opencodex-proxy is registered.
```

"Absent" should have been provable, but two gaps compounded:

1. `SCHTASKS_TASK_NOT_FOUND_EN` matched the English message only, and `legacyEncodingForLocale` had no mapping for zh (or ja) — the GBK stderr of `schtasks /query /tn opencodex-proxy /xml` (`错误: 系统找不到指定的文件。`) arrived as UTF-8 mojibake, so the decisive path never fired.
2. The locale-neutral fallback (full `schtasks /query /fo CSV /nh` listing) is bounded by `SERVICE_PROBE_TIMEOUT_MS = 2000`; on the affected host (401 scheduled tasks) the listing takes **12.3 s**, so the probe returned `unknown` and admission refused.

Once the probe was patched locally, the next stage failed intermittently with `CodexUserIdentityRefusal: Windows effective-account lookup timed out.` — the 8 s desktop budget for the `powershell.exe`-based lookup is not generous on contended desktops: measured **3.2 s (SID)** and **4.6 s (LocalAppData Add-Type)** per child on this host, with enough spawn jitter to breach 8 s occasionally. The file's own CI constant was already 30 s for the same contention reason.

## Changes

- **`src/lib/windows-text.ts`** — pair `zh → gbk` (zh-Hant → `big5`, incl. `-hant`/`-TW`/`-HK`/`-MO` tags), `ja → shift_jis` alongside the existing `ko → euc-kr` mapping. Each locale is paired with the exact code page its Windows host actually emits — never a cross-family guess; unsupported locales still fail back to the UTF-8 mojibake result. The deliberate-narrowness guard comment is updated accordingly.
- **`src/service-manager-probe.ts`** — `SCHTASKS_TASK_NOT_FOUND_EN` → `SCHTASKS_TASK_NOT_FOUND`, with the localized zh/ja messages as decisive alternatives. The German fixture path is untouched: locales outside the table still fall back to the full listing.
- **`src/codex/user-identity.ts`** — one 30 s lookup budget shared by desktop and CI (the CI gate existed only to widen this constant, so the split is now vestigial). The recoverable-refusal contract is unchanged; a genuinely hung child still fails the lookup, just at a ceiling that no longer assumes contention only happens on runners.

## Tests

- `tests/windows-text-decoding.test.ts` — real-codepage fixtures: GBK zh-Hans (the exact 31-byte schtasks message), bare `zh`/`zh-Hans-CN` tags, Big5 zh-Hant, Shift_JIS ja; the old "ja must not decode" contract test is intentionally flipped (see #2914 for why), and a new CP1251 fixture pins the "unsupported locales still fail soft" guard, plus a zh-Hant-vs-GBK cross-check.
- `tests/codex-service-manager-probe-hardening.test.ts` — new regression: GBK zh-CN task-not-found stderr is **decisive** — result is `absent` and the `/fo` full listing is never reached (that listing is the 2 s-budget path that times out on many-task hosts). The existing German fallback test still passes unchanged.
- `tests/codex-user-identity.test.ts` — regression asserting the desktop spawn options carry the 30 s budget with and without `CI=true`.

## Verification on the affected host (Windows 10 22H2, zh-CN, bun 1.4.0)

- `bun test tests/windows-text-decoding.test.ts` — 10 pass, 0 fail.
- `bun test tests/codex-service-manager-probe-hardening.test.ts` — 12 pass, 0 fail (includes the new zh-CN decisive test).
- `bun test tests/codex-user-identity.test.ts` — new budget test passes; 3 pre-existing child-probe tests time out at their 5 s limits on this host. Verified pre-existing: `git stash` → clean `dev` shows the same 3 failures; unstash → same 3 failures + the new passing test. (The host spawns `powershell.exe` at ~3 s — the very contention this PR budgets for.)
- `bun run typecheck` — clean.
- `bun run test:changed` — **not completed**: the script's own 900 s suite budget was exhausted on this host (exit 124) without producing per-test output; deferring to CI for the full gate.
- End-to-end with the same three changes applied to the installed 2.35.0 `node_modules`: probe `unknown → absent`, `admitCodexWrite` `refused → admitted`, `ocx sync` exits 0 and writes 720 models to the Codex catalog.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows identity detection reliability by allowing up to 30 seconds for PowerShell lookups.
  * Added support for Japanese and Chinese Windows text encoding, including Simplified and Traditional Chinese locales.
  * Improved scheduled-task detection for localized Chinese and Japanese Windows installations.
  * Reduced incorrect fallback decoding for unsupported locales, improving the accuracy of displayed Windows text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->