### PR TITLE
test(service): block live scheduler mutation under the test guard

### DIFF
--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process"
 import { existsSync } from "node:fs";
 import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { dlopen, ptr, type Pointer } from "bun:ffi";
+import { isTestHomeGuardArmed } from "./test-home-guard";
 
 type ElevationSpawn = (
   command: string,
@@ -526,6 +527,19 @@ export function startPowerShellCommand(commandScript: string): WindowsElevationE
       completion: Promise.reject(new WindowsElevationError(
         "launch-failed",
         "Windows elevation is only supported on Windows.",
+      )),
+    };
+  }
+
+  // HOME isolation cannot contain UAC children or other machine-global effects. Keep the
+  // final process boundary closed while the real launcher is installed; explicitly injected
+  // launchers remain available to tests that exercise the elevation protocol in memory.
+  if (isTestHomeGuardArmed() && elevationSpawn === spawn) {
+    return {
+      launcherPid: null,
+      completion: Promise.reject(new WindowsElevationError(
+        "launch-failed",
+        "Refusing to launch a live Windows elevation process from an armed test process; inject the elevation launcher instead.",
       )),
     };
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -2343,8 +2343,17 @@ export interface RemoveNativeWindowsServiceDeps {
 export function removeNativeWindowsServiceForScheduler(
   deps: RemoveNativeWindowsServiceDeps = {},
 ): void {
-  const status = deps.status ?? statusWinswRaw;
   const uninstall = deps.uninstall ?? uninstallWinswService;
+  // The test home cannot contain SCM. A partially mocked scheduler install must inject
+  // the native-service mutation too; otherwise it can stop/delete the user's live WinSW
+  // registration even though every filesystem path points at the isolated test home.
+  if (isTestHomeGuardArmed() && uninstall === uninstallWinswService) {
+    throw new Error(
+      "refusing to mutate the machine-global Windows native service from an armed test process; "
+      + "inject the native-service removal instead of calling the live manager.",
+    );
+  }
+  const status = deps.status ?? statusWinswRaw;
   const sleep = deps.sleep ?? Bun.sleepSync;
   const settleChecks = Math.max(1, deps.settleChecks ?? 20);
   // Transactional backend switch: installing the scheduler backend removes a native

--- a/src/service.ts
+++ b/src/service.ts
@@ -50,6 +50,7 @@ import { recordOwnedConfigPath } from "./lib/config-ownership";
 import { killWindowsSchedulerWrappers } from "./lib/windows-service-wrappers";
 import { maybeShowStarPrompt } from "./cli/star-prompt";
 import { systemdProperty } from "./service-manager-probe";
+import { isTestHomeGuardArmed } from "./lib/test-home-guard";
 
 const LABEL = "com.opencodex.proxy";
 const TASK = "opencodex-proxy";
@@ -900,6 +901,20 @@ function windowsWscript(): string {
 let querySchtasksForTests: ((args: string[]) => string) | null = null;
 
 function querySchtasks(args: string[]): string {
+  // The repository preload isolates HOME and OPENCODEX_HOME, but Task Scheduler is
+  // machine-global. A partially-faked service test once fell through here and replaced the
+  // user's real `opencodex-proxy` task with a launcher inside its temporary test home; the
+  // test passed and cleanup deleted that launcher. Queries are observation-only, but every
+  // other operation must be injected while the explicit test-home guard is armed.
+  if (
+    isTestHomeGuardArmed()
+    && args[0]?.trim().toLowerCase() !== "/query"
+  ) {
+    throw new Error(
+      "refusing to mutate the machine-global Windows Task Scheduler from an armed test process; "
+      + "inject the scheduler operation instead of calling the live manager.",
+    );
+  }
   if (querySchtasksForTests) return querySchtasksForTests(args);
   return runFile(windowsSchtasks(), args);
 }

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1060,6 +1060,32 @@ describe("service lifecycle cleanup ordering", () => {
     }
   });
 
+  test("an armed partial install cannot fall through to live native-service removal", async () => {
+    const calls: string[] = [];
+    await expect(installFreshWindowsSchedulerSafely({
+      stageRegistrationXml: () => { calls.push("stage"); return "attempt.xml"; },
+      register: async () => { calls.push("register"); },
+      recordOwnership: () => { calls.push("record-ownership"); return true; },
+      prepare: async () => { calls.push("prepare"); },
+      // Intentionally omit removeNativeService: the production default must fail closed.
+      publishAssets: () => { calls.push("publish-assets"); },
+      runTask: () => { calls.push("run-task"); },
+      writeState: () => { calls.push("write-state"); },
+      rollbackTask: async () => { calls.push("rollback-task"); return null; },
+      removeStagedXml: () => { calls.push("remove-stage"); },
+    })).rejects.toThrow(
+      "refusing to mutate the machine-global Windows native service from an armed test process",
+    );
+    expect(calls).toEqual([
+      "stage",
+      "register",
+      "remove-stage",
+      "record-ownership",
+      "prepare",
+      "rollback-task",
+    ]);
+  });
+
   test("native service switch treats unknown as installed and requires confirmed absence", () => {
     const calls: string[] = [];
     const statuses: Array<"unknown" | "stopped" | "nonexistent"> = [

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1034,6 +1034,32 @@ describe("launchd service plist", () => {
 });
 
 describe("service lifecycle cleanup ordering", () => {
+  test("an armed test cannot fall through to a live Task Scheduler mutation", async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const attemptNonce = "test-home-guard-registration";
+    const xmlPath = join(TEST_DIR, "guarded-task.xml");
+    writeFileSync(
+      xmlPath,
+      `\uFEFF${buildWindowsTaskXml(undefined, undefined, attemptNonce)}`,
+      { encoding: "utf16le" },
+    );
+    const observedCalls: string[][] = [];
+    serviceModule.setQuerySchtasksForTests(args => {
+      observedCalls.push([...args]);
+      return "";
+    });
+    try {
+      await expect(registerFreshWindowsSchedulerTask(xmlPath, attemptNonce)).rejects.toThrow(
+        "refusing to mutate the machine-global Windows Task Scheduler from an armed test process",
+      );
+      // The guard runs before even the test recorder. Before this regression fix the recorder
+      // receives `/create /tn opencodex-proxy ... /f`, proving the live runner was reachable.
+      expect(observedCalls).toEqual([]);
+    } finally {
+      serviceModule.setQuerySchtasksForTests(null);
+    }
+  });
+
   test("native service switch treats unknown as installed and requires confirmed absence", () => {
     const calls: string[] = [];
     const statuses: Array<"unknown" | "stopped" | "nonexistent"> = [

--- a/tests/windows-elevation-spawn.test.ts
+++ b/tests/windows-elevation-spawn.test.ts
@@ -82,6 +82,16 @@ describe("runWindowsElevated spawn contract", () => {
     return child;
   }
 
+  test("an armed test cannot launch the live Windows elevation boundary", async () => {
+    // The probe is deliberately inert: if the guard regresses, it can only start an
+    // non-RunAs PowerShell executing a fixed exit 0, never UAC or Task Scheduler mutation.
+    const execution = startPowerShellCommand("exit 0");
+    expect(execution.launcherPid).toBeNull();
+    await expect(execution.completion).rejects.toThrow(
+      "Refusing to launch a live Windows elevation process from an armed test process",
+    );
+  });
+
   test("returns exit code 0", async () => {
     fakeChild({ code: 0 });
     await expect(runWindowsElevated("schtasks.exe", ["/query"])).resolves.toBe(0);


### PR DESCRIPTION
## Summary

The repository test runner isolates `HOME`, `USERPROFILE`, and `OPENCODEX_HOME`, but Windows Task Scheduler and UAC-launched processes are machine-global.

A partially-faked service repair test crossed that boundary and executed the default `schtasks /create /tn opencodex-proxy ... /f` path. It replaced the live task with a launcher inside the temporary test home, the test still passed, and cleanup deleted the launcher. The already-running proxy hid the damaged registration until the next reconnect or restart.

When the explicit repository test-home guard is armed, this change:

- permits only read-only `/query` operations through the direct Task Scheduler runner; and
- refuses the final live Windows elevation process boundary while retaining explicitly injected test launchers; and
- blocks the default native WinSW/SCM removal boundary while the test guard is armed, while retaining explicitly injected removal operations.

This covers direct and elevated registration, create/run/rollback, delete, and other machine-global mutation paths. Production behavior is unchanged because only the repository test preload sets `OCX_TEST_HOME_GUARD=1`.

## Verification

- Regression green: a valid fresh-registration request is rejected before even the scheduler recorder is reached.
- Safe red proof: removing the direct guard reaches the fake create recorder and fails later with “registration is absent,” proving that path was reachable without touching the real scheduler.
- `bun test tests/service.test.ts tests/windows-scheduler-install-verification.test.ts tests/test-home-guard.test.ts` — 172 pass, 0 fail; 3 POSIX-only permission tests skipped on Windows.
- `bun test tests/windows-elevation-spawn.test.ts` — 53 pass, 0 fail; the live-boundary probe contains only a fixed non-RunAs `exit 0` command if its guard regresses.
- `bun run typecheck`, `bun run privacy:scan`, and `git diff --check` — clean.
- The scheduled task still points to the real OpenCodex service launcher, and the current proxy health readback is HTTP 200.
- Exact head `56bd40d242` is based on current `dev` `870a2adb6e`; three current-head scheduler, native-SCM, and explicit-injection guard regressions pass 3/3 on Bun 1.4.0. The previously completed full focused suites remain 197/0, with typecheck and privacy scan clean; the live `opencodex-proxy` registration was unchanged afterward and `/healthz` returned 200.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards that prevent test-mode processes from modifying Windows Task Scheduler tasks or native services.
  * Prevented test-mode processes from launching live Windows elevation commands.
  * Preserved supported injected test launchers and simulated service workflows.

* **Tests**
  * Added coverage verifying blocked scheduler, service, and elevation operations occur before any system changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->