### PR TITLE
test(windows): widen the launcher health budget for loaded runners

### DIFF
--- a/tests/ocx-launcher-runtime.test.ts
+++ b/tests/ocx-launcher-runtime.test.ts
@@ -14,6 +14,16 @@ const nodeAvailable = spawnSync("node", ["--version"], {
 }).status === 0;
 const runnable = process.platform === "win32" && nodeAvailable;
 
+// /healthz is the launcher's first trustworthy end-to-end startup signal: a
+// live Node parent or Bun child does not prove that the proxy is serving. The
+// old 25s budget expired on a loaded Windows runner, and equivalent real-proxy
+// starts elsewhere in this suite have taken 46-47s. 90s is more than twice the
+// measured high-water mark while still turning a hung launch into a bounded
+// failure. Keep the case budget derived so process inspection and cleanup have
+// their own headroom after readiness settles.
+const PROXY_HEALTH_TIMEOUT_MS = 90_000;
+const EFFECTIVE_RUNTIME_TEST_TIMEOUT_MS = PROXY_HEALTH_TIMEOUT_MS + 30_000;
+
 type Health = {
   status: string;
   service: string;
@@ -196,7 +206,7 @@ async function effectiveRuntime(override: string): Promise<string> {
     launcherPid = launcher.pid;
     ownedLauncher = captureWindowsProcessIdentity(launcherPid);
 
-    const health = await waitForHealth(port, 25_000, launcher);
+    const health = await waitForHealth(port, PROXY_HEALTH_TIMEOUT_MS, launcher);
     if (!health) throw new Error("proxy did not become healthy");
     const identity = windowsProcessIdentity(health.pid);
     if (!identity || identity.parentPid !== launcher.pid) {
@@ -357,7 +367,7 @@ describe.skipIf(!runnable)("ocx npm launcher effective Bun runtime", () => {
     } finally {
       removeTree(root);
     }
-  }, 120_000);
+  }, EFFECTIVE_RUNTIME_TEST_TIMEOUT_MS);
 
   test("falls back to bundled Bun for a sub-1MB override stub", async () => {
     const root = mkdtempSync(join(tmpdir(), "ocx-launcher-runtime-stub-"));
@@ -370,5 +380,5 @@ describe.skipIf(!runnable)("ocx npm launcher effective Bun runtime", () => {
     } finally {
       removeTree(root);
     }
-  }, 120_000);
+  }, EFFECTIVE_RUNTIME_TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary

The last Windows-only failure from a second dispatch on dev@223a0a287. Shard 3/4 of run
33291970929 failed the npm launcher fallback test after the 25-second /healthz poll expired
at 27 seconds on a loaded GitHub-hosted Windows runner. The same test passed in 6.62 seconds
on run 33290817128, so there is no production defect -- just a budget that does not account
for runner variance.

There is no stronger startup signal than /healthz: process existence does not prove the
proxy is serving. The budget is now 90 seconds, which is more than twice the recorded
46-47-second loaded-runner high-water mark while still bounding a hung startup. The
120-second case timeout is derived as 90s readiness + 30s process inspection/cleanup.

## Verification

Based on dev@223a0a287.

- bun test tests/ocx-launcher-runtime.test.ts -> 2 pass, 2 skip, 0 fail
- bun x tsc --noEmit -> clean

A dispatched Windows run on this branch is the verification gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime test reliability by allowing additional time for proxy health checks.
  * Updated runtime validation to use a consistent extended timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->