### PR TITLE
fix(responses): stop a namespaced MCP exec from authorizing bare shell aliases

### DIFF
--- a/src/server/responses-undeclared-tool-guard.ts
+++ b/src/server/responses-undeclared-tool-guard.ts
@@ -7,6 +7,8 @@ import { sseDataPayload, type SseBlockRewrite } from "./sse-payload-rewrite";
 
 /** Item types the client executes through a request-declared wire name. */
 const CLIENT_EXECUTED_CALL_TYPES = new Set(["function_call", "custom_tool_call"]);
+/** Codex groups ordinary top-level tools here; unlike an MCP namespace, it has no wire prefix. */
+const BUILTIN_FUNCTIONS_NAMESPACE = "functions";
 
 /**
  * Hosted declarations whose response items the PROVIDER executes, keyed by the request
@@ -86,7 +88,7 @@ function addWireToolName(names: Set<string>, tool: unknown, namespace?: string):
   // Codex routes MCP calls by an explicit `namespace` field, so the same tool is reachable
   // as a bare inner name or as the flattened form; accept both rather than guess which
   // coordinate system this provider echoes back.
-  if (!namespace) {
+  if (!namespace || namespace === BUILTIN_FUNCTIONS_NAMESPACE) {
     names.add(name);
     return;
   }

--- a/src/server/responses-undeclared-tool-guard.ts
+++ b/src/server/responses-undeclared-tool-guard.ts
@@ -1,4 +1,8 @@
-import { namespacedToolName, normalizeDeclaredToolName } from "../types";
+import {
+  CODE_MODE_EXEC_TOOL_NAME,
+  namespacedToolName,
+  normalizeDeclaredToolName,
+} from "../types";
 import { sseDataPayload, type SseBlockRewrite } from "./sse-payload-rewrite";
 
 /** Item types the client executes through a request-declared wire name. */
@@ -79,11 +83,18 @@ function addWireToolName(names: Set<string>, tool: unknown, namespace?: string):
       ? nestedFunction.name
       : undefined;
   if (!name) return;
-  names.add(name);
   // Codex routes MCP calls by an explicit `namespace` field, so the same tool is reachable
   // as a bare inner name or as the flattened form; accept both rather than guess which
   // coordinate system this provider echoes back.
