### PR TITLE
fix(config): start when proxy settings hold values the schema never constrained

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3126,6 +3126,26 @@ export function resolveEnvValue(value: string | undefined): string | undefined {
   return value;
 }
 
+const warnedProxyConfigDiscards = new Set<"proxy" | "noProxy" | "noProxyElements">();
+
+function warnProxyConfigDiscardOnce(kind: "proxy" | "noProxy" | "noProxyElements"): void {
+  if (warnedProxyConfigDiscards.has(kind)) return;
+  warnedProxyConfigDiscards.add(kind);
+  if (kind === "proxy") {
+    console.warn(
+      "⚠️  config.json proxy was discarded because it is not a non-empty resolved string — configured proxy routing is disabled; existing proxy environment variables remain authoritative, otherwise outbound requests use direct egress",
+    );
+  } else if (kind === "noProxy") {
+    console.warn(
+      "⚠️  config.json noProxy was discarded because it is not a string, string array, or resolved environment reference — existing NO_PROXY and loopback bypasses remain",
+    );
+  } else {
+    console.warn(
+      "⚠️  config.json noProxy contains invalid elements — invalid elements were ignored; valid entries, existing NO_PROXY, and loopback bypasses remain",
+    );
+  }
+}
+
 /**
  * Mirror `config.proxy` into HTTP(S)_PROXY env vars so Bun's native fetch routes every outbound
  * provider call through the proxy — no per-callsite changes (verified: Bun honors these plus
@@ -3138,10 +3158,14 @@ export function applyProxyEnv(config: OcxConfig): void {
   // `.passthrough()`, so whatever is on disk arrives here verbatim. A non-string value
   // reached string-only methods and threw out of this function, and it runs once per
   // process entry point — the failure was a startup crash, not a degraded proxy. Ignore
-  // malformed values instead: they cannot express a routing intent, and refusing to start
-  // is a worse answer than starting without them.
-  const proxy = typeof config.proxy === "string" ? resolveEnvValue(config.proxy) : undefined;
-  if (!proxy) return;
+  // malformed values with a privacy-safe warning instead: they cannot express a routing
+  // intent, and refusing to start is a worse answer than starting without them.
+  const rawProxy = config.proxy;
+  const proxy = typeof rawProxy === "string" ? resolveEnvValue(rawProxy) : undefined;
+  if (!proxy) {
+    if (rawProxy !== undefined) warnProxyConfigDiscardOnce("proxy");
+    return;
+  }
   if (!process.env.HTTP_PROXY?.trim() && !process.env.http_proxy?.trim()) process.env.HTTP_PROXY = proxy;
   if (!process.env.HTTPS_PROXY?.trim() && !process.env.https_proxy?.trim()) process.env.HTTPS_PROXY = proxy;
   const existing = process.env.NO_PROXY ?? process.env.no_proxy ?? "";
@@ -3150,10 +3174,20 @@ export function applyProxyEnv(config: OcxConfig): void {
   // Configured entries first, then loopback: loopback is unconditional, so appending it last
   // keeps it present even when the operator lists a loopback host themselves.
   const raw = config.noProxy;
-  const configured = (Array.isArray(raw)
+  let configuredEntries: string[];
+  if (Array.isArray(raw)) {
     // One unusable element must not discard the operator's other entries.
-    ? raw.filter((entry): entry is string => typeof entry === "string")
-    : (typeof raw === "string" ? resolveEnvValue(raw) ?? "" : "").split(","))
+    if (raw.some(entry => typeof entry !== "string")) warnProxyConfigDiscardOnce("noProxyElements");
+    configuredEntries = raw.filter((entry): entry is string => typeof entry === "string");
+  } else if (typeof raw === "string") {
+    const resolved = resolveEnvValue(raw);
+    if (raw && resolved === undefined) warnProxyConfigDiscardOnce("noProxy");
+    configuredEntries = (resolved ?? "").split(",");
+  } else {
+    if (raw !== undefined) warnProxyConfigDiscardOnce("noProxy");
+    configuredEntries = [];
+  }
+  const configured = configuredEntries
     .map(entry => entry.trim())
     .filter(Boolean);
   for (const host of [...configured, "localhost", "127.0.0.1", "::1", "[::1]"]) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3134,7 +3134,13 @@ export function resolveEnvValue(value: string | undefined): string | undefined {
  * that makes outbound provider requests (server start, catalog sync).
  */
 export function applyProxyEnv(config: OcxConfig): void {
-  const proxy = resolveEnvValue(config.proxy);
+  // `proxy` and `noProxy` are not declared in the top-level schema, which ends in
+  // `.passthrough()`, so whatever is on disk arrives here verbatim. A non-string value
+  // reached string-only methods and threw out of this function, and it runs once per
+  // process entry point — the failure was a startup crash, not a degraded proxy. Ignore
+  // malformed values instead: they cannot express a routing intent, and refusing to start
+  // is a worse answer than starting without them.
+  const proxy = typeof config.proxy === "string" ? resolveEnvValue(config.proxy) : undefined;
   if (!proxy) return;
   if (!process.env.HTTP_PROXY?.trim() && !process.env.http_proxy?.trim()) process.env.HTTP_PROXY = proxy;
   if (!process.env.HTTPS_PROXY?.trim() && !process.env.https_proxy?.trim()) process.env.HTTPS_PROXY = proxy;
@@ -3144,7 +3150,10 @@ export function applyProxyEnv(config: OcxConfig): void {
   // Configured entries first, then loopback: loopback is unconditional, so appending it last
   // keeps it present even when the operator lists a loopback host themselves.
   const raw = config.noProxy;
-  const configured = (Array.isArray(raw) ? raw : (resolveEnvValue(raw) ?? "").split(","))
+  const configured = (Array.isArray(raw)
+    // One unusable element must not discard the operator's other entries.
+    ? raw.filter((entry): entry is string => typeof entry === "string")
+    : (typeof raw === "string" ? resolveEnvValue(raw) ?? "" : "").split(","))
     .map(entry => entry.trim())
     .filter(Boolean);
   for (const host of [...configured, "localhost", "127.0.0.1", "::1", "[::1]"]) {

--- a/tests/proxy-env.test.ts
+++ b/tests/proxy-env.test.ts
@@ -24,6 +24,36 @@ function configWithProxy(proxy?: string, noProxy?: string | string[]): OcxConfig
   return { proxy, noProxy, providers: {} } as unknown as OcxConfig;
 }
 
+// The top-level config schema ends in `.passthrough()` and declares neither `proxy` nor
+// `noProxy`, so these shapes survive validation and reach applyProxyEnv verbatim.
+function configWithRawProxy(proxy: unknown, noProxy?: unknown): OcxConfig {
+  return { proxy, noProxy, providers: {} } as unknown as OcxConfig;
+}
+
+describe("applyProxyEnv with values the schema does not constrain", () => {
+  // applyProxyEnv runs at every process entry point that makes outbound requests, so a
+  // throw here is a startup crash rather than a degraded proxy.
+  test("a non-string proxy does not throw and sets no proxy env", () => {
+    expect(() => applyProxyEnv(configWithRawProxy(42))).not.toThrow();
+    expect(process.env.HTTP_PROXY).toBeUndefined();
+    expect(process.env.HTTPS_PROXY).toBeUndefined();
+  });
+
+  test("a non-string noProxy does not throw and keeps loopback exclusions", () => {
+    expect(() => applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", 42))).not.toThrow();
+    expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1]");
+  });
+
+  test.each([
+    ["a number", 42],
+    ["null", null],
+    ["an object", { a: 1 }],
+  ])("keeps the operator's usable noProxy entries when the array also holds %s", (_label, bad) => {
+    expect(() => applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", ["internal.example", bad]))).not.toThrow();
+    expect(process.env.NO_PROXY).toBe("internal.example,localhost,127.0.0.1,::1,[::1]");
+  });
+});
+
 describe("applyProxyEnv", () => {
   test("no-op when config.proxy is unset", () => {
     process.env.NO_PROXY = "operator-owned.example";

--- a/tests/proxy-env.test.ts
+++ b/tests/proxy-env.test.ts
@@ -31,6 +31,41 @@ function configWithRawProxy(proxy: unknown, noProxy?: unknown): OcxConfig {
 }
 
 describe("applyProxyEnv with values the schema does not constrain", () => {
+  test("warns once per discarded proxy setting without exposing its raw value", () => {
+    const secret = "raw-proxy-credential-sentinel-2947";
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      const invalidProxy = { secret };
+      applyProxyEnv(configWithRawProxy(invalidProxy));
+      applyProxyEnv(configWithRawProxy(invalidProxy));
+      expect(process.env.HTTP_PROXY).toBeUndefined();
+      expect(process.env.HTTPS_PROXY).toBeUndefined();
+
+      const invalidNoProxy = { secret };
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", invalidNoProxy));
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", invalidNoProxy));
+      expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1]");
+
+      const invalidElement = { secret };
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", ["internal.example", invalidElement]));
+      applyProxyEnv(configWithRawProxy("http://proxy.corp:8080", ["internal.example", invalidElement]));
+      expect(process.env.NO_PROXY).toBe("localhost,127.0.0.1,::1,[::1],internal.example");
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnings).toHaveLength(3);
+    expect(warnings[0]).toContain("config.json proxy was discarded");
+    expect(warnings[0]).toContain("direct egress");
+    expect(warnings[1]).toContain("config.json noProxy was discarded");
+    expect(warnings[1]).toContain("existing NO_PROXY and loopback bypasses remain");
+    expect(warnings[2]).toContain("config.json noProxy contains invalid elements");
+    expect(warnings[2]).toContain("invalid elements were ignored");
+    expect(warnings.join("\n")).not.toContain(secret);
+  });
+
   // applyProxyEnv runs at every process entry point that makes outbound requests, so a
   // throw here is a startup crash rather than a degraded proxy.
   test("a non-string proxy does not throw and sets no proxy env", () => {


### PR DESCRIPTION
## Summary

Carries #2947 by @luvs01, plus one repair commit. A `proxy` or `noProxy` value the schema never
constrained crashed startup instead of being handled.

Opened as a maintainer PR because pushing the repair to the contributor branch reset its
review-readiness checklist and returned it to draft; that attestation belongs to the author. The
cherry-pick preserves @luvs01's authorship.

Carries #2947. Close it as carried once this lands.

## The repair

Starting gracefully is right. Doing it silently is not: as originally written, an explicitly configured
but invalid `proxy` became **direct** outbound traffic with no signal, and invalid `noProxy` entries
were dropped so destinations the operator meant to bypass would traverse the proxy. That is a
fail-open network-policy change an operator has no way to notice.

Each discarded value now emits a privacy-safe warning, once per process, naming what was dropped and
what the effective behavior is. The raw value is never logged — proxy URLs can embed credentials, and
the test asserts it never appears in the output.

## Verification

Based on `dev@dca16949b`.

- `bun test tests/proxy-env.test.ts tests/config.test.ts` → **174 pass, 0 fail**
- **Red-proven**: the new assertion fails on the pre-repair head (15 pass, 1 fail) and passes after.
- `bun run privacy:scan` → pass
- `bun x tsc --noEmit` → clean

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

