### PR TITLE
fix(config): start when proxy settings hold values the schema never constrained

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3126,6 +3126,26 @@ export function resolveEnvValue(value: string | undefined): string | undefined {
   return value;
 }
 
+const warnedProxyConfigDiscards = new Set<"proxy" | "noProxy" | "noProxyElements">();
+
+function warnProxyConfigDiscardOnce(kind: "proxy" | "noProxy" | "noProxyElements"): void {
+  if (warnedProxyConfigDiscards.has(kind)) return;
+  warnedProxyConfigDiscards.add(kind);
+  if (kind === "proxy") {
+    console.warn(
+      "⚠️  config.json proxy was discarded because it is not a non-empty resolved string — configured proxy routing is disabled; existing proxy environment variables remain authoritative, otherwise outbound requests use direct egress",
+    );
+  } else if (kind === "noProxy") {
+    console.warn(
+      "⚠️  config.json noProxy was discarded because it is not a string, string array, or resolved environment reference — existing NO_PROXY and loopback bypasses remain",
+    );
+  } else {
+    console.warn(
+      "⚠️  config.json noProxy contains invalid elements — invalid elements were ignored; valid entries, existing NO_PROXY, and loopback bypasses remain",
+    );
+  }
+}
+
 /**
  * Mirror `config.proxy` into HTTP(S)_PROXY env vars so Bun's native fetch routes every outbound
  * provider call through the proxy — no per-callsite changes (verified: Bun honors these plus
@@ -3138,10 +3158,14 @@ export function applyProxyEnv(config: OcxConfig): void {
   // `.passthrough()`, so whatever is on disk arrives here verbatim. A non-string value
   // reached string-only methods and threw out of this function, and it runs once per
   // process entry point — the failure was a startup crash, not a degraded proxy. Ignore
-  // malformed values instead: they cannot express a routing intent, and refusing to start
-  // is a worse answer than starting without them.
-  const proxy = typeof config.proxy === "string" ? resolveEnvValue(config.proxy) : undefined;
-  if (!proxy) return;
+  // malformed values with a privacy-safe warning instead: they cannot express a routing
+  // intent, and refusing to start is a worse answer than starting without them.
+  const rawProxy = config.proxy;
+  const proxy = typeof rawProxy === "string" ? resolveEnvValue(rawProxy) : undefined;
+  if (!proxy) {
+    if (rawProxy !== undefined) warnProxyConfigDiscardOnce("proxy");
+    return;
+  }
   if (!process.env.HTTP_PROXY?.trim() && !process.env.http_proxy?.trim()) process.env.HTTP_PROXY = proxy;
   if (!process.env.HTTPS_PROXY?.trim() && !process.env.https_proxy?.trim()) process.env.HTTPS_PROXY = proxy;
   const existing = process.env.NO_PROXY ?? process.env.no_proxy ?? "";
@@ -3150,10 +3174,20 @@ export function applyProxyEnv(config: OcxConfig): void {
   // Configured entries first, then loopback: loopback is unconditional, so appending it last
   // keeps it present even when the operator lists a loopback host themselves.
   const raw = config.noProxy;
-  const configured = (Array.isArray(raw)
+  let configuredEntries: string[];
+  if (Array.isArray(raw)) {
     // One unusable element must not discard the operator's other entries.
-    ? raw.filter((entry): entry is string => typeof entry === "string")
-    : (typeof raw === "string" ? resolveEnvValue(raw) ?? "" : "").split(","))
+    if (raw.some(entry => typeof entry !== "string")) warnProxyConfigDiscardOnce("noProxyElements");
+    configuredEntries = raw.filter((entry): entry is string => typeof entry === "string");
+  } else if (typeof raw === "string") {
+    const resolved = resolveEnvValue(raw);
+    if (raw && resolved === undefined) warnProxyConfigDiscardOnce("noProxy");
+    configuredEntries = (resolved ?? "").split(",");
+  } else {
+    if (raw !== undefined) warnProxyConfigDiscardOnce("noProxy");
+    configuredEntries = [];
+  }
+  const configured = configuredEntries
     .map(entry => entry.trim())
     .filter(Boolean);
   for (const host of [...configured, "localhost", "127.0.0.1", "::1", "[::1]"]) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3134,7 +3134,13 @@ export function resolveEnvValue(value: string | undefined): string | undefined {
  * that makes outbound provider requests (server start, catalog sync).
  */
 export function applyProxyEnv(config: OcxConfig): void {
-  const proxy = resolveEnvValue(config.proxy);
+  // `proxy` and `noProxy` are not declared in the top-level schema, which ends in
+  // `.passthrough()`, so whatever is on disk arrives here verbatim. A non-string value
+  // reached string-only methods and threw out of this function, and it runs once per
+  // process entry point — the failure was a startup crash, not a degraded proxy. Ignore
+  // malformed values instead: they cannot express a routing intent, and refusing to start
+  // is a worse answer than starting without them.
+  const proxy = typeof config.proxy === "string" ? resolveEnvValue(config.proxy) : undefined;
   if (!proxy) return;
   if (!process.env.HTTP_PROXY?.trim() && !process.env.http_proxy?.trim()) process.env.HTTP_PROXY = proxy;
   if (!process.env.HTTPS_PROXY?.trim() && !process.env.https_proxy?.trim()) process.env.HTTPS_PROXY = proxy;
@@ -3144,7 +3150,10 @@ export function applyProxyEnv(config: OcxConfig): void {
   // Configured entries first, then loopback: loopback is unconditional, so appending it last
   // keeps it present even when the operator lists a loopback host themselves.
   const raw = config.noProxy;
-  const configured = (Array.isArray(raw) ? raw : (resolveEnvValue(raw) ?? "").split(","))
+  const configured = (Array.isArray(raw)
+    // One unusable element must not discard the operator's other entries.
+    ? raw.filter((entry): entry is string => typeof entry === "string")
+    : (typeof raw === "string" ? resolveEnvValue(raw) ?? "" : "").split(","))
     .map(entry => entry.trim())
     .filter(Boolean);
   for (const host of [...configured, "localhost", "127.0.0.1", "::1", "[::1]"]) {

--- a/tests/proxy-env.test.ts
+++ b/tests/proxy-env.test.ts
@@ -24,6 +24,36 @@ function configWithProxy(proxy?: string, noProxy?: string | string[]): OcxConfig
   return { proxy, noProxy, providers: {} } as unknown as OcxConfig;
 }
 
+// The top-level config schema ends in `.passthrough()` and declares neither `proxy` nor
+// `noProxy`, so these shapes survive validation and reach applyProxyEnv verbatim.
+function configWithRawProxy(proxy: unknown, noProxy?: unknown): OcxConfig {
+  return { proxy, noProxy, providers: {} } as unknown as OcxConfig;
+}
+
+describe("applyProxyEnv with values the schema does not constrain", () => {
+  // applyProxyEnv runs at every process entry point that makes outbound requests, so a
+  // throw here is a startup crash rather than a degraded proxy.
+  test("a non-string proxy does not throw and sets no proxy env", () => {
+    expect(() => applyProxyEnv(configWithRawProxy(42))).not.toThrow();
+    expect(process.env.HTTP_PROXY).toBeUndefined();
+    expect(process.env.HTTPS_PROXY).toBeUndefined();
+  });
+
+  test("a non-string noProxy does not throw and keeps loopback exclusions", () => {
+    expect(() => applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", 42))).not.toThrow();
+    expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1]");
+  });
+
+  test.each([
+    ["a number", 42],
+    ["null", null],
+    ["an object", { a: 1 }],
+  ])("keeps the operator's usable noProxy entries when the array also holds %s", (_label, bad) => {
+    expect(() => applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", ["internal.example", bad]))).not.toThrow();
+    expect(process.env.NO_PROXY).toBe("internal.example,localhost,127.0.0.1,::1,[::1]");
+  });
+});
+
 describe("applyProxyEnv", () => {
   test("no-op when config.proxy is unset", () => {
     process.env.NO_PROXY = "operator-owned.example";

--- a/tests/proxy-env.test.ts
+++ b/tests/proxy-env.test.ts
@@ -31,6 +31,41 @@ function configWithRawProxy(proxy: unknown, noProxy?: unknown): OcxConfig {
 }
 
 describe("applyProxyEnv with values the schema does not constrain", () => {
+  test("warns once per discarded proxy setting without exposing its raw value", () => {
+    const secret = "raw-proxy-credential-sentinel-2947";
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      const invalidProxy = { secret };
+      applyProxyEnv(configWithRawProxy(invalidProxy));
+      applyProxyEnv(configWithRawProxy(invalidProxy));
+      expect(process.env.HTTP_PROXY).toBeUndefined();
+      expect(process.env.HTTPS_PROXY).toBeUndefined();
+
+      const invalidNoProxy = { secret };
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", invalidNoProxy));
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", invalidNoProxy));
+      expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1]");
+
+      const invalidElement = { secret };
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", ["internal.example", invalidElement]));
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", ["internal.example", invalidElement]));
+      expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1],internal.example");
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnings).toHaveLength(3);
+    expect(warnings[0]).toContain("config.json proxy was discarded");
+    expect(warnings[0]).toContain("direct egress");
+    expect(warnings[1]).toContain("config.json noProxy was discarded");
+    expect(warnings[1]).toContain("existing NO_PROXY and loopback bypasses remain");
+    expect(warnings[2]).toContain("config.json noProxy contains invalid elements");
+    expect(warnings[2]).toContain("invalid elements were ignored");
+    expect(warnings.join("\n")).not.toContain(secret);
+  });
+
   // applyProxyEnv runs at every process entry point that makes outbound requests, so a
   // throw here is a startup crash rather than a degraded proxy.
   test("a non-string proxy does not throw and sets no proxy env", () => {


### PR DESCRIPTION
## Summary

`applyProxyEnv` crashed the process when `proxy` or `noProxy` held a value that was
not a string. It now ignores unusable values and starts normally.

## The defect

The top-level config schema ends in `.passthrough()` and declares neither `proxy` nor
`noProxy` (`src/config.ts`). Whatever is on disk therefore survives validation and
reaches `applyProxyEnv` verbatim, where it met string-only methods.

That function runs at every process entry point that makes outbound provider requests,
so the result was not a degraded proxy — it was a startup crash. Four shapes were
confirmed against the current code:

```text
noProxy: ["ok", 42]    TypeError: entry.trim is not a function
noProxy: ["ok", null]  TypeError: null is not an object
noProxy: [{a: 1}]      TypeError: null is not an object
proxy:   42            TypeError: value.match is not a function
```

`noProxy: "a,b"` was and remains fine; the string paths are unchanged.

## The fix

Unusable values cannot express a routing intent, and refusing to start is a worse
answer than starting without them, so they are ignored rather than thrown on.

Array filtering is deliberately per-element: one malformed entry must not discard the
operator's remaining hosts. Loopback exclusions are appended unconditionally in every
case, so `localhost`/`127.0.0.1`/`::1`/`[::1]` still bypass the proxy even when the
configured value was unusable.

## Review boundary

Two files: the `applyProxyEnv` body and its test. No schema change is included — adding
`proxy`/`noProxy` declarations would alter how existing configs validate, which is a
larger and separate decision. This change only stops the crash at the point of use.

## Verification

Based on current `dev@47b8d164366b9db9e4331b2bb8b542db22766910`.

- Bun 1.4.0-canary.1: `bun test tests/proxy-env.test.ts tests/config.test.ts` → **173 pass, 0 fail**.
- **Red-proven**: with the `src/config.ts` change stashed and only the new tests present,
  all 5 new cases fail with the exact `TypeError`s quoted above; restoring the change
  turns them green. The failure is the real crash, not an assertion artefact.
- `bun run typecheck` clean; `bun run privacy:scan` passed.
- The repository-wide suite was intentionally not duplicated locally; hosted CI remains
  the full-matrix check.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy configuration handling when unsupported value types are provided.
  * Invalid proxy values are safely ignored instead of causing errors or setting invalid environment variables.
  * Invalid entries in proxy exclusion lists are filtered while valid entries and loopback exclusions are preserved.
  * Added privacy-safe warnings when proxy configuration values are discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

