### PR TITLE
feat(codex): surface Sol and Daybreak Blue Ultrafast

### DIFF
--- a/docs-site/src/content/docs/fr/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/fr/guides/codex-app-models.md
@@ -187,7 +187,7 @@ Sur le réseau, les adaptateurs routés convertissent ou plafonnent les niveaux 
 anciens modèles natifs dont l'échelle réelle s'arrête à `xhigh`, `nativeEffortClamp` convertit une sélection
 directe `max` ou `ultra` en `xhigh` (GPT-5.5, par exemple). Sol, Terra et Luna possèdent un véritable niveau `max`.
 
-## Règles du niveau rapide
+## Règles des niveaux Fast et Ultrafast
 
 Codex enregistre le mode rapide ainsi :
 
@@ -199,8 +199,16 @@ fast_mode = true
 ```
 
 Toutefois, le catalogue de modèles et l'identifiant du niveau employé dans la requête d'exécution utilisent
-`priority`. opencodex préserve cette distinction. Les modèles OpenAI natifs transférés conservent la prise en
-charge du mode rapide ; les fournisseurs routés sont conditionnés par leurs capacités. `service_tier` n'est
+`priority`. opencodex préserve cette distinction. Les catalogues Codex actuels exposent aussi le niveau
+Ultrafast contrôlé par accès sous la forme `service_tier = "ultrafast"`. Le fallback intégré ne l'annonce que
+pour `gpt-5.6-sol` ; une ligne `gpt-daybreak-blue-latest` autorisée hérite des capacités de Sol. Terra et Luna
+conservent Fast sans recevoir Ultrafast. La source Codex épinglée conserve intentionnellement
+`additional_speed_tiers` à `["fast"]` : Ultrafast appartient à `service_tiers`. Laissez le réglage Fast
+global d'opencodex sur Auto pour préserver un `ultrafast` choisi par le modèle ; forcer Fast sélectionne
+`priority` à la place.
+
+Les modèles OpenAI natifs transférés conservent leurs niveaux de vitesse déclarés ; les fournisseurs routés
+sont conditionnés par leurs capacités. `service_tier` n'est
 retiré que si le fournisseur déclare `supportsServiceTier: false` (le registre classe OpenAI canonique comme
 `true`, et DeepSeek ainsi que Volcengine Ark comme `false`). Les passerelles personnalisées non classées
 conservent intactes les valeurs transmises par l'appelant et ne reçoivent jamais d'injection. Une passerelle
@@ -208,7 +216,7 @@ personnalisée peut l’activer globalement avec `supportsServiceTier: true`, ou
 modèles avec `modelSupportsServiceTier: { "verified-model": true }`. Une valeur exacte `false` restreint une
 valeur globale `true`, tandis que `supportsServiceTier: false` reste fermé par défaut. La décision finale de
 l’adaptateur et du modèle régit à la fois les métadonnées du catalogue et l’injection à l’exécution ;
-l’option rapide n’est donc jamais annoncée lorsqu’elle ne peut être respectée. Une destination
+une option de vitesse n’est donc jamais annoncée lorsqu’elle ne peut être respectée. Une destination
 `openai-chat` peut autoriser tous les modèles autrement admissibles avec `chatServiceTier: true`, ou
 uniquement des modèles précis avec `modelSupportsServiceTier` ; les routes Responses n’ont pas besoin de
 cette autorisation supplémentaire sur le protocole Chat.

--- a/docs-site/src/content/docs/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/guides/codex-app-models.md
@@ -225,9 +225,9 @@ On the wire, routed adapters map or clamp unsupported tiers. For older native mo
 ladder stops at `xhigh`, `nativeEffortClamp` maps a direct `max` or an `ultra` selection to `xhigh`
 (for example, GPT-5.5). Sol, Terra, and Luna have a real `max` rung.
 
-## Fast tier rules
+## Fast and Ultrafast tier rules
 
-Codex stores fast mode as:
+Codex stores Fast mode as:
 
 ```toml
 service_tier = "fast"
