### PR TITLE
fix(codex): share one identity-lookup budget between desktops and CI

### DIFF
--- a/src/codex/user-identity.ts
+++ b/src/codex/user-identity.ts
@@ -36,27 +36,29 @@ const SID_PATTERN = /^S-1-(?:\d+-)+\d+$/i;
  * Hard budget for the Windows identity-lookup PowerShell child. These lookups
  * run at startup and on config writes; a hung child must fail the lookup
  * (recoverable — the caller refuses) rather than wedge the proxy indefinitely.
- */
-const WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS = 8_000;
-
-/**
- * The same budget, widened for a contended CI runner.
  *
- * 8s is a generous ceiling for `powershell.exe -Command` on a real desktop and is not one
- * on a GitHub Windows runner executing a quarter of this suite: the composed-acceptance
- * cases fail there with "Windows effective-account lookup timed out" while the child is
- * still starting. That is runner contention, not a hung lookup, and the budget exists to
- * bound the latter.
+ * 30s, and the same on a desktop as in CI. The split below used to give desktops
+ * 8s, on the theory that only a shared runner is contended enough to need more.
+ * A zh-CN Windows 10 host measured 3.2s for the SID expression and 4.6s for the
+ * `Add-Type` LocalAppData expression — per spawn, with a bare
+ * `powershell.exe -NoProfile -Command exit` costing ~3s where a typical desktop
+ * pays ~150ms — so ordinary spawn jitter breached 8s intermittently and `ocx sync`
+ * failed with "Windows effective-account lookup timed out" (#2914).
  *
- * Gated on `CI` alone. A user's machine keeps the 8s ceiling exactly as before, so the
- * recoverable-refusal contract this budget protects is unchanged where it matters.
+ * That is the same contention the CI branch was widened for, which is what makes
+ * the split vestigial rather than merely conservative: it encoded an assumption
+ * about WHERE contention happens, and the assumption was wrong. Antivirus
+ * real-time scanning, a loaded Task Scheduler, and cold PowerShell startup do not
+ * care whether the machine is a runner.
+ *
+ * The contract this budget protects is unchanged: a genuinely hung child still
+ * fails the lookup and the caller still refuses rather than writing. Only the
+ * ceiling moved, and it moved for the case where the lookup would have succeeded.
  */
-const WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_CI_MS = 30_000;
+const WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS = 30_000;
 
 function windowsIdentityLookupTimeoutMs(): number {
-  return process.env.CI === "true"
-    ? WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_CI_MS
-    : WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS;
+  return WINDOWS_POWERSHELL_LOOKUP_TIMEOUT_MS;
 }
 
 /**

--- a/tests/codex-user-identity.test.ts
+++ b/tests/codex-user-identity.test.ts
@@ -11,42 +11,12 @@ import {
   resolveEffectiveUserIdentity,
   probeCodexCoordinatorNamespace,
   samePathIdentity,
-  windowsIdentityPowerShellSpawnOptionsForTests,
 } from "../src/codex/user-identity";
 
 let codexHome = "";
 let previousHome: string | undefined;
 
 const CHILD_TIMEOUT_MS = 10_000;
-
-/*
- * #2914. The identity lookup used to give a desktop 8s and CI 30s, on the theory
- * that only a shared runner is contended enough to need more. A zh-CN Windows 10
- * host measured 3.2s + 4.6s per spawn, so ordinary jitter breached 8s and
- * `ocx sync` failed with "Windows effective-account lookup timed out" — the same
- * contention the CI branch existed for.
- *
- * The budget must be identical either way. Reading it through the spawn options is
- * what makes that assertable: the constant alone could be right while the CI
- * branch silently reintroduced the split.
- */
-test("the Windows identity-lookup budget does not depend on running under CI", () => {
-  const previousCi = process.env.CI;
-  try {
-    process.env.CI = "true";
-    const underCi = windowsIdentityPowerShellSpawnOptionsForTests().timeout;
-    delete process.env.CI;
-    const onDesktop = windowsIdentityPowerShellSpawnOptionsForTests().timeout;
-
-    expect(onDesktop).toBe(underCi);
-    // The contended-desktop measurement is 3-5s per spawn across two spawns; the
-    // old 8s ceiling left no room for jitter on top of that.
-    expect(onDesktop).toBeGreaterThanOrEqual(30_000);
-  } finally {
-    if (previousCi === undefined) delete process.env.CI;
-    else process.env.CI = previousCi;
-  }
-});
 const userIdentityModuleUrl = pathToFileURL(
   join(import.meta.dir, "..", "src", "codex", "user-identity.ts"),
 ).href;

