### PR TITLE
test(windows): create the external prompt fixture parent directory

### DIFF
--- a/tests/codex-prompt-route.test.ts
+++ b/tests/codex-prompt-route.test.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, 
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { handleManagementAPI } from "../src/server/management-api";
-import { encodeBasicString, LAYER_INVENTORY, readPromptLayers } from "../src/codex/prompt-layers";
+import { LAYER_INVENTORY, readPromptLayers } from "../src/codex/prompt-layers";
 import {
   promptTextProbeSpawnAttemptsForTests,
   resetPromptTextProbeForTests,
@@ -1132,17 +1132,19 @@ describe("020 coverage completions", () => {
    */
   test("34. editing an external base prompt invalidates an in-flight text probe", async () => {
     const fx = fixture("model = \"x\"\n");
-    // A literal backslash makes the Windows path condition reproducible on POSIX:
-    // interpolating this path raw would create an invalid TOML escape and make the
-    // fingerprint silently classify the selection as default.
+    // On Windows the backslash is a separator; on POSIX it is a legal filename
+    // character that deterministically exercises the same TOML escaping boundary.
     const externalPath = join(fx.decoyHome, "external\\base.md");
+    mkdirSync(dirname(externalPath), { recursive: true });
     writeFileSync(externalPath, "old-external", "utf8");
-    await call("PUT", "/api/codex-prompt/base/select", fx, {
-      kind: "external", path: externalPath, revision: await revision(fx),
-    });
-    // Selection through the route is not assumed: the fixture config is what the
-    // fingerprint reads, so assert the state this case depends on.
-    writeFileSync(fx.configPath, `model_instructions_file = ${encodeBasicString(externalPath)}\n`, "utf8");
+    // JSON string encoding is an independent, compatible encoding for this TOML
+    // basic string, so the fixture does not use the production encoder as its oracle.
+    writeFileSync(fx.configPath, `model_instructions_file = ${JSON.stringify(externalPath)}\n`, "utf8");
+    expect(readPromptLayers({
+      configPath: fx.configPath,
+      storePath: fx.storePath,
+      baseVariantDir: fx.baseVariantDir,
+    }).baseSelection).toEqual({ kind: "external", path: externalPath });
 
     const startedPath = join(fx.decoyHome, "external-probe-starts.txt");
     const source = [


### PR DESCRIPTION
## Summary

The last Windows-only failure from the dispatched leg. #2968 fixed the first layer of this case and the
run at `1494acd98` showed it still failing — 4ms instead of 243ms, so it was failing *earlier*, which
is what identified the remaining defect.

The production path was never wrong. It decodes escaped paths, hashes the external path together with
the complete file bytes, and returns busy when the fingerprint differs.

## What each layer was

Two distinct test defects stacked on the same case:

- Originally the test wrote `model_instructions_file = "C:\Users\..."` as raw TOML. `decodeBasicString`
  accepts only `\\`, `\"` and `\n`, so `\U` was rejected, the base was classified `default`, the
  external file's bytes dropped out of the probe fingerprint, and the second request joined the stale
  flight — exactly what the case exists to forbid.
- #2968's fix treated the backslash as a literal filename character. That holds on POSIX and is false on
  Windows, where `external\base.md` is a *nested path* whose parent directory the test never created,
  so it failed with `ENOENT` before reaching the assertion.

The fixture now creates the parent directory, encodes the TOML value with an oracle independent of the
production encoder, and asserts `readPromptLayers(...).baseSelection` before the probe starts rather
than assuming it. The backslash stays in the fixture so the TOML-escaping boundary is still exercised on
POSIX while being a real separator on Windows.

## Verification

Based on `dev@d2a802275`.

- `bun test tests/codex-prompt-route.test.ts` → **75 pass, 0 fail**
- **Mutation-proven**: restoring the raw TOML path reproduces `baseSelection: default` and one failure.
- `bun x tsc --noEmit` → clean

A dispatched Windows run on this branch is the gate I will check before merging, since `platform-windows`
does not run on push.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for external prompt base configuration.
  * Improved test setup to validate configuration state independently of the selection API.
  * Added verification for external file paths and directory creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->