@@ -236,15 +236,22 @@ service_tier = "fast"
 fast_mode = true
 ```
 
-But the model catalog and runtime request tier id use `priority`. opencodex preserves that split.
-Native OpenAI passthrough models keep fast support; routed providers are capability-gated —
+The model catalog and runtime request tier id use `priority`, and opencodex preserves that split.
+Current Codex catalogs also expose access-controlled Ultrafast as model-owned
+`service_tier = "ultrafast"`. The pinned fallback advertises it only on `gpt-5.6-sol`; an entitled
+`gpt-daybreak-blue-latest` row inherits Sol's capability metadata. Terra and Luna retain Fast but do
+not gain Ultrafast. The pinned Codex source intentionally leaves `additional_speed_tiers` at
+`["fast"]`: Ultrafast lives in `service_tiers`. Leave opencodex's global Fast setting on Auto to
+preserve a model-selected `ultrafast`; forcing Fast explicitly selects `priority` instead.
+
+Native OpenAI passthrough models keep their declared speed tiers; routed providers are capability-gated —
 `service_tier` is stripped only when the provider declares `supportsServiceTier: false` (the registry
 classifies canonical OpenAI as `true`, DeepSeek and Volcengine Ark as `false`), while unclassified
 custom gateways keep caller-supplied values untouched and never get an injection. A custom gateway
 can opt in globally with `supportsServiceTier: true`, or narrowly with
 `modelSupportsServiceTier: { "verified-model": true }`; an exact `false` narrows a provider
 default of `true`, while provider-level `false` remains fail-closed. The same final adapter/model
-decision controls both catalog metadata and runtime injection, so the fast option is never
+decision controls both catalog metadata and runtime injection, so a speed option is never
 advertised where it cannot be honored. An `openai-chat` destination can authorize every otherwise
 eligible model with `chatServiceTier: true`, or authorize only exact models with
 `modelSupportsServiceTier`; Responses routes do not need that extra Chat wire authorization.

--- a/docs-site/src/content/docs/ja/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/ja/guides/codex-app-models.md
@@ -89,7 +89,7 @@ exact selector 行が表示されず、切り替えることもできません�
 
 回線上では、ルーティングされたアダプターがサポートされていない層をマップまたはクランプします。実際のラダーが `xhigh` で停止する古いネイティブ モデルの場合、`nativeEffortClamp` は直接 `max` または `ultra` 選択を `xhigh` にマップします (GPT-5.5 など)。ソル、テラ、ルナは本物の `max` ラングを持っています。
 
-## 高速層のルール
+## Fast / Ultrafast 層のルール
 
 Codex は高速モードを次のように保存します。
 
@@ -100,7 +100,9 @@ service_tier = "fast"
 fast_mode = true
 ```
 
-ただし、モデル カタログとランタイム リクエスト層 ID は `priority` を使用します。opencodex はその分割を保持します。ネイティブ OpenAI パススルー モデルは高速サポートを維持します。ルーティングされたプロバイダーはケイパビリティでゲートされ、`supportsServiceTier: false` と宣言された場合のみ `service_tier` が削除されます (レジストリは正規 OpenAI を `true`、DeepSeek と Volcengine Ark を `false` に分類します)。未分類のカスタム ゲートウェイは呼び出し元の値をそのまま保持し、注入もされません。そのため、受け入れられない場所で高速オプションがアドバタイズされることはなく、カスタム ゲートウェイは `true` で明示的にオプトインできます。
+ただし、モデル カタログとランタイム リクエスト層 ID は `priority` を使用します。opencodex はその分割を保持します。現在の Codex カタログは、アクセス制御された Ultrafast も `service_tier = "ultrafast"` として公開します。組み込み fallback がこれを公開するのは `gpt-5.6-sol` だけで、利用資格のある `gpt-daybreak-blue-latest` 行は Sol の能力を継承します。Terra と Luna は Fast のみを維持し、Ultrafast は追加されません。固定した Codex ソースでは `additional_speed_tiers` を意図的に `["fast"]` のままにし、Ultrafast は `service_tiers` だけで表します。モデルで選んだ `ultrafast` を維持するには opencodex のグローバル Fast 設定を Auto のままにしてください。Fast を強制すると、代わりに `priority` が選択されます。
+
+ネイティブ OpenAI パススルー モデルは宣言済みの速度層を維持します。ルーティングされたプロバイダーはケイパビリティでゲートされ、`supportsServiceTier: false` と宣言された場合のみ `service_tier` が削除されます (レジストリは正規 OpenAI を `true`、DeepSeek と Volcengine Ark を `false` に分類します)。未分類のカスタム ゲートウェイは呼び出し元の値をそのまま保持し、注入もされません。そのため、受け入れられない場所で速度オプションがアドバタイズされることはなく、カスタム ゲートウェイは `true` で明示的にオプトインできます。
 
 ## サブエージェントの選択
 

