### PR TITLE
fix(catalog): read Copilot nested vision capability

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -1094,8 +1094,14 @@ function modelInputModalities(
       .filter(value => value === "text" || value === "image" || value === "audio");
     if (inferred.length > 0) return [...new Set(inferred)];
   }
-  if (capabilityRecord?.vision === false) return ["text"];
-  if (capabilityRecord?.vision === true || capabilities?.some(value => (
+  const nestedSupports = plainRecord(capabilityRecord?.supports);
+  const explicitVisionSupport = typeof capabilityRecord?.vision === "boolean"
+    ? capabilityRecord.vision
+    : typeof nestedSupports?.vision === "boolean"
+      ? nestedSupports.vision
+      : undefined;
+  if (explicitVisionSupport === false) return ["text"];
+  if (explicitVisionSupport === true || capabilities?.some(value => (
     value === "vision" || value === "image-input" || value === "image_input"
     // llama.cpp and Ollama-compatible servers report vision as "multimodal" —
     // it is the only image signal those servers emit (#1797). Mapped to the

--- a/structure/03_catalog-and-subagents.md
+++ b/structure/03_catalog-and-subagents.md
@@ -295,6 +295,21 @@ the request, and they never raise it.
   연결한 사용자 설정에는 이 capability 분류가 전파되지 않는다.
 
 [Decision Log]
+- 목적과 의도: GitHub Copilot의 live model catalog가 명시하는 모델별 image-input 지원을
+  Codex catalog에 정확히 보존한다.
+- 기존 구현 및 제약 조건: 공용 discovery parser는 직접 `capabilities.vision`과 표준 modality
+  필드는 읽었지만 Copilot의 `capabilities.supports.vision` 중첩 boolean은 읽지 않아 모든
+  Copilot 모델이 text-only fallback으로 축소되었다.
+- 검토한 주요 대안: 모든 Copilot 모델에 정적 vision seed를 추가하기, 모델 이름을 외부
+  metadata alias에 연결하기, live 모델별 boolean을 공용 parser에서 해석하기.
+- 선택한 방식: 직접 vision boolean이 없을 때만 중첩 `supports.vision`의 명시적 boolean을
+  사용하고, `false`도 보존하며 malformed 값은 추론하지 않는다.
+- 다른 대안 대신 이 방식을 선택한 이유: live 응답이 모델별 capability의 가장 좁은 근거라서
+  새 모델에도 적용되며 text-only 모델을 image-capable로 과장하지 않는다.
+- 장점, 단점 및 영향: Copilot vision 모델은 image attachment를 받을 수 있고 명시적 text-only
+  모델은 계속 차단된다. Capability를 제공하지 않는 모델은 기존 fallback을 유지한다.
+
+[Decision Log]
 - 목적과 의도: bare `defaultModel` selectors that route into third-party providers must keep their
   adapter-owned effort ladder; only true ChatGPT-native requests should receive the mock-max repair.
 - 기존 구현 및 제약 조건: `nativeEffortClamp` already needed the original request id because

--- a/tests/provider-model-discovery-contract.test.ts
+++ b/tests/provider-model-discovery-contract.test.ts
@@ -276,6 +276,23 @@ describe("registry-owned provider model discovery", () => {
     })).toEqual({});
   });
 
+  test("reads explicit nested vision support from Copilot-style capabilities", () => {
+    expect(catalogHintsFromModelsApiItem("github-copilot", {
+      id: "vision-model",
+      capabilities: { supports: { vision: true } },
+    })).toEqual({ inputModalities: ["text", "image"] });
+
+    expect(catalogHintsFromModelsApiItem("github-copilot", {
+      id: "text-only-model",
+      capabilities: { supports: { vision: false } },
+    })).toEqual({ inputModalities: ["text"] });
+
+    expect(catalogHintsFromModelsApiItem("github-copilot", {
+      id: "unknown-model",
+      capabilities: { supports: { vision: "true" } },
+    })).toEqual({});
+  });
+
   test("preserves nested reasoning_parameters effort ladders from OpenAI-compatible catalogs", () => {
     expect(catalogHintsFromModelsApiItem("example", {
       id: "reasoning-model",
@@ -605,4 +622,3 @@ describe("same-named custom provider preservation", () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary

- parse the explicit Copilot-style `capabilities.supports.vision` boolean during live model discovery
- preserve explicit `false` and ignore malformed values so text-only or unknown models are not over-advertised
- document why live per-model metadata is preferred over a blanket Copilot registry seed

Closes #2941

## Verification

- `HOME=<tmp> OPENCODEX_HOME=<tmp> CODEX_HOME=<tmp> taskset -c 0,1 nice -n 10 bun test tests/provider-model-discovery-contract.test.ts --timeout 30000` — 31 passed, 182 expectations
- `bun run typecheck` under isolated homes — blocked by the same three pre-existing `fetch(..., { timeout })` type errors on clean `origin/dev`; the changed files add no type errors
- `bun run test:changed` under isolated homes — stopped after the import-graph selection remained silent for over five minutes; exact-head CI is still required before merge

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved model capability detection for vision-enabled models.
  - Models now correctly advertise image input when supported, including providers that report vision support through nested metadata.
  - Explicitly text-only models remain text-only, while unspecified or invalid capability values retain the existing fallback behavior.

- **Documentation**
  - Added a decision log documenting the handling of per-model image-input support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
