### PR TITLE
[WRONG BRANCH] fix: parse nested capabilities.supports.vision for GitHub Copilot models

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -1093,8 +1093,11 @@ function modelInputModalities(
       .filter(value => value === "text" || value === "image" || value === "audio");
     if (inferred.length > 0) return [...new Set(inferred)];
   }
-  if (capabilityRecord?.vision === false) return ["text"];
-  if (capabilityRecord?.vision === true || capabilities?.some(value => (
+ if (capabilityRecord?.vision === false) return ["text"];
+  // GitHub Copilot nests vision support under capabilities.supports.vision
+  // rather than the flat capabilities.vision that other providers use.
+  const nestedSupports = plainRecord(capabilityRecord?.supports);
+  if (capabilityRecord?.vision === true || nestedSupports?.vision === true || capabilities?.some(value => (
     value === "vision" || value === "image-input" || value === "image_input"
     // llama.cpp and Ollama-compatible servers report vision as "multimodal" —
     // it is the only image signal those servers emit (#1797). Mapped to the


### PR DESCRIPTION
Fixes #2941

## Problem

GitHub Copilot's `/models` endpoint reports vision support in a nested structure:

```json
{
  "capabilities": {
    "supports": { "vision": true },
    "limits": { "vision": { "max_prompt_images": 20 } }
  }
}
```

`modelInputModalities()` checks `capabilityRecord?.vision`, but since `capabilityRecord` is `plainRecord(item.capabilities)`, it yields `{ supports: {...}, limits: {...} }` — so `.vision` is `undefined`. Every Copilot model falls through to the `["text"]` default and the Codex app blocks image attachments.

## Fix

Check the nested `capabilities.supports.vision` path using the existing `plainRecord` helper, right alongside the existing flat `capabilities.vision` check. No new dependencies, no behavioral change for any other provider.

## Testing

- Verified against the live Copilot API: 32 of 47 models have `capabilities.supports.vision: true`, 15 are genuinely text-only — the fix correctly differentiates them.
- No other provider uses `capabilities.supports` as a record, so `plainRecord(capabilityRecord?.supports)` returns `undefined` for them and the new path is never reached.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vision capability detection for GitHub Copilot models.
  * Models with supported vision capabilities are now correctly advertised as accepting both text and image inputs.
  * Models explicitly marked as not supporting vision continue to accept text input only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->