### PR TITLE
test(catalog): pin Copilot vision precedence and nested/flat denial equivalence

### DIFF
--- a/devlog/_plan/260830_lane_r_2941_copilot_vision/000_units.md
+++ b/devlog/_plan/260830_lane_r_2941_copilot_vision/000_units.md
@@ -1,0 +1,70 @@
+# Lane R / #2941 — Copilot vision models are cataloged text-only
+
+## The report
+
+Every `github-copilot` model arrives in the catalog with `inputModalities: ["text"]`, so Codex refuses image attachments with "This model does not support image inputs" on 32+ models that do accept them (Claude Opus/Sonnet, GPT-4o/4.1/5.x, Gemini, Grok). The same model reached through `openrouter` accepts images, which is what makes this clearly a metadata defect rather than an upstream limitation.
+
+## Why every path returns nothing
+
+Copilot's `/models` endpoint nests the flag one level deeper than the flat form the parser reads. No other checked-in fixture uses this shape, which is all a repository search can establish — it says nothing about what other live catalogs return:
+
+```json
+{
+  "id": "claude-opus-4.6",
+  "capabilities": {
+    "supports": { "vision": true },
+    "limits": { "vision": { "max_prompt_images": 20 } }
+  }
+}
+```
+
+`modelInputModalities()` in `src/codex/catalog/provider-fetch.ts` tries three signals and all three miss:
+
+- `item.input_modalities` / `item.modalities` — Copilot emits neither.
+- `capabilityRecord?.vision` — `capabilityRecord` is the `capabilities` object itself, so its keys are `supports` and `limits`. `.vision` is `undefined`.
+- the `capabilities` string array — `supports` is an object, not the literal `true` that scan looks for.
+
+The fallback chain then lands on `["text"]`.
+
+Note the shape carries a second `vision` key under `limits`. Any fix that searches loosely for "a vision key somewhere in capabilities" would find `limits.vision`, which is an object describing image count — truthy, and meaningless as a capability signal.
+
+## Outcome: #2943 shipped the fix, this unit adds the missing coverage
+
+@Ingwannu opened #2943 for the same defect 17 minutes before my #2944. Their implementation landed as `370052648`, and it is better than mine on one case that matters — see the precedence section below. My unit reduced to the tests and the explanatory comment.
+
+## Fix
+
+Read the nested boolean, positioned after the explicit-modality and architecture signals, with precedence **by specificity**: a flat `capabilities.vision` boolean is authoritative whenever present, the nested `supports.vision` boolean is consulted only otherwise, and a non-boolean at either level decides nothing so the remaining signals still apply.
+
+**The read is not scoped to `github-copilot`, and that is deliberate rather than overlooked.** `modelInputModalities` never receives a provider name, and the nested field is the same kind of evidence wherever it appears — a boolean statement about one model. Scoping it would mean a provider reporting the identical shape gets a worse answer for no reason. What the choice does mean is that any provider emitting `capabilities.supports.vision` as a boolean now has it honoured, so the nested field must behave **exactly** like the flat field it stands in for. That equivalence is pinned by a test comparing both shapes against the same loose capability-array claim.
+
+Strictness matters in both directions. A truthy test would let the string `"yes"` advertise image support, and coercing a non-record `supports` into a denial would suppress a `features: ["vision"]` signal that is still valid.
+
+## The precedence mistake, recorded because it nearly shipped
+
+I first wrote the denial as `flat === false || nested === false` — deny-wins across both sources. It reads as the safe direction and is not.
+
+On a provider reporting flat `vision: true` with nested `supports: { vision: false }`, deny-wins returns `["text"]` where the old code returned `["text", "image"]`. That is a silent behaviour change in a parser shared by **every** provider, shipped by a patch whose entire purpose was to stop models being wrongly marked text-only. Eleven of twelve capability shapes agree between the two resolutions; that one does not, and it is the one that would have caused a regression.
+
+A differential probe over both resolutions is what surfaced it — not review, and not green tests, since neither suite covered a disagreeing pair. The case is now pinned: reintroducing deny-wins turns `a flat vision boolean outranks a disagreeing nested one` red.
+
+## Rejected: a registry seed
+
+The issue offers "just add `modelInputModalities` to the `github-copilot` registry entry" as the easier route.
+
+An audit pushed back on my first reason for rejecting it, correctly. `modelInputModalities` is a **per-model** map, not a provider-wide boolean, and other providers do seed selectively — xAI lists specific verified vision ids. So "Copilot serves both vision and text-only models" does not by itself rule out a seed, and a selective one would even help during first start or degraded `/models` discovery, since the registry model list is explicitly a cold-start fallback.
+
+The real reason to omit it here is narrower: **a seed is only as good as the audited list behind it, and no verified model-by-model Copilot vision list exists.** Writing one from the 32 models named in the issue would be guesswork duplicating a remote catalog that changes without us. A selective seed remains a legitimate follow-up for whoever can audit the list.
+
+One qualifier on "parse what upstream reports": it is the best per-model evidence available, not an oracle. When two upstream forms disagree the output can still be internally contradictory — a model can end up with `inputModalities: ["text"]` next to `capabilities: ["vision"]`. That contradiction predates this work (flat `false` has always beaten a capability-array `"vision"` string) and is left alone here rather than fixed silently under a Copilot ticket. Resolving how a boolean denial and a loose capability list should reconcile is its own unit.
+
+## Tests
+
+`tests/provider-model-discovery-contract.test.ts`, using the reporter's exact payload including the `limits.vision` sibling.
+
+| Mutation | Expected |
+|---|---|
+| remove the nested read entirely (pre-fix state) | tri-state test red — reproduces the report |
+| drop `nestedVision === false` | tri-state test red |
+| `Boolean(nestedVision)` instead of `=== true` | malformed-hint test red |
+| move the nested read above the explicit-modality return | precedence test red |

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -1094,6 +1094,16 @@ function modelInputModalities(
       .filter(value => value === "text" || value === "image" || value === "audio");
     if (inferred.length > 0) return [...new Set(inferred)];
   }