-  if (namespace) names.add(namespacedToolName(namespace, name));
+  if (!namespace) {
+    names.add(name);
+    return;
+  }
+  names.add(namespacedToolName(namespace, name));
+  // `exec` is the one name that also switches on nested-helper normalization, so a bare alias
+  // for a namespaced MCP tool would silently authorize `exec_command`/`shell_command`/
+  // `apply_patch` the request never declared. Every other inner name keeps the bare alias.
+  if (name !== CODE_MODE_EXEC_TOOL_NAME) names.add(name);
 }
 
 /**

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -351,6 +351,7 @@ import { createRoutedToolSearchRestoreBlockRewrite } from "../responses-tool-sea
 import {
   createRoutedNamespaceCallRestoreRewrite,
   NamespaceToolCollisionError,
+  restoreRoutedNamespaceCalls,
   restoreRoutedNamespaceCallsInJson,
   type RoutedNamespaceToolAliases,
 } from "../../responses/namespace-tool-compat";
@@ -3634,6 +3635,23 @@ async function handleResponsesInner(
     let outboundRequestBody: Record<string, unknown> | undefined;
     const declaredWireToolNames = new Set<string>();
     const declaredNamelessClientCallTypes = new Set<string>();
+    // `buildToolBridgeMaps` creates a bare alias only when the caller selected exactly one
+    // namespaced tool through a bare tool_choice. Restore that request-bounded identity before
+    // authorization checks instead of admitting the bare name into the declared set: for `exec`,
+    // the latter would also authorize the unrelated code-mode helper names.
+    const authorizedBareNamespaceToolAliases: RoutedNamespaceToolAliases = new Map(
+      [...toolBridgeMaps.toolNsMap].flatMap(([alias, identity]) =>
+        alias === identity.name
+          ? [[alias, {
+              namespace: identity.namespace,
+              name: identity.name,
+              kind: identity.freeform ? "custom" as const : "function" as const,
+            }] as const]
+          : []
+      ),
+    );
+    const restoreAuthorizedBareNamespaceToolCalls = (value: unknown): unknown =>
+      restoreRoutedNamespaceCalls(value, authorizedBareNamespaceToolAliases).value;
     let undeclaredToolGuardActive = false;
     const refreshUndeclaredToolGuard = (builtRequest: AdapterRequest): void => {
       outboundRequestBody = parseOutboundRequestBody(builtRequest.body);
@@ -3715,7 +3733,7 @@ async function handleResponsesInner(
       // state for exactly the passthrough traffic the guard deliberately stands down for.
       if (!undeclaredToolGuardActive || inspectionSawUndeclaredTool) return;
       if (undeclaredToolCallName(
-        payload,
+        restoreAuthorizedBareNamespaceToolCalls(payload),
         declaredWireToolNames,
         declaredNamelessClientCallTypes,
         providerExecutedCallTypes,
@@ -3727,7 +3745,7 @@ async function handleResponsesInner(
       ? (response: { id?: unknown; output?: unknown; status?: unknown }) => {
         if (inspectionSawUndeclaredTool) return;
         const restoredResponse = restoreRoutedCustomCalls(
-          response,
+          restoreAuthorizedBareNamespaceToolCalls(response),
           routedCustomToolNames,
           routedCustomToolRepairNames,
           declaredWireToolNames,
@@ -4461,6 +4479,9 @@ async function handleResponsesInner(
         routedNamespaceToolAliases.size > 0
           ? createRoutedNamespaceCallRestoreRewrite(routedNamespaceToolAliases)
           : undefined,
+        authorizedBareNamespaceToolAliases.size > 0
+          ? createRoutedNamespaceCallRestoreRewrite(authorizedBareNamespaceToolAliases)
+          : undefined,
         hasResponsesItemIdRepair(repairConfig)
           ? createResponsesItemIdPayloadRewrite(repairConfig!, translatorBudget)
           : undefined,
@@ -4690,8 +4711,12 @@ async function handleResponsesInner(
           restoreImageGenCallsInJson(text, imageGenCallAliases),
           routedNamespaceToolAliases,
         );
-        const restored = restoreRoutedCustomCallsInJson(
+        const restoredAuthorizedBareNamespace = restoreRoutedNamespaceCallsInJson(
           restoredNamespace,
+          authorizedBareNamespaceToolAliases,
+        );
+        const restored = restoreRoutedCustomCallsInJson(
+          restoredAuthorizedBareNamespace,
           routedCustomToolNames,
           routedCustomToolRepairNames,
           declaredWireToolNames,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -86,7 +86,7 @@ import {
 import { injectionDebugLog } from "../../lib/injection-debug-log";
 import { resolveClientRetryAfter } from "../../lib/retry-after";
 import { enrichOpenCodeZenRateLimitMessage } from "../../providers/opencode-zen-rate-limit";
-import { modelInList, namespacedToolName } from "../../types";
+import { CODE_MODE_EXEC_TOOL_NAME, modelInList, namespacedToolName } from "../../types";
 import type {
   AdapterEvent,
   OcxConfig,
@@ -3677,7 +3677,19 @@ async function handleResponsesInner(
       // however, the parsed maps also contain historical catalog entries, so only the bounded
       // current-turn wire snapshot above may authorize a call.
       if (replayedInputPrefixLength === 0) {
-        for (const name of toolBridgeMaps.declaredToolNames) declaredWireToolNames.add(name);
+        for (const name of toolBridgeMaps.declaredToolNames) {
+          // `buildToolBridgeMaps` also aliases a namespaced tool under its bare name when the
+          // caller's `tool_choice` selected it unambiguously, which the bridge needs to route the
+          // call back. For `exec` alone that alias would also switch on nested-helper
+          // normalization and re-authorize `exec_command`/`shell_command`/`apply_patch`, so it is
+          // admitted here only when the caller's own catalog declared a bare `exec`. Selecting an
+          // MCP `exec` is not a declaration of the code-mode shell tool.
+          if (
+            name === CODE_MODE_EXEC_TOOL_NAME
+            && !clientDeclaredWireToolNames.has(CODE_MODE_EXEC_TOOL_NAME)
+          ) continue;
+          declaredWireToolNames.add(name);
+        }
       }
       undeclaredToolGuardActive = (
         declaredWireToolNames.size > 0

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
 
 export type { OcxTool, OcxToolChoice } from "./types/tools";
 export {
+  CODE_MODE_EXEC_TOOL_NAME,
   namespacedToolName,
   normalizeDeclaredToolName,
   toolChoiceAliases,

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -44,20 +44,30 @@ export function namespacedToolName(namespace: string | undefined, name: string):
 const LEGACY_SHELL_BRIDGE_TOOL_NAMES = ["exec_command", "shell_command"] as const;
 const CODE_MODE_HELPER_TOOL_NAMES = [...LEGACY_SHELL_BRIDGE_TOOL_NAMES, "apply_patch"] as const;
 
+/**
+ * The one declared name that turns nested-helper normalization on. Declaring it is not just a
+ * name: it also decides whether an emitted `exec_command`/`shell_command`/`apply_patch` is
+ * accepted as that shell tool, so callers that build declared-name sets must add it only for a
+ * genuine bare declaration.
+ */
+export const CODE_MODE_EXEC_TOOL_NAME = "exec";
+
 export function normalizeDeclaredToolName(
   name: string,
   declared: ReadonlySet<string> | undefined,
 ): string {
-  if (!declared || !declared.has("exec")) return name;
+  if (!declared || !declared.has(CODE_MODE_EXEC_TOOL_NAME)) return name;
   if (declared.has(name)) return name;
-  if (name === "apply_patch") return "exec";
+  if (name === "apply_patch") return CODE_MODE_EXEC_TOOL_NAME;
   // When the catalog explicitly declares any legacy shell bridge name, the environment
   // genuinely exposes that tool — turn normalization off so a call is never mis-routed
   // to `exec`.
   if ((LEGACY_SHELL_BRIDGE_TOOL_NAMES as readonly string[]).some(legacy => declared.has(legacy))) {
     return name;
   }
-  return (CODE_MODE_HELPER_TOOL_NAMES as readonly string[]).includes(name) ? "exec" : name;
+  return (CODE_MODE_HELPER_TOOL_NAMES as readonly string[]).includes(name)
+    ? CODE_MODE_EXEC_TOOL_NAME
+    : name;
 }
 
 export function toolChoiceAliases(tool: Pick<OcxTool, "namespace" | "name">): string[] {

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -733,6 +733,7 @@ describe("empty and absent tool catalogs", () => {
     history: unknown[] = [],
     model = "fixture/deepseek-v4-flash",
     previousResponseId?: string,
+    toolChoice?: unknown,
   ) {
     const savedFetch = globalThis.fetch;
     globalThis.fetch = (async () => upstream()) as typeof fetch;
@@ -752,6 +753,7 @@ describe("empty and absent tool catalogs", () => {
               : [{ type: "additional_tools", role: "developer", tools: additionalTools }]),
           ],
           ...(tools === undefined ? {} : { tools }),
+          ...(toolChoice === undefined ? {} : { tool_choice: toolChoice }),
         }),
       }), requestConfig, { model: "", provider: "" });
     } finally {
@@ -1316,6 +1318,53 @@ describe("empty and absent tool catalogs", () => {
     expect(refused.status).toBe(502);
     const refusedBody = await refused.json() as { error: { message: string } };
     expect(refusedBody.error.message).toContain('undeclared client tool "apply_patch"');
+  });
+
+  test("a bare tool_choice selecting a namespaced exec does not authorize the helper names", () => {
+    // The bridge maps alias a namespaced tool under its bare name when `tool_choice` selected it
+    // unambiguously, and the live guard merges those maps into the declared set. For `exec` that
+    // alias would switch nested-helper normalization back on, so selecting an MCP `exec` would
+    // re-authorize the shell bridge the request never declared.
+    return post(
+      false,
+      [{
+        type: "namespace",
+        name: "mcp__functions",
+        tools: [{ type: "custom", name: "exec", description: "Run a command" }],
+      }],
+      jsonUpstream,
+      undefined,
+      config,
+      [],
+      "fixture/deepseek-v4-flash",
+      undefined,
+      { type: "allowed_tools", mode: "required", tools: [{ type: "custom", name: "exec" }] },
+    ).then(async response => {
+      expect(response.status).toBe(502);
+      const body = await response.json() as { error: { message: string } };
+      expect(body.error.message).toContain('undeclared client tool "apply_patch"');
+    });
+  });
+
+  test("a request that really declares a bare exec still accepts the helper names", () => {
+    return post(
+      false,
+      [
+        { type: "custom", name: "exec", description: "Run a command" },
+        {
+          type: "namespace",
+          name: "mcp__functions",
+          tools: [{ type: "custom", name: "exec", description: "Run a command" }],
+        },
+      ],
+      jsonUpstream,
+    ).then(async response => {
+      expect(response.status).toBe(200);
+      const body = await response.json() as { output: Array<Record<string, unknown>> };
+      // Accepted and normalized onto the declared code-mode shell tool, exactly as before.
+      expect(body.output[0]).toMatchObject({ name: "exec", type: "custom_tool_call" });
+      expect(String(body.output[0]?.input)).toContain("tools.apply_patch");
+    });
   });
 });
 

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -1376,30 +1376,61 @@ describe("empty and absent tool catalogs", () => {
     expect(refusedBody.error.message).toContain('undeclared client tool "apply_patch"');
   });
 