--- a/tests/codex-user-identity.test.ts
+++ b/tests/codex-user-identity.test.ts
@@ -11,12 +11,42 @@ import {
   resolveEffectiveUserIdentity,
   probeCodexCoordinatorNamespace,
   samePathIdentity,
+  windowsIdentityPowerShellSpawnOptionsForTests,
 } from "../src/codex/user-identity";
 
 let codexHome = "";
 let previousHome: string | undefined;
 
 const CHILD_TIMEOUT_MS = 10_000;
+
+/*
+ * #2914. The identity lookup used to give a desktop 8s and CI 30s, on the theory
+ * that only a shared runner is contended enough to need more. A zh-CN Windows 10
+ * host measured 3.2s + 4.6s per spawn, so ordinary jitter breached 8s and
+ * `ocx sync` failed with "Windows effective-account lookup timed out" — the same
+ * contention the CI branch existed for.
+ *
+ * The budget must be identical either way. Reading it through the spawn options is
+ * what makes that assertable: the constant alone could be right while the CI
+ * branch silently reintroduced the split.
+ */
+test("the Windows identity-lookup budget does not depend on running under CI", () => {
+  const previousCi = process.env.CI;
+  try {
+    process.env.CI = "true";
+    const underCi = windowsIdentityPowerShellSpawnOptionsForTests().timeout;
+    delete process.env.CI;
+    const onDesktop = windowsIdentityPowerShellSpawnOptionsForTests().timeout;
+
+    expect(onDesktop).toBe(underCi);
+    // The contended-desktop measurement is 3-5s per spawn across two spawns; the
+    // old 8s ceiling left no room for jitter on top of that.
+    expect(onDesktop).toBeGreaterThanOrEqual(30_000);
+  } finally {
+    if (previousCi === undefined) delete process.env.CI;
+    else process.env.CI = previousCi;
+  }
+});
 const userIdentityModuleUrl = pathToFileURL(
   join(import.meta.dir, "..", "src", "codex", "user-identity.ts"),
 ).href;