--- a/docs-site/src/content/docs/ko/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/ko/guides/codex-app-models.md
@@ -156,7 +156,7 @@ wire에서는 라우팅 어댑터가 지원하지 않는 tier를 매핑하거나
 이전 네이티브 모델에서는 `nativeEffortClamp`가 직접 지정한 `max` 또는 `ultra` 선택을 `xhigh`로 바꿉니다.
 예를 들면 GPT-5.5가 그렇습니다. Sol, Terra, Luna에는 실제 `max` 단계가 있습니다.
 
-## Fast tier 규칙
+## Fast 및 Ultrafast tier 규칙
 
 Codex는 fast 모드를 다음처럼 저장합니다.
 
@@ -168,10 +168,18 @@ fast_mode = true
 ```
 
 하지만 모델 카탈로그와 런타임 요청 tier id는 `priority`를 씁니다. opencodex는 이 분리를 그대로
-유지합니다. 네이티브 OpenAI passthrough 모델은 fast 지원을 유지하고, 라우팅된 프로바이더는
+유지합니다. 최신 Codex 카탈로그는 접근 권한이 필요한 Ultrafast도
+`service_tier = "ultrafast"`로 노출합니다. 내장 fallback은 `gpt-5.6-sol`에만 이를 광고하며,
+권한이 확인된 `gpt-daybreak-blue-latest` 행은 Sol의 케이퍼빌리티를 상속합니다. Terra와 Luna는
+Fast만 유지하고 Ultrafast를 추가하지 않습니다. 고정된 Codex 원본은 `additional_speed_tiers`를
+의도적으로 `["fast"]`로 유지하며, Ultrafast는 `service_tiers`에만 표시합니다. 모델에서 고른
+`ultrafast`를 보존하려면 opencodex의 전역 Fast 설정을 Auto로 두어야 합니다. Fast를 강제로
+켜면 대신 `priority`가 선택됩니다.
+
+네이티브 OpenAI passthrough 모델은 선언된 속도 tier를 유지하고, 라우팅된 프로바이더는
 케이퍼빌리티로 게이트되어 프로바이더가 `supportsServiceTier: false`를 선언한 경우에만
 `service_tier`가 제거됩니다(레지스트리가 정식 OpenAI를 `true`, DeepSeek과 Volcengine Ark를 `false`로 분류). 미분류 커스텀 게이트웨이는 호출자가 준 값을 그대로 보존하고 주입도 받지 않습니다. 따라서
-처리 불가능한 곳에 fast 옵션이 노출되지 않으며, 커스텀 게이트웨이는 `true`로 명시적으로 옵트인할 수 있습니다.
+처리 불가능한 곳에 속도 옵션이 노출되지 않으며, 커스텀 게이트웨이는 `true`로 명시적으로 옵트인할 수 있습니다.
 
 ## 서브에이전트 선택
 

--- a/docs-site/src/content/docs/ru/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/ru/guides/codex-app-models.md
@@ -137,7 +137,7 @@ routed provider-id `provider/model`. Account-qualified id `<selector>/<native-op
 `nativeEffortClamp` переводит прямой выбор `max` или `ultra` в `xhigh` (например, у GPT-5.5). У
 Sol, Terra и Luna есть настоящая ступень `max`.
 
-## Правила fast-tier
+## Правила Fast- и Ultrafast-tier
 
 Codex хранит fast-mode так:
 