-  test("a bare tool_choice selecting a namespaced exec does not authorize the helper names", () => {
-    // The bridge maps alias a namespaced tool under its bare name when `tool_choice` selected it
-    // unambiguously, and the live guard merges those maps into the declared set. For `exec` that
-    // alias would switch nested-helper normalization back on, so selecting an MCP `exec` would
-    // re-authorize the shell bridge the request never declared.
-    return post(
-      false,
-      [{
-        type: "namespace",
-        name: "mcp__functions",
-        tools: [{ type: "custom", name: "exec", description: "Run a command" }],
+  test("a bare tool_choice restores only its unambiguous namespaced exec", async () => {
+    const tools = [{
+      type: "namespace",
+      name: "mcp__functions",
+      tools: [{ type: "function", name: "exec", description: "Run a command", parameters: { type: "object" } }],
+    }];
+    const toolChoice = { type: "function", name: "exec" };
+    const upstreamCall = (name: string) => () => Response.json({
+      id: `resp_${name}`,
+      status: "completed",
+      output: [{
+        type: "function_call",
+        id: `fc_${name}`,
+        call_id: `call_${name}`,
+        name,
+        arguments: "{}",
+        status: "completed",
       }],
-      jsonUpstream,
+    });
+
+    const accepted = await post(
+      false,
+      tools,
+      upstreamCall("exec"),
       undefined,
       config,
       [],
       "fixture/deepseek-v4-flash",
       undefined,
-      { type: "allowed_tools", mode: "required", tools: [{ type: "custom", name: "exec" }] },
-    ).then(async response => {
-      expect(response.status).toBe(502);
-      const body = await response.json() as { error: { message: string } };
-      expect(body.error.message).toContain('undeclared client tool "apply_patch"');
+      toolChoice,
+    );
+    expect(accepted.status).toBe(200);
+    const acceptedBody = await accepted.json() as { output: Array<Record<string, unknown>> };
+    expect(acceptedBody.output[0]).toMatchObject({
+      type: "function_call",
+      name: "exec",
+      namespace: "mcp__functions",
     });
+
+    for (const name of ["apply_patch", "exec_command", "shell_command"]) {
+      const refused = await post(
+        false,
+        tools,
+        upstreamCall(name),
+        undefined,
+        config,
+        [],
+        "fixture/deepseek-v4-flash",
+        undefined,
+        toolChoice,
+      );
+      expect(refused.status).toBe(502);
+      const body = await refused.json() as { error: { message: string } };
+      expect(body.error.message).toContain(`undeclared client tool "${name}"`);
+    }
   });
 
   test("a request that really declares a bare exec still accepts the helper names", () => {

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -107,6 +107,20 @@ describe("collectDeclaredWireToolNames", () => {
     expect([...names]).toEqual(["mcp__exec"]);
   });
 
+  test("keeps exec bare in Codex's reserved functions namespace", () => {
+    // Codex groups ordinary top-level tools here; this is not an MCP namespace and the parser
+    // deliberately lowers its children without a namespace.
+    const names = collectDeclaredWireToolNames({
+      tools: [{
+        type: "namespace",
+        name: "functions",
+        tools: [{ type: "custom", name: "exec", description: "Run a command" }],
+      }],
+    });
+
+    expect([...names]).toEqual(["exec"]);
+  });
+
   test("keeps the bare alias when the request also declared a top-level exec", () => {
     const names = collectDeclaredWireToolNames({
       tools: [
@@ -1199,6 +1213,48 @@ describe("empty and absent tool catalogs", () => {
     expect(response.status).toBe(200);
     const currentBody = await response.json() as { output: Array<Record<string, unknown>> };
     expect(currentBody.output[0]).toMatchObject({ name: "exec" });
+  });
+
+  test("a replayed functions namespace still authorizes its top-level exec", async () => {
+    const previousId = "resp_replay_with_functions_exec";
+    const prime = await post(
+      false,
+      undefined,
+      () => Response.json({ id: previousId, status: "completed", output: [] }),
+      [{ type: "function", name: "historical", parameters: { type: "object" } }],
+    );
+    expect(prime.status).toBe(200);
+    await prime.arrayBuffer();
+
+    const response = await post(
+      false,
+      undefined,
+      () => Response.json({
+        id: "resp_functions_exec",
+        status: "completed",
+        output: [{
+          type: "custom_tool_call",
+          id: "ctc_functions_exec",
+          call_id: "call_functions_exec",
+          name: "exec",
+          input: "echo allowed",
+          status: "completed",
+        }],
+      }),
+      [{
+        type: "namespace",
+        name: "functions",
+        tools: [{ type: "custom", name: "exec", description: "Run a command" }],
+      }],
+      config,
+      [],
+      "fixture/deepseek-v4-flash",
+      previousId,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { output: Array<Record<string, unknown>> };
+    expect(body.output[0]).toMatchObject({ name: "exec", type: "custom_tool_call" });
   });
 
   test("a current tool-search output still authorizes its discovered tool after replay", async () => {

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -96,6 +96,28 @@ describe("collectDeclaredWireToolNames", () => {
     );
   });
 
+  test("withholds the bare alias when only a namespaced exec was declared", () => {
+    // A bare `exec` in the declared set is not just a name: it switches on nested-helper
+    // normalization, so aliasing a namespaced MCP `exec` under the bare name would authorize
+    // `exec_command`/`shell_command`/`apply_patch` this request never declared.
+    const names = collectDeclaredWireToolNames({
+      tools: [{ type: "namespace", name: "mcp", tools: [{ type: "function", name: "exec" }] }],
+    });
+
+    expect([...names]).toEqual(["mcp__exec"]);
+  });
+
+  test("keeps the bare alias when the request also declared a top-level exec", () => {
+    const names = collectDeclaredWireToolNames({
+      tools: [
+        { type: "custom", name: "exec" },
+        { type: "namespace", name: "mcp", tools: [{ type: "function", name: "exec" }] },
+      ],
+    });
+
+    expect([...names].sort()).toEqual(["exec", "mcp__exec"]);
+  });
+
   test("reads tools carried inside input as an additional_tools item", () => {
     // Codex Desktop's responses_lite WS path ships the catalog there instead of body.tools.
     const names = collectDeclaredWireToolNames({
@@ -1359,6 +1381,31 @@ describe("undeclaredToolCallNameInResponse", () => {
       "exec_command",
     );
     expect(undeclaredToolCallNameInResponse(namespaced, new Set(["exec", "mcp__server__exec_command"]))).toBeUndefined();
+  });
+
+  test("a namespaced-only exec declaration does not authorize the nested helper names", () => {
+    // End-to-end over the real collector: declaring `exec` inside an MCP namespace must not
+    // hand the request a bare code-mode shell tool.
+    const declared = collectDeclaredWireToolNames({
+      tools: [{ type: "namespace", name: "mcp", tools: [{ type: "function", name: "exec" }] }],
+    });
+
+    for (const name of ["exec_command", "shell_command", "apply_patch", "exec"]) {
+      expect(undeclaredToolCallNameInResponse(
+        { output: [{ type: "function_call", name, call_id: "call_1" }] },
+        declared,
+      )).toBe(name);
+    }
+
+    // The declared tool itself still answers under either coordinate system.
+    expect(undeclaredToolCallNameInResponse(
+      { output: [{ type: "function_call", name: "exec", namespace: "mcp", call_id: "call_1" }] },
+      declared,
+    )).toBeUndefined();
+    expect(undeclaredToolCallNameInResponse(
+      { output: [{ type: "function_call", name: "mcp__exec", call_id: "call_1" }] },
+      declared,
+    )).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

A namespaced MCP tool named `exec` silently authorized bare `exec_command`, `shell_command`, and `apply_patch` calls the request never declared. This withholds that one bare alias on both paths that build the declared set.

## The defect

`addWireToolName` adds every namespaced inner tool under two names: the bare inner name and the flattened `<namespace>__<name>` wire name. That is correct for ordinary MCP tools, because providers echo either coordinate system.

`exec` is the exception. Its presence in the declared set is not only a name — it is the switch that turns on code-mode helper normalization:

```ts
// src/types/tools.ts
if (!declared || !declared.has("exec")) return name;
...
return CODE_MODE_HELPER_TOOL_NAMES.includes(name) ? "exec" : name;
```

So a request whose only `exec` lives inside an MCP namespace still put a bare `exec` in the declared set, and `normalizeDeclaredToolName` then mapped `exec_command`, `shell_command`, and `apply_patch` onto it. An MCP server advertising its own `exec` was enough to hand the turn a bare shell tool outside the request-local catalog, which is exactly the boundary this guard exists to hold (#1700).

Measured on current dev before the fix, for a catalog declaring only a namespaced `mcp.exec`:

```
declared: exec, mcp__exec
bare exec_command -> AUTHORIZED
bare shell_command -> AUTHORIZED
bare apply_patch  -> AUTHORIZED
```

### The same hole reopened one layer up

The live guard does not use the collector alone. `refreshUndeclaredToolGuard` merges `toolBridgeMaps.declaredToolNames` into the same set, and `buildToolBridgeMaps` aliases a namespaced tool under its bare name when the caller's `tool_choice` selected it unambiguously — the bridge needs that alias to route the call back.

So a request whose only `exec` is an MCP tool, selected by a bare `tool_choice`, put `exec` back into the merged set and re-authorized all three helper names. Measured on current dev through that merge:

```
merged declared: exec, mcp__functions__exec
bare exec_command -> AUTHORIZED
bare shell_command -> AUTHORIZED
bare apply_patch  -> AUTHORIZED
```

## The fix

Two narrow rules for the one name that carries normalization authority:

1. `addWireToolName`: when `exec` is declared inside a namespace, add only the flattened wire name and skip the bare alias.
2. `refreshUndeclaredToolGuard`: admit a bare `exec` from the bridge maps only when the caller's own catalog declared a bare `exec`. Selecting an MCP `exec` is not a declaration of the code-mode shell tool.

Codex's reserved `functions` namespace is explicitly exempt from rule 1. It groups ordinary top-level tools rather than MCP tools, and the parser lowers its children without a namespace. This matters on `previous_response_id` replay: the bounded current-catalog snapshot is the only authorization source, so `functions.exec` must contribute the real bare `exec` name there.

Everything else is untouched:

- the flattened `mcp__exec` still authorizes the tool;
- a namespaced item (`{ name: "exec", namespace: "mcp" }`) still matches by full wire name;
- every other inner name keeps the bare alias it had before;
- `functions.exec` remains the top-level code-mode shell tool, including after replay expansion;
- bridge routing is unchanged, so a namespaced tool selected by a bare `tool_choice` still returns under that selector;
- a request that separately declares a top-level `exec` keeps normalization exactly as it was, including accepting an emitted `apply_patch`.

The name is exported as `CODE_MODE_EXEC_TOOL_NAME` next to the normalization rule that gives it this second meaning, so the coupling is stated where it is enforced rather than repeated as a bare string literal.

## Review boundary

Authorization only, and only for the one name that carries normalization authority. This does not change what tools are forwarded upstream, how namespaced calls are routed back, `buildToolBridgeMaps` itself, or the legacy normalization rule. Requests without a namespaced `exec` see no behavior change.

The bridged path (`declaredToolNames` in `src/bridge.ts`) builds its set from `buildToolBridgeMaps` directly and is deliberately left alone here; this change is scoped to the Responses passthrough guard.

## Verification

Based on current `dev@47b8d164366b9db9e4331b2bb8b542db22766910`.

- Bun 1.4.0-canary.1: `bun test tests/responses-undeclared-tool-guard.test.ts tests/responses-parser.test.ts tests/codex-tool-mode.test.ts tests/tool-choice-policy.test.ts` — 122 pass, 0 fail. `tests/responses-parser.test.ts` covers the bare-selector aliasing this fix deliberately preserves.
- Red-proven at each layer: stashing only `src/server/responses-undeclared-tool-guard.ts` fails the MCP collector boundary and both reserved-`functions` tests (including the replay through `handleResponses`); stashing only `src/server/responses/core.ts` fails the `tool_choice` merge test.
- `bun run typecheck` and `bun run privacy:scan` both pass.
- The repository-wide suite was intentionally not duplicated locally; hosted CI remains the full-matrix check.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authorization for namespaced tools, including tools in the `functions` namespace.
  - Prevented namespaced `exec` declarations from incorrectly authorizing undeclared bare `exec` helper calls.
  - Ensured tool choices remain consistent across streaming responses, cached responses, and standard JSON responses.
  - Added coverage for replayed tool catalogs, nested helper calls, and explicit tool selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->