--- a/tests/windows-popup-fix.test.ts
+++ b/tests/windows-popup-fix.test.ts
@@ -49,18 +49,21 @@ describe("Windows identity lookup popup fix (#1278)", () => {
     const options = windowsIdentityPowerShellSpawnOptionsForTests();
     expect(options.windowsHide).toBe(true);
     expect(options.stdin).toBe("ignore");
-    // Assert the exact budget: the identity lookup contract is an 8-second
-    // bound, and a looser assertion would let a silent re-tune through.
+    // Assert the exact budget: a looser assertion would let a silent re-tune through.
     //
-    // Both values are pinned, because there are now two. A contended CI runner cannot start
-    // powershell.exe inside 8s while it runs a quarter of this suite, and the composed
-    // acceptance cases failed there with "Windows effective-account lookup timed out" —
-    // contention, not a hung child, which is the only thing this budget exists to bound.
-    // A user's machine keeps 8s exactly as before.
+    // There is now ONE value, pinned in both environments. The two-value form this
+    // replaces gave a desktop 8s on the theory that only a shared runner is contended
+    // enough to need 30s. A zh-CN Windows 10 host measured 3.2s (SID) and 4.6s
+    // (Add-Type LocalAppData) per spawn, so ordinary jitter breached 8s and `ocx sync`
+    // failed with "Windows effective-account lookup timed out" — the same contention
+    // the CI value existed for, on a desktop (#2914).
+    //
+    // Still exact, and still both environments: the point is that they must AGREE, so a
+    // reintroduced `process.env.CI` branch fails here rather than shipping quietly.
     const previous = process.env.CI;
     try {
       delete process.env.CI;
-      expect(windowsIdentityPowerShellSpawnOptionsForTests().timeout).toBe(8_000);
+      expect(windowsIdentityPowerShellSpawnOptionsForTests().timeout).toBe(30_000);
       process.env.CI = "true";
       expect(windowsIdentityPowerShellSpawnOptionsForTests().timeout).toBe(30_000);
     } finally {


### PR DESCRIPTION
## Summary

The Windows identity lookup carried two budgets: 8 s on a desktop, 30 s under `CI`. The split assumed contention only happens on a shared runner. It does not.

A zh-CN Windows 10 host measured **3.2 s** for the SID expression and **4.6 s** for the `Add-Type` LocalAppData expression — per spawn, with a bare `powershell.exe -NoProfile -Command exit` costing ~3 s where a typical desktop pays ~150 ms. Two spawns plus ordinary jitter breached 8 s intermittently, and `ocx sync` failed with `CodexUserIdentityRefusal: Windows effective-account lookup timed out.`

That is the same contention the CI branch was widened for, which is what makes the split **vestigial** rather than merely conservative: antivirus real-time scanning, a loaded Task Scheduler, and cold PowerShell startup do not care whether the machine is a runner. One budget now, 30 s, everywhere.

The contract the budget protects is unchanged. A genuinely hung child still fails the lookup and the caller still refuses to write; only the ceiling moved, and it moved for the case where the lookup *would have succeeded*.

## Credit

This is the second half of #2925 by @ncepuee. That PR also re-fixed the schtasks probe, which had already landed in aaccef738 (#2918), so it conflicted with `dev` and I closed it — but the identity-budget argument was theirs and was the part I had explicitly deferred as out of scope when I fixed the probe. Their observation that the CI gate existed *only* to widen this constant is what turns "raise the number" into a defensible removal. I invited a rebase and offered to carry it; landing it here so the defect does not sit open in the meantime.

## Verification

- `bun test tests/codex-user-identity.test.ts` — **7 pass / 0 fail**.
- **Mutation-proven.** Reintroducing the split (`process.env.CI === "true" ? 30_000 : 8_000`) turns the new test red: `Expected: 30000, Received: 8000`. Restored and verified byte-identical by sha256; suite back to 7/0.
- `bun x tsc --noEmit` clean, `bun run privacy:scan` passed.

The test reads the budget through the existing `windowsIdentityPowerShellSpawnOptionsForTests` seam with `CI` set and unset, rather than asserting the constant. That distinction is the point: a constant can be correct while a reintroduced branch silently restores the split, and only the spawn-options readback catches that.

**What I could not verify:** I am on macOS and did not run `powershell.exe`, so the 3.2 s / 4.6 s figures are the reporter's measurements on the affected host, not mine. The change itself is a constant and a removed branch, both fully covered here.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

This touches an identity path used by config-write admission. Nothing here changes what is written or who may write it: a lookup that cannot complete still refuses. No account identifier, SID, or path is logged.

Refs #2914


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Windows PowerShell identity lookups to use a 30-second timeout across all environments.
  * Improved consistency for identity detection in desktop and continuous integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## A pre-existing test changed, and why that is scoping rather than weakening

`tests/windows-popup-fix.test.ts` pinned both budgets by value — 8 s with `CI` unset, 30 s with it set. It failed on my first push, which is exactly what an exact assertion is for; it is the reason this PR is correct now rather than quietly re-tuned.

I retargeted it at the single shared value instead of loosening it. It still asserts **both** environments and still asserts an exact number, so a reintroduced `process.env.CI` branch fails there — verified by mutation: restoring the split gives `Expected: 30000, Received: 8000`. The original comment claimed "a user's machine keeps 8s exactly as before," which is now false, so the comment records the measurement that changed it.

I also dropped the duplicate assertion I had first added in `tests/codex-user-identity.test.ts`: that file's test and this one covered the same invariant, and the pre-existing one owns it. Net effect is one authoritative pinned assertion, not two partial ones.
