### PR TITLE
perf(windows): skip the ACL mutation when the DACL is proven compliant

### DIFF
--- a/src/lib/windows-secret-acl.ts
+++ b/src/lib/windows-secret-acl.ts
@@ -33,6 +33,7 @@ import { existsSync, statSync } from "node:fs";
 import { env, platform } from "node:process";
 import { resolveTrustedWindowsIcaclsExe } from "./windows-elevation";
 import {
+  cachedCurrentWindowsIdentity,
   resolveCurrentWindowsPrincipal,
   resolveCurrentWindowsPrincipalAsync,
   setSyntheticWindowsPrincipalForTests,
@@ -500,6 +501,69 @@ function grantAce(user: string, directory: boolean): string {
   return directory ? `${user}:(OI)(CI)(F)` : `${user}:(F)`;
 }
 
+function existingAclIsCompliant(
+  targetPath: string,
+  directory: boolean,
+  stdout: string,
+  ownerName: string,
+): boolean {
+  const lines = stdout.replaceAll("\r", "").split("\n");
+  const first = lines.shift();
+  if (!first || first.slice(0, targetPath.length).toLowerCase() !== targetPath.toLowerCase()) {
+    return false;
+  }
+  const separator = first[targetPath.length];
+  if (separator !== undefined && !/\s/.test(separator)) return false;
+
+  const aceLines: string[] = [];
+  const firstAce = first.slice(targetPath.length).trim();
+  if (firstAce) aceLines.push(firstAce);
+  for (const line of lines) {
+    if (!line.trim()) break;
+    // Localized summary text is not indented like a continuation ACE.
+    if (!/^\s/.test(line)) break;
+    aceLines.push(line.trim());
+  }
+  if (aceLines.length !== 1) return false;
+
+  const match = /^([^:]+):((?:\([A-Z]+\))+)$/.exec(aceLines[0]!);
+  if (!match || match[1]!.trim().toLowerCase() !== ownerName.toLowerCase()) return false;
+  const rights = [...match[2]!.matchAll(/\(([A-Z]+)\)/g)].map(part => part[1]);
+  const expected = directory ? ["OI", "CI", "F"] : ["F"];
+  return rights.length === expected.length && rights.every((right, index) => right === expected[index]);
+}
+
+function shouldVerifyExistingAcl(): boolean {
+  return env["OPENCODEX_ACL_VERIFY_EXISTING"] === "1";
+}
+
+function existingAclAlreadyCompliant(targetPath: string, directory: boolean): boolean {
+  if (!shouldVerifyExistingAcl()) return false;
+  const identity = cachedCurrentWindowsIdentity();
+  if (!identity) return false;
+  try {
+    const result = icaclsRunner([targetPath], resolveHardenDeadlineMs());
+    return result.success && existingAclIsCompliant(targetPath, directory, result.stdout, identity.name);
+  } catch {
+    return false;
+  }
+}
+
+async function existingAclAlreadyCompliantAsync(
+  targetPath: string,
+  directory: boolean,
+): Promise<boolean> {
+  if (!shouldVerifyExistingAcl()) return false;
+  const identity = cachedCurrentWindowsIdentity();
+  if (!identity) return false;
+  try {
+    const result = await asyncIcaclsRunner([targetPath], resolveHardenDeadlineMs());
+    return result.success && existingAclIsCompliant(targetPath, directory, result.stdout, identity.name);
+  } catch {
+    return false;
+  }
+}
+
 function runIcacls(targetPath: string, directory: boolean, deadline: number): void {
   const principal = currentWindowsPrincipal(deadline);
 
@@ -724,6 +788,7 @@ function hardenEntry(
   if (!existsSync(targetPath)) { cache.delete(targetPath); return { ok: true }; }
   if (effectivePlatform() !== "win32") return { ok: true };
   if (memoSatisfied(cache, targetPath)) return { ok: true };
+  if (existingAclAlreadyCompliant(targetPath, directory)) return { ok: true };
   const memoKey = timeoutMemoKey(targetPath, opts);
   const timeoutMemoError = timeoutMemoErrorIfBlocked(memoKey, opts);
   if (timeoutMemoError) {
@@ -776,6 +841,7 @@ async function hardenEntryAsync(
   if (!existsSync(targetPath)) { cache.delete(targetPath); return { ok: true }; }
   if (effectivePlatform() !== "win32") return { ok: true };
   if (memoSatisfied(cache, targetPath)) return { ok: true };
+  if (await existingAclAlreadyCompliantAsync(targetPath, directory)) return { ok: true };
   const memoKey = timeoutMemoKey(targetPath, opts);
   const timeoutMemoError = timeoutMemoErrorIfBlocked(memoKey, opts);
   if (timeoutMemoError) {

--- a/src/lib/windows-user-principal.ts
+++ b/src/lib/windows-user-principal.ts
@@ -29,8 +29,8 @@ import {
 } from "./windows-elevation";
 
 const SID_PATTERN = /^S-1-(?:\d+-)+\d+$/i;
-const SID_EXPRESSION =
-  "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value";
+const IDENTITY_EXPRESSION =
+  "$identity=[System.Security.Principal.WindowsIdentity]::GetCurrent();$identity.User.Value;$identity.Name";
 const DEFAULT_WINDOWS_ARM64_POWERSHELL = windowsPath.join(
   "C:\\Windows\\System32",
   "WindowsPowerShell",
@@ -106,7 +106,7 @@ const POWERSHELL_ARGS = [
   "-NoProfile",
   "-NonInteractive",
   "-Command",
-  SID_EXPRESSION,
+  IDENTITY_EXPRESSION,
 ] as const;
 
 function windowsPrincipalPowerShellCommand(): string[] {
@@ -167,7 +167,12 @@ async function defaultAsyncWindowsPrincipalRunner(
 
 let principalRunner: WindowsPrincipalRunner = defaultWindowsPrincipalRunner;
 let asyncPrincipalRunner: AsyncWindowsPrincipalRunner = defaultAsyncWindowsPrincipalRunner;
-let cachedPrincipal: string | null = null;
+export interface WindowsPrincipalIdentity {
+  readonly sid: string;
+  readonly name: string;
+}
+
+let cachedIdentity: WindowsPrincipalIdentity | null = null;
 let asyncLookupInFlight: Promise<string> | null = null;
 
 /**
@@ -191,7 +196,7 @@ let syntheticPrincipalForTests: string | null = null;
  */
 export function setSyntheticWindowsPrincipalForTests(principal: string | null): void {
   syntheticPrincipalForTests = principal;
-  cachedPrincipal = null;
+  cachedIdentity = null;
 }
 
 /** True when an explicit runner override is installed and must take precedence. */
@@ -211,17 +216,27 @@ function identityError(reason: string): NodeJS.ErrnoException {
   return error;
 }
 
-function principalFromResult(result: WindowsPrincipalLookupResult): string {
+function identityFromResult(result: WindowsPrincipalLookupResult): WindowsPrincipalIdentity {
   if (!result.success) {
     throw identityError(result.timedOut
       ? "timed out"
       : `exited ${result.exitCode ?? "null"}`);
   }
-  const sid = result.stdout.trim();
+  const lines = result.stdout.trim().split(/\r?\n/);
+  const sid = lines[0]?.trim() ?? "";
+  const name = lines[1]?.trim() ?? "";
   if (!SID_PATTERN.test(sid)) {
     throw identityError(sid ? "returned an invalid SID" : "returned an empty SID");
   }
-  return `*${sid.toUpperCase()}`;
+  if (!name || lines.length !== 2) {
+    throw identityError(name ? "returned an ambiguous account name" : "returned an empty account name");
+  }
+  return Object.freeze({ sid: sid.toUpperCase(), name });
+}
+
+/** Read the effective-token identity only when an earlier lookup already cached it. */
+export function cachedCurrentWindowsIdentity(): WindowsPrincipalIdentity | null {
+  return cachedIdentity;
 }
 
 /** Resolve and process-cache the effective token SID for synchronous ACL paths. */
@@ -229,7 +244,7 @@ export function resolveCurrentWindowsPrincipal(timeoutMs: number): string {
   // Order matters: an explicitly injected runner outranks the synthetic value,
   // so a test can inject a FAILURE on a POSIX host. See the seam comment above.
   if (hasSyncRunnerOverride()) {
-    if (cachedPrincipal) return cachedPrincipal;
+    if (cachedIdentity) return `*${cachedIdentity.sid}`;
     if (timeoutMs <= 0) throw identityError("had no remaining deadline");
     let overridden: WindowsPrincipalLookupResult;
     try {
@@ -237,11 +252,10 @@ export function resolveCurrentWindowsPrincipal(timeoutMs: number): string {
     } catch {
       throw identityError("could not start");
     }
-    const principal = principalFromResult(overridden);
-    cachedPrincipal = principal;
-    return principal;
+    cachedIdentity = identityFromResult(overridden);
+    return `*${cachedIdentity.sid}`;
   }
-  if (cachedPrincipal) return cachedPrincipal;
+  if (cachedIdentity) return `*${cachedIdentity.sid}`;
   if (syntheticPrincipalForTests) return syntheticPrincipalForTests;
   if (timeoutMs <= 0) throw identityError("had no remaining deadline");
   let result: WindowsPrincipalLookupResult;
@@ -250,9 +264,8 @@ export function resolveCurrentWindowsPrincipal(timeoutMs: number): string {
   } catch {
     throw identityError("could not start");
   }
-  const principal = principalFromResult(result);
-  cachedPrincipal = principal;
-  return principal;
+  cachedIdentity = identityFromResult(result);
+  return `*${cachedIdentity.sid}`;
 }
 
 async function waitForExistingLookup(
@@ -284,7 +297,7 @@ async function waitForExistingLookup(
  */
 export async function resolveCurrentWindowsPrincipalAsync(timeoutMs: number): Promise<string> {
   const overridden = hasAsyncRunnerOverride();
-  if (cachedPrincipal) return cachedPrincipal;
+  if (cachedIdentity) return `*${cachedIdentity.sid}`;
   if (asyncLookupInFlight) return waitForExistingLookup(asyncLookupInFlight, timeoutMs);
   // Same precedence rule as the sync path: an injected runner beats the synthetic.
   if (!overridden && syntheticPrincipalForTests) return syntheticPrincipalForTests;
@@ -297,9 +310,8 @@ export async function resolveCurrentWindowsPrincipalAsync(timeoutMs: number): Pr
     } catch {
       throw identityError("could not start");
     }
-    const principal = principalFromResult(result);
-    cachedPrincipal = principal;
-    return principal;
+    cachedIdentity = identityFromResult(result);
+    return `*${cachedIdentity.sid}`;
   })();
   asyncLookupInFlight = lookup;
   try {
@@ -317,7 +329,7 @@ export function setWindowsPrincipalRunnerForTests(
     throw new Error("Cannot replace the Windows principal runner while a lookup is in flight.");
   }
   principalRunner = runner ?? defaultWindowsPrincipalRunner;
-  cachedPrincipal = null;
+  cachedIdentity = null;
 }
 
 /** Test seam: replace the async resolver process and clear its successful cache. */
@@ -328,7 +340,7 @@ export function setAsyncWindowsPrincipalRunnerForTests(
     throw new Error("Cannot replace the Windows principal runner while a lookup is in flight.");
   }
   asyncPrincipalRunner = runner ?? defaultAsyncWindowsPrincipalRunner;
-  cachedPrincipal = null;
+  cachedIdentity = null;
 }
 
 /** Test seam: clear only process-local principal state. */
@@ -336,6 +348,6 @@ export function resetWindowsPrincipalForTests(): void {
   if (asyncLookupInFlight) {
     throw new Error("Cannot reset the Windows principal while a lookup is in flight.");
   }
-  cachedPrincipal = null;
+  cachedIdentity = null;
   syntheticPrincipalForTests = null;
 }

--- a/tests/windows-secret-acl.test.ts
+++ b/tests/windows-secret-acl.test.ts
@@ -38,6 +38,7 @@ import { nativeMainClaimPath, withNativeMainSharedClaim } from "../src/codex/nat
 import { NATIVE_MAIN_OWNER_DB, retainNativeMainOwner } from "../src/codex/native-main-owner";
 import {
   resetWindowsPrincipalForTests,
+  resolveCurrentWindowsPrincipal,
   setAsyncWindowsPrincipalRunnerForTests,
   setWindowsPrincipalRunnerForTests,
 } from "../src/lib/windows-user-principal";
@@ -49,16 +50,21 @@ let testDir = "";
 // budget pins it explicitly, and a stray value in the developer's environment cannot change
 // what any of these assert.
 let previousAclTimeout: string | undefined;
+let previousAclVerifyExisting: string | undefined;
 
 beforeEach(() => {
   previousAclTimeout = process.env.OPENCODEX_ACL_TIMEOUT_MS;
+  previousAclVerifyExisting = process.env.OPENCODEX_ACL_VERIFY_EXISTING;
   delete process.env.OPENCODEX_ACL_TIMEOUT_MS;
+  delete process.env.OPENCODEX_ACL_VERIFY_EXISTING;
   testDir = mkdtempSync(join(tmpdir(), "ocx-acl-test-"));
 });
 
 afterEach(() => {
   if (previousAclTimeout === undefined) delete process.env.OPENCODEX_ACL_TIMEOUT_MS;
   else process.env.OPENCODEX_ACL_TIMEOUT_MS = previousAclTimeout;
+  if (previousAclVerifyExisting === undefined) delete process.env.OPENCODEX_ACL_VERIFY_EXISTING;
+  else process.env.OPENCODEX_ACL_VERIFY_EXISTING = previousAclVerifyExisting;
   if (testDir && existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
   testDir = "";
 });
@@ -303,6 +309,147 @@ describe("effective Windows principal integration", () => {
       if (oldUser === undefined) delete process.env.USERNAME;
       else process.env.USERNAME = oldUser;
     }
+  });
+});
+
+describe("opt-in existing ACL proof", () => {
+  const ownerSid = "S-1-5-21-111-222-333-1001";
+  const ownerName = "EXAMPLE\\Owner";
+  const success = (stdout = ""): IcaclsResult => ({
+    success: true,
+    exitCode: 0,
+    timedOut: false,
+    stdout,
+  });
+
+  function seedIdentity(): void {
+    setWindowsPrincipalRunnerForTests(() => ({
+      ...success(`${ownerSid}\r\n${ownerName}\r\n`),
+    }));
+    expect(resolveCurrentWindowsPrincipal(1_000)).toBe(`*${ownerSid}`);
+  }
+
+  beforeEach(() => {
+    resetHardenedStateForTests();
+    resetWindowsPrincipalForTests();
+    setPlatformForTests("win32");
+    process.env.OPENCODEX_ACL_VERIFY_EXISTING = "1";
+    seedIdentity();
+  });
+
+  afterEach(() => {
+    setIcaclsRunnerForTests(null);
+    setAsyncIcaclsRunnerForTests(null);
+    setPlatformForTests(null);
+    resetHardenedStateForTests();
+    setWindowsPrincipalRunnerForTests(null);
+    setAsyncWindowsPrincipalRunnerForTests(null);
+    resetWindowsPrincipalForTests();
+  });
+
+  test("a same-line explicit owner ACE skips sync mutation", () => {
+    const target = join(testDir, "already-private.json");
+    writeFileSync(target, "secret");
+    const calls: string[][] = [];
+    setIcaclsRunnerForTests(args => {
+      calls.push(args);
+      return success(`${target} ${ownerName}:(F)\r\n\r\nSuccessfully processed 1 files; Failed processing 0 files\r\n`);
+    });
+
+    expect(hardenSecretPath(target, { required: true })).toEqual({ ok: true });
+    expect(calls).toEqual([[target]]);
+  });
+
+  test("localized summary text and case-varied owner skip async directory mutation", async () => {
+    const target = join(testDir, "already-private-dir");
+    mkdirSync(target);
+    const calls: string[][] = [];
+    setAsyncWindowsPrincipalRunnerForTests(async () => success(`${ownerSid}\n${ownerName}\n`));
+    seedIdentity();
+    setAsyncIcaclsRunnerForTests(async args => {
+      calls.push(args);
+      return success(`${target} ${ownerName.toLowerCase()}:(OI)(CI)(F)\r\n\r\n1 archivos procesados correctamente; error al procesar 0 archivos\r\n`);
+    });
+
+    expect(await hardenSecretDirAsync(target, { required: true })).toEqual({ ok: true });
+    expect(calls).toEqual([[target]]);
+  });
+
+  test("an inherited owner ACE falls through to the mutation sequence", () => {
+    const target = join(testDir, "inherited.json");
+    writeFileSync(target, "secret");
+    const calls: string[][] = [];
+    setIcaclsRunnerForTests(args => {
+      calls.push(args);
+      if (calls.length === 1) return success(`${target} ${ownerName}:(I)(F)\r\n`);
+      return success();
+    });
+
+    expect(hardenSecretPath(target, { required: true })).toEqual({ ok: true });
+    expect(calls.map(args => args[1] ?? "read")).toEqual(["read", "/grant:r", "/inheritance:r", "/remove:g"]);
+  });
+
+  test("an unexpected broad principal falls through to mutation", () => {
+    const target = join(testDir, "broad.json");
+    writeFileSync(target, "secret");
+    const calls: string[][] = [];
+    setIcaclsRunnerForTests(args => {
+      calls.push(args);
+      if (calls.length === 1) {
+        return success(`${target} ${ownerName}:(F)\r\n        BUILTIN\\Users:(RX)\r\n`);
+      }
+      return success();
+    });
+
+    expect(hardenSecretPath(target, { required: true })).toEqual({ ok: true });
+    expect(calls.map(args => args[1] ?? "read")).toEqual(["read", "/grant:r", "/inheritance:r", "/remove:g"]);
+  });
+
+  test("an identity cache miss performs no read and uses the existing harden path", () => {
+    const target = join(testDir, "cold-identity.json");
+    writeFileSync(target, "secret");
+    resetWindowsPrincipalForTests();
+    let identityCalls = 0;
+    const calls: string[][] = [];
+    setWindowsPrincipalRunnerForTests(() => {
+      identityCalls += 1;
+      return { ...success(`${ownerSid}\n${ownerName}\n`) };
+    });
+    setIcaclsRunnerForTests(args => { calls.push(args); return success(); });
+
+    expect(hardenSecretPath(target, { required: true })).toEqual({ ok: true });
+    expect(identityCalls).toBe(1);
+    expect(calls.map(args => args[1])).toEqual(["/grant:r", "/inheritance:r", "/remove:g"]);
+  });
+
+  test("read-only success never enters the post-mutation memo", () => {
+    const target = join(testDir, "memo-free.json");
+    writeFileSync(target, "secret");
+    setIcaclsRunnerForTests(() => success(`${target} ${ownerName}:(F)\r\n`));
+
+    expect(hardenSecretPath(target, { required: true })).toEqual({ ok: true });
+    expect(hardenedSecretPathCountForTests()).toBe(0);
+    delete process.env.OPENCODEX_ACL_VERIFY_EXISTING;
+    const mutations: string[][] = [];
+    setIcaclsRunnerForTests(args => { mutations.push(args); return success(); });
+    expect(hardenSecretPath(target, { required: true })).toEqual({ ok: true });
+    expect(mutations.map(args => args[1])).toEqual(["/grant:r", "/inheritance:r", "/remove:g"]);
+    expect(hardenedSecretPathCountForTests()).toBe(1);
+  });
+
+  test("the default flag-off path preserves the exact mutation sequence", () => {
+    const target = join(testDir, "default-mutation.json");
+    writeFileSync(target, "secret");
+    delete process.env.OPENCODEX_ACL_VERIFY_EXISTING;
+    const calls: string[][] = [];
+    setIcaclsRunnerForTests(args => { calls.push(args); return success(); });
+
+    expect(hardenSecretPath(target, { required: true })).toEqual({ ok: true });
+    expect(calls).toEqual([
+      [target, "/grant:r", `*${ownerSid}:(F)`],
+      [target, "/inheritance:r"],
+      [target, "/remove:g", "*S-1-1-0", "*S-1-5-11", "*S-1-5-32-545"],
+    ]);
   });
 });
 

--- a/tests/windows-user-principal.test.ts
+++ b/tests/windows-user-principal.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  cachedCurrentWindowsIdentity,
   resetWindowsPrincipalForTests,
   resolveCurrentWindowsPrincipal,
   resolveCurrentWindowsPrincipalAsync,
@@ -14,7 +15,7 @@ import {
   WindowsSystemDirectoryFfiUnavailableError,
 } from "../src/lib/windows-elevation";
 
-const ok = (stdout = "S-1-5-21-111-222-333-1001\r\n") => ({
+const ok = (stdout = "S-1-5-21-111-222-333-1001\r\nEXAMPLE\\Owner\r\n") => ({
   success: true,
   exitCode: 0,
   timedOut: false,
@@ -38,7 +39,7 @@ describe("Windows effective ACL principal", () => {
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      "[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value",
+      "$identity=[System.Security.Principal.WindowsIdentity]::GetCurrent();$identity.User.Value;$identity.Name",
     ]);
   });
 
@@ -206,6 +207,21 @@ describe("Windows effective ACL principal", () => {
     expect(resolveCurrentWindowsPrincipal(1_000)).toMatch(/^\*S-1-/);
     expect(resolveCurrentWindowsPrincipal(1_000)).toMatch(/^\*S-1-/);
     expect(calls).toBe(1);
+    expect(cachedCurrentWindowsIdentity()).toEqual({
+      sid: "S-1-5-21-111-222-333-1001",
+      name: "EXAMPLE\\Owner",
+    });
+    expect(resolveCurrentWindowsPrincipal(0)).toBe("*S-1-5-21-111-222-333-1001");
+  });
+
+  test("a cache-only identity read never starts the resolver", () => {
+    let calls = 0;
+    setWindowsPrincipalRunnerForTests(() => {
+      calls += 1;
+      return ok();
+    });
+    expect(cachedCurrentWindowsIdentity()).toBeNull();
+    expect(calls).toBe(0);
   });
 
   test("invalid output fails closed and is retried rather than cached", () => {


### PR DESCRIPTION
## Summary

On Windows, securing a secret path always ran the full mutation sequence — `/grant:r`,
`/inheritance:r`, and broad-SID removal — even when the DACL already matched the policy exactly.
That is measurable multi-second startup cost spent to reach a state the path was already in.

This adds an opt-in read-only proof gate: when the DACL can be proven compliant, skip the
mutation. Anything less than a proof falls through to the existing code path unchanged.

Closes #1298.

## Why opt-in and strict

This is a permission path, so the failure mode of a wrong "already compliant" answer is a secret
left readable. The gate is therefore built to be hard to fool rather than easy to satisfy:

- Off by default. Behavior with `OPENCODEX_ACL_VERIFY_EXISTING` unset is byte-for-byte what it is
  today, which the tests assert directly.
- Success requires an exact proof: explicit owner Full Control, inheritance disabled, and no
  unexpected principal. A parse failure, a localized `icacls` output it cannot read, an inherited
  ACE, a broad principal, or an identity cache miss all fall through and mutate.
- A read-only success does **not** enter the post-mutation memo. A proof that the state is correct
  is not a record that this process set it.
- No recursive scan; descendant cost stays constant.

The cached effective SID/name lookup this needs already exists in `windows-user-principal.ts`, so
the gate spends no extra identity budget.

## Verification

Based on `dev@47b8d1643`.

- `bun test tests/windows-secret-acl.test.ts tests/windows-user-principal.test.ts` → **185 pass, 0 fail**
- `bun x tsc --noEmit` → clean
- **Mutation-proven**: inverting the proof verdict turns two of the new assertions red; restoring it
  returns them to green, so the gate is not vacuous.

New cases cover same-line ACEs, localized output, an inherited ACE, an unexpected broad principal,
an identity cache miss, both the sync and async paths, and the assertion that the read-only success
path leaves the memo untouched.

## Review boundary

This changes when a Windows ACL mutation is skipped, so it wants a non-author security review
rather than a routine pass. The Windows-specific assertions run on the dispatched Windows leg.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in Windows ACL verification mode that detects compliant permissions before making changes.
  - Existing compliant file and directory permissions can now skip unnecessary updates.

- **Bug Fixes**
  - Improved Windows identity detection by reliably tracking both the account name and security identifier.

- **Tests**
  - Added coverage for compliant, inherited, and broader permission scenarios, along with identity caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->