### PR TITLE
fix(release): advance dev to 2.36.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

- Advance the `dev` package version from the already-published `2.36.0` line to `2.36.1`.
- Restore the repository-wide release-version invariant without contaminating unrelated feature PRs.
- Keep the repair to the single authoritative `package.json` version field; `bun.lock` carries no workspace package version.

`2.36.1` is currently unused: npm returns 404 for `@bitkyc08/opencodex@2.36.1`, `refs/tags/v2.36.1` is absent, and GitHub has no `v2.36.1` release.

## Verification

- `bun test tests/release-version-line.test.ts tests/compatibility-version.test.ts` — 4 pass, 0 fail.
- `bun run typecheck` — passed.
- `git diff --check` — passed.
- All checks ran with isolated temporary `HOME`, `OPENCODEX_HOME`, and `CODEX_HOME` and a two-CPU/nice limit.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No docs change is needed for an internal development version-line repair.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This patch changes version metadata only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.36.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->