### PR TITLE
docs(devlog): record the terminal outcome the unit close claimed

### DIFF
--- a/devlog/_fin/260829_cursor_tool_continuation_pairing/070_phase8_checkpoint_suffix_orphan_strip.md
+++ b/devlog/_fin/260829_cursor_tool_continuation_pairing/070_phase8_checkpoint_suffix_orphan_strip.md
@@ -686,3 +686,29 @@ Full replay has no abandon branch to rescue it, which makes it a genuine follow-
 non-problem, and it belongs to its own phase.
 
 Four-suite total is 213 pass / 0 fail; `cursor-blob` alone 127.
+
+## Terminal outcome
+
+PR #2940 landed on `dev` as squash commit `62df78d8dd2451accdc0ddd615b9fad080d64a60`, from head
+`0340d17599b65dda8b739a30107f59297e0d145b`, with CI green at that exact head. The remote gate on
+`ssh lidge` was re-run against the merge commit itself and reported exit 0 with 16359 pass / 0 fail /
+16 skip, so the landed tree is verified rather than only the pre-merge head.
+
+Round 11 is the closing verdict: PASS, with two minor notes, both addressed in `0340d1759` before the
+merge — a threshold case pinned from the tight side, and the correction of a wrong secondary claim in
+the round 10 record. Rounds 1 through 10 each found a genuine blocker, and rounds 5 through 10 were
+each triggered by the previous round's own fix. That is the finding worth carrying forward: every one
+of those fixes added a fact to the pruning code without asking which existing block had assumed that
+fact absent.
+
+Three items were scoped out on purpose and are not defects of this unit. The `envelope_exhausted`
+reason still does not reach the checkpoint store, and the spread copy in `live-transport.ts` makes it
+provably inert rather than merely unobserved; propagating it needs a signature change on a shared
+prepare path. On the extreme byte axis near a 523 KB system prompt the repetition note can survive
+while the result truncates to a marker, which is pre-existing and measurably better here than on the
+parent. And `composer-2.5` assembles 194 roots because it is a hybrid — `echoToolResultInRoot` true
+with `externalModel` false — which places it outside the envelope guard; that behaviour is identical
+on `dev` and predates this work.
+
+This unit moves to `_fin` under the rule in `AGENTS.md`: the work it records is now visible in public
+git history.


### PR DESCRIPTION
## Summary

- Add the Terminal outcome section to `070_phase8_checkpoint_suffix_orphan_strip.md` that #2970 said it added but did not. That PR landed as a pure rename — 10 files, 0 insertions, 0 deletions — because the edit was unstaged when the commit was taken, so `git commit` recorded only the staged `git mv`. The commit message on `13ba8f11f` therefore describes a section that is not in the tree; this PR makes the tree match the claim.
- The section records what closes the unit: merge commit `62df78d8d` for the final phase, the remote gate re-run against that merge commit rather than only the pre-merge head (exit 0, 16359 pass / 0 fail / 16 skip), and the round 11 PASS verdict together with the two notes it left, both of which were addressed in `0340d1759` before the merge.
- It also carries forward the one finding worth keeping from eleven audit rounds: rounds 5 through 10 were each triggered by the previous round's own fix, because every one of those fixes added a fact to the pruning code without asking which existing block had assumed that fact absent.
- Finally it names the three items scoped out on purpose, so a later reader does not reopen them as defects of this unit — the `envelope_exhausted` reason that a spread copy in `live-transport.ts` makes provably inert rather than merely unobserved, the extreme byte axis near a 523 KB system prompt where the repetition note can outlive the result, and `composer-2.5`'s 194 roots from being a hybrid (`echoToolResultInRoot` true, `externalModel` false) outside the envelope guard. The latter two are identical on `dev` before this unit.

Documentation only: one appended section, 26 insertions, no deletions. Nothing under `src/`, `gui/`, `scripts/`, or `tests/` is touched, and no build, typecheck, or test path reads `devlog/`.

## Verification

- `bun run privacy:scan` — passed. This is the gate that actually reads `devlog/`, so it is the one that matters for a diff whose entire content is devlog prose.
- `bun test tests/repo-hygiene.test.ts` — 12 pass / 0 fail, captured against the committed tree at `8af52dec0` with a clean worktree. It covers the guards governing `devlog/` content: no tracked gitlink, devlog markdown as ordinary blobs, vendored clones and excised security triage staying untracked, and no open plan carrying an unresolved security verdict.
- `git show --stat` on the commit — 1 file changed, 26 insertions. Checked deliberately, since the defect this PR repairs was a commit whose stat was empty while its message claimed content.
- No full suite: there is no source change, and the suite was already green against the merge commit this unit closes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Security review note: prose about an already-public fix, with no credential, auth, or workflow surface. The pre-disclosure rule in `AGENTS.md` is satisfied by construction — every weakness discussed already has a public diff on `dev`, which is the test that separates a `_fin` record from pre-disclosure material belonging in scratch space.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a final project checkpoint documenting the completed fix for a Cursor tool-continuation issue.
  - Recorded successful integration and validation results, including all passing checks.
  - Documented the closing review outcome, minor notes addressed before integration, and deliberately out-of-scope edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->