+  // GitHub Copilot nests vision support one level down as `capabilities.supports.vision`, so the
+  // flat read alone finds nothing and every Copilot model falls through to `["text"]` — Codex then
+  // refuses image attachments on models that accept them (#2941). Precedence is by specificity:
+  // a flat boolean is authoritative when present, the nested boolean is consulted only otherwise,
+  // and a non-boolean at either level decides NOTHING so the signals below still apply. Two things
+  // this ordering deliberately avoids: a deny-wins rule across both levels would flip a provider
+  // reporting flat `true` with nested `false` from image-capable to text-only, changing behaviour
+  // that predates Copilot support; and a truthy test would let the string `"no"` advertise image
+  // input. The payload also carries a SECOND `vision` key under `limits` holding an image count,
+  // which is why this reads one exact path instead of searching `capabilities` for a vision-ish key.
   const nestedSupports = plainRecord(capabilityRecord?.supports);
   const explicitVisionSupport = typeof capabilityRecord?.vision === "boolean"
     ? capabilityRecord.vision

--- a/tests/provider-model-discovery-contract.test.ts
+++ b/tests/provider-model-discovery-contract.test.ts
@@ -293,6 +293,74 @@ describe("registry-owned provider model discovery", () => {
     })).toEqual({});
   });
 
