### PR TITLE
fix(cli): send the cleanup percent in the policy target the server reads

### DIFF
--- a/src/cli/storage.ts
+++ b/src/cli/storage.ts
@@ -173,7 +173,16 @@ async function policy(argv: string[], deps: RuntimeApiDeps): Promise<void> {
     }
     const body: Record<string, unknown> = {};
     if (enabled !== undefined) body.enabled = enabled === "true";
-    if (percent !== undefined) body.percent = percent;
+    // The policy target is nested. A top-level `percent` is not part of the PUT contract:
+    // `normalizeStorageCleanupPolicy` reads only `target`, so the field was dropped and the
+    // previously stored target survived. `--percent 10` on a policy still holding the
+    // default 25% therefore reported success while leaving cleanup authorized to delete
+    // more than the operator asked for.
+    //
+    // An out-of-range value is deliberately still sent: the server owns the 1-100
+    // vocabulary and answers with a named 400, which is a rejected write rather than the
+    // silent wrong write this replaces.
+    if (percent !== undefined) body.target = { removeOldestPercent: percent };
     if (mode !== undefined) body.mode = mode;
     if (schedule !== undefined) body.schedule = schedule;
     if (Object.keys(body).length === 0) {

--- a/tests/cli-storage-inspect.test.ts
+++ b/tests/cli-storage-inspect.test.ts
@@ -142,7 +142,31 @@ describe("ocx storage trash and policy", () => {
     expect(calls[0]?.method).toBe("PUT");
     // `enabled` is absent, which the server reads as "keep the stored value". Sending
     // `enabled: false` here would silently disable a policy the operator never mentioned.
-    expect(calls[0]?.body).toEqual({ percent: 40 });
+    // The percent travels inside `target`: the PUT contract has no top-level `percent`, so
+    // that shape was accepted, dropped, and left the stored target in place.
+    expect(calls[0]?.body).toEqual({ target: { removeOldestPercent: 40 } });
+  });
+
+  test("--percent reaches the server in the shape the policy target actually reads", async () => {
+    // A top-level `percent` round-trips as HTTP 200 while changing nothing:
+    // `normalizeStorageCleanupPolicy` reads only `target`, so a policy still holding the
+    // default 25% stayed at 25% after `--percent 10` reported success — cleanup remained
+    // authorized to delete more than the operator asked for.
+    const { calls, deps } = harness(() => ({ json: { ok: true, policy: {} } }));
+    const cap = capture();
+    try { await handleStorageCommand(["policy", "set", "--percent", "10"], deps); } finally { cap.restore(); }
+    const body = calls[0]?.body as Record<string, unknown>;
+    expect(body).toEqual({ target: { removeOldestPercent: 10 } });
+    expect(body).not.toHaveProperty("percent");
+  });
+
+  test("an out-of-range percent is still sent so the server can name the rejection", async () => {
+    // Rejecting locally would duplicate the server's 1-100 vocabulary. A named 400 is a
+    // refused write; the defect being fixed here was a silent accepted one.
+    const { calls, deps } = harness(() => ({ json: { ok: true, policy: {} } }));
+    const cap = capture();
+    try { await handleStorageCommand(["policy", "set", "--percent", "0"], deps); } finally { cap.restore(); }
+    expect(calls[0]?.body).toEqual({ target: { removeOldestPercent: 0 } });
   });
 
   test("policy set with no fields is refused rather than sent as an empty write", async () => {


### PR DESCRIPTION
## Summary

- Send `ocx storage policy set --percent N` as `target: { removeOldestPercent: N }`, the shape the cleanup-policy PUT route actually reads.
- Update the existing wire-shape assertion and add regressions for the corrected shape and for out-of-range forwarding.

## The defect

The CLI serialized a top-level `percent` field. That field is not part of the PUT contract: `parseStorageCleanupPolicyInput` spreads the body, but `normalizeStorageCleanupPolicy` reads the percent only from `target`, so an absent `target` key leaves the previously stored target in place.

The request still returned 200 with a policy body, so the operator saw success while nothing changed. On a policy holding the 25% default, `--percent 10` reported success and left cleanup authorized to remove considerably more data than was requested. Reducing the percent is the direction an operator reaches for when they want to delete *less*, which is what makes the silent no-op consequential rather than cosmetic.

## Scope

Client-side only. No server contract, validation vocabulary, or policy semantics change, and omission behavior for `enabled`, `mode`, and `schedule` is untouched.

An out-of-range percent is still forwarded rather than rejected locally. The server owns the 1-100 range and answers with a named 400; duplicating that vocabulary in the CLI would be a second thing to keep in sync, and a refused write is already the correct outcome. The failure being removed here is the silent *accepted* one.

## Verification

- Based on current `dev@d882caed5eb2`.
- Bun `1.4.0+34cbb9a40`, `tests/cli-storage-inspect.test.ts`: `21` passed, `0` failed.
- Red-proven: with the source change reverted, `3` tests fail — the updated shape assertion plus both new regressions.
- Bun `1.4.0+34cbb9a40`, with `tests/storage-policy-config-race.test.ts`: `23` passed, `0` failed (`68` expectations).
- `bun run typecheck`: passed.
- `bun run privacy:scan`: passed.
- The repository-wide suite was intentionally not duplicated locally; hosted CI remains the full-matrix check.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. The documented `--percent` usage is unchanged; only the wire shape it produces is corrected.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed storage cleanup policy updates so the requested cleanup percentage is correctly applied.
  * Invalid percentage values are now sent to the server for clear validation errors instead of being silently ignored.

* **Tests**
  * Added coverage for valid and out-of-range cleanup percentages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->