@@ -149,9 +149,17 @@ fast_mode = true
 ```
 
 Но каталог моделей и id tier'а во время выполнения используют `priority`. opencodex сохраняет это
-разделение. Нативные passthrough-модели OpenAI сохраняют поддержку fast; routed-провайдеры ограничены
+разделение. Современные каталоги Codex также публикуют доступный по разрешению Ultrafast как
+`service_tier = "ultrafast"`. Встроенный fallback объявляет его только для `gpt-5.6-sol`, а доступная
+учётной записи строка `gpt-daybreak-blue-latest` наследует возможности Sol. Terra и Luna сохраняют Fast,
+но не получают Ultrafast. Закреплённый источник Codex намеренно оставляет
+`additional_speed_tiers` равным `["fast"]`: Ultrafast задаётся через `service_tiers`. Чтобы сохранить
+выбранный моделью `ultrafast`, оставьте глобальную настройку Fast в opencodex в режиме Auto; явное
+включение Fast вместо этого выбирает `priority`.
+
+Нативные passthrough-модели OpenAI сохраняют объявленные speed-tier; routed-провайдеры ограничены
 capability-гейтом — `service_tier` удаляется только когда провайдер объявил `supportsServiceTier: false` (registry классифицирует canonical OpenAI как `true`, DeepSeek и Volcengine Ark как `false`); неклассифицированные custom gateway'и сохраняют значения вызывающего без изменений и не получают подстановку.
-Так что опция fast не рекламируется там, где её нельзя выполнить, а custom gateway'и могут включить её явно через `true`.
+Так что speed-опция не рекламируется там, где её нельзя выполнить, а custom gateway'и могут включить её явно через `true`.
 
 ## Выбор подагентов
 

--- a/docs-site/src/content/docs/tr/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/tr/guides/codex-app-models.md
@@ -224,7 +224,7 @@ Gerçek merdiveni `xhigh` ile duran daha eski yerel modeller için
 eşler (örneğin GPT-5.5). Sol, Terra ve Luna gerçek bir `max` basamağına
 sahiptir.
 
-## Hızlı katman kuralları
+## Fast ve Ultrafast katman kuralları
 
 Codex hızlı modu şu şekilde saklar:
 
@@ -236,13 +236,22 @@ fast_mode = true
 ```
 
 Ancak model kataloğu ve çalışma zamanı istek katmanı kimliği `priority`
-kullanır. opencodex bu ayrımı korur. Yerel OpenAI doğrudan geçiş modelleri hızlı
-desteği korur; yönlendirilen sağlayıcılar yetenek geçişlidir — `service_tier`
+kullanır. opencodex bu ayrımı korur. Güncel Codex katalogları erişim denetimli
+Ultrafast katmanını da `service_tier = "ultrafast"` olarak sunar. Yerleşik fallback
+bunu yalnızca `gpt-5.6-sol` için bildirir; yetkili bir `gpt-daybreak-blue-latest`
+satırı Sol yeteneklerini devralır. Terra ve Luna Fast'i korur ancak Ultrafast almaz.
+Sabitlenmiş Codex kaynağı `additional_speed_tiers` alanını bilinçli olarak `["fast"]`
+değerinde tutar; Ultrafast yalnızca `service_tiers` içinde yer alır. Modelin seçtiği
+`ultrafast` değerini korumak için opencodex genel Fast ayarını Auto'da bırakın; Fast'i
+zorlamak bunun yerine `priority` seçer.
+
+Yerel OpenAI doğrudan geçiş modelleri bildirdikleri hız katmanlarını korur;
+yönlendirilen sağlayıcılar yetenek geçişlidir — `service_tier`
 yalnızca sağlayıcı `supportsServiceTier: false` bildirdiğinde kaldırılır (kayıt
 defteri kurallı OpenAI'yi `true`, DeepSeek ve Volcengine Ark'ı `false` olarak
 sınıflandırır), sınıflandırılmamış özel ağ geçitleri ise arayan tarafından
 sağlanan değerleri dokunulmadan korur ve asla bir enjeksiyon almaz. Hızlı
-seçenek yerine getirilemediği yerlerde asla tanıtılmaz ve özel ağ geçitleri
+hız seçeneği yerine getirilemediği yerlerde asla tanıtılmaz ve özel ağ geçitleri
 `true` ile açıkça dahil olabilir.
 
 ## Alt ajan seçimi
@@ -314,4 +323,3 @@ ocx sync
 opencodex, katalog görünürlüğü, önceliği veya meta verileri her değiştiğinde
 `models_cache.json` dosyasını kasıtlı olarak eski bir önbellek sarmalayıcısıyla
 yeniden yazar, böylece bir sonraki Codex model yenilemesi yeni kataloğu okur.