+  test("a flat vision boolean outranks a disagreeing nested one (#2941)", () => {
+    // Precedence is by specificity, NOT deny-wins. A deny-wins rule across both levels would flip
+    // this shape from image-capable to text-only, silently changing behaviour that predates Copilot
+    // support — the flat `true` alone already meant image input. Pinned so it cannot regress.
+    expect(catalogHintsFromModelsApiItem("example", {
+      id: "flat-true-nested-false",
+      capabilities: { vision: true, supports: { vision: false } },
+    })).toEqual({ inputModalities: ["text", "image"], capabilities: ["vision"] });
+
+    // The mirror image: a flat denial is authoritative over a nested claim.
+    expect(catalogHintsFromModelsApiItem("example", {
+      id: "flat-false-nested-true",
+      capabilities: { vision: false, supports: { vision: true } },
+    })).toEqual({ inputModalities: ["text"] });
+  });
+
+  test("the reporter's full Copilot payload is read despite the limits.vision sibling (#2941)", () => {
+    // `capabilities` carries a SECOND vision key under `limits` holding an image count. Anything
+    // that searched loosely for a vision-ish key would find that object and treat it as a signal.
+    expect(catalogHintsFromModelsApiItem("github-copilot", {
+      id: "claude-opus-4.6",
+      capabilities: {
+        supports: { vision: true },
+        limits: { vision: { max_prompt_images: 20 } },
+      },
+    })).toEqual({ inputModalities: ["text", "image"] });
+  });
+
+  test("an explicit nested denial outranks a loose capability-array claim, exactly as a flat one does (#2941)", () => {
+    // A boolean capability field is a specific statement; a "vision" string in a capability array is
+    // a loose one. Flat `false` has always won that contest, and the internal contradiction it
+    // produces -- text-only modalities reported next to capabilities: ["vision"] -- predates the
+    // nested read. These two shapes must agree, or the nested field would mean something subtly
+    // different from the flat field it stands in for.
+    const nested = catalogHintsFromModelsApiItem("example", {
+      id: "nested-denial-vs-array",
+      metadata: { capabilities: { supports: { vision: false } } },
+      capabilities: ["vision"],
+    });
+    const flat = catalogHintsFromModelsApiItem("example", {
+      id: "flat-denial-vs-array",
+      metadata: { capabilities: { vision: false } },
+      capabilities: ["vision"],
+    });
+    expect(nested).toEqual({ inputModalities: ["text"], capabilities: ["vision"] });
+    expect(nested).toEqual(flat);
+  });
+
+  test("a non-record supports container decides nothing and leaves the fallback chain intact (#2941)", () => {
+    // It must not collapse into a denial either — the `features` signal further down still decides.
+    expect(catalogHintsFromModelsApiItem("github-copilot", {
+      id: "malformed-container",
+      capabilities: { supports: 5 },
+      features: ["vision"],
+    })).toEqual({
+      inputModalities: ["text", "image"],
+      capabilities: ["vision"],
+    });
+  });
+
+  test("explicit item input modalities still outrank a nested Copilot vision claim (#2941)", () => {
+    expect(catalogHintsFromModelsApiItem("github-copilot", {
+      id: "explicit-audio-model",
+      input_modalities: ["audio"],
+      capabilities: { supports: { vision: true } },
+    })).toEqual({ inputModalities: ["audio"] });
+  });
+
   test("preserves nested reasoning_parameters effort ladders from OpenAI-compatible catalogs", () => {
     expect(catalogHintsFromModelsApiItem("example", {
       id: "reasoning-model",


### PR DESCRIPTION
## Summary

Follow-up coverage for #2941 on top of #2943 (`370052648`), which shipped the fix. **No production behaviour change** — the resolution here is #2943's implementation; this adds the cases its tests do not cover, plus the comment explaining why the precedence is shaped the way it is.

@Ingwannu and I hit this issue simultaneously and theirs was the better patch, so I withdrew my implementation. The reason is worth having in the tree.

### Flat-versus-nested disagreement

I had written the denial as `flat === false || nested === false` — deny-wins across both sources. It reads like the conservative direction and is not. For a provider reporting flat `vision: true` with nested `supports: { vision: false }`:

```text
old code      → ["text", "image"]
deny-wins     → ["text"]            ← silent regression
#2943         → ["text", "image"]   ← preserved
```

That is a behaviour change in a parser shared by **every** provider, from a patch whose entire purpose was to stop models being wrongly marked text-only. I found it with a differential probe across twelve capability shapes: eleven agree between the two resolutions, and the twelfth is that one. Neither test suite covered a disagreeing pair, so nothing would have caught it — not review, not green CI.

It is pinned now: reintroducing deny-wins turns `a flat vision boolean outranks a disagreeing nested one` red.

### The unscoped read, and why the equivalence is the property to pin

An independent review of my withdrawn head raised a second point worth answering: the nested read is **not** scoped to `github-copilot`, and a nested denial beats a loose `"vision"` string in a capability array — producing `inputModalities: ["text"]` next to `capabilities: ["vision"]`.

I probed the merged code on that. The nested denial and the **flat** denial behave identically, contradiction included:

```text
nested false + capability array vision   {"inputModalities":["text"],"capabilities":["vision"]}
flat   false + capability array vision   {"inputModalities":["text"],"capabilities":["vision"]}
```

So this is not something #2943 introduced — flat `false` has beaten a capability-array string since long before Copilot support existed. Given the read is unscoped (and `modelInputModalities` never receives a provider name, so scoping it would mean inventing a plumbing path to give an identical shape a worse answer), the property that actually matters is that **the nested field means exactly what the flat field it stands in for means**. A test now asserts both shapes produce the same result, so the two cannot drift apart.

Reconciling a boolean denial against a loose capability list is a real question, and a separate one. I am not answering it silently under a Copilot ticket.

### Also covered

- **The reporter's full payload**, including the `limits.vision` sibling holding `max_prompt_images`. Anything searching `capabilities` for a vision-ish key would find that object and treat an image count as a capability signal.
- **A non-record `supports`** (e.g. `5`) falling through so a `features: ["vision"]` signal still decides, rather than collapsing into a denial.
- **Explicit `input_modalities`** still outranking a nested vision claim.

## Verification

`bun test tests/provider-model-discovery-contract.test.ts tests/catalog-input-modality-enum.test.ts` → **67 pass / 0 fail / 296 expectations**. `bun x tsc --noEmit` exit 0 (verified live — a planted type error exits 1). `bun run privacy:scan` passed.

| Mutation | Result |
|---|---|
| replace specificity precedence with deny-wins (my rejected design) | precedence test red |
| stop honouring the nested denial (flat-only check) | equivalence test **and** #2943's own nested test red |

The other three assertions were mutation-proven against my own implementation before I withdrew it: removing the nested read reproduced the reporter's `{}`, `Boolean()` instead of `=== true` let `"yes"` advertise image support, and moving the read above the explicit-modality return turned `["audio"]` into `["text","image"]`.

## Corrections to my own earlier claims

Two in the devlog, both fair hits from the review:

- "nested one level deeper than any other provider" is unsupported. A repository search only shows no **checked-in fixture** uses the shape; it says nothing about live catalogs.
- "parsing what upstream reports is authoritative per model" is too strong. It is the best per-model evidence available; when two upstream forms disagree the output can still be internally contradictory, as above.

And one from earlier in this PR: I first justified skipping a `github-copilot` registry seed because Copilot serves both vision and text-only models. That argument is weak — `modelInputModalities` is a per-model map and other providers seed selectively. The real reason is that no audited per-model list exists and inventing one duplicates a changing remote catalog. A selective seed stays open as follow-up.

**Not verified:** no Copilot account here, so live discovery was not exercised end to end; upstream image acceptance is inferred from Copilot's own `max_prompt_images` metadata.

## Checklist

- [x] Focused regressions beside the existing discovery-contract tests, mutation-proven
- [x] `bun x tsc --noEmit` clean
- [x] `bun run privacy:scan` green
- [x] No credentials, tokens, or account identifiers logged
- [x] Targets `dev`
- [x] Not a GUI change, so no screenshot applies



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vision capability detection for GitHub Copilot models.
  * Image attachments are now correctly supported for eligible vision-capable models.
  * Preserved existing precedence and fallback behavior when model capability signals conflict or are incomplete.

* **Tests**
  * Added coverage for nested vision capabilities, conflicting signals, invalid data, and explicit modality settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->