### PR TITLE
fix(service): enumerate the machine once per startup, not once per inspection

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,6 +31,10 @@ import {
   type NativeCodexOwnership,
   type OwnershipInspection,
 } from "../integrations/native/ownership-preflight";
+import {
+  createServiceProbeStartupCache,
+  type ServiceProbeStartupCache,
+} from "../service-manager-probe";
 import { registerCodexCooldownRecoveryProbeWorker } from "../codex/auth-api";
 import {
   reconcileLiveStateStores,
@@ -499,6 +503,7 @@ function inspectStartupOwnership(
   deps: StartServerDeps,
   currentHomes: ReturnType<typeof currentServiceHomes> | null,
   statePaths: readonly string[] | null,
+  startupCache?: ServiceProbeStartupCache,
 ): OwnershipInspection {
   try {
     if (currentHomes === null || statePaths === null) {
@@ -510,7 +515,7 @@ function inspectStartupOwnership(
     if (deps.inspectNativeCodexOwnership) {
       return deps.inspectNativeCodexOwnership({ currentHomes, statePaths });
     }
-    return inspectNativeCodexOwnership({ currentHomes, statePaths });
+    return inspectNativeCodexOwnership({ currentHomes, statePaths, startupCache });
   } catch {
     return {
       ownership: "unknown",
@@ -606,10 +611,21 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
     startupOwnershipHomes = homes;
     startupOwnershipStatePaths = statePaths;
   } catch { /* inspection below stays unknown */ }
+  /*
+   * One shared listing across this startup's ownership inspections (#2923).
+   *
+   * Both inspections below run the targeted scheduled-task query, so the race the
+   * second one exists to close is unaffected. What they no longer do is enumerate
+   * every task on the machine twice: on a localized host with hundreds of tasks the
+   * fallback listing is the expensive step, and paying it at both sites put up to
+   * 40s in front of `Bun.serve`.
+   */
+  const serviceProbeStartupCache = createServiceProbeStartupCache();
   const startupCacheOwnership = inspectStartupOwnership(
     deps,
     startupOwnershipHomes,
     startupOwnershipStatePaths,
+    serviceProbeStartupCache,
   );
   // Startup cache invalidation is best-effort and must never block the server from
   // serving. It now takes K so it cannot race a convergence commit. Use the home
@@ -785,7 +801,12 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
   // clients; no Codex request can use this lifecycle in that state.
   // Re-probe here instead of trusting the earlier cache decision: startup work
   // between the two sites must not widen the service-install race.
-  const nativeOwnership = inspectStartupOwnership(deps, startupOwnershipHomes, startupOwnershipStatePaths);
+  const nativeOwnership = inspectStartupOwnership(
+    deps,
+    startupOwnershipHomes,
+    startupOwnershipStatePaths,
+    serviceProbeStartupCache,
+  );
   const preparedNativeMainLifecycle = nativeOwnership.ownership !== "foreign"
     && startupOwnershipHomes !== null
     ? prepareNativeMainStartupLifecycle(

--- a/src/service-manager-probe.ts
+++ b/src/service-manager-probe.ts
@@ -45,6 +45,36 @@ export const SERVICE_PROBE_TIMEOUT_MS = 2_000;
  */
 export const SERVICE_PROBE_LISTING_TIMEOUT_MS = 20_000;
 
+/**
+ * Caller-owned reuse of the whole-machine `schtasks` enumeration (#2923).
+ *
+ * The listing is the locale-neutral fallback, and on a host with hundreds of tasks
+ * it costs seconds. `startServer` inspects ownership twice on purpose — once
+ * before the startup cache decision, once before native lifecycle preparation — so
+ * a localized host paid the full enumeration TWICE before `Bun.serve`, up to 40s
+ * at the ceiling.
+ *
+ * The scope is deliberately the CALLER'S, not this module's. A module-level cache
+ * would leak across unrelated inspections (and, in tests, across cases), and the
+ * lifetime that is actually correct here is "one startup" — something only the
+ * caller knows. Passing an explicit object makes the sharing visible at both call
+ * sites and impossible anywhere else.
+ *
+ * What is shared is only the listing. The targeted `/query /tn` still runs on
+ * every inspection, so the race the second check exists to close is unaffected: a
+ * task that appears between the two checks is seen by the targeted query, which is
+ * what decides `present`. The listing only ever answers "our task is not among
+ * this machine's tasks", and only after the targeted query was not decisive.
+ */
+export interface ServiceProbeStartupCache {
+  /** Task names the machine reported, lowercased; absent until a listing succeeds. */
+  listedTaskNames?: ReadonlySet<string>;
+}
+
+export function createServiceProbeStartupCache(): ServiceProbeStartupCache {
+  return {};
+}
+
 export type ServiceManagerBackend = "launchd" | "systemd" | "scheduler" | "winsw";
 
 export interface ServiceManagerClaim {
@@ -139,6 +169,12 @@ export interface ProbeDeps {
   readonly winswStatus?: () => "started" | "stopped" | "nonexistent" | "unknown";
   /** Test seam for redirected Windows legacy-codepage output. */
   readonly windowsLocale?: string;
+  /**
+   * Opt-in reuse of the expensive task listing across the inspections of ONE
+   * startup. Omit it and every inspection enumerates independently, exactly as
+   * before.
+   */
+  readonly startupCache?: ServiceProbeStartupCache;
 }
 
 const LABEL = "com.opencodex.proxy";
@@ -552,6 +588,16 @@ function windowsTaskListContains(body: string, taskName: string): boolean {
   });
 }
 
+/** The same normalization {@link windowsTaskListContains} applies, kept for reuse. */
+function windowsTaskListNames(body: string): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const line of body.split(/\r?\n/)) {
+    const field = csvFirstField(line).replace(/\//g, "\\").replace(/^\\+/, "");
+    if (field.length > 0) names.add(field.toLowerCase());
+  }
+  return names;
+}
+
 /**
  * The English message: a fast path on an English host, and nothing more.
  *
@@ -579,7 +625,7 @@ const SCHTASKS_TASK_NOT_FOUND_EN = /cannot find the file specified/i;
  * fallback, and only a successful list without our task proves absence.
  */
 function probeWindowsTaskRegistration(
-  deps: Required<Pick<ProbeDeps, "runRaw">> & Pick<ProbeDeps, "windowsLocale">,
+  deps: Required<Pick<ProbeDeps, "runRaw">> & Pick<ProbeDeps, "windowsLocale" | "startupCache">,
 ): {
   registered: "present" | "absent" | "unknown";
   registeredXml: string;
@@ -606,16 +652,26 @@ function probeWindowsTaskRegistration(
     return { registered: "absent", registeredXml: "" };
   }
 
+  const shared = deps.startupCache?.listedTaskNames;
+  if (shared !== undefined) {
+    return shared.has(windowsTaskName().toLowerCase())
+      ? { registered: "unknown", registeredXml: "" }
+      : { registered: "absent", registeredXml: "" };
+  }
+
   const listed = deps.runRaw(
     schtasks,
     ["/query", "/fo", "CSV", "/nh"],
     { timeoutMs: SERVICE_PROBE_LISTING_TIMEOUT_MS },
   );
   if (listed.spawnFailed || listed.timedOut || listed.status !== 0) {
+    // Deliberately not shared: caching a stall would turn one transient failure
+    // into an unprovable ownership for the rest of the startup, which refuses writes.
     return { registered: "unknown", registeredXml: "" };
   }
   const listing = decodeWindowsTextBytes(listed.stdout, { locale: deps.windowsLocale })
     || decodeWindowsTextBytes(listed.stderr, { locale: deps.windowsLocale });
+  if (deps.startupCache) deps.startupCache.listedTaskNames = windowsTaskListNames(listing);
   return windowsTaskListContains(listing, windowsTaskName())
     ? { registered: "unknown", registeredXml: "" }
     : { registered: "absent", registeredXml: "" };
@@ -654,7 +710,7 @@ function probeWinswRegistration(
 
 function inspectWindows(
   deps: Required<Pick<ProbeDeps, "runRaw" | "home">>
-    & Pick<ProbeDeps, "configDir" | "winswStatus" | "windowsLocale">,
+    & Pick<ProbeDeps, "configDir" | "winswStatus" | "windowsLocale" | "startupCache">,
 ): ServiceManagerInstallation {
   const configDir = windowsConfigDirPath(deps);
   const taskXmlPath = join(configDir, "opencodex-service-task.xml");
@@ -934,6 +990,7 @@ export function inspectServiceManagerInstallation(deps: ProbeDeps = {}): Service
       configDir: deps.configDir,
       winswStatus: deps.winswStatus,
       windowsLocale: deps.windowsLocale,
+      startupCache: deps.startupCache,
     });
   }
   return unknown(`no service manager probe for platform ${platform}`);

--- a/tests/codex-service-manager-probe-hardening.test.ts
+++ b/tests/codex-service-manager-probe-hardening.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 
 import {
   inspectServiceManagerInstallation,
+  createServiceProbeStartupCache,
+  type ServiceManagerInstallation,
   type RawProbeRunner,
 } from "../src/service-manager-probe";
 import { inspectNativeCodexOwnership } from "../src/integrations/native/ownership-preflight";
@@ -206,6 +208,124 @@ describe("Windows ownership probe hardening regressions", () => {
 
     // A wider budget must not become an excuse to guess when it still expires.
     expect(result.kind).toBe("unknown");
+  });
+
+  /*
+   * #2923, a regression from #2914's own fix. `startServer` inspects ownership
+   * twice on purpose — before the startup cache decision and before native
+   * lifecycle preparation — so on a localized host the 20s full-machine listing
+   * was paid at BOTH sites: ~25s measured, 40s at the ceiling, all of it before
+   * `Bun.serve`.
+   *
+   * The listing is shared through a caller-owned cache. These cases pin the three
+   * things that make that safe rather than merely faster.
+   */
+  function localizedListingRunner(
+    calls: Array<{ args: readonly string[] }>,
+    listing: string,
+  ): RawProbeRunner {
+    return (file, args) => {
+      calls.push({ args });
+      if (file.toLowerCase().endsWith("sc.exe")) return raw(1, "", "1060");
+      if (args.includes("/xml")) {
+        return { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false };
+      }
+      if (args.includes("/fo")) return raw(0, listing);
+      return raw(1, "", "");
+    };
+  }
+
+  test("one startup enumerates the whole machine once, not once per inspection (#2923)", () => {
+    const calls: Array<{ args: readonly string[] }> = [];
+    const runRaw = localizedListingRunner(calls, '"\\SomeOtherTask","N/A","Ready"\r\n');
+    const startupCache = createServiceProbeStartupCache();
+    const probe = (): ServiceManagerInstallation => inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      startupCache,
+    });
+
+    expect(probe().kind).toBe("absent");
+    expect(probe().kind).toBe("absent");
+
+    // The expensive enumeration happened once for the startup...
+    expect(calls.filter(call => call.args.includes("/fo"))).toHaveLength(1);
+    // ...while the targeted query — the race-sensitive evidence the second
+    // inspection exists for — still ran on both.
+    expect(calls.filter(call => call.args.includes("/xml")).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("a task registered between the two inspections is not reported absent (#2923)", () => {
+    const calls: Array<{ args: readonly string[] }> = [];
+    let registered = false;
+    const runRaw: RawProbeRunner = (file, args) => {
+      calls.push({ args });
+      if (file.toLowerCase().endsWith("sc.exe")) return raw(1, "", "1060");
+      if (args.includes("/xml")) {
+        // Absent on the first inspection, registered by the second.
+        if (!registered) {
+          return { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false };
+        }
+        return raw(0, schedulerXml(join(configDir, "opencodex-service-launcher.vbs")));
+      }
+      if (args.includes("/fo")) return raw(0, '"\\SomeOtherTask","N/A","Ready"\r\n');
+      return raw(1, "", "");
+    };
+    const startupCache = createServiceProbeStartupCache();
+    const probe = (): ServiceManagerInstallation => inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      startupCache,
+    });
+
+    expect(probe().kind).toBe("absent");
+    registered = true;
+    // A cached LISTING must not mask a newly present task: the targeted query
+    // decides `present`, and it is never cached. Reporting `absent` here is the
+    // race the second inspection exists to close.
+    expect(probe().kind).not.toBe("absent");
+  });
+
+  test("a stalled listing is not cached as evidence for the rest of the startup (#2923)", () => {
+    const calls: Array<{ args: readonly string[] }> = [];
+    let stall = true;
+    const runRaw: RawProbeRunner = (file, args) => {
+      calls.push({ args });
+      if (file.toLowerCase().endsWith("sc.exe")) return raw(1, "", "1060");
+      if (args.includes("/xml")) {
+        return { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false };
+      }
+      if (args.includes("/fo")) {
+        if (stall) return raw(null, "", "", { timedOut: true });
+        return raw(0, '"\\SomeOtherTask","N/A","Ready"\r\n');
+      }
+      return raw(1, "", "");
+    };
+    const startupCache = createServiceProbeStartupCache();
+    const probe = (): ServiceManagerInstallation => inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      startupCache,
+    });
+
+    expect(probe().kind).toBe("unknown");
+    stall = false;
+    // A transient stall must not become a sticky refusal: the second inspection
+    // retries the listing and reaches a real answer.
+    expect(probe().kind).toBe("absent");
+    expect(calls.filter(call => call.args.includes("/fo"))).toHaveLength(2);
   });
 
   test("a scheduler registered for another OpenCodex home does not claim the current home (#2800)", () => {


### PR DESCRIPTION
## Summary

A regression from my own #2914 fix, correctly diagnosed in #2923.

That fix gave the whole-machine `schtasks /query /fo CSV /nh` listing a 20 s budget, because with the localized message decoded it is still the only *locale-neutral* absence evidence. What I missed is that `startServer` inspects ownership **twice** on purpose — once before the startup cache decision, once before native lifecycle preparation — so a localized host with hundreds of tasks paid the full enumeration at both sites. The reporter measured ~12.3 s per listing on a 401-task host: about **25 s of startup, 40 s at the ceiling, all of it before `Bun.serve`**.

The listing is now shared across one startup through a cache object the caller owns. `startServer` creates it once and hands it to both inspections.

## Why the caller owns the cache

I tried module-level memoization first and it was wrong, in a way the existing suite caught immediately: state leaked across unrelated inspections, and in tests an access-denied host started reporting `present` instead of `unknown` — a fail-open direction. The lifetime that is actually correct here is "one startup," and only the caller knows when that is. An explicit object makes the sharing visible at both call sites and impossible anywhere else; omit it and every inspection enumerates independently, exactly as before.

## What is shared, and what deliberately is not

Only the listing, and only which task names the machine reported.

- **The targeted `/query /tn` still runs on every inspection.** That is the evidence that decides `present`, and it is never cached — so a task registered *between* the two checks is still seen, and the race the second inspection exists to close is untouched. The issue was explicit that the fix must not delete the revalidation, and it does not.
- **A stalled or failed listing is not cached.** Caching a failure would convert one transient stall into an unprovable ownership for the rest of the startup, which is the direction that refuses writes.
- The 20 s budget, the fail-closed `unknown`, and the absence of any guessed `absent` are all unchanged.

## Verification

- `bun test tests/codex-service-manager-probe-hardening.test.ts tests/codex-service-manager-probe.test.ts tests/service-probe-docker.test.ts` — **77 pass / 0 fail**.
- `bun test tests/core-lab-boundary.test.ts` — 17 pass (this touches `src/server/index.ts`, which that guard governs).
- `bun x tsc --noEmit` clean, `bun run privacy:scan` passed.

### Three mutations, each red on its own

| mutation | result |
| --- | --- |
| ignore the shared listing | `Expected length: 1, Received length: 2` — double enumeration returns |
| cache the stalled listing too | `Expected: "absent", Received: "unknown"` — sticky refusal |
| let the cached listing preempt the targeted query | `Expected: not "absent"` — a newly registered task is masked |

The third is the one worth having. It is the fail-open failure mode this change could plausibly introduce, and it is exactly what #2923 warned against; the source was restored and verified byte-identical by sha256 after each.

**What I could not verify:** I am on macOS, so no real `schtasks` ran and I did not reproduce the 12.3 s or ~25 s measurements. The call-count and caching behavior are fully covered by injected probes; the wall-clock improvement follows from removing one enumeration and rests on the reporter's timing.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

This is an ownership-admission path. Every final decision stays fail-closed, no cached value can produce `absent` on its own, and `present` still requires the live targeted query. No task names, registry data, or account identifiers are logged.

Closes #2923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced Windows startup overhead by reusing service inspection results during repeated startup checks.
  * Expensive scheduled-task listings now run only once when possible.
* **Reliability**
  * Targeted task checks continue to run for each inspection.
  * Failed or timed-out listings are not reused, helping preserve accurate results.
* **Tests**
  * Added coverage for cache reuse, task registration changes, targeted queries, and listing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->