### PR TITLE
test(codex): isolate the tombstone guard with a credential-carrying tombstone

### DIFF
--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -1100,6 +1100,50 @@ describe("codex-account-store CRUD", () => {
     }
   });
 
+  test("a TOKENFUL tombstone is not resurrected either, isolating the deletedAt guard (#2892 gap 3)", async () => {
+    // The sibling test above cannot prove the `deletedAt` check is load-bearing: `tombstoneCodexAccount`
+    // drops the credential, so the separate `!alias.credential` guard already skips that record and the
+    // assertion passes with `deletedAt` removed. A tombstone that still CARRIES a credential is the only
+    // shape that reaches the `deletedAt` check, and it is reachable — a store written by an older build,
+    // or a tombstone raced by a concurrent save, produces exactly this record. `tokenful tombstone is
+    // treated as absent` earlier in this file pins the same shape for the read path.
+    const { getValidCodexToken, readCodexAccountRecord, saveCodexAccountCredential } =
+      await import("../src/codex/account-store");
+    const shared = {
+      accessToken: "tokenful-old",
+      refreshToken: "tokenful-grant",
+      expiresAt: 0,
+      chatgptAccountId: "tokenful-acc",
+    };
+    saveCodexAccountCredential("tokenful-owner", { ...shared });
+    const ownerGeneration = readCodexAccountRecord("tokenful-owner")!.generation;
+    // Written directly: no public API produces a tombstone that retains its credential.
+    writeFileSync(ACCOUNTS_PATH, JSON.stringify({
+      "tokenful-owner": { credential: { ...shared }, generation: ownerGeneration },
+      "tokenful-deleted": { credential: { ...shared }, generation: ownerGeneration, deletedAt: Date.now() },
+    }, null, 2));
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => Response.json({
+      access_token: "tokenful-new",
+      refresh_token: "tokenful-rotated",
+      expires_in: 3600,
+    })) as typeof fetch;
+    try {
+      await getValidCodexToken("tokenful-owner");
+      // The owner rotated.
+      expect(readCodexAccountRecord("tokenful-owner")!.credential!.refreshToken).toBe("tokenful-rotated");
+      // The tombstone kept its stale grant and stayed deleted: propagation skipped it on `deletedAt`
+      // alone, since its credential was present and every other eligibility field matched the owner.
+      const deleted = readCodexAccountRecord("tokenful-deleted")!;
+      expect(deleted.deletedAt).toBeGreaterThan(0);
+      expect(deleted.credential!.refreshToken).toBe("tokenful-grant");
+      expect(deleted.generation).toBe(ownerGeneration);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
 
   test("a same-grant sibling on a DIFFERENT upstream identity is never adopted (#2892 review)", async () => {
     const { forceRefreshCodexPoolToken, getCodexAccountCredential, readCodexAccountRecord, saveCodexAccountCredential } =


### PR DESCRIPTION
## Summary

Closes an over-claim I made in #2934's merge record. That PR's mutation table said removing the `alias.deletedAt != null` check in `commitRefreshedCodexCredentialWithAliases` turns the resurrection test red. **It does not**, and an independent audit of the merged head caught it:

```text
(pass) a tombstoned same-grant record is not resurrected by grant propagation
1 pass, 0 fail          ← with the deletedAt guard deleted
```

`tombstoneCodexAccount` drops the credential, so the separate `!alias.credential` guard already skips that record and the assertion never reaches `deletedAt`. The two guards overlap on the only fixture that exercised them, so **neither was independently proven** — the test showed "no resurrection happens", not "this check is what prevents it".

A tombstone that still carries a credential is the only shape that reaches the `deletedAt` check. It is reachable rather than hypothetical: a store written by an older build, or a tombstone raced by a concurrent save. `tokenful tombstone is treated as absent` already pins that shape for the read path, so this test uses the same construction for the propagation path.

The fixture makes **every other eligibility field match the owner** — same fingerprint, same access token, same expiry, same `chatgptAccountId` — so `deletedAt` is the only thing that can skip it. That is what makes the mutation decisive rather than incidental.

No production change.

## Verification

`bun test tests/codex-account-store.test.ts` → **42 pass / 0 fail**. `bun x tsc --noEmit` exit 0. `bun run privacy:scan` passed.

| Mutation | Before | Now |
|---|---|---|
| remove `alias.deletedAt != null` from the propagation guard | resurrection test **green** (vacuous) | new test **red**, other 41 green |

## Why this is worth a PR rather than a note

A mutation table is the only thing standing between "these credential fences are real" and "these tests happen to pass". An entry that does not reproduce is worse than no entry, because it makes the fence look proven when it is not. I corrected the claim in a comment on #2934 when the audit surfaced it; this closes the underlying gap so the guard is actually covered.

## Checklist

- [x] Focused regression beside the existing tests for this subsystem, mutation-proven
- [x] `bun x tsc --noEmit` clean
- [x] `bun run privacy:scan` green
- [x] No credentials, tokens, or account identifiers logged (fixture values are synthetic)
- [x] Targets `dev`
- [x] Not a GUI change, so no screenshot applies



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that deleted credentials with retained tokens are not restored during refresh operations.
  * Verified deleted records retain their deletion status, stale grant, and generation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->