### PR TITLE
fix(codex): bound the provenance ledger by bytes, not only by transaction count

### DIFF
--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -196,6 +196,20 @@ export function captureCodexPreImages(): CodexPreImages {
  */
 export const CODEX_PROVENANCE_MAX_TRANSACTIONS = 16;
 
+/**
+ * How many serialized bytes of evidence the ledger keeps.
+ *
+ * The transaction window alone bounds the ledger only if each transaction is small, and a
+ * baseline embeds the artifact's exact bytes. Those artifacts sit outside this proxy's trust
+ * boundary: a native `config.toml` grown to hundreds of megabytes is copied into the record as
+ * base64 and re-serialized on every append, so a single oversized file turns a 16-transaction
+ * window into a multi-gigabyte write.
+ *
+ * 1 MiB holds a normal 16-transaction window many times over, so ordinary evidence is never
+ * touched and only the pathological case is refused.
+ */
+export const CODEX_PROVENANCE_MAX_BYTES = 1024 * 1024;
+
 function provenanceBaseline(bytes: string | null): CodexProvenanceEntry["baseline"] {
   if (bytes === null) return { kind: "absent" };
   return {
@@ -214,21 +228,40 @@ function provenancePostImage(path: string): string | null {
 }
 
 /**
- * Keep the newest `CODEX_PROVENANCE_MAX_TRANSACTIONS` transactions, whole.
+ * Keep the newest transactions that fit both the transaction window and the byte ceiling, whole.
  *
  * Trimming by ENTRY count would cut a transaction in half and leave evidence that says a
  * transaction touched two artifacts when it touched three — worse than dropping it outright,
  * because a partial record still reads as complete. Order is preserved; only whole leading
  * transactions are removed.
+ *
+ * The byte ceiling applies the same rule: a transaction that does not fit is omitted whole,
+ * including the newest one — a record silently truncated to fit would be read as a faithful
+ * pre-image. An oversized transaction is skipped rather than ending the scan, so one pathological
+ * artifact cannot erase the smaller transactions that still fit and are still diagnosable.
  */
 export function boundProvenanceEntries(
   entries: readonly CodexProvenanceEntry[],
   maxTransactions = CODEX_PROVENANCE_MAX_TRANSACTIONS,
+  maxBytes = CODEX_PROVENANCE_MAX_BYTES,
 ): readonly CodexProvenanceEntry[] {
   const order: string[] = [];
   for (const entry of entries) if (!order.includes(entry.txId)) order.push(entry.txId);
-  if (order.length <= maxTransactions) return entries;
-  const keep = new Set(order.slice(order.length - maxTransactions));
+  const windowed = order.length <= maxTransactions
+    ? order
+    : order.slice(order.length - maxTransactions);
+  // Newest first, so the transactions anyone diagnoses against are the ones that fit.
+  const keep = new Set<string>();
+  let bytes = 0;
+  for (let i = windowed.length - 1; i >= 0; i--) {
+    const txId = windowed[i]!;
+    const txEntries = entries.filter(entry => entry.txId === txId);
+    const txBytes = Buffer.byteLength(JSON.stringify(txEntries), "utf-8");
+    if (bytes + txBytes > maxBytes) continue;
+    bytes += txBytes;
+    keep.add(txId);
+  }
+  if (keep.size === order.length) return entries;
   return entries.filter(entry => keep.has(entry.txId));
 }
 

--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -16,6 +16,7 @@ import { CODEX_CONFIG_PATH, CODEX_PROFILE_PATH } from "./paths";
 import type {
   CodexArtifactId,
   CodexProvenanceEntry,
+  CodexProvenanceLedger,
 } from "./convergence-types";
 import {
   codexWriteCoordination,
@@ -221,10 +222,13 @@ export const CODEX_PROVENANCE_MAX_BYTES = 4 * 1024 * 1024;
  * slightly conservative as a ledger-only ceiling, which is preferable to admitting an entry that
  * expands past the limit when `JSON.stringify(record, null, 2)` writes it.
  */
-function serializedProvenanceBytes(entries: readonly CodexProvenanceEntry[]): number {
+function serializedProvenanceBytes(
+  entries: readonly CodexProvenanceEntry[],
+  ledger: CodexProvenanceLedger | undefined,
+): number {
   return Buffer.byteLength(`${JSON.stringify({
     version: 1,
-    provenance: { entries },
+    provenance: { ...ledger, entries },
   }, null, 2)}\n`, "utf-8");
 }
 
@@ -262,6 +266,7 @@ export function boundProvenanceEntries(
   entries: readonly CodexProvenanceEntry[],
   maxTransactions = CODEX_PROVENANCE_MAX_TRANSACTIONS,
   maxBytes = CODEX_PROVENANCE_MAX_BYTES,
+  ledger?: CodexProvenanceLedger,
 ): readonly CodexProvenanceEntry[] {
   const transactions = new Map<string, CodexProvenanceEntry[]>();
   for (const entry of entries) {
@@ -278,7 +283,10 @@ export function boundProvenanceEntries(
       (total, entry) => total + (entry.baseline.kind === "present" ? entry.baseline.bytesBase64.length : 0),
       0,
     );
-    if (baselineBytes <= maxBytes && serializedProvenanceBytes(entries) <= maxBytes) return entries;
+    if (
+      baselineBytes <= maxBytes
+      && serializedProvenanceBytes(entries, ledger) <= maxBytes
+    ) return entries;
   }
   // Newest first, so the transactions anyone diagnoses against are the ones that fit.
   const keep = new Set<string>();
@@ -300,7 +308,7 @@ export function boundProvenanceEntries(
     const candidateEntries = windowed.flatMap(id =>
       candidateKeep.has(id) ? transactions.get(id)! : []
     );
-    if (serializedProvenanceBytes(candidateEntries) > maxBytes) continue;
+    if (serializedProvenanceBytes(candidateEntries, ledger) > maxBytes) continue;
     baselineBytes += transactionBaselineBytes;
     keep.add(txId);
   }
@@ -326,13 +334,21 @@ export function recordCodexNativeTransactionProvenance(
     txId,
     at,
   }));
-  return updateIntegrationRecord(record => ({
-    ...record,
-    provenance: {
-      ...record.provenance,
-      entries: boundProvenanceEntries([...(record.provenance?.entries ?? []), ...entries]),
-    },
-  }));
+  return updateIntegrationRecord(record => {
+    const previousLedger = record.provenance;
+    return {
+      ...record,
+      provenance: {
+        ...previousLedger,
+        entries: boundProvenanceEntries(
+          [...(previousLedger?.entries ?? []), ...entries],
+          CODEX_PROVENANCE_MAX_TRANSACTIONS,
+          CODEX_PROVENANCE_MAX_BYTES,
+          previousLedger,
+        ),
+      },
+    };
+  });
 }
 
 /**

--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -205,10 +205,28 @@ export const CODEX_PROVENANCE_MAX_TRANSACTIONS = 16;
  * base64 and re-serialized on every append, so a single oversized file turns a 16-transaction
  * window into a multi-gigabyte write.
  *
- * 1 MiB holds a normal 16-transaction window many times over, so ordinary evidence is never
- * touched and only the pathological case is refused.
+ * The size is derived from the window above rather than picked: the 25 KB `config.toml` that
+ * comment describes measures 100.8 KiB per transaction, so a full 16-transaction window is
+ * 1.58 MiB. 4 MiB leaves that ordinary window untouched with room to spare while still refusing
+ * the pathological case, and a regression test pins the ordinary window so the two cannot drift
+ * apart silently.
  */
-export const CODEX_PROVENANCE_MAX_BYTES = 1024 * 1024;
+export const CODEX_PROVENANCE_MAX_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Measure the representation the integration-record writer actually emits.
+ *
+ * The minimal wrapper reproduces the final indentation depth of `provenance.entries`, including
+ * structured unknown extension fields preserved from older records. Its fixed wrapper makes this
+ * slightly conservative as a ledger-only ceiling, which is preferable to admitting an entry that
+ * expands past the limit when `JSON.stringify(record, null, 2)` writes it.
+ */
+function serializedProvenanceBytes(entries: readonly CodexProvenanceEntry[]): number {
+  return Buffer.byteLength(`${JSON.stringify({
+    version: 1,
+    provenance: { entries },
+  }, null, 2)}\n`, "utf-8");
+}
 
 function provenanceBaseline(bytes: string | null): CodexProvenanceEntry["baseline"] {
   if (bytes === null) return { kind: "absent" };
@@ -245,20 +263,45 @@ export function boundProvenanceEntries(
   maxTransactions = CODEX_PROVENANCE_MAX_TRANSACTIONS,
   maxBytes = CODEX_PROVENANCE_MAX_BYTES,
 ): readonly CodexProvenanceEntry[] {
-  const order: string[] = [];
-  for (const entry of entries) if (!order.includes(entry.txId)) order.push(entry.txId);
+  const transactions = new Map<string, CodexProvenanceEntry[]>();
+  for (const entry of entries) {
+    const transaction = transactions.get(entry.txId);
+    if (transaction) transaction.push(entry);
+    else transactions.set(entry.txId, [entry]);
+  }
+  const order = [...transactions.keys()];
   const windowed = order.length <= maxTransactions
     ? order
     : order.slice(order.length - maxTransactions);
+  if (windowed.length === order.length) {
+    const baselineBytes = entries.reduce(
+      (total, entry) => total + (entry.baseline.kind === "present" ? entry.baseline.bytesBase64.length : 0),
+      0,
+    );
+    if (baselineBytes <= maxBytes && serializedProvenanceBytes(entries) <= maxBytes) return entries;
+  }
   // Newest first, so the transactions anyone diagnoses against are the ones that fit.
   const keep = new Set<string>();
-  let bytes = 0;
+  let baselineBytes = 0;
   for (let i = windowed.length - 1; i >= 0; i--) {
     const txId = windowed[i]!;
-    const txEntries = entries.filter(entry => entry.txId === txId);
-    const txBytes = Buffer.byteLength(JSON.stringify(txEntries), "utf-8");
-    if (bytes + txBytes > maxBytes) continue;
-    bytes += txBytes;
+    const txEntries = transactions.get(txId)!;
+    // Measure the embedded pre-images first: a pathological baseline is refused without
+    // serializing it, so the ceiling does not itself allocate the payload it exists to reject.
+    const transactionBaselineBytes = txEntries.reduce(
+      (total, entry) => total + (entry.baseline.kind === "present" ? entry.baseline.bytesBase64.length : 0),
+      0,
+    );
+    if (baselineBytes + transactionBaselineBytes > maxBytes) continue;
+    const candidateKeep = new Set(keep);
+    candidateKeep.add(txId);
+    // Reuse the already-grouped transactions: this avoids another full-ledger filter on each
+    // iteration while preserving the original transaction and entry order.
+    const candidateEntries = windowed.flatMap(id =>
+      candidateKeep.has(id) ? transactions.get(id)! : []
+    );
+    if (serializedProvenanceBytes(candidateEntries) > maxBytes) continue;
+    baselineBytes += transactionBaselineBytes;
     keep.add(txId);
   }
   if (keep.size === order.length) return entries;

--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -254,8 +254,8 @@ function provenancePostImage(path: string): string | null {
  *
  * Trimming by ENTRY count would cut a transaction in half and leave evidence that says a
  * transaction touched two artifacts when it touched three — worse than dropping it outright,
- * because a partial record still reads as complete. Order is preserved; only whole leading
- * transactions are removed.
+ * because a partial record still reads as complete. Order is preserved; only whole transactions
+ * are removed.
  *
  * The byte ceiling applies the same rule: a transaction that does not fit is omitted whole,
  * including the newest one — a record silently truncated to fit would be read as a faithful
@@ -275,10 +275,7 @@ export function boundProvenanceEntries(
     else transactions.set(entry.txId, [entry]);
   }
   const order = [...transactions.keys()];
-  const windowed = order.length <= maxTransactions
-    ? order
-    : order.slice(order.length - maxTransactions);
-  if (windowed.length === order.length) {
+  if (order.length <= maxTransactions) {
     const baselineBytes = entries.reduce(
       (total, entry) => total + (entry.baseline.kind === "present" ? entry.baseline.bytesBase64.length : 0),
       0,
@@ -291,8 +288,8 @@ export function boundProvenanceEntries(
   // Newest first, so the transactions anyone diagnoses against are the ones that fit.
   const keep = new Set<string>();
   let baselineBytes = 0;
-  for (let i = windowed.length - 1; i >= 0; i--) {
-    const txId = windowed[i]!;
+  for (let i = order.length - 1; i >= 0 && keep.size < maxTransactions; i--) {
+    const txId = order[i]!;
     const txEntries = transactions.get(txId)!;
     // Measure the embedded pre-images first: a pathological baseline is refused without
     // serializing it, so the ceiling does not itself allocate the payload it exists to reject.
@@ -305,7 +302,7 @@ export function boundProvenanceEntries(
     candidateKeep.add(txId);
     // Reuse the already-grouped transactions: this avoids another full-ledger filter on each
     // iteration while preserving the original transaction and entry order.
-    const candidateEntries = windowed.flatMap(id =>
+    const candidateEntries = order.flatMap(id =>
       candidateKeep.has(id) ? transactions.get(id)! : []
     );
     if (serializedProvenanceBytes(candidateEntries, ledger) > maxBytes) continue;

--- a/src/codex/inject-coordination.ts
+++ b/src/codex/inject-coordination.ts
@@ -336,6 +336,14 @@ export function recordCodexNativeTransactionProvenance(
   }));
   return updateIntegrationRecord(record => {
     const previousLedger = record.provenance;
+    // Unknown ledger extensions are forward-compatible and must be preserved. If those fixed
+    // fields alone exceed the ceiling, no entry selection can make the write compliant. Keep the
+    // existing record byte-for-byte instead of deleting all known evidence and rewriting the
+    // same oversized extension on every native transaction.
+    if (
+      previousLedger
+      && serializedProvenanceBytes([], previousLedger) > CODEX_PROVENANCE_MAX_BYTES
+    ) return record;
     return {
       ...record,
       provenance: {

--- a/src/codex/integration-record.ts
+++ b/src/codex/integration-record.ts
@@ -204,22 +204,17 @@ function mergeEntry(previous: CodexProvenanceEntry, next: CodexProvenanceEntry):
 function mergeLedger(previous: CodexProvenanceLedger, next: CodexProvenanceLedger): CodexProvenanceLedger {
   const unused = new Set(previous.entries.map((_, index) => index));
   const entries = next.entries.map((entry, nextIndex) => {
-    let previousIndex = previous.entries.findIndex((candidate, index) =>
+    // Extensions follow provenance identity, never position. A bounded ledger may drop an
+    // oversized transaction, shifting an unrelated entry into that slot, and even within one
+    // transaction and timestamp the artifact may differ. Since this search already requires
+    // txId, timestamp, and artifact identity, any remaining positional match is by definition
+    // a different artifact, so preserving its unknown entry/artifact/baseline fields would
+    // attach false evidence and could regrow the record past the measured byte ceiling.
+    const previousIndex = previous.entries.findIndex((candidate, index) =>
       unused.has(index)
       && candidate.txId === entry.txId
       && candidate.at === entry.at
       && knownArtifactIdentity(candidate.artifact) === knownArtifactIdentity(entry.artifact));
-    if (previousIndex < 0 && unused.has(nextIndex)) {
-      const positional = previous.entries[nextIndex]!;
-      // Position alone is not provenance identity: a bounded ledger may drop an oversized
-      // transaction, shifting a newly appended transaction into its slot. Preserve extensions
-      // positionally only within the same transaction; otherwise an omitted transaction's
-      // unknown evidence would be falsely attached to the replacement and could regrow the
-      // record past the byte ceiling.
-      if (positional.txId === entry.txId && positional.at === entry.at) {
-        previousIndex = nextIndex;
-      }
-    }
     if (previousIndex < 0) return entry;
     unused.delete(previousIndex);
     return mergeEntry(previous.entries[previousIndex]!, entry);

--- a/src/codex/integration-record.ts
+++ b/src/codex/integration-record.ts
@@ -209,7 +209,17 @@ function mergeLedger(previous: CodexProvenanceLedger, next: CodexProvenanceLedge
       && candidate.txId === entry.txId
       && candidate.at === entry.at
       && knownArtifactIdentity(candidate.artifact) === knownArtifactIdentity(entry.artifact));
-    if (previousIndex < 0 && unused.has(nextIndex)) previousIndex = nextIndex;
+    if (previousIndex < 0 && unused.has(nextIndex)) {
+      const positional = previous.entries[nextIndex]!;
+      // Position alone is not provenance identity: a bounded ledger may drop an oversized
+      // transaction, shifting a newly appended transaction into its slot. Preserve extensions
+      // positionally only within the same transaction; otherwise an omitted transaction's
+      // unknown evidence would be falsely attached to the replacement and could regrow the
+      // record past the byte ceiling.
+      if (positional.txId === entry.txId && positional.at === entry.at) {
+        previousIndex = nextIndex;
+      }
+    }
     if (previousIndex < 0) return entry;
     unused.delete(previousIndex);
     return mergeEntry(previous.entries[previousIndex]!, entry);

--- a/src/codex/integration-record.ts
+++ b/src/codex/integration-record.ts
@@ -255,6 +255,11 @@ export const updateIntegrationRecord = (
       if (read.kind === "invalid") return read;
       const previous: CodexIntegrationRecord = read.kind === "ready" ? read.record : { version: 1 };
       const proposed = mutate(previous);
+      // The mutator can explicitly decline an update by returning the exact record it received.
+      // This matters when a preserved forward-compatible extension already exceeds a caller's
+      // write budget: rewriting the same oversized bytes would amplify I/O while deleting known
+      // entries cannot make that irreducible overhead fit.
+      if (proposed === previous) return { kind: "updated" as const, record: previous };
       if (!validateRecord(proposed)) {
         return { kind: "invalid", message: "Codex integration record update produced a malformed v1 shape" };
       }

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -15,7 +15,11 @@ import {
   resolveCodexCoordinatorDatabasePath,
   resolveEffectiveUserIdentity,
 } from "../src/codex/user-identity";
-import { boundProvenanceEntries, STABLE_ZERO_BYTE_COORDINATOR_AGE_MS } from "../src/codex/inject-coordination";
+import {
+  boundProvenanceEntries,
+  CODEX_PROVENANCE_MAX_BYTES,
+  STABLE_ZERO_BYTE_COORDINATOR_AGE_MS,
+} from "../src/codex/inject-coordination";
 import { SPAWN_BUDGET_MS } from "./helpers/test-budget";
 
 const repoRoot = join(import.meta.dir, "..");
@@ -507,5 +511,49 @@ describe("provenance ledger bound", () => {
   test("a ledger within the window is returned unchanged", () => {
     const entries = Array.from({ length: 16 }, (_, i) => transaction(`tx-${i}`)).flat();
     expect(boundProvenanceEntries(entries, 16)).toBe(entries);
+  });
+
+  test("an oversized baseline is omitted whole rather than amplified into the record", () => {
+    // The native artifacts sit outside this proxy's trust boundary, so a `config.toml` grown to
+    // an arbitrary size would otherwise be copied into the record as base64 and re-serialized on
+    // every append — the transaction window alone does not bound that.
+    const huge = (txId: string) => transaction(txId).map(entry => ({
+      ...entry,
+      baseline: {
+        kind: "present" as const,
+        sha256: "0".repeat(64),
+        bytesBase64: "A".repeat(CODEX_PROVENANCE_MAX_BYTES),
+      },
+    }));
+    const entries = [...transaction("tx-small"), ...huge("tx-huge")];
+
+    const bounded = boundProvenanceEntries(entries, 16);
+
+    expect(bounded.map(e => e.txId)).toEqual(["tx-small", "tx-small", "tx-small"]);
+    expect(Buffer.byteLength(JSON.stringify(bounded), "utf-8"))
+      .toBeLessThanOrEqual(CODEX_PROVENANCE_MAX_BYTES);
+  });
+
+  test("the byte ceiling drops whole transactions, oldest first", () => {
+    const padded = (txId: string) => transaction(txId).map(entry => ({
+      ...entry,
+      baseline: {
+        kind: "present" as const,
+        sha256: "0".repeat(64),
+        bytesBase64: "A".repeat(120 * 1024),
+      },
+    }));
+    const entries = Array.from({ length: 6 }, (_, i) => padded(`tx-${i}`)).flat();
+
+    const bounded = boundProvenanceEntries(entries, 16);
+    const kept = [...new Set(bounded.map(e => e.txId))];
+
+    expect(kept.length).toBeGreaterThan(0);
+    expect(kept.length).toBeLessThan(6);
+    // Newest survive; the dropped ones are the oldest, and each survivor is whole.
+    expect(kept.at(-1)).toBe("tx-5");
+    for (const txId of kept) expect(bounded.filter(e => e.txId === txId)).toHaveLength(3);
+    expect(Buffer.byteLength(JSON.stringify(bounded), "utf-8"))
+      .toBeLessThanOrEqual(CODEX_PROVENANCE_MAX_BYTES);
   });
 });

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -592,6 +592,29 @@ describe("provenance ledger bound", () => {
       .toBeLessThanOrEqual(CODEX_PROVENANCE_MAX_BYTES);
   });
 
+  test("backfills the transaction window after an oversized newest transaction is skipped", () => {
+    const maxBytes = 64 * 1024;
+    const oversized = transaction("tx-16");
+    oversized[0] = {
+      ...oversized[0]!,
+      baseline: {
+        kind: "present" as const,
+        sha256: "0".repeat(64),
+        bytesBase64: "A".repeat(maxBytes + 1),
+      },
+    };
+    const entries = [
+      ...Array.from({ length: 16 }, (_, i) => transaction(`tx-${i}`)).flat(),
+      ...oversized,
+    ];
+
+    const bounded = boundProvenanceEntries(entries, 16, maxBytes);
+    const kept = [...new Set(bounded.map(entry => entry.txId))];
+
+    expect(kept).toEqual(Array.from({ length: 16 }, (_, i) => `tx-${i}`));
+    for (const txId of kept) expect(bounded.filter(entry => entry.txId === txId)).toHaveLength(3);
+  });
+
   test("the byte ceiling drops whole transactions, oldest first", () => {
     const padded = (txId: string) => transaction(txId).map(entry => ({
       ...entry,

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -251,6 +251,55 @@ describe("the lock is on the production path", () => {
       .toBe("{ malformed");
   });
 
+  test("irreducible ledger extension overhead refuses the append without rewriting", () => {
+    seedNative();
+    const recordPath = join(opencodexHome, "integrations", "codex.json");
+    mkdirSync(join(opencodexHome, "integrations"), { recursive: true });
+    writeFileSync(recordPath, JSON.stringify({
+      version: 1,
+      provenance: {
+        futureLedger: "x".repeat(CODEX_PROVENANCE_MAX_BYTES + 1),
+        entries: [{
+          artifact: { kind: "config" },
+          baseline: { kind: "absent" },
+          postImage: null,
+          txId: "tx-existing",
+          at: "2026-08-30T00:00:00.000Z",
+        }],
+      },
+    }));
+    const before = readFileSync(recordPath, "utf8");
+
+    const result = parseChildJson<{ kind?: string; entryCount?: number }>(
+      runChild(["--eval", `
+        const {
+          captureCodexPreImages,
+          recordCodexNativeTransactionProvenance,
+        } = require("./src/codex/inject-coordination");
+        const result = recordCodexNativeTransactionProvenance(
+          captureCodexPreImages(),
+          "tx-must-not-append",
+        );
+        console.log(JSON.stringify({
+          kind: result.kind,
+          entryCount: result.kind === "updated"
+            ? result.record.provenance?.entries?.length
+            : undefined,
+        }));
+      `], {
+        ...process.env,
+        CODEX_HOME: codexHome,
+        OPENCODEX_HOME: opencodexHome,
+      }),
+      "irreducible ledger extension overhead",
+    );
+
+    expect(result.kind).toBe("updated");
+    expect(result.entryCount).toBe(1);
+    // Exact bytes, not just semantics: a no-op must not pretty-print/rewrite the oversized file.
+    expect(readFileSync(recordPath, "utf8")).toBe(before);
+  });
+
   /**
    * The contention proof. A real second process holds N through the production
    * lock module while a real injection runs; the injection must report busy and

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -593,6 +593,29 @@ describe("provenance ledger bound", () => {
     expect([...new Set(bounded.map(entry => entry.txId))]).toEqual(["tx-new"]);
   });
 
+  test("unknown ledger extensions consume the same byte budget as entries", () => {
+    const entries = [...transaction("tx-old"), ...transaction("tx-new")];
+    const ledger = {
+      entries,
+      futureLedger: {
+        rows: Array.from({ length: 200 }, () => ({ left: "x", right: "y" })),
+      },
+    };
+    const writeBytes = (candidate: readonly (typeof entries)[number][]) =>
+      Buffer.byteLength(`${JSON.stringify({
+        version: 1,
+        provenance: { ...ledger, entries: candidate },
+      }, null, 2)}\n`, "utf-8");
+    const newest = transaction("tx-new");
+    const maxBytes = writeBytes(newest);
+
+    expect(writeBytes(entries)).toBeGreaterThan(maxBytes);
+    const bounded = boundProvenanceEntries(entries, 16, maxBytes, ledger);
+
+    expect([...new Set(bounded.map(entry => entry.txId))]).toEqual(["tx-new"]);
+    expect(writeBytes(bounded)).toBeLessThanOrEqual(maxBytes);
+  });
+
   test("a full window of ordinary transactions is still kept whole", () => {
     // The ceiling exists to refuse pathological artifacts, not to shrink the window above it.
     // This pins the two together: the 25 KB `config.toml` the window comment describes measures

--- a/tests/codex-inject-write-lock.test.ts
+++ b/tests/codex-inject-write-lock.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   boundProvenanceEntries,
   CODEX_PROVENANCE_MAX_BYTES,
+  CODEX_PROVENANCE_MAX_TRANSACTIONS,
   STABLE_ZERO_BYTE_COORDINATOR_AGE_MS,
 } from "../src/codex/inject-coordination";
 import { SPAWN_BUDGET_MS } from "./helpers/test-budget";
@@ -517,15 +518,23 @@ describe("provenance ledger bound", () => {
     // The native artifacts sit outside this proxy's trust boundary, so a `config.toml` grown to
     // an arbitrary size would otherwise be copied into the record as base64 and re-serialized on
     // every append — the transaction window alone does not bound that.
-    const huge = (txId: string) => transaction(txId).map(entry => ({
-      ...entry,
+    const huge = transaction("tx-huge");
+    huge[0] = {
+      ...huge[0]!,
       baseline: {
         kind: "present" as const,
         sha256: "0".repeat(64),
-        bytesBase64: "A".repeat(CODEX_PROVENANCE_MAX_BYTES),
+        bytesBase64: "A".repeat(CODEX_PROVENANCE_MAX_BYTES + 1),
       },
-    }));
-    const entries = [...transaction("tx-small"), ...huge("tx-huge")];
+    };
+    // The baseline-size prefilter must reject this transaction before JSON.stringify reaches
+    // the tripwire. Only one sibling is oversized; all three must still be omitted together.
+    Object.defineProperty(huge[0]!, "toJSON", {
+      value: () => {
+        throw new Error("oversized transaction was serialized");
+      },
+    });
+    const entries = [...transaction("tx-small"), ...huge];
 
     const bounded = boundProvenanceEntries(entries, 16);
 
@@ -540,20 +549,68 @@ describe("provenance ledger bound", () => {
       baseline: {
         kind: "present" as const,
         sha256: "0".repeat(64),
-        bytesBase64: "A".repeat(120 * 1024),
+        bytesBase64: "A".repeat(Math.floor(CODEX_PROVENANCE_MAX_BYTES / 4)),
       },
     }));
-    const entries = Array.from({ length: 6 }, (_, i) => padded(`tx-${i}`)).flat();
+    const entries = Array.from({ length: 4 }, (_, i) => padded(`tx-${i}`)).flat();
 
     const bounded = boundProvenanceEntries(entries, 16);
     const kept = [...new Set(bounded.map(e => e.txId))];
 
     expect(kept.length).toBeGreaterThan(0);
-    expect(kept.length).toBeLessThan(6);
+    expect(kept.length).toBeLessThan(4);
     // Newest survive; the dropped ones are the oldest, and each survivor is whole.
-    expect(kept.at(-1)).toBe("tx-5");
+    expect(kept.at(-1)).toBe("tx-3");
     for (const txId of kept) expect(bounded.filter(e => e.txId === txId)).toHaveLength(3);
     expect(Buffer.byteLength(JSON.stringify(bounded), "utf-8"))
       .toBeLessThanOrEqual(CODEX_PROVENANCE_MAX_BYTES);
+  });
+
+  test("the ceiling measures structured extensions in the pretty-printed record shape", () => {
+    const extended = (txId: string) => transaction(txId).map((entry, index) => ({
+      ...entry,
+      // Integration records preserve unknown structured fields. Compact JSON can fit while the
+      // writer's two-space indentation does not, so the bound must use the actual write shape.
+      extension: index === 0
+        ? { rows: Array.from({ length: 400 }, () => ({ left: "x", right: "y" })) }
+        : undefined,
+    }));
+    const entries = [...extended("tx-old"), ...extended("tx-new")];
+    const oneTransactionBytes = Buffer.byteLength(`${JSON.stringify({
+      version: 1,
+      provenance: { entries: extended("tx-new") },
+    }, null, 2)}\n`, "utf-8");
+    const bothCompactBytes = Buffer.byteLength(JSON.stringify(entries), "utf-8");
+    const bothPrettyBytes = Buffer.byteLength(`${JSON.stringify({
+      version: 1,
+      provenance: { entries },
+    }, null, 2)}\n`, "utf-8");
+    const maxBytes = Math.max(oneTransactionBytes, bothCompactBytes);
+
+    expect(bothPrettyBytes).toBeGreaterThan(maxBytes);
+    const bounded = boundProvenanceEntries(entries, 16, maxBytes);
+
+    expect([...new Set(bounded.map(entry => entry.txId))]).toEqual(["tx-new"]);
+  });
+
+  test("a full window of ordinary transactions is still kept whole", () => {
+    // The ceiling exists to refuse pathological artifacts, not to shrink the window above it.
+    // This pins the two together: the 25 KB `config.toml` the window comment describes measures
+    // about 100 KiB per transaction, so a full window is roughly 1.6 MiB and must survive intact.
+    const ordinary = Buffer.from("x".repeat(25 * 1024)).toString("base64");
+    const entries = Array.from(
+      { length: CODEX_PROVENANCE_MAX_TRANSACTIONS },
+      (_, i) => transaction(`tx-${i}`).map(entry => ({
+        ...entry,
+        baseline: { kind: "present" as const, sha256: "0".repeat(64), bytesBase64: ordinary },
+        postImage: "0".repeat(64),
+      })),
+    ).flat();
+
+    const bounded = boundProvenanceEntries(entries);
+
+    expect(bounded).toBe(entries);
+    expect(new Set(bounded.map(e => e.txId)).size).toBe(CODEX_PROVENANCE_MAX_TRANSACTIONS);
+    expect(bounded).toHaveLength(entries.length);
   });
 });

--- a/tests/codex-integration-record.test.ts
+++ b/tests/codex-integration-record.test.ts
@@ -196,6 +196,45 @@ describe("Codex integration record", () => {
       .toBeLessThanOrEqual(maxBytes);
   });
 
+  test("does not move extensions onto a different artifact in the same transaction", () => {
+    const at = "2026-08-04T00:00:00.000Z";
+    writeRecord({
+      version: 1,
+      provenance: {
+        entries: [{
+          artifact: { kind: "config", futureArtifact: { owner: "config" } },
+          baseline: { kind: "absent", futureBaseline: { owner: "config" } },
+          postImage: null,
+          txId: "tx-same",
+          at,
+          futureEntry: { owner: "config" },
+        } as unknown as CodexProvenanceEntry],
+      },
+    });
+
+    const result = updateIntegrationRecord(record => ({
+      ...record,
+      provenance: {
+        ...record.provenance,
+        entries: [{
+          artifact: { kind: "generated-profile" },
+          baseline: { kind: "absent" },
+          postImage: null,
+          txId: "tx-same",
+          at,
+        }],
+      },
+    }));
+
+    expect(result.kind).toBe("updated");
+    const saved = persistedRecord();
+    const entries = (saved.provenance as { entries: Array<Record<string, unknown>> }).entries;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.artifact).toEqual({ kind: "generated-profile" });
+    expect(entries[0]!.baseline).toEqual({ kind: "absent" });
+    expect(entries[0]).not.toHaveProperty("futureEntry");
+  });
+
   test("fails closed on unparseable bytes without invoking the mutator or resetting the file", () => {
     mkdirSync(join(opencodexHome, "integrations"), { recursive: true });
     writeFileSync(integrationRecordPath(), "{ definitely-not-json", "utf8");

--- a/tests/codex-integration-record.test.ts
+++ b/tests/codex-integration-record.test.ts
@@ -6,6 +6,7 @@ import {
   readIntegrationRecord,
   updateIntegrationRecord,
 } from "../src/codex/integration-record";
+import { boundProvenanceEntries } from "../src/codex/inject-coordination";
 import type {
   CodexArtifactId,
   CodexIntegrationRecord,
@@ -143,6 +144,56 @@ describe("Codex integration record", () => {
     expect(entries.map(entry => entry.postImage)).toEqual(
       artifacts.map((_, index) => `new-post-image-${index}`),
     );
+  });
+
+  test("does not move an omitted transaction's extensions onto its positional replacement", () => {
+    const maxBytes = 16 * 1024;
+    const entry = (
+      txId: string,
+      at: string,
+      baseline: CodexProvenanceEntry["baseline"],
+      futureEntry?: unknown,
+    ): CodexProvenanceEntry => ({
+      artifact: { kind: "config" },
+      baseline,
+      postImage: null,
+      txId,
+      at,
+      ...(futureEntry === undefined ? {} : { futureEntry }),
+    });
+    const kept = entry("tx-kept", "2026-08-04T00:00:00.000Z", { kind: "absent" });
+    const oversized = entry(
+      "tx-oversized",
+      "2026-08-04T00:00:01.000Z",
+      {
+        kind: "present",
+        sha256: "0".repeat(64),
+        bytesBase64: "A".repeat(maxBytes + 1),
+      },
+      { mustNotMove: "x".repeat(maxBytes * 2) },
+    );
+    writeRecord({ version: 1, provenance: { entries: [kept, oversized] } });
+
+    const appended = entry("tx-new", "2026-08-04T00:00:02.000Z", { kind: "absent" });
+    const result = updateIntegrationRecord(record => ({
+      ...record,
+      provenance: {
+        ...record.provenance,
+        entries: boundProvenanceEntries(
+          [...record.provenance!.entries, appended],
+          16,
+          maxBytes,
+        ),
+      },
+    }));
+
+    expect(result.kind).toBe("updated");
+    const saved = persistedRecord();
+    const entries = (saved.provenance as { entries: Array<Record<string, unknown>> }).entries;
+    expect(entries.map(savedEntry => savedEntry.txId)).toEqual(["tx-kept", "tx-new"]);
+    expect(entries[1]).not.toHaveProperty("futureEntry");
+    expect(Buffer.byteLength(JSON.stringify(saved, null, 2), "utf-8"))
+      .toBeLessThanOrEqual(maxBytes);
   });
 
   test("fails closed on unparseable bytes without invoking the mutator or resetting the file", () => {


### PR DESCRIPTION
## Summary

The provenance ledger was bounded only by transaction count, so one oversized native artifact was amplified into a multi-hundred-megabyte record. This adds a serialized byte ceiling that preserves the ordinary full transaction window and remains intact through extension preservation.

## The defect

`boundProvenanceEntries` keeps the newest `CODEX_PROVENANCE_MAX_TRANSACTIONS` (16) transactions. That bounds the ledger only while each transaction is small, and a `present` baseline embeds the artifact's exact bytes:

```ts
return {
  kind: "present",
  sha256: createHash("sha256").update(bytes).digest("hex"),
  bytesBase64: Buffer.from(bytes).toString("base64"),
};
```

The native `config.toml`, generated profile, and journal are not size-controlled by this ledger. Because the integration record is re-read and re-serialized on every append, a large artifact is rewritten per transaction.

Measured against current dev, three admitted transactions over a 64 MiB config:

```
retained transactions: 3
serialized ledger: 576.0 MiB
```

## The fix

Add `CODEX_PROVENANCE_MAX_BYTES` (4 MiB) alongside the existing window.

- The value is derived from the documented ordinary case: a transaction over three 25 KiB pre-images is 100.8 KiB; the full 16-transaction window is 1.58 MiB. A regression proves all 16 transactions / 48 entries remain unchanged and retain the same array instance.
- Transactions are admitted newest-first and only whole. One oversized sibling drops its whole transaction, never a partial record.
- Admission keeps scanning older transactions after an oversized newest transaction is skipped, until 16 fitting whole transactions have been retained or candidates are exhausted.
- Embedded base64 length is checked before serialization, so the pathological payload is rejected without allocating the JSON it exists to prevent.
- The final decision measures the same pretty-printed `{ version, provenance: { entries } }` representation and final newline that the integration-record writer emits. Structured unknown entry extensions are therefore counted as written.
- The existing ledger is supplied as the measurement template, so forward-compatible fields directly under `provenance` consume the same budget instead of bypassing it.
- If preserved ledger fields alone exceed the ceiling, no entry selection can make the write compliant. The append becomes an explicit no-op: existing evidence and exact file bytes remain unchanged instead of deleting all entries and rewriting the same oversized extension.
- Transactions are grouped once, avoiding repeated full-ledger filtering.

One integration boundary also had to be fenced. `preserveExtensions` used a positional fallback after matching entry identity. If bounding removed transaction B from `[A, B]` and append produced `[A, C]`, that fallback copied B's unknown extensions onto C. That both falsified provenance and could regrow the written record past the ceiling.

Per maintainer review of `1d181467`, restricting that fallback to the same `txId` and timestamp was not sufficient: a same-transaction, same-timestamp positional replacement whose artifact differs still inherited unrelated entry, artifact, and baseline extensions. The positional fallback is now removed entirely. The exact-identity search already requires `txId`, timestamp, and artifact identity, so any remaining positional match is by definition a different artifact; legitimate extension preservation for matching entries is unchanged.

With the fix, the 576 MiB input retains no oversized transaction, while ordinary 16-transaction evidence remains intact.

## Review boundary

Retention and provenance identity only.

- No change to what a transaction records or to restoration.
- No schema change.
- Known and unknown extensions on the same transaction are still preserved.
- Extensions move only between entries with the same `txId`, timestamp, and artifact identity; they never follow position.
- A ledger already within both bounds returns the identical array instance.
- `updateIntegrationRecord` treats the exact input object returned by its mutator as an explicit no-write result; all normal update objects retain the previous validation, extension merge, and atomic replace path.

## Verification

Rebased onto current `dev@223a0a2871f9ebd0f2d81be4064575d0d02f0e02`; exact head `32db37e69443e0d96747efe165340fd76a91223e`.

- Bun 1.4.0-canary.1: `bun test tests/codex-integration-record.test.ts tests/codex-inject-write-lock.test.ts` — 23 pass, 0 fail, 109 expectations, on the exact rebased head.
- Red-proven for the maintainer's finding: with only `src/codex/integration-record.ts` reverted, the new regression fails exactly as reported — a `generated-profile` replacement at the same `txId` and `at` inherits the `config` entry's `futureArtifact`, `futureBaseline`, and `futureEntry`. With the fix it keeps only its own fields.
- Red-proven: unmodified `dev` retains three oversized transactions and serializes 576.0 MiB; the bounded implementation retains none.
- Red-proven: reverting only the extension-identity fence makes the end-to-end integration-record regression attach the omitted transaction's `futureEntry` to its positional replacement.
- Red-proven: removing the ledger template from byte measurement retains both transactions even though the actual pretty-written ledger exceeds the configured ceiling.
- Red-proven: removing the irreducible-overhead/no-write checks drops the existing entry count from 1 to 0 and rewrites the oversized file.
- Regression: with 17 transactions and an oversized newest transaction, the implementation skips it and backfills all 16 older fitting transactions.
- `bun run typecheck`, `bun run privacy:scan`, and `git diff --check` pass.
- The repository-wide suite was intentionally not duplicated locally; hosted CI remains the full-matrix check.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
