### PR TITLE
docs(devlog): record the Kiro contract landed-state verification

### DIFF
--- a/devlog/_plan/260830_kiro_post_answer_tool_calls/020_close_out.md
+++ b/devlog/_plan/260830_kiro_post_answer_tool_calls/020_close_out.md
@@ -66,3 +66,16 @@ Causality is not claimed as proven. The pre-change selection rate is recorded at
 same measurement on traffic served by a proxy running `f5a625cf3` or later.
 Both hosts were on older builds at measurement time (local 2.36.0, `macmini-cf`
 2.35.0), so a restart onto current `dev` is the precondition for that comparison.
+
+## Landed-state verification
+
+Checked against `origin/dev` after both merges (`6f75616f0`), reading the files
+out of the remote ref rather than the working tree:
+
+- `src/adapters/kiro.ts` contains the terminal schema description.
+- `src/adapters/kiro-constants.ts` contains the appended terminal clause.
+- `tests/kiro-adapter.test.ts` contains the both-surfaces regression test.
+- This unit's close-out record is present.
+
+Merge trail: `f5a625cf3` (#3012, the contract change) and `6f75616f0`
+(#3014, this record).


### PR DESCRIPTION
## Summary

Follow-up to #3014: records the landed-state verification for the Kiro terminal completion contract unit. Documentation only.

After both merges, all four changed surfaces were read back out of `origin/dev` at `6f75616f0` rather than from the working tree: the terminal schema description in `src/adapters/kiro.ts`, the appended terminal clause in `src/adapters/kiro-constants.ts`, the both-surfaces regression test in `tests/kiro-adapter.test.ts`, and the close-out record itself. The merge trail (`f5a625cf3` for #3012, `6f75616f0` for #3014) is recorded alongside it.

## Verification

- `bun run privacy:scan` passes.
- `bun test tests/kiro-adapter.test.ts tests/kiro-stream.test.ts tests/tool-catalog-nudge.test.ts` — 197 pass / 0 fail, unchanged by this docs commit.
- Nothing in the build, typecheck, or test path reads from `devlog/`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No GUI change, no runtime change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a landed-state verification record confirming terminal completion contract changes were checked after merging.
  * Documented the verified files and merge history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->