-

--- a/docs-site/src/content/docs/zh-cn/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/zh-cn/guides/codex-app-models.md
@@ -102,7 +102,7 @@ Models 页面上的 v1/base/v2 控件会改变每个选择器条目使用的 Cod
 
 在传输层面，路由 adapter 会映射或钳制不受支持的档位。对于真实阶梯止于 `xhigh` 的较老原生模型，`nativeEffortClamp` 会把直接的 `max` 或 `ultra` 选择映射到 `xhigh`，例如 GPT-5.5。Sol、Terra 和 Luna 都有真实的 `max` 档位。
 
-## Fast tier 规则
+## Fast 与 Ultrafast tier 规则
 
 Codex 会把 fast 模式保存为：
 
@@ -113,7 +113,9 @@ service_tier = "fast"
 fast_mode = true
 ```
 
-但模型目录和运行时请求里的 tier id 使用的是 `priority`。opencodex 保留了这个拆分。原生 OpenAI 透传模型保留 fast 支持；路由的提供商会按能力门控——只有当提供商声明 `supportsServiceTier: false` 时才会剥离 `service_tier`（注册表已将官方 OpenAI 分类为 `true`，DeepSeek 和 Volcengine Ark 分类为 `false`）；未分类的自定义网关会原样保留调用方提供的值且绝不注入，因此无法兑现的 fast 选项不会被展示，自定义网关也可以用 `true` 显式启用。
+但模型目录和运行时请求里的 tier id 使用的是 `priority`。opencodex 保留了这个拆分。当前 Codex 目录还会把受访问控制的 Ultrafast 暴露为 `service_tier = "ultrafast"`。内置 fallback 只为 `gpt-5.6-sol` 宣告该档位；已获权限的 `gpt-daybreak-blue-latest` 条目会继承 Sol 的能力。Terra 和 Luna 继续保留 Fast，但不会新增 Ultrafast。固定的 Codex 源会有意把 `additional_speed_tiers` 保持为 `["fast"]`，Ultrafast 只存在于 `service_tiers` 中。要保留模型选择的 `ultrafast`，请把 opencodex 的全局 Fast 设置留在 Auto；强制启用 Fast 会改为选择 `priority`。
+
+原生 OpenAI 透传模型保留其声明的速度档位；路由的提供商会按能力门控——只有当提供商声明 `supportsServiceTier: false` 时才会剥离 `service_tier`（注册表已将官方 OpenAI 分类为 `true`，DeepSeek 和 Volcengine Ark 分类为 `false`）；未分类的自定义网关会原样保留调用方提供的值且绝不注入，因此无法兑现的速度选项不会被展示，自定义网关也可以用 `true` 显式启用。
 
 ## 子代理选择
 

--- a/docs-site/src/content/docs/zh-tw/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/zh-tw/guides/codex-app-models.md
@@ -134,7 +134,7 @@ Models 頁面的 v1/base/v2 控制會改變每個選擇器條目使用的 Codex 
 模型，`nativeEffortClamp` 會把直接指定的 `max` 或 `ultra` 選擇轉換為 `xhigh`，例如 GPT-5.5。
 Sol、Terra 和 Luna 都有真實的 `max` 檔位。
 
-## Fast tier 規則
+## Fast 與 Ultrafast tier 規則
 
 Codex 在設定檔中這樣儲存 fast 模式：
 
@@ -145,11 +145,17 @@ service_tier = "fast"
 fast_mode = true
 ```
 
