### PR TITLE
fix(test): install gui dependencies the local runner needs

### DIFF
--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -442,7 +442,7 @@ async function runTestLane(lane: BunTestLane, runId: string, capture = false): P
  *
  * `.github/workflows/ci.yml` already installs them explicitly for exactly this reason; the local
  * runner had no equivalent. Install on demand rather than fail, because the tests genuinely
- * require the directory and `gui/node_modules` is a gitignored build artifact, not source.
+ * require the dependency and `gui/node_modules` is a gitignored build artifact, not source.
  */
 export function ensureGuiDependencies(io: {
   cwd?: string;
@@ -455,9 +455,9 @@ export function ensureGuiDependencies(io: {
   const log = io.log ?? (message => console.warn(message));
   const guiDir = join(cwd, "gui");
   if (!exists(join(guiDir, "package.json"))) return { kind: "absent" };
-  if (exists(join(guiDir, "node_modules"))) return { kind: "present" };
+  if (exists(join(guiDir, "node_modules", "react", "package.json"))) return { kind: "present" };
 
-  log("[test] gui/node_modules is missing; installing it so the tests that import gui/src can resolve React.");
+  log("[test] gui dependencies are missing or incomplete; installing them so tests importing gui/src can resolve React.");
   const install = io.install ?? ((dir: string) => {
     const result = Bun.spawnSync(["bun", "install", "--frozen-lockfile"], {
       cwd: dir,

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { acquireTestRunLock, TEST_RUN_ID_ENV } from "./test-run-lock";
@@ -433,14 +433,66 @@ async function runTestLane(lane: BunTestLane, runId: string, capture = false): P
   }
 }
 
+/**
+ * `gui` is not a workspace of the root package and declares React only in `gui/package.json`, so a
+ * root `bun install` never creates `gui/node_modules`. Twenty-five files under `tests/` import
+ * modules from `gui/src`, which makes those tests fail on a fresh clone or worktree with
+ * `Cannot find package 'react'` — reported as an "Unhandled error between tests" that names no
+ * test, so the cause is not obvious from the output.
+ *
+ * `.github/workflows/ci.yml` already installs them explicitly for exactly this reason; the local
+ * runner had no equivalent. Install on demand rather than fail, because the tests genuinely
+ * require the directory and `gui/node_modules` is a gitignored build artifact, not source.
+ */
+export function ensureGuiDependencies(io: {
+  cwd?: string;
+  exists?: (path: string) => boolean;
+  install?: (guiDir: string) => { ok: boolean; detail: string };
+  log?: (message: string) => void;
+} = {}): { kind: "present" | "installed" | "absent" | "failed"; detail?: string } {
+  const cwd = io.cwd ?? process.cwd();
+  const exists = io.exists ?? existsSync;
+  const log = io.log ?? (message => console.warn(message));
+  const guiDir = join(cwd, "gui");
+  if (!exists(join(guiDir, "package.json"))) return { kind: "absent" };
+  if (exists(join(guiDir, "node_modules"))) return { kind: "present" };
+
+  log("[test] gui/node_modules is missing; installing it so the tests that import gui/src can resolve React.");
+  const install = io.install ?? ((dir: string) => {
+    const result = Bun.spawnSync(["bun", "install", "--frozen-lockfile"], {
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      ok: result.exitCode === 0,
+      detail: decodeOutput(result.stderr) || decodeOutput(result.stdout),
+    };
+  });
+  const outcome = install(guiDir);
+  if (outcome.ok) return { kind: "installed" };
+  return { kind: "failed", detail: outcome.detail };
+}
+
 if (import.meta.main) {
   const requestedTests = process.argv.slice(2);
-  let changedRun: ReturnType<typeof inspectChangedRun> = null;
-  try {
-    changedRun = inspectChangedRun(requestedTests);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+  const guiDependencies = ensureGuiDependencies();
+  if (guiDependencies.kind === "failed") {
+    console.error(
+      "[test] could not install gui/node_modules, which tests importing gui/src need to resolve React.\n"
+      + "       Run it manually: cd gui && bun install --frozen-lockfile\n"
+      + (guiDependencies.detail ? `       ${guiDependencies.detail.trim().split("\n").slice(-3).join("\n       ")}` : ""),
+    );
     process.exitCode = 1;
+  }
+  let changedRun: ReturnType<typeof inspectChangedRun> = null;
+  if (process.exitCode !== 1) {
+    try {
+      changedRun = inspectChangedRun(requestedTests);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
   }
   if (process.exitCode !== 1) {
     if (changedRun) {

--- a/tests/test-runner.test.ts
+++ b/tests/test-runner.test.ts
@@ -465,7 +465,16 @@ describe("ensureGuiDependencies", () => {
   // `gui` is not a workspace, so a root `bun install` leaves gui/node_modules absent and the
   // twenty-five tests importing gui/src die on `Cannot find package 'react'` — an "Unhandled error
   // between tests" that names no test. CI already installs them; this closes the local gap.
-  const paths = (present: string[]) => (path: string) => present.some(entry => path.endsWith(entry));
+  const paths = (present: string[]) => {
+    const normalized = present.map(path => path.replaceAll("\\", "/"));
+    return (path: string) => normalized.some(entry => path.replaceAll("\\", "/").endsWith(entry));
+  };
+
+  test("mocked paths match POSIX and Windows separators", () => {
+    const exists = paths(["gui/package.json"]);
+    expect(exists("/repo/gui/package.json")).toBe(true);
+    expect(exists("C:\\repo\\gui\\package.json")).toBe(true);
+  });
 
   test("installs when gui/package.json exists but node_modules does not", () => {
     const installed: string[] = [];
@@ -479,14 +488,27 @@ describe("ensureGuiDependencies", () => {
 
     expect(result).toEqual({ kind: "installed" });
     expect(installed).toEqual([join("/repo", "gui")]);
-    expect(logged[0]).toContain("gui/node_modules is missing");
+    expect(logged[0]).toContain("gui dependencies are missing or incomplete");
   });
 
-  test("does nothing when node_modules is already there", () => {
+  test("retries when node_modules exists without the required dependency", () => {
     let installs = 0;
     const result = ensureGuiDependencies({
       cwd: "/repo",
       exists: paths(["gui/package.json", "gui/node_modules"]),
+      install: () => { installs += 1; return { ok: true, detail: "" }; },
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "installed" });
+    expect(installs).toBe(1);
+  });
+
+  test("does nothing when the required dependency is already there", () => {
+    let installs = 0;
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json", "gui/node_modules/react/package.json"]),
       install: () => { installs += 1; return { ok: true, detail: "" }; },
       log: () => {},
     });

--- a/tests/test-runner.test.ts
+++ b/tests/test-runner.test.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join } from "node:path";
 import {
   changedSelectionFailure,
   createIsolatedTestEnvironment,
+  ensureGuiDependencies,
   inspectChangedRun,
   resolveBunTestArgs,
   resolveBunTestPlan,
@@ -457,5 +458,67 @@ describe("bun test machine lock", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("ensureGuiDependencies", () => {
+  // `gui` is not a workspace, so a root `bun install` leaves gui/node_modules absent and the
+  // twenty-five tests importing gui/src die on `Cannot find package 'react'` — an "Unhandled error
+  // between tests" that names no test. CI already installs them; this closes the local gap.
+  const paths = (present: string[]) => (path: string) => present.some(entry => path.endsWith(entry));
+
+  test("installs when gui/package.json exists but node_modules does not", () => {
+    const installed: string[] = [];
+    const logged: string[] = [];
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json"]),
+      install: dir => { installed.push(dir); return { ok: true, detail: "" }; },
+      log: message => logged.push(message),
+    });
+
+    expect(result).toEqual({ kind: "installed" });
+    expect(installed).toEqual([join("/repo", "gui")]);
+    expect(logged[0]).toContain("gui/node_modules is missing");
+  });
+
+  test("does nothing when node_modules is already there", () => {
+    let installs = 0;
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json", "gui/node_modules"]),
+      install: () => { installs += 1; return { ok: true, detail: "" }; },
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "present" });
+    expect(installs).toBe(0);
+  });
+
+  // A published install tree has no gui/ at all; the runner must not try to install there.
+  test("does nothing when there is no gui package", () => {
+    let installs = 0;
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: () => false,
+      install: () => { installs += 1; return { ok: true, detail: "" }; },
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "absent" });
+    expect(installs).toBe(0);
+  });
+
+  // Offline or a lockfile drift has to surface as its own message, not as twenty-five
+  // unexplained React failures once the lanes start.
+  test("reports the failure detail instead of continuing", () => {
+    const result = ensureGuiDependencies({
+      cwd: "/repo",
+      exists: paths(["gui/package.json"]),
+      install: () => ({ ok: false, detail: "lockfile had changes" }),
+      log: () => {},
+    });
+
+    expect(result).toEqual({ kind: "failed", detail: "lockfile had changes" });
   });
 });


### PR DESCRIPTION
## Summary

Carries #2957 by @olddonkey, plus one repair commit. The local test runner assumed `gui/node_modules`
was already populated, so a fresh worktree failed inside the GUI tests instead of installing what it
needs.

Opened as a maintainer PR because pushing the repair to the contributor branch reset its
review-readiness checklist and returned it to draft. That checklist is an author attestation bound to
an exact head, so it is not mine to tick. Cherry-pick preserves @olddonkey's authorship on the
original commit.

Carries #2957. Close that PR as carried once this lands.

## The repairs

Two defects found while auditing the original:

- `tests/test-runner.test.ts` compared mocked path suffixes built with a hardcoded `/`. On Windows
  `join()` yields `\repo\gui\package.json`, so three of the four new cases reported `absent` and
  failed. The suffixes are now built platform-aware, and the test exercises both separators rather
  than trusting the host.
- `scripts/test.ts` treated the mere existence of `gui/node_modules` as a finished install. An
  interrupted `bun install` leaves that directory behind, so the next run reported `present` and
  proceeded with missing React. It now checks a concrete dependency marker, so an incomplete install
  retries.

## Verification

Based on `dev@dca16949b`.

- `bun run test tests/test-runner.test.ts` → **28 pass, 2 skip, 0 fail**
- `bun x tsc --noEmit` → clean

Windows separator behavior is covered by simulating both separators in the test; the Windows leg is
dispatched separately since `platform-windows` does not run on push.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

