### PR TITLE
fix(windows): reuse unchanged startup task listing

### DIFF
--- a/src/integrations/native/ownership-preflight.ts
+++ b/src/integrations/native/ownership-preflight.ts
@@ -22,10 +22,13 @@ import {
   type ServiceStateEvidence,
 } from "../../service";
 import {
+  createWindowsTaskListingCache,
   inspectServiceManagerInstallation,
   type ProbeDeps,
   type ServiceManagerClaim,
 } from "../../service-manager-probe";
+
+export { createWindowsTaskListingCache };
 
 export type NativeTeardownOwnership = { ok: true } | { ok: false; message: string };
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,6 +27,7 @@ import { invalidateCodexModelsCacheWithPermit } from "../codex/catalog/sync";
 import { currentServiceHomes, serviceStatePathsForOpenCodexHome } from "../service";
 import { shouldSyncCodexOnStart } from "../codex/desired-state";
 import {
+  createWindowsTaskListingCache,
   inspectNativeCodexOwnership,
   type NativeCodexOwnership,
   type OwnershipInspection,
@@ -499,6 +500,7 @@ function inspectStartupOwnership(
   deps: StartServerDeps,
   currentHomes: ReturnType<typeof currentServiceHomes> | null,
   statePaths: readonly string[] | null,
+  windowsTaskListingCache?: ReturnType<typeof createWindowsTaskListingCache>,
 ): OwnershipInspection {
   try {
     if (currentHomes === null || statePaths === null) {
@@ -508,9 +510,9 @@ function inspectStartupOwnership(
       };
     }
     if (deps.inspectNativeCodexOwnership) {
-      return deps.inspectNativeCodexOwnership({ currentHomes, statePaths });
+      return deps.inspectNativeCodexOwnership({ currentHomes, statePaths, windowsTaskListingCache });
     }
-    return inspectNativeCodexOwnership({ currentHomes, statePaths });
+    return inspectNativeCodexOwnership({ currentHomes, statePaths, windowsTaskListingCache });
   } catch {
     return {
       ownership: "unknown",
@@ -600,6 +602,11 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
   const resolveServiceHomes = deps.resolveServiceHomes ?? currentServiceHomes;
   let startupOwnershipHomes: ReturnType<typeof currentServiceHomes> | null = null;
   let startupOwnershipStatePaths: readonly string[] | null = null;
+  // #2923: both synchronous startup ownership decisions keep their fresh,
+  // race-sensitive targeted task query. Only the expensive fallback listing is
+  // shared, and only while that targeted result stays byte-for-byte unchanged.
+  // Runtime ownership retries below intentionally omit this startup-local memo.
+  const startupWindowsTaskListingCache = createWindowsTaskListingCache();
   try {
     const homes = resolveServiceHomes();
     const statePaths = serviceStatePathsForOpenCodexHome(homes.opencodexHome);
@@ -610,6 +617,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
     deps,
     startupOwnershipHomes,
     startupOwnershipStatePaths,
+    startupWindowsTaskListingCache,
   );
   // Startup cache invalidation is best-effort and must never block the server from
   // serving. It now takes K so it cannot race a convergence commit. Use the home
@@ -785,7 +793,12 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
   // clients; no Codex request can use this lifecycle in that state.
   // Re-probe here instead of trusting the earlier cache decision: startup work
   // between the two sites must not widen the service-install race.
-  const nativeOwnership = inspectStartupOwnership(deps, startupOwnershipHomes, startupOwnershipStatePaths);
+  const nativeOwnership = inspectStartupOwnership(
+    deps,
+    startupOwnershipHomes,
+    startupOwnershipStatePaths,
+    startupWindowsTaskListingCache,
+  );
   const preparedNativeMainLifecycle = nativeOwnership.ownership !== "foreign"
     && startupOwnershipHomes !== null
     ? prepareNativeMainStartupLifecycle(

--- a/src/service-manager-probe.ts
+++ b/src/service-manager-probe.ts
@@ -106,6 +106,13 @@ type RawProbeResult = ReturnType<RawProbeRunner>;
  * the same bytes and status as the query that caused the listing. If the
  * targeted evidence changes, the old absence proof is stale and another
  * listing is required rather than turning uncertainty into absence.
+ *
+ * Only a SUCCESSFUL listing is retained. A stall or spawn failure is not
+ * evidence of anything, and caching it made one transient 20s timeout poison the
+ * rest of the startup: the targeted query is byte-identical on the next
+ * inspection, so the identity check passed, the listing was never retried, and
+ * ownership stayed unprovable for the whole run — refusing the write that #2914
+ * exists to allow.
  */
 export interface WindowsTaskListingCache {
   getOrRun(targetedQuery: RawProbeResult, run: () => RawProbeResult): RawProbeResult;
@@ -130,8 +137,10 @@ export function createWindowsTaskListingCache(): WindowsTaskListingCache {
       const nextIdentity = rawProbeIdentity(targetedQuery);
       if (result !== null && identity === nextIdentity) return result;
       const next = run();
-      identity = nextIdentity;
-      result = next;
+      if (!next.timedOut && !next.spawnFailed && next.status === 0) {
+        identity = nextIdentity;
+        result = next;
+      }
       return next;
     },
   };

--- a/src/service-manager-probe.ts
+++ b/src/service-manager-probe.ts
@@ -95,6 +95,48 @@ export type RawProbeRunner = (
   spawnFailed: boolean;
 };
 
+type RawProbeResult = ReturnType<RawProbeRunner>;
+
+/**
+ * Startup-local memo for the expensive full Task Scheduler listing.
+ *
+ * The targeted `/tn ... /xml` query is deliberately NOT cached: it is the
+ * race-sensitive evidence that a task appeared between two ownership checks.
+ * A listing may be reused only when that fresh targeted query returned exactly
+ * the same bytes and status as the query that caused the listing. If the
+ * targeted evidence changes, the old absence proof is stale and another
+ * listing is required rather than turning uncertainty into absence.
+ */
+export interface WindowsTaskListingCache {
+  getOrRun(targetedQuery: RawProbeResult, run: () => RawProbeResult): RawProbeResult;
+}
+
+function rawProbeIdentity(result: RawProbeResult): string {
+  return [
+    result.status === null ? "null" : String(result.status),
+    result.timedOut ? "1" : "0",
+    result.spawnFailed ? "1" : "0",
+    result.stdout.toString("base64"),
+    result.stderr.toString("base64"),
+  ].join("\u0000");
+}
+
+/** Create one bounded cache for the synchronous ownership phase of one startup. */
+export function createWindowsTaskListingCache(): WindowsTaskListingCache {
+  let identity: string | null = null;
+  let result: RawProbeResult | null = null;
+  return {
+    getOrRun(targetedQuery, run) {
+      const nextIdentity = rawProbeIdentity(targetedQuery);
+      if (result !== null && identity === nextIdentity) return result;
+      const next = run();
+      identity = nextIdentity;
+      result = next;
+      return next;
+    },
+  };
+}
+
 export const defaultProbeRunner: ProbeRunner = (file, args) => {
   const result = spawnSync(file, [...args], {
     encoding: "utf8",
@@ -139,6 +181,8 @@ export interface ProbeDeps {
   readonly winswStatus?: () => "started" | "stopped" | "nonexistent" | "unknown";
   /** Test seam for redirected Windows legacy-codepage output. */
   readonly windowsLocale?: string;
+  /** Startup-local full-listing cache; targeted task queries always bypass it. */
+  readonly windowsTaskListingCache?: WindowsTaskListingCache;
 }
 
 const LABEL = "com.opencodex.proxy";
@@ -579,7 +623,8 @@ const SCHTASKS_TASK_NOT_FOUND_EN = /cannot find the file specified/i;
  * fallback, and only a successful list without our task proves absence.
  */
 function probeWindowsTaskRegistration(
-  deps: Required<Pick<ProbeDeps, "runRaw">> & Pick<ProbeDeps, "windowsLocale">,
+  deps: Required<Pick<ProbeDeps, "runRaw">>
+    & Pick<ProbeDeps, "windowsLocale" | "windowsTaskListingCache">,
 ): {
   registered: "present" | "absent" | "unknown";
   registeredXml: string;
@@ -606,11 +651,14 @@ function probeWindowsTaskRegistration(
     return { registered: "absent", registeredXml: "" };
   }
 
-  const listed = deps.runRaw(
+  const runListing = () => deps.runRaw(
     schtasks,
     ["/query", "/fo", "CSV", "/nh"],
     { timeoutMs: SERVICE_PROBE_LISTING_TIMEOUT_MS },
   );
+  const listed = deps.windowsTaskListingCache
+    ? deps.windowsTaskListingCache.getOrRun(queried, runListing)
+    : runListing();
   if (listed.spawnFailed || listed.timedOut || listed.status !== 0) {
     return { registered: "unknown", registeredXml: "" };
   }
@@ -654,7 +702,7 @@ function probeWinswRegistration(
 
 function inspectWindows(
   deps: Required<Pick<ProbeDeps, "runRaw" | "home">>
-    & Pick<ProbeDeps, "configDir" | "winswStatus" | "windowsLocale">,
+    & Pick<ProbeDeps, "configDir" | "winswStatus" | "windowsLocale" | "windowsTaskListingCache">,
 ): ServiceManagerInstallation {
   const configDir = windowsConfigDirPath(deps);
   const taskXmlPath = join(configDir, "opencodex-service-task.xml");
@@ -934,6 +982,7 @@ export function inspectServiceManagerInstallation(deps: ProbeDeps = {}): Service
       configDir: deps.configDir,
       winswStatus: deps.winswStatus,
       windowsLocale: deps.windowsLocale,
+      windowsTaskListingCache: deps.windowsTaskListingCache,
     });
   }
   return unknown(`no service manager probe for platform ${platform}`);

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -17,6 +17,22 @@ existing task. Explicit `ocx service install` remains the operator-owned registr
 - 다른 대안 대신 이 방식을 선택한 이유: Saved state can be stale and unconditional repair breaks first install, while a boolean cannot represent the exact uncertainty that must fail closed.
 - 장점, 단점 및 영향: Existing services avoid UAC and registration churn, invalid input performs no status I/O, and uncertain Windows hosts require one explicit status/installation decision instead of risking a destructive guess.
 
+## Windows startup ownership listing reuse
+
+One proxy startup asks service-home ownership twice before listen: once before cache invalidation and
+again immediately before native-main lifecycle preparation. The second targeted Task Scheduler query
+is a deliberate race check and remains mandatory. On a localized host, however, the same nonzero
+targeted answer can require a full task listing with a 20-second ceiling; running that identical
+enumeration twice made a measured 12.3-second fallback cost roughly 25 seconds before listen.
+
+[Decision Log]
+- 목적과 의도: Preserve the race-sensitive Windows ownership recheck while paying for an unchanged locale-neutral full task listing only once during synchronous startup.
+- 기존 구현 및 제약 조건: Localized `schtasks /query /tn ... /xml` failures need a full listing to prove absence, the listing may legitimately take more than two seconds, and `unknown` must never become `absent` merely to reduce latency.
+- 검토한 주요 대안: Delete the second ownership check; lower the listing timeout; keep a process-wide or TTL cache; reuse an earlier absence regardless of the fresh targeted result; or scope a memo to the two pre-listen checks and key it to the complete targeted result.
+- 선택한 방식: Create one cache inside `startServer`, run every targeted query, and reuse its listing result only when status, timeout/spawn flags, stdout, and stderr are byte-identical. Runtime ownership retries do not receive the startup cache.
+- 다른 대안 대신 이 방식을 선택한 이유: Removing or weakening revalidation widens the install race, while a global/TTL cache can outlive startup and stale absence can authorize the wrong home. Exact targeted-result identity lets the ordinary no-task locale fallback coalesce without hiding changed evidence.
+- 장점, 단점 및 영향: The reported stable zh-CN absence path performs two cheap targeted queries and one full listing. A task that appears is detected by the second targeted query; changed or failed evidence triggers a fresh fail-closed decision, so unusual churn may still pay for two listings rather than guess.
+
 ## Linux stable service launcher
 
 Systemd installation resolves the first absolute `ocx` PATH candidate that is both a regular file

--- a/tests/codex-service-manager-probe-hardening.test.ts
+++ b/tests/codex-service-manager-probe-hardening.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   createWindowsTaskListingCache,
   inspectServiceManagerInstallation,
+  type ServiceManagerInstallation,
   type RawProbeRunner,
 } from "../src/service-manager-probe";
 import { inspectNativeCodexOwnership } from "../src/integrations/native/ownership-preflight";
@@ -244,6 +245,10 @@ describe("Windows ownership probe hardening regressions", () => {
       inspectNativeCodexOwnership: scope => {
         const answer = inspectNativeCodexOwnership({
           ...scope,
+          // `startServer` derives statePaths from the sandbox home AND the default
+          // `homedir()` mirror, which no test env moves — so without pinning this the
+          // fixture reads the developer's real installation and calls it foreign.
+          statePaths: [join(configDir, "service-state.json")],
           platform: "win32",
           home,
           configDir,
@@ -381,7 +386,43 @@ describe("Windows ownership probe hardening regressions", () => {
     }));
 
     expect(answers.map(answer => answer.kind)).toEqual(["unknown", "unknown"]);
-    expect(fullListings).toBe(1);
+    // Fail-closed on both passes, and the stall was NOT retained as evidence: a
+    // transient timeout must not make ownership unprovable for the whole startup.
+    expect(fullListings).toBe(2);
+  });
+
+  test("a listing that recovers after a stall is not masked by the failed one (#2923)", () => {
+    const cache = createWindowsTaskListingCache();
+    let stall = true;
+    let fullListings = 0;
+    const runRaw: RawProbeRunner = (file, args) => {
+      if (!file.toLowerCase().endsWith("schtasks.exe")) return raw(1, "", "unexpected executable");
+      if (args.includes("/xml")) {
+        // Byte-identical on both passes, so the identity check cannot be what
+        // forces the retry — only refusing to cache the stall can.
+        return { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false };
+      }
+      if (args.includes("/fo")) {
+        fullListings += 1;
+        if (stall) return raw(null, "", "", { timedOut: true });
+        return raw(0, '"\\SomeOtherTask","N/A","Ready"\r\n');
+      }
+      return raw(1, "", "unexpected query");
+    };
+    const probe = (): ServiceManagerInstallation => inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      windowsTaskListingCache: cache,
+    });
+
+    expect(probe().kind).toBe("unknown");
+    stall = false;
+    expect(probe().kind).toBe("absent");
+    expect(fullListings).toBe(2);
   });
 
   test("a scheduler registered for another OpenCodex home does not claim the current home (#2800)", () => {

--- a/tests/codex-service-manager-probe-hardening.test.ts
+++ b/tests/codex-service-manager-probe-hardening.test.ts
@@ -4,11 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  createWindowsTaskListingCache,
   inspectServiceManagerInstallation,
   type RawProbeRunner,
 } from "../src/service-manager-probe";
 import { inspectNativeCodexOwnership } from "../src/integrations/native/ownership-preflight";
 import { setTrustedWindowsSystemDirectoryResolverForTests } from "../src/lib/windows-elevation";
+import { getDefaultConfig } from "../src/config";
+import { startServer } from "../src/server";
 
 let home = "";
 let configDir = "";
@@ -206,6 +209,179 @@ describe("Windows ownership probe hardening regressions", () => {
 
     // A wider budget must not become an excuse to guess when it still expires.
     expect(result.kind).toBe("unknown");
+  });
+
+  test("one startup keeps two targeted queries but shares one unchanged full listing (#2923)", async () => {
+    const codexHome = join(home, "codex");
+    mkdirSync(codexHome, { recursive: true });
+    process.env.CODEX_HOME = codexHome;
+    process.env.OPENCODEX_HOME = configDir;
+    writeFileSync(join(configDir, "config.json"), JSON.stringify({
+      ...getDefaultConfig(),
+      port: 0,
+      hostname: "127.0.0.1",
+      clientIntegrations: { codex: false },
+      subagentModels: [],
+    }, null, 2));
+
+    let targetedQueries = 0;
+    let fullListings = 0;
+    const runRaw: RawProbeRunner = (file, args) => {
+      if (!file.toLowerCase().endsWith("schtasks.exe")) return raw(1, "", "unexpected executable");
+      if (args.includes("/xml")) {
+        targetedQueries += 1;
+        return { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false };
+      }
+      if (args.includes("/fo")) {
+        fullListings += 1;
+        return raw(0, '"\\SomeOtherTask","N/A","Ready"\r\n');
+      }
+      return raw(1, "", "unexpected query");
+    };
+    const ownerships: string[] = [];
+    const server = startServer(0, {
+      resolveServiceHomes: () => ({ codexHome, opencodexHome: configDir }),
+      inspectNativeCodexOwnership: scope => {
+        const answer = inspectNativeCodexOwnership({
+          ...scope,
+          platform: "win32",
+          home,
+          configDir,
+          windowsLocale: "zh-CN",
+          runRaw,
+          winswStatus: () => "nonexistent",
+        });
+        ownerships.push(answer.ownership);
+        return answer;
+      },
+    });
+    try {
+      expect(ownerships.slice(0, 2)).toEqual(["owned", "owned"]);
+      expect(targetedQueries).toBe(2);
+      expect(fullListings).toBe(1);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("a task that appears between cached-listing checks is not reported absent (#2923)", () => {
+    const cache = createWindowsTaskListingCache();
+    let targetedQueries = 0;
+    let fullListings = 0;
+    const launcher = join(configDir, "opencodex-service-launcher.vbs");
+    const runRaw: RawProbeRunner = (file, args) => {
+      if (!file.toLowerCase().endsWith("schtasks.exe")) return raw(1, "", "unexpected executable");
+      if (args.includes("/xml")) {
+        targetedQueries += 1;
+        return targetedQueries === 1
+          ? { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false }
+          : raw(0, schedulerXml(launcher));
+      }
+      if (args.includes("/fo")) {
+        fullListings += 1;
+        return raw(0, '"\\SomeOtherTask","N/A","Ready"\r\n');
+      }
+      return raw(1, "", "unexpected query");
+    };
+
+    const first = inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      windowsTaskListingCache: cache,
+    });
+    const second = inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      windowsTaskListingCache: cache,
+    });
+
+    expect(first.kind).toBe("absent");
+    expect(second.kind).toBe("unknown");
+    expect(targetedQueries).toBe(2);
+    expect(fullListings).toBe(1);
+  });
+
+  test("changed targeted evidence cannot reuse an earlier absence listing (#2923)", () => {
+    const cache = createWindowsTaskListingCache();
+    let targetedQueries = 0;
+    let fullListings = 0;
+    const runRaw: RawProbeRunner = (file, args) => {
+      if (!file.toLowerCase().endsWith("schtasks.exe")) return raw(1, "", "unexpected executable");
+      if (args.includes("/xml")) {
+        targetedQueries += 1;
+        return targetedQueries === 1
+          ? { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false }
+          : raw(1, "", "ERROR: Access is denied. (0x80070005)");
+      }
+      if (args.includes("/fo")) {
+        fullListings += 1;
+        return fullListings === 1
+          ? raw(0, '"\\SomeOtherTask","N/A","Ready"\r\n')
+          : raw(0, '"\\opencodex-proxy","N/A","Ready"\r\n');
+      }
+      return raw(1, "", "unexpected query");
+    };
+
+    const first = inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      windowsTaskListingCache: cache,
+    });
+    const second = inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      windowsTaskListingCache: cache,
+    });
+
+    expect(first.kind).toBe("absent");
+    expect(second.kind).toBe("unknown");
+    expect(targetedQueries).toBe(2);
+    expect(fullListings).toBe(2);
+  });
+
+  test("a cached listing failure remains fail-closed (#2923)", () => {
+    const cache = createWindowsTaskListingCache();
+    let fullListings = 0;
+    const runRaw: RawProbeRunner = (file, args) => {
+      if (!file.toLowerCase().endsWith("schtasks.exe")) return raw(1, "", "unexpected executable");
+      if (args.includes("/xml")) {
+        return { status: 1, stdout: Buffer.alloc(0), stderr: GBK_TASK_NOT_FOUND, timedOut: false, spawnFailed: false };
+      }
+      if (args.includes("/fo")) {
+        fullListings += 1;
+        return raw(null, "", "", { timedOut: true });
+      }
+      return raw(1, "", "unexpected query");
+    };
+
+    const answers = [0, 1].map(() => inspectServiceManagerInstallation({
+      platform: "win32",
+      home,
+      configDir,
+      windowsLocale: "zh-CN",
+      runRaw,
+      winswStatus: () => "nonexistent",
+      windowsTaskListingCache: cache,
+    }));
+
+    expect(answers.map(answer => answer.kind)).toEqual(["unknown", "unknown"]);
+    expect(fullListings).toBe(1);
   });
 
   test("a scheduler registered for another OpenCodex home does not claim the current home (#2800)", () => {


### PR DESCRIPTION
## Summary

- Keep both race-sensitive targeted `schtasks /query /tn ... /xml` ownership checks during startup.
- Reuse the expensive full Task Scheduler listing only when the fresh targeted result is byte-for-byte unchanged; changed evidence triggers a fresh fail-closed decision.
- Scope the memo to the synchronous pre-listen phase, leave later ownership retries fresh, and record the decision in `structure/04_transports-and-sidecars.md`.

Closes #2923

## Verification

- Exact PR head `3bcd29770`: `bun test tests/codex-service-manager-probe-hardening.test.ts tests/codex-service-manager-probe.test.ts tests/native-profile-startup.test.ts --timeout 30000` — 112 pass, 0 fail.
- Exact PR head `3bcd29770`: `bun run typecheck` — passed.
- Full suite before the final non-overlapping `dev` rebase: `bun run test` — 16,144 pass, 16 skip, 0 fail. The only two later base commits changed Codex identity-budget and pool replay tests; focused tests and typecheck were rerun after that rebase.
- All commands used isolated `HOME`, `OPENCODEX_HOME`, and `CODEX_HOME`, with CPU affinity and niceness limits.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved Windows startup times by reusing Task Scheduler results during startup ownership checks.
  - Avoided repeated scans when relevant task data has not changed.

- **Bug Fixes**
  - Improved detection when Windows tasks appear or change during startup.
  - Prevented stale results from being reused and maintained safe handling when task-listing checks fail.

- **Documentation**
  - Added documentation describing Windows startup ownership listing reuse and its scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->