-模型目錄和執行環境請求使用的 tier id 則是 `priority`。opencodex 會保留這一差異。原生 OpenAI
-透傳模型繼續支援 fast；路由 provider 則依能力閘控 —— 只有當 provider 宣告
+模型目錄和執行環境請求使用的 tier id 則是 `priority`。opencodex 會保留這一差異。現行 Codex
+目錄也會把受存取控制的 Ultrafast 顯示為 `service_tier = "ultrafast"`。內建 fallback 只會為
+`gpt-5.6-sol` 宣告此級別；已取得權限的 `gpt-daybreak-blue-latest` 列會繼承 Sol 的能力。Terra
+和 Luna 保留 Fast，但不會新增 Ultrafast。固定的 Codex 來源會刻意把
+`additional_speed_tiers` 保持為 `["fast"]`；Ultrafast 只存在於 `service_tiers`。若要保留模型選擇的
+`ultrafast`，請將 opencodex 的全域 Fast 設定留在 Auto；強制啟用 Fast 會改為選擇 `priority`。
+
+原生 OpenAI 透傳模型繼續保留已宣告的速度 tier；路由 provider 則依能力閘控 —— 只有當 provider 宣告
 `supportsServiceTier: false` 時才會移除 `service_tier`（registry 將正規 OpenAI 歸類為 `true`，
 DeepSeek 與 Volcengine Ark 歸類為 `false`），而未分類的自訂 gateway 會原封不動保留呼叫端提供
-的值，絕不注入。無法兌現的地方絕不會宣傳 fast 選項；自訂 gateway 也可以明確以 `true` 選擇加入。
+的值，絕不注入。無法兌現的地方絕不會宣傳速度選項；自訂 gateway 也可以明確以 `true` 選擇加入。
 
 ## 子代理選擇
 

--- a/docs/codex-app-model-catalog.md
+++ b/docs/codex-app-model-catalog.md
@@ -119,17 +119,23 @@ The recognized Codex effort ladder is `low < medium < high < xhigh < max < ultra
 
 ## Fast tier handling
 
-Codex uses a split between config spelling and runtime/catalog spelling:
+Codex uses model-owned service-tier metadata. Fast keeps a split between its config spelling and
+runtime/catalog id, while Ultrafast uses the same id on both surfaces:
 
 | Surface | Value |
 |---|---|
-| `config.toml` persistence | `service_tier = "fast"` |
-| catalog/request tier id | `priority` |
-| feature gate | `[features].fast_mode = true` |
+| `config.toml` persistence | Fast: `service_tier = "fast"`; Ultrafast: `service_tier = "ultrafast"` |
+| catalog/request tier id | Fast: `priority`; Ultrafast: `ultrafast` |
+| feature gate | Fast only: `[features].fast_mode = true`; Ultrafast is access-controlled model metadata |
 | provider/account gate | `requires_openai_auth = true` |
 
-Native OpenAI passthrough models can keep fast metadata. Routed non-OpenAI models must not inherit
-that metadata from the native template:
+The pinned fallback advertises Ultrafast only for `gpt-5.6-sol`; the entitlement-gated
+`gpt-daybreak-blue-latest` capability alias inherits the same Sol tier set. Terra and Luna retain
+Fast without Ultrafast. The pinned Codex source intentionally keeps `additional_speed_tiers` at
+`["fast"]`; Ultrafast is represented by `service_tiers`, not that legacy field. An explicit global
+Fast override still selects `priority`, while Auto/passthrough preserves a caller-selected
+`ultrafast`. Native OpenAI passthrough models can keep their declared tier metadata.
+Routed non-OpenAI models must not inherit that metadata from the native template:
 
 ```text
 delete additional_speed_tiers
