### PR TITLE
fix(test): install gui dependencies the local runner already needs

### DIFF
--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -442,7 +442,7 @@ async function runTestLane(lane: BunTestLane, runId: string, capture = false): P
  *
  * `.github/workflows/ci.yml` already installs them explicitly for exactly this reason; the local
  * runner had no equivalent. Install on demand rather than fail, because the tests genuinely
- * require the directory and `gui/node_modules` is a gitignored build artifact, not source.
+ * require the dependency and `gui/node_modules` is a gitignored build artifact, not source.
  */
 export function ensureGuiDependencies(io: {
   cwd?: string;
@@ -455,9 +455,9 @@ export function ensureGuiDependencies(io: {
   const log = io.log ?? (message => console.warn(message));
   const guiDir = join(cwd, "gui");
   if (!exists(join(guiDir, "package.json"))) return { kind: "absent" };
-  if (exists(join(guiDir, "node_modules"))) return { kind: "present" };
+  if (exists(join(guiDir, "node_modules", "react", "package.json"))) return { kind: "present" };
 
-  log("[test] gui/node_modules is missing; installing it so the tests that import gui/src can resolve React.");
+  log("[test] gui dependencies are missing or incomplete; installing them so tests importing gui/src can resolve React.");
   const install = io.install ?? ((dir: string) => {
     const result = Bun.spawnSync(["bun", "install", "--frozen-lockfile"], {
       cwd: dir,

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { acquireTestRunLock, TEST_RUN_ID_ENV } from "./test-run-lock";
@@ -433,14 +433,66 @@ async function runTestLane(lane: BunTestLane, runId: string, capture = false): P
   }
 }
 
+/**
+ * `gui` is not a workspace of the root package and declares React only in `gui/package.json`, so a
+ * root `bun install` never creates `gui/node_modules`. Twenty-five files under `tests/` import
+ * modules from `gui/src`, which makes those tests fail on a fresh clone or worktree with
+ * `Cannot find package 'react'` — reported as an "Unhandled error between tests" that names no
+ * test, so the cause is not obvious from the output.
+ *
+ * `.github/workflows/ci.yml` already installs them explicitly for exactly this reason; the local
+ * runner had no equivalent. Install on demand rather than fail, because the tests genuinely
+ * require the directory and `gui/node_modules` is a gitignored build artifact, not source.
+ */
+export function ensureGuiDependencies(io: {
+  cwd?: string;
+  exists?: (path: string) => boolean;
+  install?: (guiDir: string) => { ok: boolean; detail: string };
+  log?: (message: string) => void;
+} = {}): { kind: "present" | "installed" | "absent" | "failed"; detail?: string } {
+  const cwd = io.cwd ?? process.cwd();
+  const exists = io.exists ?? existsSync;
+  const log = io.log ?? (message => console.warn(message));
+  const guiDir = join(cwd, "gui");
+  if (!exists(join(guiDir, "package.json"))) return { kind: "absent" };
+  if (exists(join(guiDir, "node_modules"))) return { kind: "present" };
+
+  log("[test] gui/node_modules is missing; installing it so the tests that import gui/src can resolve React.");
+  const install = io.install ?? ((dir: string) => {
+    const result = Bun.spawnSync(["bun", "install", "--frozen-lockfile"], {
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      ok: result.exitCode === 0,
+      detail: decodeOutput(result.stderr) || decodeOutput(result.stdout),
+    };
+  });
+  const outcome = install(guiDir);
+  if (outcome.ok) return { kind: "installed" };
+  return { kind: "failed", detail: outcome.detail };
+}
+
 if (import.meta.main) {
   const requestedTests = process.argv.slice(2);
-  let changedRun: ReturnType<typeof inspectChangedRun> = null;
-  try {
-    changedRun = inspectChangedRun(requestedTests);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+  const guiDependencies = ensureGuiDependencies();
+  if (guiDependencies.kind === "failed") {
+    console.error(
+      "[test] could not install gui/node_modules, which tests importing gui/src need to resolve React.\n"
+      + "       Run it manually: cd gui && bun install --frozen-lockfile\n"
+      + (guiDependencies.detail ? `       ${guiDependencies.detail.trim().split("\n").slice(-3).join("\n       ")}` : ""),
+    );
     process.exitCode = 1;
+  }
+  let changedRun: ReturnType<typeof inspectChangedRun> = null;
+  if (process.exitCode !== 1) {
+    try {
+      changedRun = inspectChangedRun(requestedTests);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
   }
   if (process.exitCode !== 1) {
     if (changedRun) {

--- a/tests/test-runner.test.ts
+++ b/tests/test-runner.test.ts
@@ -465,7 +465,16 @@ describe("ensureGuiDependencies", () => {
   // `gui` is not a workspace, so a root `bun install` leaves gui/node_modules absent and the
   // twenty-five tests importing gui/src die on `Cannot find package 'react'` — an "Unhandled error
   // between tests" that names no test. CI already installs them; this closes the local gap.
-  const paths = (present: string[]) => (path: string) => present.some(entry => path.endsWith(entry));
+  const paths = (present: string[]) => {
+    const normalized = present.map(path => path.replaceAll("\\", "/"));
+    return (path: string) => normalized.some(entry => path.replaceAll("\\", "/").endsWith(entry));
+  };
+
+  test("mocked paths match POSIX and Windows separators", () => {
+    const exists = paths(["gui/package.json"]);
+    expect(exists("/repo/gui/package.json")).toBe(true);
+    expect(exists("C:\\repo\\gui\\package.json")).toBe(true);
+  });
 
   test("installs when gui/package.json exists but node_modules does not", () => {
     const installed: string[] = [];
@@ -479,14 +488,27 @@ describe("ensureGuiDependencies", () => {
 
     expect(result).toEqual({ kind: "installed" });
     expect(installed).toEqual([join("/repo", "gui")]);
-    expect(logged[0]).toContain("gui/node_modules is missing");
+    expect(logged[0]).toContain("gui dependencies are missing or incomplete");
   });
 
-  test("does nothing when node_modules is already there", () => {
+  test("retries when node_modules exists without the required dependency", () => {
     let installs = 0;
     const result = ensureGuiDependencies({
       cwd: "/repo",
       exists: paths(["gui/package.json", "gui/node_modules"]),
+      install: () => { installs += 1; return { ok: true, detail: "" }; },
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "installed" });
+    expect(installs).toBe(1);
+  });
+
+  test("does nothing when the required dependency is already there", () => {
+    let installs = 0;
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json", "gui/node_modules/react/package.json"]),
       install: () => { installs += 1; return { ok: true, detail: "" }; },
       log: () => {},
     });

--- a/tests/test-runner.test.ts
+++ b/tests/test-runner.test.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join } from "node:path";
 import {
   changedSelectionFailure,
   createIsolatedTestEnvironment,
+  ensureGuiDependencies,
   inspectChangedRun,
   resolveBunTestArgs,
   resolveBunTestPlan,
@@ -457,5 +458,67 @@ describe("bun test machine lock", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("ensureGuiDependencies", () => {
+  // `gui` is not a workspace, so a root `bun install` leaves gui/node_modules absent and the
+  // twenty-five tests importing gui/src die on `Cannot find package 'react'` — an "Unhandled error
+  // between tests" that names no test. CI already installs them; this closes the local gap.
+  const paths = (present: string[]) => (path: string) => present.some(entry => path.endsWith(entry));
+
+  test("installs when gui/package.json exists but node_modules does not", () => {
+    const installed: string[] = [];
+    const logged: string[] = [];
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json"]),
+      install: dir => { installed.push(dir); return { ok: true, detail: "" }; },
+      log: message => logged.push(message),
+    });
+
+    expect(result).toEqual({ kind: "installed" });
+    expect(installed).toEqual([join("/repo", "gui")]);
+    expect(logged[0]).toContain("gui/node_modules is missing");
+  });
+
+  test("does nothing when node_modules is already there", () => {
+    let installs = 0;
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json", "gui/node_modules"]),
+      install: () => { installs += 1; return { ok: true, detail: "" }; },
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "present" });
+    expect(installs).toBe(0);
+  });
+
+  // A published install tree has no gui/ at all; the runner must not try to install there.
+  test("does nothing when there is no gui package", () => {
+    let installs = 0;
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: () => false,
+      install: () => { installs += 1; return { ok: true, detail: "" }; },
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "absent" });
+    expect(installs).toBe(0);
+  });
+
+  // Offline or a lockfile drift has to surface as its own message, not as twenty-five
+  // unexplained React failures once the lanes start.
+  test("reports the failure detail instead of continuing", () => {
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json"]),
+      install: () => ({ ok: false, detail: "lockfile had changes" }),
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "failed", detail: "lockfile had changes" });
   });
 });


### PR DESCRIPTION
## Summary

`gui` is not a workspace of the root package and declares React only in `gui/package.json`, so a root `bun install` never creates `gui/node_modules`. Twenty-five files under `tests/` import modules from `gui/src`, so on a fresh clone or worktree those tests fail with `Cannot find package 'react'`.

It surfaces as an **"Unhandled error between tests"** that names no test, which is why this has been read as a flake rather than a missing setup step:

```
tests/tencent-siliconflow-providers.test.ts:

# Unhandled error between tests
-------------------------------
error: Cannot find package 'react' from '<repo>/gui/src/i18n/shared.ts'
-------------------------------
```

## CI already does this; the local runner did not

`.github/workflows/ci.yml` installs them explicitly, and its comment says why:

> Several files under tests/ import JSX-bearing modules from gui/src (ProviderRail and friends), and React is declared only in gui/package.json. Without this the affected shards die on `Cannot find module 'react/jsx-dev-runtime'` while the other shards pass.

```yaml
bun install --frozen-lockfile
cd gui
bun install --frozen-lockfile
```

`bun run test` had no equivalent, so the two did not agree about what the suite needs. Two tests also carry `allowPrivateNetwork`-style workarounds for adjacent environment gaps; this one had none.

## Verification

A/B on a worktree created with only the root install (`gui/node_modules` confirmed absent), running the same gui-importing test:

| `scripts/test.ts` | result |
| --- | --- |
| before | `Cannot find package 'react'` — **0 pass / 1 fail** |
| after | `[test] gui/node_modules is missing; installing it…` — **4 pass / 0 fail** |

- `bun run test` — **16148 pass, 12 skip, 0 fail, exit 0**; all six serial lanes green.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `tests/test-runner.test.ts` — 26 pass / 0 fail, including four new cases.

## Why install rather than fail

`gui/node_modules` is a gitignored build artifact, not source, and the tests genuinely require it. The bounds are what matter:

- runs **only** when `gui/package.json` exists and `gui/node_modules` does not — a published install tree has no `gui/`, so it is untouched (covered by a test);
- uses `--frozen-lockfile`, matching CI;
- a failed install (offline, lockfile drift) **aborts with the manual command** rather than continuing into twenty-five unexplained React failures.

The new cases inject `exists` / `install` / `log`, so they assert the decision without touching a real filesystem or network.

## Scope

This closes the **deterministic** half. A separate intermittent resolution failure still occurs at full-suite scale with the directory present — it does not reproduce with the 25 files run as a group (361 pass / 0 fail under `--isolate --parallel=4`), so it is not addressed here.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test runs now detect missing GUI dependencies and install them automatically when the GUI package is available.
  * Test execution provides actionable failure details if dependency installation fails.
  * Test runs continue without attempting installation when dependencies are already present or no GUI package exists.

* **Tests**
  * Added coverage for dependency detection, installation, existing dependencies, absent GUI packages, and installation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->