### PR TITLE
fix(codex): reconcile the refreshed plan on the shared flight, not the owner's wait

### DIFF
--- a/src/codex/account-store.ts
+++ b/src/codex/account-store.ts
@@ -638,7 +638,7 @@ async function resolveCodexToken(
   const abort = new AbortController();
   const signal = AbortSignal.any([abort.signal, AbortSignal.timeout(30_000)]);
   let flight!: RefreshFlight;
-  const refreshPromise = withCodexRefreshFileLock(refreshGrantFingerprint, signal, async (): Promise<CodexRefreshResult> => {
+  const fetchPromise = withCodexRefreshFileLock(refreshGrantFingerprint, signal, async (): Promise<CodexRefreshResult> => {
     const current = readCodexAccountRecord(id);
     const lockedRecord = readCodexAccountRecord(id);
     const lockedCred = lockedRecord?.deletedAt == null ? lockedRecord?.credential : undefined;
@@ -759,6 +759,22 @@ async function resolveCodexToken(
       resolvedGrantFingerprint: refreshGrantFingerprint,
       selfRefreshed: true,
     };
+  });
+  /*
+   * Plan reconciliation belongs to the FLIGHT, not to whichever caller opened it.
+   *
+   * The flight outlives its initiating caller by design (gap 2): an aborted owner stops
+   * waiting while the shared work still runs and still commits the rotated credential.
+   * Reconciling the plan only after the owner's caller-scoped wait therefore dropped it
+   * whenever that owner walked away, and a same-account joiner returning through the
+   * adopt-stored branch does not reconcile either — so a changed `chatgpt_plan_type`
+   * stayed invisible in `codexAccounts[].plan` for the life of the process and skewed
+   * plan-selected quota projection. Attaching it to the flight runs it exactly once per
+   * committed result, for every waiter, including none.
+   */
+  const refreshPromise = fetchPromise.then(async (result): Promise<CodexRefreshResult> => {
+    await notePlanFromRefreshedAccessToken(id, result.accessToken, result.generation);
+    return result;
   }).finally(() => {
     if (refreshLocks.get(refreshGrantFingerprint) === flight) refreshLocks.delete(refreshGrantFingerprint);
   });
@@ -769,7 +785,6 @@ async function resolveCodexToken(
   // registered, so a joiner that arrives after this caller walks away still receives
   // the committed result.
   const result = await awaitOwnCancellation(refreshPromise, callerSignal);
-  await notePlanFromRefreshedAccessToken(id, result.accessToken, result.generation);
   return {
     accessToken: result.accessToken,
     chatgptAccountId: result.chatgptAccountId,

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -16,6 +16,17 @@ function refreshLockPathForToken(refreshToken: string): string {
   return join(TEST_DIR, `codex-refresh-${digest}.lock`);
 }
 
+/** Minimal unsigned JWT carrying the plan claim the store reconciles from. */
+function planJwt(plan: string, accountId = "acct-plan-flight"): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify({
+    chatgpt_account_id: accountId,
+    chatgpt_plan_type: plan,
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId, chatgpt_plan_type: plan },
+  })).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
 describe("codex-account-store CRUD", () => {
   beforeEach(() => {
     // These exercises cover credential-store contention, not Windows ACL behavior.
@@ -992,6 +1003,92 @@ describe("codex-account-store CRUD", () => {
       expect((error as InstanceType<typeof TokenRefreshError>).reason).toBe("unknown");
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("shared refresh flight plan reconciliation (#2892 gap 2 follow-up)", () => {
+  beforeEach(() => {
+    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "" }));
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    setIcaclsRunnerForTests(null);
+    delete process.env.OPENCODEX_HOME;
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  test("an aborted owner still reconciles the refreshed plan for the shared flight", async () => {
+    // The flight deliberately outlives the caller that opened it, so plan reconciliation
+    // must not hang off that caller's wait: a rotated token carrying a NEW
+    // chatgpt_plan_type would otherwise commit while codexAccounts[].plan stayed stale
+    // for the rest of the process, skewing plan-selected quota projection.
+    const { forceRefreshCodexPoolToken, readCodexAccountRecord, saveCodexAccountCredential } =
+      await import("../src/codex/account-store");
+    const { loadConfig, saveConfig } = await import("../src/config");
+    const { resetJwtPlanNotesForTests } = await import("../src/codex/plan-from-token");
+    resetJwtPlanNotesForTests();
+
+    saveConfig({
+      port: 10199,
+      providers: {},
+      defaultProvider: "openai",
+      codexAccounts: [{ id: "plan-flight", email: "flight@example.test", plan: "plus", isMain: false }],
+    });
+    saveCodexAccountCredential("plan-flight", {
+      accessToken: planJwt("plus"),
+      refreshToken: "plan-grant",
+      expiresAt: Date.now() + 3600_000,
+      chatgptAccountId: "acct-plan-flight",
+    });
+    const generation = readCodexAccountRecord("plan-flight")!.generation;
+
+    const originalFetch = globalThis.fetch;
+    let releaseFetch: (() => void) | undefined;
+    const fetchStarted = new Promise<void>(resolve => {
+      globalThis.fetch = (async () => {
+        resolve();
+        await new Promise<void>(release => { releaseFetch = release; });
+        return Response.json({
+          access_token: planJwt("pro"),
+          refresh_token: "plan-grant2",
+          expires_in: 3600,
+        });
+      }) as typeof fetch;
+    });
+
+    try {
+      const owner = new AbortController();
+      const ownerCall = forceRefreshCodexPoolToken("plan-flight", {
+        rejectedGeneration: generation,
+        rejectedAccessToken: planJwt("plus"),
+        signal: owner.signal,
+      });
+      await fetchStarted;
+      owner.abort(new Error("client disconnected"));
+      await expect(ownerCall).rejects.toThrow("client disconnected");
+
+      releaseFetch?.();
+      // The flight is detached from every caller now, so there is nothing to await. Poll
+      // for the persisted outcome under a deadline instead of a fixed delay: a fixed
+      // sleep can pass before the flight commits on a loaded worker and let teardown race
+      // unfinished work, and it never proves the reconciliation actually ran.
+      const deadline = Date.now() + 5_000;
+      let persisted = loadConfig().codexAccounts?.[0];
+      while ((persisted?.plan !== "pro" || persisted?.planSource !== "jwt") && Date.now() < deadline) {
+        await Bun.sleep(10);
+        persisted = loadConfig().codexAccounts?.[0];
+      }
+
+      expect(persisted?.plan).toBe("pro");
+      expect(persisted?.planSource).toBe("jwt");
+      expect(readCodexAccountRecord("plan-flight")!.credential!.accessToken).toBe(planJwt("pro"));
+    } finally {
+      globalThis.fetch = originalFetch;
+      resetJwtPlanNotesForTests();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Attach Codex pool plan reconciliation to the shared refresh flight's committed result instead of the initiating caller's cancellable wait.
- Keep the existing joiner-CAS reconciliation for a different account id unchanged.
- Add a regression proving an aborted owner still lands the refreshed `chatgpt_plan_type`.

## Why

A refresh flight deliberately outlives the caller that opened it: an aborted owner stops waiting while the shared work keeps running and still commits the rotated credential for every joiner. Plan reconciliation still ran only after the owner's caller-scoped wait, and the same-account joiner path returns through the adopt-stored branch without reconciling either.

A rotated token carrying a changed `chatgpt_plan_type` therefore committed while `codexAccounts[].plan` stayed stale for the life of the process, skewing plan-selected quota projection until a restart or an unrelated WHAM refresh.

Reconciliation now runs exactly once per flight, for every waiter and for none.

## Review boundary

This is a focused correctness follow-up to the caller-scoped cancellation change. It does not touch grant fan-out to inactive aliases, routing side-effect atomicity, credential CAS semantics, or the recovery-budget path; those remain separate slices of #2892.

## Verification

- Based on current `dev@6a907d2a3c6496935ec87d86240a6a12b0ffa00b`; exact head `c32576407c1bc120a01b87f45bfe1ae22063146e`.
- Bun `1.4.0+34cbb9a40`, `tests/codex-account-store.test.ts`: `37` passed, `0` failed (`117` expectations).
- Red-proven: with the source change reverted, the new regression fails by exceeding its 5s deadline without the plan ever reconciling.
- Bun `1.4.0+34cbb9a40`, wider credential/plan/routing set (`codex-account-store`, `responses-pool-401-refresh`, `responses-native-main-refresh`, `codex-plan`, `codex-routing`): `227` passed. The single non-green line was a Windows `EBUSY` teardown race on the shared fixture directory when five files share one machine lock; that same test passes in the per-file run and is unrelated to this change.
- `bun run typecheck`: passed.
- `bun run privacy:scan`: passed.
- The repository-wide suite was intentionally not duplicated locally; hosted CI remains the full-matrix check.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

Refs #2892



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account plan information is now reconciled even when the initiating refresh request is canceled.
  * Shared account refreshes consistently save rotated access tokens and updated plan details.

* **Tests**
  * Added coverage for canceled refresh requests that complete successfully and update the account based on the refreshed token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