@@ -138,8 +144,8 @@ delete service_tiers
 delete default_service_tier
 ```
 
-This prevents fast from appearing for providers where Codex/OpenAI priority processing is not a valid
-request option.
+This prevents OpenAI speed tiers from appearing for providers where the corresponding processing
+mode is not a valid request option.
 
 ## Cache invalidation
 

--- a/src/codex/data/upstream-models.json
+++ b/src/codex/data/upstream-models.json
@@ -110,6 +110,11 @@
           "id": "priority",
           "name": "Fast",
           "description": "1.5x speed, increased usage"
+        },
+        {
+          "id": "ultrafast",
+          "name": "Ultrafast",
+          "description": "The fastest available responses for latency-sensitive work."
         }
       ],
       "additional_speed_tiers": [

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -2729,6 +2729,23 @@ describe("Codex catalog routed normalization", () => {
     expect(sol?.description).toBe("Latest frontier agentic coding model.");
     expect(sol?.availability_nux).toBeDefined();
 
+    // Codex 0.151 exposes model-owned service tiers. Ultrafast is currently Sol-only;
+    // Terra and Luna keep the existing Fast row and must not inherit the new tier.
+    expect(sol?.service_tiers).toEqual([
+      { id: "priority", name: "Fast", description: "1.5x speed, increased usage" },
+      {
+        id: "ultrafast",
+        name: "Ultrafast",
+        description: "The fastest available responses for latency-sensitive work.",
+      },
+    ]);
+    expect(terra?.service_tiers).toEqual([
+      { id: "priority", name: "Fast", description: "1.5x speed, increased usage" },
+    ]);
+    expect(luna?.service_tiers).toEqual([
+      { id: "priority", name: "Fast", description: "1.5x speed, increased usage" },
+    ]);
+
     // Per-slug multi-agent generation: sol/terra v2, luna v1.
     expect(sol?.multi_agent_version).toBe("v2");
     expect(terra?.multi_agent_version).toBe("v2");
@@ -2913,6 +2930,12 @@ describe("Codex catalog routed normalization", () => {
       supports_parallel_tool_calls: true,
       supports_search_tool: true,
       multi_agent_version: "v2",
+    });
+    expect(source?.service_tiers).toEqual(upstreamNativeEntry("gpt-5.6-sol")?.service_tiers);
+    expect(source?.service_tiers).toContainEqual({
+      id: "ultrafast",
+      name: "Ultrafast",
+      description: "The fastest available responses for latency-sensitive work.",
     });
     expect(source).not.toHaveProperty("availability_nux");
     expect(source?.base_instructions).toContain("powered by the gpt-daybreak-blue-latest");

--- a/tests/service-tier-capability.test.ts
+++ b/tests/service-tier-capability.test.ts
@@ -419,10 +419,18 @@ describe("the gate fires on the live handleResponses path", () => {
     expect("service_tier" in off).toBe(false);
   });
 
-  test("canonical OpenAI preserves a caller value when fastMode is unset", async () => {
-    const body = await drive("openai-apikey", openAiKeyProvider(), "gpt-5.5", { service_tier: "flex" });
-    expect(body.service_tier).toBe("flex");
-  });
+  test.each(["flex", "ultrafast"])(
+    "canonical OpenAI preserves caller service_tier=%s when fastMode is unset",
+    async serviceTier => {
+      const body = await drive(
+        "openai-apikey",
+        openAiKeyProvider(),
+        "gpt-5.6-sol",
+        { service_tier: serviceTier },
+      );
+      expect(body.service_tier).toBe(serviceTier);
+    },
+  );
 
   test("xAI API-key runtime injects priority while OAuth does not", async () => {
     const keyBody = await drive("xai", xaiKeyProvider(), "grok-4.6", {}, true);


### PR DESCRIPTION
## Summary

- Add Codex's current `ultrafast` service-tier descriptor to the pinned `gpt-5.6-sol` fallback while keeping the existing Fast/`priority` row unchanged.
- Reuse the existing entitlement-gated Sol capability inheritance for `gpt-daybreak-blue-latest`; Terra, Luna, Spark, and routed provider rows do not gain Ultrafast.
- Preserve caller-selected `service_tier: "ultrafast"` on canonical OpenAI Responses while the global Fast setting is Auto, with a regression test for the live request path.
- Document why `additional_speed_tiers` remains `["fast"]`, why a forced global Fast setting still selects `priority`, and how the model-owned picker tier behaves across all shipped guide locales.

Closes #2993

## Verification

- `bun test tests/codex-catalog.test.ts tests/service-tier-capability.test.ts` — 253 pass, 0 fail
- `bun run typecheck`
- `bun run test --parallel=2` — full isolated suite passed with CPU and worker parallelism both limited to two
- `cd docs-site && bun run build` — 401 pages built
- `git diff --check`
- `jq empty src/codex/data/upstream-models.json`
- Protected local Codex/OpenCodex/Paseo configuration hashes were unchanged after every test/build phase.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Ultrafast service tier for eligible GPT-5.6 Sol models.
  * Daybreak Blue inherits Sol’s Fast and Ultrafast capabilities, while Terra and Luna remain Fast-only.
  * Preserved model-selected Ultrafast behavior when the global Fast setting is set to Auto.

* **Documentation**
  * Updated Codex model and service-tier guidance across multiple languages.
  * Clarified provider handling and the difference between Fast and Ultrafast tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->