### PR TITLE
fix(claude): drop admission credentials paired with a replaced stale proxy

### DIFF
--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -132,6 +132,18 @@ export function buildClaudeEnv(
         const replacement = `http://127.0.0.1:${port}`;
         console.error(`⚠ Replacing stale opencodex ANTHROPIC_BASE_URL ${parsed.origin} with ${replacement}.`);
         env.ANTHROPIC_BASE_URL = replacement;
+        // The credentials in this environment were paired with the destination we just
+        // replaced. An admission secret minted by that other proxy is not valid here, and
+        // leaving it in place makes Claude Code authenticate as a host-managed provider
+        // instead of using its own subscription OAuth — the launch then bypasses the
+        // subscription-preserving default below. Only OUR OWN admission forms are dropped:
+        // a genuine user `sk-ant-` credential is upstream auth that native passthrough
+        // needs (server/claude-messages.ts), so it must survive the destination rewrite.
+        for (const slot of ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"] as const) {
+          const value = env[slot]?.trim();
+          if (!value) continue;
+          if (value === PROXY_MARKER || isProxyAdmissionSecret(value, config)) delete env[slot];
+        }
       }
     } catch {
       // Preserve user-provided values that are not parseable URLs.

--- a/tests/claude-cli.test.ts
+++ b/tests/claude-cli.test.ts
@@ -270,6 +270,48 @@ describe("ocx claude env assembly", () => {
     expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBeUndefined();
   });
 
+  // A stale loopback ANTHROPIC_BASE_URL is rewritten to this launch's port. The credentials
+  // in that environment were minted by the proxy we just stopped pointing at, so keeping
+  // them makes Claude Code launch as a host-managed provider instead of using its own
+  // subscription OAuth.
+  test("replacing a stale loopback base URL drops the admission credential paired with it", () => {
+    // This proxy requires no admission key, so the launch must stay in subscription mode.
+    // The inherited token was minted by the proxy on :19999 that we just stopped targeting.
+    const env = buildClaudeEnv(cfg(), 10100, {
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:19999",
+      ANTHROPIC_AUTH_TOKEN: "ocx_data_other_proxy_key",
+    }, {}, { ...AUTH_PRESENT, preBunAnthropicSlots: ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"] });
+    expect(env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:10100");
+    // A surviving token makes Claude Code authenticate as a host-managed provider and
+    // overrides the caller's own claude.ai OAuth.
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("a stale admission token is replaced by THIS proxy's key, never carried over", () => {
+    const env = buildClaudeEnv(
+      cfg({ apiKeys: [{ id: "k1", name: "local", key: "ocx_data_this_proxy_key", createdAt: "2026-01-01T00:00:00Z" }] }),
+      10100,
+      {
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:19999",
+        ANTHROPIC_AUTH_TOKEN: "ocx_data_other_proxy_key",
+      },
+      {},
+      { ...AUTH_PRESENT, preBunAnthropicSlots: ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"] },
+    );
+    expect(env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:10100");
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("ocx_data_this_proxy_key");
+  });
+
+  test("a user sk-ant- credential survives the stale base-URL rewrite (native passthrough auth)", () => {
+    const env = buildClaudeEnv(cfg(), 10100, {
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:19999",
+      ANTHROPIC_API_KEY: "sk-ant-user-owned-key",
+    }, {}, { ...AUTH_PRESENT, preBunAnthropicSlots: ["ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY"] });
+    expect(env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:10100");
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-user-owned-key");
+  });
+
 });
 
 describe("ocx claude Windows launch (devlog 260715_cross_platform_audit/020)", () => {


### PR DESCRIPTION
## Summary

`buildClaudeEnv` rewrites a stale loopback `ANTHROPIC_BASE_URL` to the current launch port but left the Anthropic credential slots paired with that replaced destination in place. This drops the ones that are opencodex's own admission material.

The launcher already treats a loopback `ANTHROPIC_BASE_URL` on a different port as a previous opencodex launch: that is the condition it logs and overwrites. A token inherited alongside it was minted by that other proxy, so it is not valid admission here. Worse, `setDefault` preserves any non-empty value, so this proxy's own configured key was never injected and `hostOwnsAuthentication` decided `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` on foreign evidence. On a proxy that requires no admission key, the launch silently left subscription mode and overrode the caller's claude.ai OAuth, which is exactly what the subscription-preserving comment below the rewrite warns against.

Scope is deliberately narrow. Only values matched by `PROXY_MARKER` or `isProxyAdmissionSecret` are removed, and only inside the branch that already decided the destination was stale. A genuine user `sk-ant-` credential is upstream auth that `wantsNativePassthrough` needs, so it still survives the rewrite. The pre-existing `PROXY_MARKER` strip and `inheritedTokenIsOurs` check are untouched; neither was keyed on the destination rewrite, which is why this pairing stayed open.

Closes #3004.

## Verification

- `bun test tests/claude-cli.test.ts` — 28 pass, 0 fail
- `bun run test:changed` — 112 pass across 6 files, 0 fail
- `bun run typecheck` — clean
- `bun run privacy:scan` — passed
- Both new assertions were driven red against the unpatched launcher to prove they are not vacuous: reverting `src/cli/claude.ts` alone fails exactly the two new cases and nothing else.
- The full local suite was not run in this session; exact-head CI is the gate.

Three regression cases in `tests/claude-cli.test.ts`:

1. an admission token paired with a replaced stale destination is dropped, and a proxy with no `apiKeys` stays token-free
2. when this proxy does configure a key, that key is injected instead of the stale one being carried over
3. a user `sk-ant-` credential survives the rewrite

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale loopback proxy URL updates to remove outdated proxy credentials and markers.
  * Preserved user-provided API credentials during proxy URL refreshes.
  * Ensured launches remain in subscription mode when previous proxy credentials are no longer valid.

* **Tests**
  * Added coverage for replacing stale proxy credentials and preserving user-owned credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->