### PR TITLE
fix(responses): keep the empty-completion notice to one log record

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -371,6 +371,7 @@ import { responsesJsonToSseStream } from "../responses-json-events";
 import { guardTerminalEventStream } from "./terminal-guard";
 import {
   emptyCompletionRetryEnabled,
+  emptyCompletionNotice,
   observeEmptyCompletion,
   guardEmptyCompletionEventStream,
 } from "./empty-completion-guard";
@@ -5271,10 +5272,7 @@ async function handleResponsesInner(
         // result (#2472). Retrying by default would re-send a turn that may already have had
         // billable side effects, so the honest default is observability, not recovery.
         : observeEmptyCompletion(eventSource, () => {
-          console.warn(
-            `[opencodex] ${route.providerName}/${route.modelId} completed with no output text `
-            + "and no tool call. Set \"emptyCompletionRetry\": true to retry such turns once.",
-          );
+          console.warn(emptyCompletionNotice(route.providerName, route.modelId));
         });
       const sseStream = bridgeToResponsesSSE(
         guardedSource, parsed._responseModelId ?? parsed.modelId, toolNsMap, freeformToolNames, toolSearchToolNames,

--- a/src/server/responses/empty-completion-guard.ts
+++ b/src/server/responses/empty-completion-guard.ts
@@ -1,4 +1,5 @@
 import type { AdapterEvent, OcxConfig, OcxUsage } from "../../types";
+import { sanitizeLogMetadataString } from "../../lib/redact";
 
 /**
  * Empty-completion guard for Responses turns (port of codex-router's
@@ -20,6 +21,21 @@ import type { AdapterEvent, OcxConfig, OcxUsage } from "../../types";
  * the previous relay behavior without editing the persisted config.
  */
 export const EMPTY_COMPLETION_RETRY_ENV = "OCX_EMPTY_COMPLETION_RETRY";
+
+/**
+ * The observability notice for a turn that ended empty with the retry guard off.
+ *
+ * Both labels are caller-supplied: the request names its provider and model. Interpolated raw,
+ * a model name carrying newlines or terminal escapes writes additional lines into whatever
+ * reads this warning, so a caller could forge log records it never produced. Both are reduced
+ * to bounded single-line metadata first.
+ */
+export function emptyCompletionNotice(providerName: unknown, modelId: unknown): string {
+  const provider = sanitizeLogMetadataString(providerName) ?? "unknown";
+  const model = sanitizeLogMetadataString(modelId) ?? "unknown";
+  return `[opencodex] ${provider}/${model} completed with no output text and no tool call. `
+    + "Set \"emptyCompletionRetry\": true to retry such turns once.";
+}
 
 /** Retained pre-content events are bounded independently by count and encoded size. */
 export const EMPTY_COMPLETION_MAX_BUFFERED_EVENTS = 1_024;

--- a/tests/empty-completion-guard.test.ts
+++ b/tests/empty-completion-guard.test.ts
@@ -3,6 +3,7 @@ import {
   EMPTY_COMPLETION_RETRY_ENV,
   EMPTY_COMPLETION_RETRY_FAILED_CODE,
   emptyCompletionRetryEnabled,
+  emptyCompletionNotice,
   guardEmptyCompletionEventStream,
   isContentEvent,
   observeEmptyCompletion,
@@ -443,5 +444,28 @@ describe("#2472 an empty turn is observable even when the retry guard is off", (
     const { empties } = await drain([]);
     expect(empties).toBe(1);
   });
-});
 
+  test("the notice cannot be forged through the caller-supplied provider or model label", () => {
+    // Both labels come from the request. Interpolated raw, a model name carrying newlines or
+    // terminal escapes writes extra lines into whatever reads this warning, so a caller could
+    // fabricate log records it never produced.
+    const notice = emptyCompletionNotice(
+      "fixture",
+      "model\r\n[opencodex] forged: injected\u001b[31m",
+    );
+
+    expect(notice).not.toContain("\n");
+    expect(notice).not.toContain("\r");
+    expect(notice).not.toContain("\u001b");
+    expect(notice).toContain("completed with no output text and no tool call");
+    // The forged text may survive as inert characters; what must not survive is its ability to
+    // become a separate record, so the notice stays exactly one line.
+    expect(notice.split(/\r|\n|\u2028|\u2029/)).toHaveLength(1);
+  });
+
+  test("the notice still names an ordinary route and degrades to a stated placeholder", () => {
+    expect(emptyCompletionNotice("fixture", "gpt-5.4")).toContain("fixture/gpt-5.4");
+    // An unusable label must not silently vanish into an empty slot in the sentence.
+    expect(emptyCompletionNotice(undefined, "")).toContain("unknown/unknown");
+  });
+});


### PR DESCRIPTION
## Summary

The empty-completion notice was built by interpolating caller-supplied route labels, so one warning could be split into several apparent log records. This keeps it to exactly one line.

## The defect

With `emptyCompletionRetry` off — the default — an empty turn is not retried but is reported, so the user has something to correlate instead of an unexplained blank result (#2472). That notice was assembled inline:

```ts
console.warn(
  `[opencodex] ${route.providerName}/${route.modelId} completed with no output text `
  + "and no tool call. Set \"emptyCompletionRetry\": true to retry such turns once.",
);
```

`route.modelId` is whatever the request asked for. A model name containing CR/LF therefore ends the record early and begins new ones, and terminal escapes pass through to whatever renders the log. Measured against current dev with a hostile model name:

```
before: 3 log line(s), escapes=true
after:  1 log line(s), escapes=false
```

This is the same exposure the neighbouring fast-wire warning already avoids — it reduces both labels through `sanitizeLogMetadataString` before logging.

## The fix

Move the sentence into `emptyCompletionNotice` in `empty-completion-guard.ts`, beside the observer whose behavior it describes, and reduce both labels with the existing helper. No new sanitizing logic is introduced.

An unusable label degrades to a stated `unknown` rather than an empty slot, so `unknown/unknown` still reads as a complete sentence.

## Review boundary

Log text only. When the notice fires, what the observer treats as content, the stream itself, and the retry guard are all unchanged. An ordinary route still logs `provider/model` exactly as before.

## Verification

Based on current `dev@47b8d164366b9db9e4331b2bb8b542db22766910`.

- Bun 1.4.0-canary.1: `bun test tests/empty-completion-guard.test.ts tests/empty-completion-core.test.ts tests/empty-completion-hardening.test.ts` — 46 pass, 0 fail.
- Red-proven by measured behavior: the exact pre-fix interpolation yields 3 log lines carrying an ANSI escape for the same hostile model name; the new builder yields 1 line with none.
- `bun run typecheck` and `bun run privacy:scan` both pass.
- The repository-wide suite was intentionally not duplicated locally; hosted CI remains the full-matrix check.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warnings for completed runs that produce no text or tool call.
  * Sanitized provider and model details in warnings to prevent multiline or misleading log entries.
  * Added fallback labels when provider or model information is unavailable.

* **Tests**
  * Added coverage for sanitization, standard route details, and unknown-value fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->