### PR TITLE
fix(codex): recover pool quota auth after WHAM 401

### DIFF
--- a/src/codex/account-store.ts
+++ b/src/codex/account-store.ts
@@ -376,7 +376,13 @@ function withCredentialMutationLockSync<T>(fn: () => T): T {
   }
 }
 
-type CodexTokenResult = { accessToken: string; chatgptAccountId: string; generation: number };
+type CodexTokenResult = {
+  accessToken: string;
+  chatgptAccountId: string;
+  generation: number;
+  /** This call's own generation CAS produced the returned credential. */
+  selfRefreshed?: boolean;
+};
 type CodexRefreshResult = CodexTokenResult & {
   credential?: CodexAccountCredentials;
   /**
@@ -609,6 +615,17 @@ export async function getValidCodexToken(id: string): Promise<CodexTokenResult> 
   };
 }
 
+/** Quota recovery also needs to distinguish this call's refresh from an external replacement. */
+export async function getValidCodexTokenWithLineage(id: string): Promise<CodexTokenResult> {
+  const result = await resolveCodexToken(id);
+  return {
+    accessToken: result.accessToken,
+    chatgptAccountId: result.chatgptAccountId,
+    generation: result.generation,
+    ...(result.selfRefreshed !== undefined ? { selfRefreshed: result.selfRefreshed } : {}),
+  };
+}
+
 async function resolveCodexToken(
   id: string,
   forced?: ForcedRefreshFence,
@@ -697,6 +714,11 @@ async function resolveCodexToken(
         // the owner's own credential was replaced while it waited for the lock. Adopting
         // that would copy another account's access and refresh tokens onto this one.
         refreshed.resolvedGrantFingerprint === refreshGrantFingerprint &&
+        // A shared refresh grant is not an identity proof. The joined flight's
+        // credential may belong to another ChatGPT account, so require the same
+        // non-empty upstream identity before copying the complete credential.
+        !!currentCred.chatgptAccountId &&
+        currentCred.chatgptAccountId === refreshed.credential.chatgptAccountId &&
         // A joined flight that resolved to the rejected token proves nothing; fall
         // through and open a real refresh instead of bumping the generation.
         !(forced !== undefined && refreshed.credential.accessToken === forced.rejectedAccessToken) &&

--- a/src/codex/account-store.ts
+++ b/src/codex/account-store.ts
@@ -17,7 +17,7 @@ type LegacyCodexAccountStore = Record<string, CodexAccountCredentials>;
 type CodexAccountStore = Record<string, CodexAccountCredentialRecord>;
 type RawCodexAccountStore = Record<string, CodexAccountCredentials | CodexAccountCredentialRecord>;
 
-const REFRESH_SKEW_MS = 60_000;
+export const CODEX_TOKEN_REFRESH_SKEW_MS = 60_000;
 const REFRESH_LOCK_STALE_MS = 60_000;
 const REFRESH_LOCK_WAIT_MS = REFRESH_LOCK_STALE_MS + 5_000;
 const REFRESH_LOCK_POLL_MS = 50;
@@ -128,6 +128,17 @@ export function getCodexAccountCredential(id: string): CodexAccountCredentials |
   return record.credential ?? null;
 }
 
+function nextCredentialReplacedAt(current: CodexAccountCredentialRecord | undefined): number | undefined {
+  if (!current) return undefined;
+  const previous = current.replacedAt;
+  if (previous === undefined) return Date.now();
+  const next = previous + 1;
+  // A malformed/out-of-range legacy value must not be reused as lineage evidence. A current
+  // timestamp differs from it and therefore fails closed instead of pretending continuity.
+  if (!Number.isSafeInteger(previous) || previous < 0 || !Number.isSafeInteger(next)) return Date.now();
+  return Math.max(Date.now(), next);
+}
+
 export function saveCodexAccountCredential(id: string, cred: CodexAccountCredentials): void {
   withCredentialMutationLockSync(() => {
     const store = loadCodexAccountRecordStore();
@@ -139,7 +150,9 @@ export function saveCodexAccountCredential(id: string, cred: CodexAccountCredent
       credential: cred,
       generation: (current?.generation ?? 0) + 1,
       refreshGrantFingerprint,
-      replacedAt: current ? Date.now() : undefined,
+      // External replacement is the lineage fence used to distinguish reauthentication from a
+      // refresh-owned CAS. Advance it even when two saves share one millisecond.
+      replacedAt: nextCredentialReplacedAt(current),
       ...preservedValidationMetadata(current),
     };
     persist(store);
@@ -314,7 +327,13 @@ export function tombstoneCodexAccount(id: string): number {
     const store = loadCodexAccountRecordStore();
     const current = store[id];
     const generation = (current?.generation ?? 0) + 1;
-    store[id] = { generation, deletedAt: Date.now() };
+    store[id] = {
+      generation,
+      deletedAt: Date.now(),
+      // Delete/re-add is also an external replacement boundary. Retaining an advanced fence
+      // prevents a same-millisecond recreation from looking like a refresh-owned descendant.
+      replacedAt: nextCredentialReplacedAt(current),
+    };
     persist(store);
     return generation;
   });
@@ -376,13 +395,7 @@ function withCredentialMutationLockSync<T>(fn: () => T): T {
   }
 }
 
-type CodexTokenResult = {
-  accessToken: string;
-  chatgptAccountId: string;
-  generation: number;
-  /** This call's own generation CAS produced the returned credential. */
-  selfRefreshed?: boolean;
-};
+type CodexTokenResult = { accessToken: string; chatgptAccountId: string; generation: number };
 type CodexRefreshResult = CodexTokenResult & {
   credential?: CodexAccountCredentials;
   /**
@@ -515,7 +528,7 @@ function findFreshCredentialForGrant(
     // just rejected. Reusing it would bump the generation and replay the identical
     // bearer — a second 401 dressed up as recovery.
     if (rejectedAccessToken !== undefined && candidate.credential.accessToken === rejectedAccessToken) continue;
-    if (candidate.credential.expiresAt > now + REFRESH_SKEW_MS) return candidate.credential;
+    if (candidate.credential.expiresAt > now + CODEX_TOKEN_REFRESH_SKEW_MS) return candidate.credential;
   }
   return null;
 }
@@ -615,17 +628,6 @@ export async function getValidCodexToken(id: string): Promise<CodexTokenResult> 
   };
 }
 
-/** Quota recovery also needs to distinguish this call's refresh from an external replacement. */
-export async function getValidCodexTokenWithLineage(id: string): Promise<CodexTokenResult> {
-  const result = await resolveCodexToken(id);
-  return {
-    accessToken: result.accessToken,
-    chatgptAccountId: result.chatgptAccountId,
-    generation: result.generation,
-    ...(result.selfRefreshed !== undefined ? { selfRefreshed: result.selfRefreshed } : {}),
-  };
-}
-
 async function resolveCodexToken(
   id: string,
   forced?: ForcedRefreshFence,
@@ -643,7 +645,7 @@ async function resolveCodexToken(
   // is still the one that was rejected. Once it has been replaced, the shortcut is
   // correct again and refreshing would burn a rotation for nothing.
   const forcedTargetsStoredCredential = forced !== undefined && !forcedFenceSuperseded(record.generation, forced);
-  if (cred.expiresAt > Date.now() + REFRESH_SKEW_MS && !forcedTargetsStoredCredential) {
+  if (cred.expiresAt > Date.now() + CODEX_TOKEN_REFRESH_SKEW_MS && !forcedTargetsStoredCredential) {
     return { accessToken: cred.accessToken, chatgptAccountId: cred.chatgptAccountId, generation: record.generation };
   }
 
@@ -697,7 +699,7 @@ async function resolveCodexToken(
       if (
         current && currentCred
         && forcedFenceSuperseded(current.generation, forced)
-        && currentCred.expiresAt > Date.now() + REFRESH_SKEW_MS
+        && currentCred.expiresAt > Date.now() + CODEX_TOKEN_REFRESH_SKEW_MS
         && !(forced !== undefined && currentCred.accessToken === forced.rejectedAccessToken)
       ) {
         return {
@@ -773,7 +775,7 @@ async function resolveCodexToken(
     const startGeneration = lockedRecord.generation;
     const lockedRefreshGrantFingerprint = recordGrantFingerprint(lockedRecord);
     if (lockedRefreshGrantFingerprint !== refreshGrantFingerprint) {
-      if (lockedCred.expiresAt > Date.now() + REFRESH_SKEW_MS) {
+      if (lockedCred.expiresAt > Date.now() + CODEX_TOKEN_REFRESH_SKEW_MS) {
         return {
           accessToken: lockedCred.accessToken,
           chatgptAccountId: lockedCred.chatgptAccountId,
@@ -793,7 +795,7 @@ async function resolveCodexToken(
     // authoritative, so a superseded forced refresh stops here rather than
     // spending a rotation on a credential nobody rejected.
     const forcedStillTargetsStored = forced !== undefined && !forcedFenceSuperseded(startGeneration, forced);
-    if (lockedCred.expiresAt > Date.now() + REFRESH_SKEW_MS && !forcedStillTargetsStored) {
+    if (lockedCred.expiresAt > Date.now() + CODEX_TOKEN_REFRESH_SKEW_MS && !forcedStillTargetsStored) {
       return {
         accessToken: lockedCred.accessToken,
         chatgptAccountId: lockedCred.chatgptAccountId,

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -9,6 +9,8 @@ import { codexAccountLogLabel, withCodexAccountLogLabel } from "./account-label"
 import {
   getCodexAccountCredential,
   getValidCodexToken,
+  getValidCodexTokenWithLineage,
+  forceRefreshCodexPoolToken,
   isCodexAccountGenerationLive,
   markCodexAccountValidated,
   readCodexAccountRecord,
@@ -74,6 +76,13 @@ import {
   type StoredAccountQuota,
   type WhamUsageResponse,
 } from "./quota";
+import {
+  clearPoolQuota401Recovery,
+  clearPoolQuota401RecoveryForTests,
+  getLivePoolQuota401Recovery,
+  prunePoolQuota401Recovery,
+  setPoolQuota401Recovery,
+} from "./quota-401-recovery";
 export {
   applyAccountQuotaFromUpstreamHeaders,
   clearAccountQuota,
@@ -599,7 +608,7 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
-const MAIN_TERMINAL_AUTH_CODES = new Set([
+const WHAM_TERMINAL_AUTH_CODES = new Set([
   "invalid_workspace_selected",
   "invalid_refresh_token",
 ]);
@@ -614,18 +623,18 @@ const MAIN_TERMINAL_AUTH_CODES = new Set([
  * `exp` cannot be decoded is NOT live — an undecodable token that vouched for
  * itself would make a real 401 permanently transient.
  */
-async function isTerminalMainAuthResponse(resp: Response, accessTokenLive: boolean): Promise<boolean> {
+async function isTerminalWhamAuthResponse(resp: Response, accessTokenLive: boolean): Promise<boolean> {
   if (resp.status === 401) {
     if (!accessTokenLive) return true;
-    const code = await readMainAuthErrorCode(resp);
-    return typeof code === "string" && MAIN_TERMINAL_AUTH_CODES.has(code);
+    const code = await readWhamAuthErrorCode(resp);
+    return typeof code === "string" && WHAM_TERMINAL_AUTH_CODES.has(code);
   }
   if (resp.status !== 403) return false;
-  const code = await readMainAuthErrorCode(resp);
-  return typeof code === "string" && MAIN_TERMINAL_AUTH_CODES.has(code);
+  const code = await readWhamAuthErrorCode(resp);
+  return typeof code === "string" && WHAM_TERMINAL_AUTH_CODES.has(code);
 }
 
-async function readMainAuthErrorCode(resp: Response): Promise<unknown> {
+async function readWhamAuthErrorCode(resp: Response): Promise<unknown> {
   try {
     const body = await readBoundedResponseBody(resp, { totalTimeoutMs: 1_000, inactivityTimeoutMs: 1_000 });
     if (!body.displaySafe) return undefined;
@@ -769,7 +778,7 @@ async function fetchMainAccountInfoWhileOwned(
       signal: AbortSignal.timeout(8000),
     });
     if (!resp.ok) {
-      const terminalAuthFailure = await isTerminalMainAuthResponse(resp, isMainAccountTokenVerifiablyLive());
+      const terminalAuthFailure = await isTerminalWhamAuthResponse(resp, isMainAccountTokenVerifiablyLive());
       const retried = await retryMainAccountInfoIfIdentityChanged(requestAccountId, retriesRemaining, nativeMainLease, explicitRefresh);
       if (retried) return retried;
       if (terminalAuthFailure) {
@@ -836,16 +845,37 @@ interface PoolQuotaResult {
   quotaProbeSkipped?: true;
 }
 
+export interface PoolQuotaRefreshFlightState {
+  startCredentialGeneration?: number;
+  startCredentialReplacedAt?: number;
+  startChatgptAccountId?: string;
+  resolvedCredentialGeneration?: number;
+}
+
 interface PoolQuotaRefreshFlight {
-  state: {
-    startCredentialGeneration?: number;
-    resolvedCredentialGeneration?: number;
-  };
+  state: PoolQuotaRefreshFlightState;
   promise: Promise<PoolQuotaResult>;
 }
 
 const poolQuotaRefreshInFlight = new Map<string, Set<PoolQuotaRefreshFlight>>();
+/**
+ * A WHAM 401 may require a time-valid pool credential to rotate before its plan can be read.
+ * Keep that recovery to one token exchange per credential generation in this worker. A bare
+ * second 401 remains transient: later probes may retry WHAM with the same bearer, but never spend
+ * another token exchange until the credential generation changes.
+ */
 const MAX_POOL_QUOTA_FLIGHTS = 16;
+
+function isTerminalPoolQuotaRefreshFailure(error: unknown): boolean {
+  return error instanceof TokenRefreshError && (error.reason === "revoked" || error.reason === "expired");
+}
+
+function fetchPoolWhamUsage(accessToken: string, chatgptAccountId: string): Promise<Response> {
+  return fetch("https://chatgpt.com/backend-api/wham/usage", {
+    headers: { Authorization: `Bearer ${accessToken}`, "ChatGPT-Account-Id": chatgptAccountId },
+    signal: AbortSignal.timeout(8000),
+  });
+}
 
 export class PoolQuotaProbeBusyError extends ResourceAdmissionError {
   constructor() {
@@ -923,15 +953,13 @@ function reconcileFreshPoolAccountPlans(runtimeConfig: OcxConfig, updates: Fresh
         const persistedAccount = configuredPoolAccount(persistedConfig, update.accountId);
         if (!liveAccount || !persistedAccount) continue;
         accepted.push(update);
-        if (persistedAccount.plan !== update.plan) {
+        if (persistedAccount.plan !== update.plan
+          || persistedAccount.planSource !== "wham"
+          || persistedAccount.planCredentialGeneration !== update.credentialGeneration) {
           persistedAccount.plan = update.plan;
-          // WHAM is the authoritative plan source: stamp provenance so a later JWT
-          // reconcile cannot overwrite this observation within the same credential
-          // generation (src/codex/plan-from-token.ts jwtMayWritePlan). Stamped only
-          // alongside a real plan change: a steady-state refresh whose plan is
-          // unchanged must stay write-free (no-config-write contract), and an
-          // unchanged value needs no fence — a JWT rewrite to the same text is a
-          // no-op under the caller's own equality check.
+          // WHAM is authoritative even when the plan text matches a JWT observation.
+          // Stamp the source+generation so disk and runtime agree and a later JWT
+          // reconcile cannot overwrite this same-generation observation.
           persistedAccount.planSource = "wham";
           persistedAccount.planCredentialGeneration = update.credentialGeneration;
           changed = true;
@@ -964,24 +992,124 @@ async function fetchFreshPoolAccountQuota(
   existing: StoredAccountQuota | null,
   configuredPlan?: string,
   onCredentialGeneration?: (generation: number) => void,
+  tokenRefreshSpentGeneration?: number,
 ): Promise<PoolQuotaResult> {
   const writerGeneration = captureConfigGeneration();
-  let requestCredentialGeneration = readCodexAccountRecord(accountId)?.generation;
+  const startingCredentialGeneration = readCodexAccountRecord(accountId)?.generation;
+  let requestCredentialGeneration = startingCredentialGeneration;
+  let quotaRecoveryActive = tokenRefreshSpentGeneration !== undefined
+    && tokenRefreshSpentGeneration === startingCredentialGeneration;
+  let externalReplacementObserved = false;
   try {
-    const { accessToken, chatgptAccountId, generation } = await getValidCodexToken(accountId);
+    const resolved = await getValidCodexTokenWithLineage(accountId);
+    let { accessToken, chatgptAccountId, generation } = resolved;
     requestCredentialGeneration = generation;
     onCredentialGeneration?.(generation);
-    const resp = await fetch("https://chatgpt.com/backend-api/wham/usage", {
-      headers: { Authorization: `Bearer ${accessToken}`, "ChatGPT-Account-Id": chatgptAccountId },
-      signal: AbortSignal.timeout(8000),
-    });
+    // getValidCodexToken may itself have refreshed an expired credential. Do not spend a
+    // second exchange if WHAM rejects the resulting generation in this same request.
+    if (startingCredentialGeneration !== undefined && generation !== startingCredentialGeneration) {
+      if (resolved.selfRefreshed === true) quotaRecoveryActive = true;
+      else {
+        // Another owner replaced the credential between our pre-read and resolution. A bare
+        // rejection may be observed, but this stale request cannot spend or exhaust G+1's budget.
+        quotaRecoveryActive = false;
+        externalReplacementObserved = true;
+      }
+    }
+    let resp = await fetchPoolWhamUsage(accessToken, chatgptAccountId);
     if (!resp.ok) {
+      const terminal = await isTerminalWhamAuthResponse(resp, true);
+      await resp.body?.cancel().catch(() => {});
+      if (terminal) {
+        setPoolQuota401Recovery(accountId, { generation, disposition: "terminal" });
+        return { quota: existing ?? null, needsReauth: true, credentialGeneration: generation };
+      }
+      if (resp.status !== 401) {
+        if (quotaRecoveryActive) {
+          setPoolQuota401Recovery(accountId, {
+            generation,
+            disposition: "spent",
+            retryAt: Date.now() + POOL_CACHE_TTL,
+          });
+        }
+        return {
+          quota: existing ?? null,
+          needsReauth: false,
+          credentialGeneration: generation,
+          ...(quotaRecoveryActive ? { quotaProbeSkipped: true as const } : {}),
+        };
+      }
+      if (externalReplacementObserved) {
+        return {
+          quota: getAccountQuota(accountId),
+          needsReauth: false,
+          credentialGeneration: generation,
+          quotaProbeSkipped: true,
+        };
+      }
+      if (quotaRecoveryActive) {
+        setPoolQuota401Recovery(accountId, {
+          generation,
+          disposition: "spent",
+          retryAt: Date.now() + POOL_CACHE_TTL,
+        });
+        return {
+          quota: existing ?? null,
+          needsReauth: false,
+          credentialGeneration: generation,
+          quotaProbeSkipped: true,
+        };
+      }
+
+      quotaRecoveryActive = true;
+      const refreshed = await forceRefreshCodexPoolToken(accountId, {
+        rejectedGeneration: generation,
+        rejectedAccessToken: accessToken,
+      });
+      requestCredentialGeneration = refreshed.generation;
+      onCredentialGeneration?.(refreshed.generation);
+      // A replacement written by another owner is not descended from this stale WHAM 401.
+      // Leave it for a fresh poll instead of replaying or quarantining somebody else's credential.
+      if (!refreshed.selfRefreshed) {
+        return {
+          quota: getAccountQuota(accountId),
+          needsReauth: false,
+          credentialGeneration: refreshed.generation,
+          quotaProbeSkipped: true,
+        };
+      }
+      if (!refreshed.rotated) {
+        setPoolQuota401Recovery(accountId, {
+          generation: refreshed.generation,
+          disposition: "spent",
+          retryAt: Date.now() + POOL_CACHE_TTL,
+        });
+        return {
+          quota: existing ?? null,
+          needsReauth: false,
+          credentialGeneration: refreshed.generation,
+          quotaProbeSkipped: true,
+        };
+      }
+      accessToken = refreshed.accessToken;
+      chatgptAccountId = refreshed.chatgptAccountId;
+      generation = refreshed.generation;
+      resp = await fetchPoolWhamUsage(accessToken, chatgptAccountId);
+    }
+    if (!resp.ok) {
+      const terminal = await isTerminalWhamAuthResponse(resp, true);
+      await resp.body?.cancel().catch(() => {});
+      setPoolQuota401Recovery(accountId, terminal
+        ? { generation, disposition: "terminal" }
+        : { generation, disposition: "spent", retryAt: Date.now() + POOL_CACHE_TTL });
       return {
         quota: existing ?? null,
-        needsReauth: resp.status === 401,
+        needsReauth: terminal,
         credentialGeneration: generation,
+        ...(!terminal ? { quotaProbeSkipped: true as const } : {}),
       };
     }
+    clearPoolQuota401Recovery(accountId, generation);
     const data = (await resp.json()) as WhamUsageResponse;
     const freshPlan = nonEmptyPlan(data.plan_type) ?? undefined;
     const quota = parseUsageQuota({ ...data, plan_type: freshPlan ?? configuredPlan });
@@ -1010,6 +1138,15 @@ async function fetchFreshPoolAccountQuota(
       ...(freshResetCredits !== undefined ? { freshResetCredits } : {}),
     };
   } catch (e) {
+    if (quotaRecoveryActive && requestCredentialGeneration !== undefined) {
+      setPoolQuota401Recovery(accountId, isTerminalPoolQuotaRefreshFailure(e)
+        ? { generation: requestCredentialGeneration, disposition: "terminal" }
+        : {
+            generation: requestCredentialGeneration,
+            disposition: "spent",
+            retryAt: Date.now() + POOL_CACHE_TTL,
+          });
+    }
     if (e instanceof CodexCredentialGenerationConflictError || e instanceof CodexCredentialRefreshLockTimeoutError
       || e instanceof CodexCredentialRefreshBusyError || e instanceof CodexCredentialRefreshStaleError) {
       return {
@@ -1022,14 +1159,67 @@ async function fetchFreshPoolAccountQuota(
       };
     }
     if (e instanceof TokenRefreshError) {
-      return { quota: existing ?? null, needsReauth: true, credentialGeneration: requestCredentialGeneration };
+      const terminal = isTerminalPoolQuotaRefreshFailure(e);
+      return {
+        quota: existing ?? null,
+        needsReauth: terminal,
+        credentialGeneration: requestCredentialGeneration,
+        ...(!terminal ? { quotaProbeSkipped: true as const } : {}),
+      };
     }
-    return { quota: existing ?? null, needsReauth: false, credentialGeneration: requestCredentialGeneration };
+    return {
+      quota: existing ?? null,
+      needsReauth: false,
+      credentialGeneration: requestCredentialGeneration,
+      ...(quotaRecoveryActive ? { quotaProbeSkipped: true as const } : {}),
+    };
   }
+}
+
+function poolQuotaRefreshFlightIsCurrent(accountId: string, state: PoolQuotaRefreshFlightState): boolean {
+  const startGeneration = state.startCredentialGeneration;
+  const advertisedGeneration = state.resolvedCredentialGeneration ?? startGeneration;
+  if (advertisedGeneration === undefined) return false;
+  if (isCodexAccountGenerationLive(accountId, advertisedGeneration)) return true;
+  // The credential CAS precedes async plan settlement. During that narrow G -> G+1 window,
+  // keep joining the original quota flight only when the established replacedAt lineage and
+  // upstream identity are intact; an external replacement stamps a new replacedAt value.
+  const currentRecord = readCodexAccountRecord(accountId);
+  return startGeneration !== undefined
+    && (state.resolvedCredentialGeneration === undefined
+      || state.resolvedCredentialGeneration === startGeneration)
+    && currentRecord?.generation === startGeneration + 1
+    && currentRecord.replacedAt === state.startCredentialReplacedAt
+    && currentRecord.credential?.chatgptAccountId === state.startChatgptAccountId;
+}
+
+/** Focused tests only: prove the quota single-flight's G -> G+1 lineage matcher. */
+export function isCodexQuotaRefreshFlightCurrentForTests(
+  accountId: string,
+  state: PoolQuotaRefreshFlightState,
+): boolean {
+  return poolQuotaRefreshFlightIsCurrent(accountId, state);
 }
 
 async function fetchPoolAccountQuota(accountId: string, forceRefresh = false, configuredPlan?: string): Promise<PoolQuotaResult> {
   const existing = getAccountQuota(accountId);
+  const record = readCodexAccountRecord(accountId);
+  const recovery = getLivePoolQuota401Recovery(accountId, record?.generation);
+  if (recovery?.disposition === "terminal") {
+    return {
+      quota: existing,
+      needsReauth: true,
+      credentialGeneration: recovery.generation,
+    };
+  }
+  if (recovery?.disposition === "spent" && !forceRefresh && recovery.retryAt > Date.now()) {
+    return {
+      quota: existing,
+      needsReauth: false,
+      credentialGeneration: recovery.generation,
+      quotaProbeSkipped: true,
+    };
+  }
   if (!forceRefresh && existing && Date.now() - existing.updatedAt < POOL_CACHE_TTL) {
     return {
       quota: existing,
@@ -1040,24 +1230,24 @@ async function fetchPoolAccountQuota(accountId: string, forceRefresh = false, co
   // A token refresh may increment the generation (and rotate the refresh token) before WHAM
   // completes. Join a flight whose starting or resolved generation is still current, but let a
   // replacement credential with the same pool id start its own request.
-  const record = readCodexAccountRecord(accountId);
   const flights = poolQuotaRefreshInFlight.get(accountId);
-  const current = flights && [...flights].find(flight => {
-    const generation = flight.state.resolvedCredentialGeneration
-      ?? flight.state.startCredentialGeneration;
-    return generation !== undefined && isCodexAccountGenerationLive(accountId, generation);
-  });
+  const current = flights && [...flights].find(flight => poolQuotaRefreshFlightIsCurrent(accountId, flight.state));
   if (current) return current.promise;
   if (poolQuotaFlightCount() >= MAX_POOL_QUOTA_FLIGHTS) throw new PoolQuotaProbeBusyError();
 
-  const state: PoolQuotaRefreshFlight["state"] = {
+  const state: PoolQuotaRefreshFlightState = {
     startCredentialGeneration: record?.generation,
+    ...(record?.replacedAt !== undefined ? { startCredentialReplacedAt: record.replacedAt } : {}),
+    ...(record?.credential?.chatgptAccountId !== undefined
+      ? { startChatgptAccountId: record.credential.chatgptAccountId }
+      : {}),
   };
   const refresh = fetchFreshPoolAccountQuota(
     accountId,
     existing,
     configuredPlan,
     generation => { state.resolvedCredentialGeneration = generation; },
+    recovery?.disposition === "spent" ? recovery.generation : undefined,
   );
   const flight: PoolQuotaRefreshFlight = { state, promise: refresh };
   const activeFlights = flights ?? new Set<PoolQuotaRefreshFlight>();
@@ -1203,10 +1393,10 @@ export async function primeCodexPoolQuotas(
   return primeInFlight;
 }
 
-/** Test-only: drop any in-flight prime pass so a leaked single-flight promise
- * from another suite cannot coalesce into the next prime. */
+/** Test-only: drop quota-prime single-flight and generation-bound 401 recovery state. */
 export function clearCodexQuotaPrimeState(): void {
   primeInFlight = null;
+  clearPoolQuota401RecoveryForTests();
 }
 
 /** Test-only reset for the worker-level single-flight. */
@@ -1229,6 +1419,9 @@ export async function listCodexAuthAccountsSnapshot(
 ): Promise<CodexAuthAccountsSnapshot> {
   const runtimeConfig = getRuntimeConfig(config);
   const poolAccounts = (runtimeConfig.codexAccounts ?? []).filter(isSelectableCodexPoolAccount);
+  // Recovery rows exist only for currently configured, generation-live accounts. Unlike an
+  // arbitrary LRU cap, this cannot evict a live no-repeat fence and start refresh churn.
+  prunePoolQuota401Recovery(new Set(poolAccounts.map(account => account.id)));
   const mainResult = await fetchMainAccountInfoAttempt(forceRefresh, 1);
   const refreshedPool = await mapWithConcurrency(poolAccounts, POOL_QUOTA_REFRESH_CONCURRENCY, async account => {
     const cred = getCodexAccountCredential(account.id);

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -9,12 +9,12 @@ import { codexAccountLogLabel, withCodexAccountLogLabel } from "./account-label"
 import {
   getCodexAccountCredential,
   getValidCodexToken,
-  getValidCodexTokenWithLineage,
   forceRefreshCodexPoolToken,
   isCodexAccountGenerationLive,
   markCodexAccountValidated,
   readCodexAccountRecord,
   saveCodexAccountCredential,
+  CODEX_TOKEN_REFRESH_SKEW_MS,
   CodexCredentialGenerationConflictError,
   CodexCredentialRefreshLockTimeoutError,
   CodexCredentialRefreshBusyError,
@@ -82,6 +82,7 @@ import {
   getLivePoolQuota401Recovery,
   prunePoolQuota401Recovery,
   setPoolQuota401Recovery,
+  type PoolQuota401Recovery,
 } from "./quota-401-recovery";
 export {
   applyAccountQuotaFromUpstreamHeaders,
@@ -860,14 +861,68 @@ interface PoolQuotaRefreshFlight {
 const poolQuotaRefreshInFlight = new Map<string, Set<PoolQuotaRefreshFlight>>();
 /**
  * A WHAM 401 may require a time-valid pool credential to rotate before its plan can be read.
- * Keep that recovery to one token exchange per credential generation in this worker. A bare
- * second 401 remains transient: later probes may retry WHAM with the same bearer, but never spend
- * another token exchange until the credential generation changes.
+ * Keep successful token exchange to one per credential generation in this worker. A transient
+ * exchange failure gets a bounded retryable backoff instead: after it expires, the same generation
+ * may try the exchange again because no replacement credential was committed.
  */
 const MAX_POOL_QUOTA_FLIGHTS = 16;
 
 function isTerminalPoolQuotaRefreshFailure(error: unknown): boolean {
   return error instanceof TokenRefreshError && (error.reason === "revoked" || error.reason === "expired");
+}
+
+function poolQuotaRecoveryAfterFailure(
+  generation: number,
+  refreshBudgetSpent: boolean,
+): PoolQuota401Recovery {
+  return {
+    generation,
+    disposition: refreshBudgetSpent ? "spent" : "retryable",
+    retryAt: Date.now() + POOL_CACHE_TTL,
+  };
+}
+
+function credentialRefreshStayedOnLineage(
+  before: ReturnType<typeof readCodexAccountRecord>,
+  after: ReturnType<typeof readCodexAccountRecord>,
+): boolean {
+  return !!before?.credential
+    && !!after?.credential
+    && after.generation > before.generation
+    && after.replacedAt === before.replacedAt
+    && after.credential.chatgptAccountId === before.credential.chatgptAccountId;
+}
+
+function credentialRecordMatchesToken(
+  record: ReturnType<typeof readCodexAccountRecord>,
+  token: { accessToken: string; chatgptAccountId: string; generation: number },
+): boolean {
+  return !!record?.credential
+    && record.generation === token.generation
+    && record.credential.accessToken === token.accessToken
+    && record.credential.chatgptAccountId === token.chatgptAccountId;
+}
+
+type PoolQuotaRecoveryDeps = {
+  getValidToken: typeof getValidCodexToken;
+  forceRefreshToken: typeof forceRefreshCodexPoolToken;
+  getRecovery: typeof getLivePoolQuota401Recovery;
+};
+
+const defaultPoolQuotaRecoveryDeps: PoolQuotaRecoveryDeps = {
+  getValidToken: getValidCodexToken,
+  forceRefreshToken: forceRefreshCodexPoolToken,
+  getRecovery: getLivePoolQuota401Recovery,
+};
+let poolQuotaRecoveryDeps = defaultPoolQuotaRecoveryDeps;
+
+/** Focused tests only: install reliable seams before exercising direct-import recovery races. */
+export function setPoolQuotaRecoveryDepsForTests(
+  overrides: Partial<PoolQuotaRecoveryDeps> | null,
+): void {
+  poolQuotaRecoveryDeps = overrides
+    ? { ...defaultPoolQuotaRecoveryDeps, ...overrides }
+    : defaultPoolQuotaRecoveryDeps;
 }
 
 function fetchPoolWhamUsage(accessToken: string, chatgptAccountId: string): Promise<Response> {
@@ -995,64 +1050,57 @@ async function fetchFreshPoolAccountQuota(
   tokenRefreshSpentGeneration?: number,
 ): Promise<PoolQuotaResult> {
   const writerGeneration = captureConfigGeneration();
-  const startingCredentialGeneration = readCodexAccountRecord(accountId)?.generation;
+  const startingRecord = readCodexAccountRecord(accountId);
+  const startingCredentialGeneration = startingRecord?.generation;
   let requestCredentialGeneration = startingCredentialGeneration;
-  let quotaRecoveryActive = tokenRefreshSpentGeneration !== undefined
+  let refreshBudgetSpent = tokenRefreshSpentGeneration !== undefined
     && tokenRefreshSpentGeneration === startingCredentialGeneration;
-  let externalReplacementObserved = false;
+  let credentialResolutionPending = true;
+  let forcedRefreshAttempted = false;
   try {
-    const resolved = await getValidCodexTokenWithLineage(accountId);
+    const resolved = await poolQuotaRecoveryDeps.getValidToken(accountId);
+    credentialResolutionPending = false;
     let { accessToken, chatgptAccountId, generation } = resolved;
     requestCredentialGeneration = generation;
     onCredentialGeneration?.(generation);
-    // getValidCodexToken may itself have refreshed an expired credential. Do not spend a
-    // second exchange if WHAM rejects the resulting generation in this same request.
-    if (startingCredentialGeneration !== undefined && generation !== startingCredentialGeneration) {
-      if (resolved.selfRefreshed === true) quotaRecoveryActive = true;
-      else {
-        // Another owner replaced the credential between our pre-read and resolution. A bare
-        // rejection may be observed, but this stale request cannot spend or exhaust G+1's budget.
-        quotaRecoveryActive = false;
-        externalReplacementObserved = true;
-      }
-    }
+    // A successful ordinary expiry refresh advances to a NEW generation whose WHAM-401
+    // recovery has not been tried. Only a persisted spent verdict for the exact resolved
+    // generation carries forward.
+    refreshBudgetSpent = tokenRefreshSpentGeneration === generation;
+    const resolvedRecord = readCodexAccountRecord(accountId);
+    // Capture the record corresponding to the bearer BEFORE WHAM. If another writer replaces it
+    // after the rejection, the monotonic replacement fence distinguishes that replacement from a
+    // refresh-owned G -> G+n settlement.
+    const rejectedRecord = credentialRecordMatchesToken(resolvedRecord, resolved)
+      ? resolvedRecord
+      : credentialRecordMatchesToken(startingRecord, resolved) ? startingRecord : null;
     let resp = await fetchPoolWhamUsage(accessToken, chatgptAccountId);
     if (!resp.ok) {
       const terminal = await isTerminalWhamAuthResponse(resp, true);
       await resp.body?.cancel().catch(() => {});
-      if (terminal) {
-        setPoolQuota401Recovery(accountId, { generation, disposition: "terminal" });
-        return { quota: existing ?? null, needsReauth: true, credentialGeneration: generation };
-      }
       if (resp.status !== 401) {
-        if (quotaRecoveryActive) {
-          setPoolQuota401Recovery(accountId, {
-            generation,
-            disposition: "spent",
-            retryAt: Date.now() + POOL_CACHE_TTL,
-          });
+        if (terminal) {
+          clearPoolQuota401Recovery(accountId, generation);
+          markAccountNeedsReauth(accountId, writerGeneration, generation);
+          return { quota: existing ?? null, needsReauth: true, credentialGeneration: generation };
+        }
+        if (refreshBudgetSpent) {
+          setPoolQuota401Recovery(accountId, poolQuotaRecoveryAfterFailure(generation, true));
         }
         return {
           quota: existing ?? null,
           needsReauth: false,
           credentialGeneration: generation,
-          ...(quotaRecoveryActive ? { quotaProbeSkipped: true as const } : {}),
+          ...(refreshBudgetSpent ? { quotaProbeSkipped: true as const } : {}),
         };
       }
-      if (externalReplacementObserved) {
-        return {
-          quota: getAccountQuota(accountId),
-          needsReauth: false,
-          credentialGeneration: generation,
-          quotaProbeSkipped: true,
-        };
-      }
-      if (quotaRecoveryActive) {
-        setPoolQuota401Recovery(accountId, {
-          generation,
-          disposition: "spent",
-          retryAt: Date.now() + POOL_CACHE_TTL,
-        });
+      if (refreshBudgetSpent) {
+        if (terminal) {
+          clearPoolQuota401Recovery(accountId, generation);
+          markAccountNeedsReauth(accountId, writerGeneration, generation);
+          return { quota: existing ?? null, needsReauth: true, credentialGeneration: generation };
+        }
+        setPoolQuota401Recovery(accountId, poolQuotaRecoveryAfterFailure(generation, true));
         return {
           quota: existing ?? null,
           needsReauth: false,
@@ -1060,30 +1108,33 @@ async function fetchFreshPoolAccountQuota(
           quotaProbeSkipped: true,
         };
       }
-
-      quotaRecoveryActive = true;
-      const refreshed = await forceRefreshCodexPoolToken(accountId, {
+      forcedRefreshAttempted = true;
+      const refreshed = await poolQuotaRecoveryDeps.forceRefreshToken(accountId, {
         rejectedGeneration: generation,
         rejectedAccessToken: accessToken,
       });
       requestCredentialGeneration = refreshed.generation;
       onCredentialGeneration?.(refreshed.generation);
-      // A replacement written by another owner is not descended from this stale WHAM 401.
-      // Leave it for a fresh poll instead of replaying or quarantining somebody else's credential.
-      if (!refreshed.selfRefreshed) {
-        return {
-          quota: getAccountQuota(accountId),
-          needsReauth: false,
-          credentialGeneration: refreshed.generation,
-          quotaProbeSkipped: true,
-        };
-      }
+      const refreshedRecord = readCodexAccountRecord(accountId);
+      // `selfRefreshed` identifies this caller's CAS, not whether a joined flight already
+      // spent the exchange. Preserve that budget across same-lineage G -> G+n adoption while
+      // still probing an externally replaced credential once.
+      refreshBudgetSpent = refreshed.selfRefreshed
+        || credentialRefreshStayedOnLineage(rejectedRecord, refreshedRecord);
       if (!refreshed.rotated) {
-        setPoolQuota401Recovery(accountId, {
-          generation: refreshed.generation,
-          disposition: "spent",
-          retryAt: Date.now() + POOL_CACHE_TTL,
-        });
+        if (terminal && refreshBudgetSpent) {
+          clearPoolQuota401Recovery(accountId, refreshed.generation);
+          markAccountNeedsReauth(accountId, writerGeneration, refreshed.generation);
+          return {
+            quota: existing ?? null,
+            needsReauth: true,
+            credentialGeneration: refreshed.generation,
+          };
+        }
+        setPoolQuota401Recovery(
+          accountId,
+          poolQuotaRecoveryAfterFailure(refreshed.generation, refreshBudgetSpent),
+        );
         return {
           quota: existing ?? null,
           needsReauth: false,
@@ -1099,9 +1150,12 @@ async function fetchFreshPoolAccountQuota(
     if (!resp.ok) {
       const terminal = await isTerminalWhamAuthResponse(resp, true);
       await resp.body?.cancel().catch(() => {});
-      setPoolQuota401Recovery(accountId, terminal
-        ? { generation, disposition: "terminal" }
-        : { generation, disposition: "spent", retryAt: Date.now() + POOL_CACHE_TTL });
+      if (terminal) {
+        clearPoolQuota401Recovery(accountId, generation);
+        markAccountNeedsReauth(accountId, writerGeneration, generation);
+      } else {
+        setPoolQuota401Recovery(accountId, poolQuotaRecoveryAfterFailure(generation, refreshBudgetSpent));
+      }
       return {
         quota: existing ?? null,
         needsReauth: terminal,
@@ -1138,14 +1192,20 @@ async function fetchFreshPoolAccountQuota(
       ...(freshResetCredits !== undefined ? { freshResetCredits } : {}),
     };
   } catch (e) {
-    if (quotaRecoveryActive && requestCredentialGeneration !== undefined) {
-      setPoolQuota401Recovery(accountId, isTerminalPoolQuotaRefreshFailure(e)
-        ? { generation: requestCredentialGeneration, disposition: "terminal" }
-        : {
-            generation: requestCredentialGeneration,
-            disposition: "spent",
-            retryAt: Date.now() + POOL_CACHE_TTL,
-          });
+    const terminal = isTerminalPoolQuotaRefreshFailure(e);
+    if (requestCredentialGeneration !== undefined) {
+      if (terminal) {
+        clearPoolQuota401Recovery(accountId, requestCredentialGeneration);
+        markAccountNeedsReauth(accountId, writerGeneration, requestCredentialGeneration);
+      } else if (credentialResolutionPending || forcedRefreshAttempted || refreshBudgetSpent) {
+        setPoolQuota401Recovery(
+          accountId,
+          poolQuotaRecoveryAfterFailure(
+            requestCredentialGeneration,
+            credentialResolutionPending ? false : refreshBudgetSpent,
+          ),
+        );
+      }
     }
     if (e instanceof CodexCredentialGenerationConflictError || e instanceof CodexCredentialRefreshLockTimeoutError
       || e instanceof CodexCredentialRefreshBusyError || e instanceof CodexCredentialRefreshStaleError) {
@@ -1159,7 +1219,6 @@ async function fetchFreshPoolAccountQuota(
       };
     }
     if (e instanceof TokenRefreshError) {
-      const terminal = isTerminalPoolQuotaRefreshFailure(e);
       return {
         quota: existing ?? null,
         needsReauth: terminal,
@@ -1171,7 +1230,9 @@ async function fetchFreshPoolAccountQuota(
       quota: existing ?? null,
       needsReauth: false,
       credentialGeneration: requestCredentialGeneration,
-      ...(quotaRecoveryActive ? { quotaProbeSkipped: true as const } : {}),
+      ...(credentialResolutionPending || forcedRefreshAttempted || refreshBudgetSpent
+        ? { quotaProbeSkipped: true as const }
+        : {}),
     };
   }
 }
@@ -1203,16 +1264,38 @@ export function isCodexQuotaRefreshFlightCurrentForTests(
 
 async function fetchPoolAccountQuota(accountId: string, forceRefresh = false, configuredPlan?: string): Promise<PoolQuotaResult> {
   const existing = getAccountQuota(accountId);
-  const record = readCodexAccountRecord(accountId);
-  const recovery = getLivePoolQuota401Recovery(accountId, record?.generation);
-  if (recovery?.disposition === "terminal") {
+  let record = readCodexAccountRecord(accountId);
+  // Canonical reauth state is generation-fenced and shared with routing. It is set only
+  // after a refresh grant is proven dead (or a refreshed credential returns structured
+  // terminal WHAM evidence), so unlike the former quota-local terminal row this cannot
+  // block the ordinary expiry refresh that would advance the generation.
+  if (isAccountNeedsReauth(accountId)) {
     return {
       quota: existing,
       needsReauth: true,
-      credentialGeneration: recovery.generation,
+      credentialGeneration: record?.generation,
     };
   }
-  if (recovery?.disposition === "spent" && !forceRefresh && recovery.retryAt > Date.now()) {
+  let recovery = poolQuotaRecoveryDeps.getRecovery(accountId, record?.generation);
+  // A test seam or another process can replace the credential while the recovery row is read.
+  // Rebase the decision on the latest generation before honoring any backoff.
+  const postRecoveryRecord = readCodexAccountRecord(accountId);
+  if (postRecoveryRecord?.generation !== record?.generation) {
+    record = postRecoveryRecord;
+    recovery = poolQuotaRecoveryDeps.getRecovery(accountId, record?.generation);
+  }
+  const now = Date.now();
+  const ordinaryRefreshDue = !!record?.credential
+    && record.credential.expiresAt <= now + CODEX_TOKEN_REFRESH_SKEW_MS;
+  if (
+    recovery
+    && recovery.retryAt > now
+    // A user-forced refresh may re-probe WHAM after a committed exchange, but it must not
+    // spend another token exchange. A retryable token-endpoint failure keeps its backoff even
+    // for a forced quota read so the UI cannot hammer the credential endpoint.
+    && (recovery.disposition === "retryable" || (!forceRefresh && !ordinaryRefreshDue))
+    && readCodexAccountRecord(accountId)?.generation === recovery.generation
+  ) {
     return {
       quota: existing,
       needsReauth: false,
@@ -1247,6 +1330,8 @@ async function fetchPoolAccountQuota(accountId: string, forceRefresh = false, co
     existing,
     configuredPlan,
     generation => { state.resolvedCredentialGeneration = generation; },
+    // Only a committed refresh spends this generation's exchange budget. A retryable
+    // token-endpoint failure gets another chance after its backoff expires.
     recovery?.disposition === "spent" ? recovery.generation : undefined,
   );
   const flight: PoolQuotaRefreshFlight = { state, promise: refresh };

--- a/src/codex/quota-401-recovery.ts
+++ b/src/codex/quota-401-recovery.ts
@@ -1,0 +1,51 @@
+import type { GenerationContext } from "../lib/state-store-sweeper";
+import { isCodexAccountGenerationLive } from "./account-store";
+
+export type PoolQuota401Recovery =
+  | { generation: number; disposition: "terminal" }
+  | { generation: number; disposition: "spent"; retryAt: number };
+
+const recoveryByAccount = new Map<string, PoolQuota401Recovery>();
+
+export function getLivePoolQuota401Recovery(
+  accountId: string,
+  generation?: number,
+): PoolQuota401Recovery | undefined {
+  const state = recoveryByAccount.get(accountId);
+  if (state && state.generation !== generation) {
+    recoveryByAccount.delete(accountId);
+    return undefined;
+  }
+  return state;
+}
+
+export function setPoolQuota401Recovery(accountId: string, state: PoolQuota401Recovery): void {
+  if (!isCodexAccountGenerationLive(accountId, state.generation)) return;
+  recoveryByAccount.set(accountId, state);
+}
+
+export function clearPoolQuota401Recovery(accountId: string, generation: number): void {
+  if (recoveryByAccount.get(accountId)?.generation === generation) {
+    recoveryByAccount.delete(accountId);
+  }
+}
+
+export function prunePoolQuota401Recovery(liveAccountIds: ReadonlySet<string>): number {
+  let removed = 0;
+  for (const [accountId, state] of recoveryByAccount) {
+    if (!liveAccountIds.has(accountId) || !isCodexAccountGenerationLive(accountId, state.generation)) {
+      recoveryByAccount.delete(accountId);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+export function reconcilePoolQuota401Recovery(context: GenerationContext): number {
+  return prunePoolQuota401Recovery(context.codexAccountIds);
+}
+
+/** Test-only reset for process-local recovery hints. */
+export function clearPoolQuota401RecoveryForTests(): void {
+  recoveryByAccount.clear();
+}

--- a/src/codex/quota-401-recovery.ts
+++ b/src/codex/quota-401-recovery.ts
@@ -2,8 +2,8 @@ import type { GenerationContext } from "../lib/state-store-sweeper";
 import { isCodexAccountGenerationLive } from "./account-store";
 
 export type PoolQuota401Recovery =
-  | { generation: number; disposition: "terminal" }
-  | { generation: number; disposition: "spent"; retryAt: number };
+  | { generation: number; disposition: "spent"; retryAt: number }
+  | { generation: number; disposition: "retryable"; retryAt: number };
 
 const recoveryByAccount = new Map<string, PoolQuota401Recovery>();
 
@@ -13,7 +13,11 @@ export function getLivePoolQuota401Recovery(
 ): PoolQuota401Recovery | undefined {
   const state = recoveryByAccount.get(accountId);
   if (state && state.generation !== generation) {
-    recoveryByAccount.delete(accountId);
+    // A stale reader may still be holding G after another flight committed G+1 and installed its
+    // live fence. Never let the stale lookup erase the newer generation's recovery state.
+    if (!isCodexAccountGenerationLive(accountId, state.generation)) {
+      recoveryByAccount.delete(accountId);
+    }
     return undefined;
   }
   return state;

--- a/src/lib/state-store-registrations.ts
+++ b/src/lib/state-store-registrations.ts
@@ -9,6 +9,7 @@ import { reconcileProviderFetchWarnings } from "../codex/catalog/provider-fetch"
 import { reconcileModelCacheGeneration } from "../codex/model-cache";
 import { reconcilePoolRotationState } from "../codex/pool-rotation";
 import { reconcileCodexQuotaAccounts } from "../codex/quota";
+import { reconcilePoolQuota401Recovery } from "../codex/quota-401-recovery";
 import {
   listLiveCodexAccountIds,
   reconcileCodexRoutingHealth,
@@ -98,6 +99,7 @@ export const STATE_STORE_REGISTRATIONS = [
   { name: "combo-warning-memos", reconcileGeneration: (context: GenerationContext) => reconcileComboWarningMemos(context.generation) },
   { name: "router-warning-memos", reconcileGeneration: (context: GenerationContext) => reconcileRouterWarningMemos(context.generation) },
   { name: "codex-quota", reconcileGeneration: reconcileCodexQuotaAccounts },
+  { name: "codex-quota-401-recovery", reconcileGeneration: reconcilePoolQuota401Recovery },
   { name: "provider-quota-history", reconcileGeneration: reconcileProviderAccountQuotaRows },
   { name: "codex-routing-health", reconcileGeneration: reconcileCodexRoutingHealth },
   { name: "model-cache-history", reconcileGeneration: reconcileModelCacheGeneration },

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -757,7 +757,9 @@ describe("codex-account-store CRUD", () => {
         expect(ownerResult).toMatchObject({ accessToken: `owner-new-${scenario.suffix}`, chatgptAccountId: scenario.ownerIdentity });
         expect(joinerResult).toMatchObject({ accessToken: `joiner-new-${scenario.suffix}`, chatgptAccountId: scenario.joinerIdentity });
         expect(readCodexAccountRecord(ownerId)?.credential?.accessToken).toBe(`owner-new-${scenario.suffix}`);
+        expect(readCodexAccountRecord(ownerId)?.credential?.refreshToken).toBe(`owner-grant-${scenario.suffix}`);
         expect(readCodexAccountRecord(joinerId)?.credential?.accessToken).toBe(`joiner-new-${scenario.suffix}`);
+        expect(readCodexAccountRecord(joinerId)?.credential?.refreshToken).toBe(`joiner-grant-${scenario.suffix}`);
       }
     } finally {
       globalThis.fetch = originalFetch;

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -196,6 +196,50 @@ describe("codex-account-store CRUD", () => {
     expect(getCodexAccountCredential("cas")).toEqual(second);
   });
 
+  test("external replacement lineage advances even within one millisecond", async () => {
+    const {
+      readCodexAccountRecord,
+      saveCodexAccountCredential,
+      saveCodexAccountCredentialIfGeneration,
+      tombstoneCodexAccount,
+    } = await import("../src/codex/account-store");
+    const credential = { accessToken: "first", refreshToken: "first-r", expiresAt: 1, chatgptAccountId: "acc" };
+    let refreshedReplacedAt: number | undefined;
+    const clock = spyOn(Date, "now").mockReturnValue(1234);
+    try {
+      saveCodexAccountCredential("replacement-lineage", credential);
+      saveCodexAccountCredential("replacement-lineage", { ...credential, accessToken: "second" });
+      const second = readCodexAccountRecord("replacement-lineage")!;
+      saveCodexAccountCredential("replacement-lineage", { ...credential, accessToken: "third" });
+      const third = readCodexAccountRecord("replacement-lineage")!;
+
+      expect(second.replacedAt).toBe(1234);
+      expect(third.replacedAt).toBe(1235);
+      expect(saveCodexAccountCredentialIfGeneration(
+        "replacement-lineage",
+        third.generation,
+        { ...credential, accessToken: "refreshed" },
+      )).toBe(true);
+      const refreshed = readCodexAccountRecord("replacement-lineage")!;
+      expect(refreshed.replacedAt).toBe(third.replacedAt);
+      refreshedReplacedAt = refreshed.replacedAt;
+    } finally {
+      clock.mockRestore();
+    }
+
+    const tombstoneClock = spyOn(Date, "now").mockReturnValue(2234);
+    try {
+      tombstoneCodexAccount("replacement-lineage");
+      const tombstone = readCodexAccountRecord("replacement-lineage")!;
+      saveCodexAccountCredential("replacement-lineage", credential);
+      const recreated = readCodexAccountRecord("replacement-lineage")!;
+      expect(tombstone.replacedAt).toBeGreaterThan(refreshedReplacedAt!);
+      expect(recreated.replacedAt).toBeGreaterThan(tombstone.replacedAt!);
+    } finally {
+      tombstoneClock.mockRestore();
+    }
+  });
+
   test("validation metadata survives credential replacement and CAS refresh saves", async () => {
     const {
       markCodexAccountValidated,

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -700,6 +700,70 @@ describe("codex-account-store CRUD", () => {
     }
   });
 
+  test("a shared-grant flight never copies credentials across ChatGPT account identities", async () => {
+    const { forceRefreshCodexPoolToken, readCodexAccountRecord, saveCodexAccountCredential } =
+      await import("../src/codex/account-store");
+    const originalFetch = globalThis.fetch;
+    try {
+      for (const scenario of [
+        { suffix: "different", ownerIdentity: "acct-owner", joinerIdentity: "acct-joiner" },
+        { suffix: "empty", ownerIdentity: "", joinerIdentity: "" },
+      ]) {
+        const ownerId = `identity-owner-${scenario.suffix}`;
+        const joinerId = `identity-joiner-${scenario.suffix}`;
+        const grant = `identity-shared-grant-${scenario.suffix}`;
+        const expiresAt = Date.now() + 3600_000;
+        saveCodexAccountCredential(ownerId, {
+          accessToken: `owner-rejected-${scenario.suffix}`,
+          refreshToken: grant,
+          expiresAt,
+          chatgptAccountId: scenario.ownerIdentity,
+        });
+        saveCodexAccountCredential(joinerId, {
+          accessToken: `joiner-rejected-${scenario.suffix}`,
+          refreshToken: grant,
+          expiresAt,
+          chatgptAccountId: scenario.joinerIdentity,
+        });
+        const ownerGeneration = readCodexAccountRecord(ownerId)!.generation;
+        const joinerGeneration = readCodexAccountRecord(joinerId)!.generation;
+        let calls = 0;
+        let releaseOwner!: () => void;
+        const ownerStarted = new Promise<void>(resolve => {
+          globalThis.fetch = (async () => {
+            calls += 1;
+            if (calls === 1) {
+              resolve();
+              await new Promise<void>(release => { releaseOwner = release; });
+              return Response.json({ access_token: `owner-new-${scenario.suffix}`, refresh_token: `owner-grant-${scenario.suffix}`, expires_in: 3600 });
+            }
+            return Response.json({ access_token: `joiner-new-${scenario.suffix}`, refresh_token: `joiner-grant-${scenario.suffix}`, expires_in: 3600 });
+          }) as typeof fetch;
+        });
+
+        const owner = forceRefreshCodexPoolToken(ownerId, {
+          rejectedGeneration: ownerGeneration,
+          rejectedAccessToken: `owner-rejected-${scenario.suffix}`,
+        });
+        await ownerStarted;
+        const joiner = forceRefreshCodexPoolToken(joinerId, {
+          rejectedGeneration: joinerGeneration,
+          rejectedAccessToken: `joiner-rejected-${scenario.suffix}`,
+        });
+        releaseOwner();
+
+        const [ownerResult, joinerResult] = await Promise.all([owner, joiner]);
+        expect(calls).toBe(2);
+        expect(ownerResult).toMatchObject({ accessToken: `owner-new-${scenario.suffix}`, chatgptAccountId: scenario.ownerIdentity });
+        expect(joinerResult).toMatchObject({ accessToken: `joiner-new-${scenario.suffix}`, chatgptAccountId: scenario.joinerIdentity });
+        expect(readCodexAccountRecord(ownerId)?.credential?.accessToken).toBe(`owner-new-${scenario.suffix}`);
+        expect(readCodexAccountRecord(joinerId)?.credential?.accessToken).toBe(`joiner-new-${scenario.suffix}`);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   /*
    * #2892 gap 2. Flights are shared: a later caller on the same grant joins the
    * running promise instead of opening its own. The flight's abort signal used to

--- a/tests/codex-auth-api.test.ts
+++ b/tests/codex-auth-api.test.ts
@@ -17,6 +17,7 @@ import {
   clearCodexQuotaPrimeState, primeCodexPoolQuotas, seedCodexAuthAdmissionForTests,
   type CodexAuthAccountDto,
   listCodexAuthAccounts,
+  isCodexQuotaRefreshFlightCurrentForTests,
   setAccountQuotaFromParsed,
 } from "../src/codex/auth-api";
 import {
@@ -24,8 +25,10 @@ import {
   listCodexAccountIds,
   readCodexAccountRecord,
   saveCodexAccountCredential,
+  saveCodexAccountCredentialIfGeneration,
 } from "../src/codex/account-store";
 import * as accountStoreModule from "../src/codex/account-store";
+import * as quotaRecoveryModule from "../src/codex/quota-401-recovery";
 import {
   clearCodexUpstreamHealth,
   clearThreadAccountMap,
@@ -272,6 +275,7 @@ beforeEach(() => {
   clearCodexWebSocketRegistry();
   resetMainCodexAccountIdentityTrackingForTests();
   resetJwtPlanNotesForTests();
+  clearCodexQuotaPrimeState();
 });
 
 afterEach(() => {
@@ -286,6 +290,7 @@ afterEach(() => {
   clearThreadAccountMap();
   clearPoolRotationState();
   clearCodexWebSocketRegistry();
+  clearCodexQuotaPrimeState();
   globalThis.fetch = previousFetch;
   if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
   else process.env.OPENCODEX_HOME = previousOpencodexHome;
@@ -1430,6 +1435,451 @@ describe("codex-auth API", () => {
     }
   });
 
+  test("a time-valid pool token rejected by WHAM refreshes and retries once", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-plan-upgrade",
+      email: "pool-plan-upgrade@example.com",
+      plan: "plus",
+      accessToken: "old-plan-access",
+      refreshToken: "old-plan-refresh",
+      chatgptAccountId: "acct-plan-upgrade",
+      expiresAt: Date.now() + 24 * 60 * 60_000,
+    });
+    saveConfig(structuredClone(config));
+    const startGeneration = readCodexAccountRecord("pool-plan-upgrade")!.generation;
+    const refreshedAccess = chatgptPlanJwt("prolite", "acct-plan-upgrade");
+    let whamCalls = 0;
+    let refreshCalls = 0;
+
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        expect(String(init?.body)).toContain("refresh_token=old-plan-refresh");
+        return Response.json({
+          access_token: refreshedAccess,
+          refresh_token: "new-plan-refresh",
+          expires_in: 3600,
+        });
+      }
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        whamCalls += 1;
+        const authorization = new Headers(init?.headers).get("Authorization");
+        if (whamCalls === 1) {
+          expect(authorization).toBe("Bearer old-plan-access");
+          return new Response("", { status: 401 });
+        }
+        expect(authorization).toBe(`Bearer ${refreshedAccess}`);
+        return Response.json({
+          plan_type: "prolite",
+          rate_limit: { primary_window: { used_percent: 21, reset_at: 1782628379 } },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
+    }) as typeof fetch;
+
+    const req = new Request("http://localhost/api/codex-auth/accounts?refresh=1", { method: "GET" });
+    const resp = await handleCodexAuthAPI(req, new URL(req.url), config);
+    const data = await resp!.json() as {
+      accounts: Array<{ id: string; plan?: string; needsReauth?: boolean; quota?: { weeklyPercent?: number } }>;
+    };
+    const account = data.accounts.find(candidate => candidate.id === "pool-plan-upgrade");
+
+    expect(account).toMatchObject({ plan: "prolite", needsReauth: false, quota: { weeklyPercent: 21 } });
+    expect(whamCalls).toBe(2);
+    expect(refreshCalls).toBe(1);
+    expect(readCodexAccountRecord("pool-plan-upgrade")?.generation).toBe(startGeneration + 1);
+    expect(getCodexAccountCredential("pool-plan-upgrade")?.accessToken).toBe(refreshedAccess);
+    expect(config.codexAccounts?.find(candidate => candidate.id === "pool-plan-upgrade")).toMatchObject({
+      plan: "prolite",
+      planSource: "wham",
+      planCredentialGeneration: startGeneration + 1,
+    });
+    expect(loadConfig().codexAccounts?.find(candidate => candidate.id === "pool-plan-upgrade")).toMatchObject({
+      plan: "prolite",
+      planSource: "wham",
+      planCredentialGeneration: startGeneration + 1,
+    });
+  });
+
+  test("terminal refresh or WHAM evidence is memoized for the affected credential generation", async () => {
+    for (const scenario of [
+      { id: "pool-terminal-first", terminalAt: "initial" as const, expectedWhamCalls: 1, expectedRefreshCalls: 0 },
+      { id: "pool-invalid-grant", terminalAt: "refresh" as const, expectedWhamCalls: 1, expectedRefreshCalls: 1 },
+      { id: "pool-terminal-retry", terminalAt: "retry" as const, terminalStatus: 403, expectedWhamCalls: 2, expectedRefreshCalls: 1 },
+    ]) {
+      const config = makeConfig();
+      const oldAccess = `old-${scenario.id}`;
+      const refreshedAccess = `new-${scenario.id}`;
+      seedPoolAccount(config, {
+        id: scenario.id,
+        email: `${scenario.id}@example.com`,
+        plan: "plus",
+        accessToken: oldAccess,
+        refreshToken: `refresh-${scenario.id}`,
+        chatgptAccountId: `acct-${scenario.id}`,
+        expiresAt: Date.now() + 24 * 60 * 60_000,
+      });
+      let refreshCalls = 0;
+      const authorizations: Array<string | null> = [];
+      globalThis.fetch = (async (input, init) => {
+        const target = String(input);
+        if (target === "https://auth.openai.com/oauth/token") {
+          refreshCalls += 1;
+          if (scenario.terminalAt === "refresh") {
+            return Response.json({ error: "invalid_grant" }, { status: 400 });
+          }
+          return Response.json({
+            access_token: refreshedAccess,
+            refresh_token: `rotated-${scenario.id}`,
+            expires_in: 3600,
+          });
+        }
+        if (target === "https://chatgpt.com/backend-api/wham/usage") {
+          authorizations.push(new Headers(init?.headers).get("Authorization"));
+          if (scenario.terminalAt === "initial") {
+            return Response.json({ detail: { code: "invalid_refresh_token" } }, { status: 401 });
+          }
+          if (authorizations.length === 1) return new Response("", { status: 401 });
+          return Response.json({ code: "invalid_workspace_selected" }, { status: scenario.terminalStatus ?? 401 });
+        }
+        throw new Error(`Unexpected fetch: ${target}`);
+      }) as typeof fetch;
+
+      const list = async () => (await listCodexAuthAccounts(config, true))
+        .find(account => account.id === scenario.id);
+      expect(await list()).toMatchObject({ needsReauth: true });
+      expect(authorizations).toHaveLength(scenario.expectedWhamCalls);
+      expect(refreshCalls).toBe(scenario.expectedRefreshCalls);
+      expect(await list()).toMatchObject({ needsReauth: true });
+      expect(authorizations).toHaveLength(scenario.expectedWhamCalls);
+      expect(refreshCalls).toBe(scenario.expectedRefreshCalls);
+    }
+  });
+
+  test("bare WHAM failures spend one exchange without falsely expiring the credential", async () => {
+    for (const scenario of [
+      { id: "pool-same-bearer", sameBearer: true, expectedWhamCalls: 1 },
+      { id: "pool-second-bare-401", sameBearer: false, expectedWhamCalls: 2 },
+      { id: "pool-expiry-refresh-then-401", sameBearer: false, expired: true, expectedWhamCalls: 1 },
+    ]) {
+      const config = makeConfig();
+      const oldAccess = `old-${scenario.id}`;
+      const refreshedAccess = scenario.sameBearer ? oldAccess : `new-${scenario.id}`;
+      seedPoolAccount(config, {
+        id: scenario.id,
+        email: `${scenario.id}@example.com`,
+        plan: "plus",
+        accessToken: oldAccess,
+        refreshToken: `refresh-${scenario.id}`,
+        chatgptAccountId: `acct-${scenario.id}`,
+        expiresAt: scenario.expired ? 0 : Date.now() + 24 * 60 * 60_000,
+      });
+      let refreshCalls = 0;
+      const authorizations: Array<string | null> = [];
+      globalThis.fetch = (async (input, init) => {
+        const target = String(input);
+        if (target === "https://auth.openai.com/oauth/token") {
+          refreshCalls += 1;
+          return Response.json({
+            access_token: refreshedAccess,
+            refresh_token: `rotated-${scenario.id}`,
+            expires_in: 3600,
+          });
+        }
+        if (target === "https://chatgpt.com/backend-api/wham/usage") {
+          authorizations.push(new Headers(init?.headers).get("Authorization"));
+          return new Response("", { status: 401 });
+        }
+        throw new Error(`Unexpected fetch: ${target}`);
+      }) as typeof fetch;
+
+      const list = async (forceRefresh: boolean) => (await listCodexAuthAccounts(config, forceRefresh))
+        .find(account => account.id === scenario.id);
+      expect(await list(true)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+      expect(authorizations).toHaveLength(scenario.expectedWhamCalls);
+      expect(refreshCalls).toBe(1);
+      expect(await list(false)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+      expect(authorizations).toHaveLength(scenario.expectedWhamCalls);
+      expect(refreshCalls).toBe(1);
+      expect(await list(true)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+      expect(authorizations).toHaveLength(scenario.expectedWhamCalls + 1);
+      expect(refreshCalls).toBe(1);
+      expect(await list(false)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+      expect(authorizations).toHaveLength(scenario.expectedWhamCalls + 1);
+      expect(refreshCalls).toBe(1);
+    }
+  });
+
+  test("an ambiguous token refresh is not repeated, and the same bearer is re-probed after backoff", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-transient-refresh",
+      email: "pool-transient-refresh@example.com",
+      plan: "plus",
+      accessToken: "old-transient-access",
+      refreshToken: "old-transient-refresh",
+      chatgptAccountId: "acct-transient-refresh",
+      expiresAt: Date.now() + 24 * 60 * 60_000,
+    });
+    saveConfig(structuredClone(config));
+    let whamCalls = 0;
+    let refreshCalls = 0;
+    const authorizations: Array<string | null> = [];
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({ error: "server_error" }, { status: 503 });
+      }
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        whamCalls += 1;
+        authorizations.push(new Headers(init?.headers).get("Authorization"));
+        if (whamCalls === 1) return new Response("", { status: 401 });
+        return Response.json({
+          plan_type: "prolite",
+          rate_limit: { primary_window: { used_percent: 18, reset_at: 1782628379 } },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
+    }) as typeof fetch;
+
+    const list = async (forceRefresh: boolean) => (await listCodexAuthAccounts(config, forceRefresh))
+      .find(account => account.id === "pool-transient-refresh");
+
+    expect(await list(true)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+    expect(whamCalls).toBe(1);
+    expect(refreshCalls).toBe(1);
+    expect(await list(false)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+    expect(whamCalls).toBe(1);
+    expect(refreshCalls).toBe(1);
+    const now = Date.now();
+    const clock = spyOn(Date, "now").mockReturnValue(now + 5 * 60_000 + 1);
+    try {
+      const recovered = await list(false);
+      expect(recovered).toMatchObject({
+        plan: "prolite",
+        needsReauth: false,
+        quota: { weeklyPercent: 18 },
+      });
+      expect(recovered?.quotaProbeSkipped).toBeUndefined();
+      expect(whamCalls).toBe(2);
+      expect(refreshCalls).toBe(1);
+      expect(authorizations).toEqual([
+        "Bearer old-transient-access",
+        "Bearer old-transient-access",
+      ]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("reauthenticated credentials do not inherit a prior generation's terminal quota verdict", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-terminal-replaced",
+      email: "pool-terminal-replaced@example.com",
+      accessToken: "terminal-old",
+      chatgptAccountId: "acct-terminal-old",
+    });
+    let whamCalls = 0;
+    globalThis.fetch = (async (_input, init) => {
+      whamCalls += 1;
+      const authorization = new Headers(init?.headers).get("Authorization");
+      if (whamCalls === 1) {
+        expect(authorization).toBe("Bearer terminal-old");
+        return Response.json({ detail: { code: "invalid_refresh_token" } }, { status: 401 });
+      }
+      expect(authorization).toBe("Bearer terminal-replacement");
+      return Response.json({
+        plan_type: "prolite",
+        rate_limit: { primary_window: { used_percent: 7 } },
+      });
+    }) as typeof fetch;
+
+    const list = async () => (await listCodexAuthAccounts(config, true))
+      .find(account => account.id === "pool-terminal-replaced");
+    expect(await list()).toMatchObject({ needsReauth: true });
+    saveCodexAccountCredential("pool-terminal-replaced", {
+      accessToken: "terminal-replacement",
+      refreshToken: "terminal-replacement-grant",
+      expiresAt: Date.now() + 3600_000,
+      chatgptAccountId: "acct-terminal-replacement",
+    });
+    expect(await list()).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 7 } });
+    expect(whamCalls).toBe(2);
+  });
+
+  test("a pre-resolution external replacement keeps its own WHAM recovery budget", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-pre-resolution-replacement",
+      email: "pool-pre-resolution-replacement@example.com",
+      accessToken: "pre-resolution-old",
+      refreshToken: "pre-resolution-old-grant",
+      chatgptAccountId: "acct-pre-resolution-old",
+    });
+    const realGetValidWithLineage = accountStoreModule.getValidCodexTokenWithLineage;
+    let replacementWritten = false;
+    const lineageSpy = spyOn(accountStoreModule, "getValidCodexTokenWithLineage").mockImplementation(async id => {
+      if (!replacementWritten && id === "pool-pre-resolution-replacement") {
+        replacementWritten = true;
+        saveCodexAccountCredential(id, {
+          accessToken: "pre-repl",
+          refreshToken: "pre-resolution-replacement-grant",
+          expiresAt: Date.now() + 3600_000,
+          chatgptAccountId: "acct-pre-resolution-replacement",
+        });
+      }
+      return realGetValidWithLineage(id);
+    });
+    let whamCalls = 0;
+    let refreshCalls = 0;
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({
+          access_token: "pre-new",
+          refresh_token: "pre-resolution-refreshed-grant",
+          expires_in: 3600,
+        });
+      }
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        whamCalls += 1;
+        const authorization = new Headers(init?.headers).get("Authorization");
+        if (whamCalls <= 2) {
+          expect(authorization).toBe("Bearer pre-repl");
+          return new Response("", { status: 401 });
+        }
+        expect(authorization).toBe("Bearer pre-new");
+        return Response.json({ rate_limit: { primary_window: { used_percent: 9 } } });
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
+    }) as typeof fetch;
+
+    try {
+      const list = async () => (await listCodexAuthAccounts(config, true))
+        .find(account => account.id === "pool-pre-resolution-replacement");
+      expect(await list()).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+      expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 1, refreshCalls: 0 });
+      expect(await list()).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 9 } });
+      expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 3, refreshCalls: 1 });
+    } finally {
+      lineageSpy.mockRestore();
+    }
+  });
+
+  test("a spent verdict cannot cross an outer-read credential replacement", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-spent-outer-replacement",
+      email: "pool-spent-outer-replacement@example.com",
+      accessToken: "spent-outer-old",
+      refreshToken: "spent-outer-old-grant",
+      chatgptAccountId: "acct-spent-outer-old",
+    });
+    const oldGeneration = readCodexAccountRecord("pool-spent-outer-replacement")!.generation;
+    quotaRecoveryModule.setPoolQuota401Recovery("pool-spent-outer-replacement", {
+      generation: oldGeneration,
+      disposition: "spent",
+      retryAt: 0,
+    });
+    const realGetRecovery = quotaRecoveryModule.getLivePoolQuota401Recovery;
+    let replacementWritten = false;
+    const recoverySpy = spyOn(quotaRecoveryModule, "getLivePoolQuota401Recovery").mockImplementation((id, generation) => {
+      const result = realGetRecovery(id, generation);
+      if (!replacementWritten && id === "pool-spent-outer-replacement") {
+        replacementWritten = true;
+        saveCodexAccountCredential(id, {
+          accessToken: "spent-outer-replacement",
+          refreshToken: "spent-outer-replacement-grant",
+          expiresAt: Date.now() + 3600_000,
+          chatgptAccountId: "acct-spent-outer-replacement",
+        });
+      }
+      return result;
+    });
+    let whamCalls = 0;
+    let refreshCalls = 0;
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({
+          access_token: "spent-outer-refreshed",
+          refresh_token: "spent-outer-refreshed-grant",
+          expires_in: 3600,
+        });
+      }
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        whamCalls += 1;
+        const authorization = new Headers(init?.headers).get("Authorization");
+        if (whamCalls === 1) {
+          expect(authorization).toBe("Bearer spent-outer-replacement");
+          return new Response("", { status: 401 });
+        }
+        expect(authorization).toBe("Bearer spent-outer-refreshed");
+        return Response.json({ rate_limit: { primary_window: { used_percent: 12 } } });
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
+    }) as typeof fetch;
+
+    try {
+      const account = (await listCodexAuthAccounts(config, true))
+        .find(candidate => candidate.id === "pool-spent-outer-replacement");
+      expect(account).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 12 } });
+      expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 2, refreshCalls: 1 });
+    } finally {
+      recoverySpy.mockRestore();
+    }
+  });
+
+  test("quota flights join only an intact refresh-owned G to G+1 settlement window", () => {
+    const credential = {
+      accessToken: "flight-old",
+      refreshToken: "flight-grant",
+      expiresAt: Date.now() + 3600_000,
+      chatgptAccountId: "acct-flight-lineage",
+    };
+    saveCodexAccountCredential("pool-flight-lineage", credential);
+    const start = readCodexAccountRecord("pool-flight-lineage")!;
+    const baseState = {
+      startCredentialGeneration: start.generation,
+      startCredentialReplacedAt: start.replacedAt,
+      startChatgptAccountId: credential.chatgptAccountId,
+    };
+    expect(saveCodexAccountCredentialIfGeneration("pool-flight-lineage", start.generation, {
+      ...credential,
+      accessToken: "flight-refreshed",
+      refreshToken: "flight-refreshed-grant",
+    })).toBe(true);
+    expect(isCodexQuotaRefreshFlightCurrentForTests("pool-flight-lineage", baseState)).toBe(true);
+    expect(isCodexQuotaRefreshFlightCurrentForTests("pool-flight-lineage", {
+      ...baseState,
+      resolvedCredentialGeneration: start.generation,
+    })).toBe(true);
+
+    saveCodexAccountCredential("pool-flight-external", credential);
+    const externalStart = readCodexAccountRecord("pool-flight-external")!;
+    const externalState = {
+      startCredentialGeneration: externalStart.generation,
+      startCredentialReplacedAt: externalStart.replacedAt,
+      startChatgptAccountId: credential.chatgptAccountId,
+    };
+    saveCodexAccountCredential("pool-flight-external", {
+      ...credential,
+      accessToken: "external-replacement",
+      refreshToken: "external-replacement-grant",
+    });
+    expect(isCodexQuotaRefreshFlightCurrentForTests("pool-flight-external", externalState)).toBe(false);
+    expect(isCodexQuotaRefreshFlightCurrentForTests("pool-flight-external", {
+      ...externalState,
+      resolvedCredentialGeneration: externalStart.generation,
+    })).toBe(false);
+  });
+
   test("GET /api/codex-auth/accounts reconciles and persists a fresh pool plan on a cache miss", async () => {
     const config = makeConfig();
     seedPoolAccount(config, {
@@ -1535,12 +1985,12 @@ describe("codex-auth API", () => {
       id: "pool-plan-unchanged",
       email: "pool-plan-unchanged@example.com",
       plan: "plus",
-      // Provenance already stamped: steady state. The FIRST WHAM observation after the
-      // provenance feature landed performs one migration write; that case is covered by
-      // the WHAM-wins gate tests. Steady-state refreshes must stay write-free.
-      planSource: "wham",
-      planCredentialGeneration: 1,
     });
+    const account = config.codexAccounts?.find(candidate => candidate.id === "pool-plan-unchanged")!;
+    account.planSource = "wham";
+    account.planCredentialGeneration = readCodexAccountRecord("pool-plan-unchanged")!.generation;
+    // Provenance is already stamped for the live generation. The first WHAM observation
+    // after the provenance feature landed may migrate metadata, but steady state is write-free.
     saveConfig(structuredClone(config));
     let configCommits = 0;
     setPersistedConfigMutationBeforeCommitForTests(() => { configCommits += 1; });

--- a/tests/codex-auth-api.test.ts
+++ b/tests/codex-auth-api.test.ts
@@ -1766,6 +1766,7 @@ describe("codex-auth API", () => {
       expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 1, refreshCalls: 0 });
       expect(await list()).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 9 } });
       expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 3, refreshCalls: 1 });
+      expect(lineageSpy).toHaveBeenCalledWith("pool-pre-resolution-replacement");
     } finally {
       lineageSpy.mockRestore();
     }
@@ -1831,6 +1832,7 @@ describe("codex-auth API", () => {
         .find(candidate => candidate.id === "pool-spent-outer-replacement");
       expect(account).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 12 } });
       expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 2, refreshCalls: 1 });
+      expect(recoverySpy).toHaveBeenCalledWith("pool-spent-outer-replacement", oldGeneration);
     } finally {
       recoverySpy.mockRestore();
     }

--- a/tests/codex-auth-api.test.ts
+++ b/tests/codex-auth-api.test.ts
@@ -18,6 +18,7 @@ import {
   type CodexAuthAccountDto,
   listCodexAuthAccounts,
   isCodexQuotaRefreshFlightCurrentForTests,
+  setPoolQuotaRecoveryDepsForTests,
   setAccountQuotaFromParsed,
 } from "../src/codex/auth-api";
 import {
@@ -276,6 +277,7 @@ beforeEach(() => {
   resetMainCodexAccountIdentityTrackingForTests();
   resetJwtPlanNotesForTests();
   clearCodexQuotaPrimeState();
+  setPoolQuotaRecoveryDepsForTests(null);
 });
 
 afterEach(() => {
@@ -291,6 +293,7 @@ afterEach(() => {
   clearPoolRotationState();
   clearCodexWebSocketRegistry();
   clearCodexQuotaPrimeState();
+  setPoolQuotaRecoveryDepsForTests(null);
   globalThis.fetch = previousFetch;
   if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
   else process.env.OPENCODEX_HOME = previousOpencodexHome;
@@ -1468,7 +1471,7 @@ describe("codex-auth API", () => {
         const authorization = new Headers(init?.headers).get("Authorization");
         if (whamCalls === 1) {
           expect(authorization).toBe("Bearer old-plan-access");
-          return new Response("", { status: 401 });
+          return Response.json({ detail: { code: "invalid_refresh_token" } }, { status: 401 });
         }
         expect(authorization).toBe(`Bearer ${refreshedAccess}`);
         return Response.json({
@@ -1503,11 +1506,40 @@ describe("codex-auth API", () => {
     });
   });
 
-  test("terminal refresh or WHAM evidence is memoized for the affected credential generation", async () => {
+  test("an expired credential invalid_grant marks canonical reauth exactly once before WHAM", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-expired-invalid-grant",
+      email: "pool-expired-invalid-grant@example.com",
+      accessToken: "expired-access",
+      refreshToken: "expired-refresh",
+      chatgptAccountId: "acct-expired-invalid-grant",
+      expiresAt: 0,
+    });
+    let refreshCalls = 0;
+    globalThis.fetch = (async input => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      throw new Error(`WHAM must not run after terminal expiry refresh: ${target}`);
+    }) as typeof fetch;
+
+    const list = async () => (await listCodexAuthAccounts(config, true))
+      .find(candidate => candidate.id === "pool-expired-invalid-grant");
+    expect(await list()).toMatchObject({ needsReauth: true });
+    expect(isAccountNeedsReauth("pool-expired-invalid-grant")).toBe(true);
+    expect(resolveCodexAccountForThread("terminal-refresh-routing", config)).toBeNull();
+    expect(await list()).toMatchObject({ needsReauth: true });
+    expect(refreshCalls).toBe(1);
+  });
+
+  test("terminal refresh evidence is canonical and memoized for the affected credential generation", async () => {
     for (const scenario of [
-      { id: "pool-terminal-first", terminalAt: "initial" as const, expectedWhamCalls: 1, expectedRefreshCalls: 0 },
-      { id: "pool-invalid-grant", terminalAt: "refresh" as const, expectedWhamCalls: 1, expectedRefreshCalls: 1 },
-      { id: "pool-terminal-retry", terminalAt: "retry" as const, terminalStatus: 403, expectedWhamCalls: 2, expectedRefreshCalls: 1 },
+      { id: "pool-invalid-grant", terminalAt: "refresh" as const, expectedWhamCalls: 1 },
+      { id: "pool-terminal-retry", terminalAt: "retry" as const, expectedWhamCalls: 2 },
+      { id: "pool-terminal-same-bearer", terminalAt: "same-bearer" as const, expectedWhamCalls: 1 },
     ]) {
       const config = makeConfig();
       const oldAccess = `old-${scenario.id}`;
@@ -1527,22 +1559,24 @@ describe("codex-auth API", () => {
         const target = String(input);
         if (target === "https://auth.openai.com/oauth/token") {
           refreshCalls += 1;
+          if (scenario.terminalAt === "same-bearer") expect(isAccountNeedsReauth(scenario.id)).toBe(false);
           if (scenario.terminalAt === "refresh") {
             return Response.json({ error: "invalid_grant" }, { status: 400 });
           }
           return Response.json({
-            access_token: refreshedAccess,
+            access_token: scenario.terminalAt === "same-bearer" ? oldAccess : refreshedAccess,
             refresh_token: `rotated-${scenario.id}`,
             expires_in: 3600,
           });
         }
         if (target === "https://chatgpt.com/backend-api/wham/usage") {
           authorizations.push(new Headers(init?.headers).get("Authorization"));
-          if (scenario.terminalAt === "initial") {
-            return Response.json({ detail: { code: "invalid_refresh_token" } }, { status: 401 });
+          if (authorizations.length === 1) {
+            return scenario.terminalAt === "same-bearer"
+              ? Response.json({ code: "invalid_workspace_selected" }, { status: 401 })
+              : new Response("", { status: 401 });
           }
-          if (authorizations.length === 1) return new Response("", { status: 401 });
-          return Response.json({ code: "invalid_workspace_selected" }, { status: scenario.terminalStatus ?? 401 });
+          return Response.json({ code: "invalid_workspace_selected" }, { status: 401 });
         }
         throw new Error(`Unexpected fetch: ${target}`);
       }) as typeof fetch;
@@ -1551,10 +1585,11 @@ describe("codex-auth API", () => {
         .find(account => account.id === scenario.id);
       expect(await list()).toMatchObject({ needsReauth: true });
       expect(authorizations).toHaveLength(scenario.expectedWhamCalls);
-      expect(refreshCalls).toBe(scenario.expectedRefreshCalls);
+      expect(refreshCalls).toBe(1);
+      expect(isAccountNeedsReauth(scenario.id)).toBe(true);
       expect(await list()).toMatchObject({ needsReauth: true });
       expect(authorizations).toHaveLength(scenario.expectedWhamCalls);
-      expect(refreshCalls).toBe(scenario.expectedRefreshCalls);
+      expect(refreshCalls).toBe(1);
     }
   });
 
@@ -1562,7 +1597,6 @@ describe("codex-auth API", () => {
     for (const scenario of [
       { id: "pool-same-bearer", sameBearer: true, expectedWhamCalls: 1 },
       { id: "pool-second-bare-401", sameBearer: false, expectedWhamCalls: 2 },
-      { id: "pool-expiry-refresh-then-401", sameBearer: false, expired: true, expectedWhamCalls: 1 },
     ]) {
       const config = makeConfig();
       const oldAccess = `old-${scenario.id}`;
@@ -1574,7 +1608,7 @@ describe("codex-auth API", () => {
         accessToken: oldAccess,
         refreshToken: `refresh-${scenario.id}`,
         chatgptAccountId: `acct-${scenario.id}`,
-        expiresAt: scenario.expired ? 0 : Date.now() + 24 * 60 * 60_000,
+        expiresAt: Date.now() + 24 * 60 * 60_000,
       });
       let refreshCalls = 0;
       const authorizations: Array<string | null> = [];
@@ -1612,7 +1646,56 @@ describe("codex-auth API", () => {
     }
   });
 
-  test("an ambiguous token refresh is not repeated, and the same bearer is re-probed after backoff", async () => {
+  test("an ordinary expiry refresh clears the old spent fence and retains one WHAM recovery", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-spent-then-expired",
+      email: "pool-spent-then-expired@example.com",
+      accessToken: "spent-expired-old",
+      refreshToken: "spent-expired-grant",
+      chatgptAccountId: "acct-spent-then-expired",
+      expiresAt: 0,
+    });
+    const generation = readCodexAccountRecord("pool-spent-then-expired")!.generation;
+    quotaRecoveryModule.setPoolQuota401Recovery("pool-spent-then-expired", {
+      generation,
+      disposition: "spent",
+      retryAt: Date.now() + 5 * 60_000,
+    });
+    let refreshCalls = 0;
+    let whamCalls = 0;
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        if (refreshCalls === 2) expect(isAccountNeedsReauth("pool-spent-then-expired")).toBe(false);
+        return Response.json({
+          access_token: refreshCalls === 1 ? "spent-expired-ordinary" : "spent-expired-forced",
+          refresh_token: refreshCalls === 1 ? "spent-expired-ordinary-grant" : "spent-expired-forced-grant",
+          expires_in: 3600,
+        });
+      }
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        whamCalls += 1;
+        const authorization = new Headers(init?.headers).get("Authorization");
+        if (whamCalls === 1) {
+          expect(authorization).toBe("Bearer spent-expired-ordinary");
+          return Response.json({ detail: { code: "invalid_refresh_token" } }, { status: 401 });
+        }
+        expect(authorization).toBe("Bearer spent-expired-forced");
+        return Response.json({ rate_limit: { primary_window: { used_percent: 11 } } });
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
+    }) as typeof fetch;
+
+    const account = (await listCodexAuthAccounts(config, false))
+      .find(candidate => candidate.id === "pool-spent-then-expired");
+    expect(account).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 11 } });
+    expect({ refreshCalls, whamCalls }).toEqual({ refreshCalls: 2, whamCalls: 2 });
+    expect(readCodexAccountRecord("pool-spent-then-expired")?.generation).toBe(generation + 2);
+  });
+
+  test("a transient token refresh can retry and recover after backoff", async () => {
     const config = makeConfig();
     seedPoolAccount(config, {
       id: "pool-transient-refresh",
@@ -1623,7 +1706,6 @@ describe("codex-auth API", () => {
       chatgptAccountId: "acct-transient-refresh",
       expiresAt: Date.now() + 24 * 60 * 60_000,
     });
-    saveConfig(structuredClone(config));
     let whamCalls = 0;
     let refreshCalls = 0;
     const authorizations: Array<string | null> = [];
@@ -1631,14 +1713,19 @@ describe("codex-auth API", () => {
       const target = String(input);
       if (target === "https://auth.openai.com/oauth/token") {
         refreshCalls += 1;
-        return Response.json({ error: "server_error" }, { status: 503 });
+        if (refreshCalls === 1) return Response.json({ error: "server_error" }, { status: 503 });
+        return Response.json({
+          access_token: "new-transient-access",
+          refresh_token: "new-transient-refresh",
+          expires_in: 3600,
+        });
       }
       if (target === "https://chatgpt.com/backend-api/wham/usage") {
         whamCalls += 1;
-        authorizations.push(new Headers(init?.headers).get("Authorization"));
-        if (whamCalls === 1) return new Response("", { status: 401 });
+        const authorization = new Headers(init?.headers).get("Authorization");
+        authorizations.push(authorization);
+        if (authorization === "Bearer old-transient-access") return new Response("", { status: 401 });
         return Response.json({
-          plan_type: "prolite",
           rate_limit: { primary_window: { used_percent: 18, reset_at: 1782628379 } },
         });
       }
@@ -1654,21 +1741,24 @@ describe("codex-auth API", () => {
     expect(await list(false)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
     expect(whamCalls).toBe(1);
     expect(refreshCalls).toBe(1);
+    expect(await list(true)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+    expect(whamCalls).toBe(1);
+    expect(refreshCalls).toBe(1);
     const now = Date.now();
     const clock = spyOn(Date, "now").mockReturnValue(now + 5 * 60_000 + 1);
     try {
       const recovered = await list(false);
       expect(recovered).toMatchObject({
-        plan: "prolite",
         needsReauth: false,
         quota: { weeklyPercent: 18 },
       });
       expect(recovered?.quotaProbeSkipped).toBeUndefined();
-      expect(whamCalls).toBe(2);
-      expect(refreshCalls).toBe(1);
+      expect(whamCalls).toBe(3);
+      expect(refreshCalls).toBe(2);
       expect(authorizations).toEqual([
         "Bearer old-transient-access",
         "Bearer old-transient-access",
+        "Bearer new-transient-access",
       ]);
     } finally {
       clock.mockRestore();
@@ -1684,23 +1774,31 @@ describe("codex-auth API", () => {
       chatgptAccountId: "acct-terminal-old",
     });
     let whamCalls = 0;
-    globalThis.fetch = (async (_input, init) => {
-      whamCalls += 1;
-      const authorization = new Headers(init?.headers).get("Authorization");
-      if (whamCalls === 1) {
-        expect(authorization).toBe("Bearer terminal-old");
-        return Response.json({ detail: { code: "invalid_refresh_token" } }, { status: 401 });
+    let refreshCalls = 0;
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({ error: "invalid_grant" }, { status: 400 });
       }
-      expect(authorization).toBe("Bearer terminal-replacement");
-      return Response.json({
-        plan_type: "prolite",
-        rate_limit: { primary_window: { used_percent: 7 } },
-      });
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        whamCalls += 1;
+        const authorization = new Headers(init?.headers).get("Authorization");
+        if (authorization === "Bearer terminal-old") return new Response("", { status: 401 });
+        expect(authorization).toBe("Bearer terminal-replacement");
+        return Response.json({
+          plan_type: "prolite",
+          rate_limit: { primary_window: { used_percent: 7 } },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
     }) as typeof fetch;
 
     const list = async () => (await listCodexAuthAccounts(config, true))
       .find(account => account.id === "pool-terminal-replaced");
     expect(await list()).toMatchObject({ needsReauth: true });
+    expect(isAccountNeedsReauth("pool-terminal-replaced")).toBe(true);
+    expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 1, refreshCalls: 1 });
     saveCodexAccountCredential("pool-terminal-replaced", {
       accessToken: "terminal-replacement",
       refreshToken: "terminal-replacement-grant",
@@ -1708,10 +1806,12 @@ describe("codex-auth API", () => {
       chatgptAccountId: "acct-terminal-replacement",
     });
     expect(await list()).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 7 } });
+    expect(isAccountNeedsReauth("pool-terminal-replaced")).toBe(false);
     expect(whamCalls).toBe(2);
+    expect(refreshCalls).toBe(1);
   });
 
-  test("a pre-resolution external replacement keeps its own WHAM recovery budget", async () => {
+  test("a pre-resolution external replacement is probed and may spend its own recovery budget", async () => {
     const config = makeConfig();
     seedPoolAccount(config, {
       id: "pool-pre-resolution-replacement",
@@ -1720,19 +1820,23 @@ describe("codex-auth API", () => {
       refreshToken: "pre-resolution-old-grant",
       chatgptAccountId: "acct-pre-resolution-old",
     });
-    const realGetValidWithLineage = accountStoreModule.getValidCodexTokenWithLineage;
+    const realGetValidToken = accountStoreModule.getValidCodexToken;
     let replacementWritten = false;
-    const lineageSpy = spyOn(accountStoreModule, "getValidCodexTokenWithLineage").mockImplementation(async id => {
-      if (!replacementWritten && id === "pool-pre-resolution-replacement") {
-        replacementWritten = true;
-        saveCodexAccountCredential(id, {
-          accessToken: "pre-repl",
-          refreshToken: "pre-resolution-replacement-grant",
-          expiresAt: Date.now() + 3600_000,
-          chatgptAccountId: "acct-pre-resolution-replacement",
-        });
-      }
-      return realGetValidWithLineage(id);
+    const lineageIds: string[] = [];
+    setPoolQuotaRecoveryDepsForTests({
+      getValidToken: async id => {
+        lineageIds.push(id);
+        if (!replacementWritten && id === "pool-pre-resolution-replacement") {
+          replacementWritten = true;
+          saveCodexAccountCredential(id, {
+            accessToken: "pre-repl",
+            refreshToken: "pre-resolution-replacement-grant",
+            expiresAt: Date.now() + 3600_000,
+            chatgptAccountId: "acct-pre-resolution-replacement",
+          });
+        }
+        return realGetValidToken(id);
+      },
     });
     let whamCalls = 0;
     let refreshCalls = 0;
@@ -1749,7 +1853,7 @@ describe("codex-auth API", () => {
       if (target === "https://chatgpt.com/backend-api/wham/usage") {
         whamCalls += 1;
         const authorization = new Headers(init?.headers).get("Authorization");
-        if (whamCalls <= 2) {
+        if (whamCalls === 1) {
           expect(authorization).toBe("Bearer pre-repl");
           return new Response("", { status: 401 });
         }
@@ -1759,17 +1863,200 @@ describe("codex-auth API", () => {
       throw new Error(`Unexpected fetch: ${target}`);
     }) as typeof fetch;
 
-    try {
-      const list = async () => (await listCodexAuthAccounts(config, true))
-        .find(account => account.id === "pool-pre-resolution-replacement");
-      expect(await list()).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
-      expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 1, refreshCalls: 0 });
-      expect(await list()).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 9 } });
-      expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 3, refreshCalls: 1 });
-      expect(lineageSpy).toHaveBeenCalledWith("pool-pre-resolution-replacement");
-    } finally {
-      lineageSpy.mockRestore();
-    }
+    const list = async () => (await listCodexAuthAccounts(config, true))
+      .find(account => account.id === "pool-pre-resolution-replacement");
+    expect(await list()).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 9 } });
+    expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 2, refreshCalls: 1 });
+    expect(lineageIds).toContain("pool-pre-resolution-replacement");
+  });
+
+  test("a joined forced refresh persists a spent fence without caller-owned CAS metadata", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-joined-lineage",
+      email: "pool-joined-lineage@example.com",
+      accessToken: "joined-old",
+      refreshToken: "joined-old-grant",
+      chatgptAccountId: "acct-joined-lineage",
+      expiresAt: Date.now() + 3600_000,
+    });
+    const start = readCodexAccountRecord("pool-joined-lineage")!;
+    let resolutionCalls = 0;
+    let forcedRefreshCalls = 0;
+    setPoolQuotaRecoveryDepsForTests({
+      getValidToken: async id => {
+        resolutionCalls += 1;
+        expect(id).toBe("pool-joined-lineage");
+        return {
+          accessToken: "joined-old",
+          chatgptAccountId: "acct-joined-lineage",
+          generation: start.generation,
+        };
+      },
+      forceRefreshToken: async (id, options) => {
+        forcedRefreshCalls += 1;
+        expect(id).toBe("pool-joined-lineage");
+        expect(options).toMatchObject({
+          rejectedGeneration: start.generation,
+          rejectedAccessToken: "joined-old",
+        });
+        const credential = {
+          accessToken: "joined-new",
+          refreshToken: "joined-new-grant",
+          expiresAt: Date.now() + 3600_000,
+          chatgptAccountId: "acct-joined-lineage",
+        };
+        expect(saveCodexAccountCredentialIfGeneration(id, start.generation, credential)).toBe(true);
+        return {
+          accessToken: credential.accessToken,
+          chatgptAccountId: credential.chatgptAccountId,
+          generation: start.generation + 1,
+          rotated: true,
+          selfRefreshed: false,
+        };
+      },
+    });
+    let whamCalls = 0;
+    const authorizations: Array<string | null> = [];
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target !== "https://chatgpt.com/backend-api/wham/usage") {
+        throw new Error(`Unexpected fetch: ${target}`);
+      }
+      whamCalls += 1;
+      authorizations.push(new Headers(init?.headers).get("Authorization"));
+      return new Response("", { status: 401 });
+    }) as typeof fetch;
+
+    const account = (await listCodexAuthAccounts(config, true))
+      .find(candidate => candidate.id === "pool-joined-lineage");
+    expect(account).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+    expect({ resolutionCalls, forcedRefreshCalls, whamCalls }).toEqual({
+      resolutionCalls: 1,
+      forcedRefreshCalls: 1,
+      whamCalls: 2,
+    });
+    expect(authorizations).toEqual(["Bearer joined-old", "Bearer joined-new"]);
+
+    const firstCounts = { resolutionCalls, forcedRefreshCalls, whamCalls };
+    expect((await listCodexAuthAccounts(config, false))
+      .find(candidate => candidate.id === "pool-joined-lineage"))
+      .toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+    expect({ resolutionCalls, forcedRefreshCalls, whamCalls }).toEqual(firstCounts);
+    expect(authorizations).toEqual(["Bearer joined-old", "Bearer joined-new"]);
+  });
+
+  test("a failed WHAM replay preserves the spent fence for the refreshed generation", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-replay-network-failure",
+      email: "pool-replay-network-failure@example.com",
+      accessToken: "replay-old",
+      refreshToken: "replay-old-grant",
+      chatgptAccountId: "acct-replay-network-failure",
+      expiresAt: 0,
+    });
+    const startGeneration = readCodexAccountRecord("pool-replay-network-failure")!.generation;
+    let refreshCalls = 0;
+    const authorizations: Array<string | null> = [];
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({
+          access_token: refreshCalls === 1 ? "replay-ordinary" : "replay-forced",
+          refresh_token: refreshCalls === 1 ? "replay-ordinary-grant" : "replay-forced-grant",
+          expires_in: 3600,
+        });
+      }
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        const authorization = new Headers(init?.headers).get("Authorization");
+        authorizations.push(authorization);
+        if (authorization === "Bearer replay-ordinary") return new Response("", { status: 401 });
+        expect(authorization).toBe("Bearer replay-forced");
+        throw new Error("WHAM replay transport failure");
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
+    }) as typeof fetch;
+
+    const list = async (forceRefresh: boolean) => (await listCodexAuthAccounts(config, forceRefresh))
+      .find(candidate => candidate.id === "pool-replay-network-failure");
+    expect(await list(true)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+    const refreshedGeneration = readCodexAccountRecord("pool-replay-network-failure")!.generation;
+    expect(refreshedGeneration).toBe(startGeneration + 2);
+    expect(quotaRecoveryModule.getLivePoolQuota401Recovery(
+      "pool-replay-network-failure",
+      refreshedGeneration,
+    )?.disposition).toBe("spent");
+    expect(isAccountNeedsReauth("pool-replay-network-failure")).toBe(false);
+    expect({ refreshCalls, authorizations }).toEqual({
+      refreshCalls: 2,
+      authorizations: ["Bearer replay-ordinary", "Bearer replay-forced"],
+    });
+
+    expect(await list(false)).toMatchObject({ needsReauth: false, quotaProbeSkipped: true });
+    expect({ refreshCalls, authorizations }).toEqual({
+      refreshCalls: 2,
+      authorizations: ["Bearer replay-ordinary", "Bearer replay-forced"],
+    });
+  });
+
+  test("an ordinary expiry refresh keeps its WHAM recovery after a first-probe transport failure", async () => {
+    const config = makeConfig();
+    seedPoolAccount(config, {
+      id: "pool-expiry-first-probe-failure",
+      email: "pool-expiry-first-probe-failure@example.com",
+      accessToken: "expiry-first-old",
+      refreshToken: "expiry-first-old-grant",
+      chatgptAccountId: "acct-expiry-first-probe-failure",
+      expiresAt: 0,
+    });
+    const startGeneration = readCodexAccountRecord("pool-expiry-first-probe-failure")!.generation;
+    let refreshCalls = 0;
+    let whamCalls = 0;
+    let failFirstWham = true;
+    globalThis.fetch = (async (input, init) => {
+      const target = String(input);
+      if (target === "https://auth.openai.com/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({
+          access_token: refreshCalls === 1 ? "expiry-first-ordinary" : "expiry-first-forced",
+          refresh_token: refreshCalls === 1 ? "expiry-first-ordinary-grant" : "expiry-first-forced-grant",
+          expires_in: 3600,
+        });
+      }
+      if (target === "https://chatgpt.com/backend-api/wham/usage") {
+        whamCalls += 1;
+        const authorization = new Headers(init?.headers).get("Authorization");
+        if (failFirstWham) {
+          failFirstWham = false;
+          expect(authorization).toBe("Bearer expiry-first-ordinary");
+          throw new Error("first WHAM transport failure");
+        }
+        if (authorization === "Bearer expiry-first-ordinary") return new Response("", { status: 401 });
+        expect(authorization).toBe("Bearer expiry-first-forced");
+        return Response.json({ rate_limit: { primary_window: { used_percent: 14 } } });
+      }
+      throw new Error(`Unexpected fetch: ${target}`);
+    }) as typeof fetch;
+
+    const list = async () => (await listCodexAuthAccounts(config, true))
+      .find(candidate => candidate.id === "pool-expiry-first-probe-failure");
+    const first = await list();
+    expect(first).toMatchObject({ needsReauth: false });
+    expect(first?.quotaProbeSkipped).toBeUndefined();
+    const ordinaryGeneration = readCodexAccountRecord("pool-expiry-first-probe-failure")!.generation;
+    expect(ordinaryGeneration).toBe(startGeneration + 1);
+    expect(quotaRecoveryModule.getLivePoolQuota401Recovery(
+      "pool-expiry-first-probe-failure",
+      ordinaryGeneration,
+    )).toBeUndefined();
+    expect(isAccountNeedsReauth("pool-expiry-first-probe-failure")).toBe(false);
+    expect({ refreshCalls, whamCalls }).toEqual({ refreshCalls: 1, whamCalls: 1 });
+
+    expect(await list()).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 14 } });
+    expect(readCodexAccountRecord("pool-expiry-first-probe-failure")?.generation).toBe(startGeneration + 2);
+    expect({ refreshCalls, whamCalls }).toEqual({ refreshCalls: 2, whamCalls: 3 });
   });
 
   test("a spent verdict cannot cross an outer-read credential replacement", async () => {
@@ -1785,22 +2072,26 @@ describe("codex-auth API", () => {
     quotaRecoveryModule.setPoolQuota401Recovery("pool-spent-outer-replacement", {
       generation: oldGeneration,
       disposition: "spent",
-      retryAt: 0,
+      retryAt: Date.now() + 5 * 60_000,
     });
     const realGetRecovery = quotaRecoveryModule.getLivePoolQuota401Recovery;
     let replacementWritten = false;
-    const recoverySpy = spyOn(quotaRecoveryModule, "getLivePoolQuota401Recovery").mockImplementation((id, generation) => {
-      const result = realGetRecovery(id, generation);
-      if (!replacementWritten && id === "pool-spent-outer-replacement") {
-        replacementWritten = true;
-        saveCodexAccountCredential(id, {
-          accessToken: "spent-outer-replacement",
-          refreshToken: "spent-outer-replacement-grant",
-          expiresAt: Date.now() + 3600_000,
-          chatgptAccountId: "acct-spent-outer-replacement",
-        });
-      }
-      return result;
+    const recoveryCalls: Array<[string, number | undefined]> = [];
+    setPoolQuotaRecoveryDepsForTests({
+      getRecovery: (id, generation) => {
+        recoveryCalls.push([id, generation]);
+        const result = realGetRecovery(id, generation);
+        if (!replacementWritten && id === "pool-spent-outer-replacement") {
+          replacementWritten = true;
+          saveCodexAccountCredential(id, {
+            accessToken: "spent-outer-replacement",
+            refreshToken: "spent-outer-replacement-grant",
+            expiresAt: Date.now() + 3600_000,
+            chatgptAccountId: "acct-spent-outer-replacement",
+          });
+        }
+        return result;
+      },
     });
     let whamCalls = 0;
     let refreshCalls = 0;
@@ -1827,15 +2118,11 @@ describe("codex-auth API", () => {
       throw new Error(`Unexpected fetch: ${target}`);
     }) as typeof fetch;
 
-    try {
-      const account = (await listCodexAuthAccounts(config, true))
-        .find(candidate => candidate.id === "pool-spent-outer-replacement");
-      expect(account).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 12 } });
-      expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 2, refreshCalls: 1 });
-      expect(recoverySpy).toHaveBeenCalledWith("pool-spent-outer-replacement", oldGeneration);
-    } finally {
-      recoverySpy.mockRestore();
-    }
+    const account = (await listCodexAuthAccounts(config, true))
+      .find(candidate => candidate.id === "pool-spent-outer-replacement");
+    expect(account).toMatchObject({ needsReauth: false, quota: { weeklyPercent: 12 } });
+    expect({ whamCalls, refreshCalls }).toEqual({ whamCalls: 2, refreshCalls: 1 });
+    expect(recoveryCalls).toContainEqual(["pool-spent-outer-replacement", oldGeneration]);
   });
 
   test("quota flights join only an intact refresh-owned G to G+1 settlement window", () => {

--- a/tests/state-store-sweeper.test.ts
+++ b/tests/state-store-sweeper.test.ts
@@ -159,6 +159,35 @@ describe("state-store sweeper", () => {
     expect(getLivePoolQuota401Recovery("swept-quota-account", generation)).toBeUndefined();
   });
 
+  test("a stale generation lookup cannot erase a newer live quota recovery row", () => {
+    const accountId = "quota-recovery-stale-reader";
+    const first = {
+      accessToken: "stale-reader-old",
+      refreshToken: "stale-reader-old-grant",
+      expiresAt: Date.now() + 3600_000,
+      chatgptAccountId: "acct-stale-reader",
+    };
+    saveCodexAccountCredential(accountId, first);
+    const staleGeneration = readCodexAccountRecord(accountId)!.generation;
+    saveCodexAccountCredential(accountId, {
+      ...first,
+      accessToken: "stale-reader-new",
+      refreshToken: "stale-reader-new-grant",
+    });
+    const liveGeneration = readCodexAccountRecord(accountId)!.generation;
+    setPoolQuota401Recovery(accountId, {
+      generation: liveGeneration,
+      disposition: "spent",
+      retryAt: Date.now() + 300_000,
+    });
+
+    expect(getLivePoolQuota401Recovery(accountId, staleGeneration)).toBeUndefined();
+    expect(getLivePoolQuota401Recovery(accountId, liveGeneration)).toMatchObject({
+      generation: liveGeneration,
+      disposition: "spent",
+    });
+  });
+
   test("a sweeper tick expires continuation and Antigravity rows without store traffic", () => {
     rememberResponseState({ input: "old" }, { id: "resp_sweeper_ttl", output: [], status: "completed" });
     observeAntigravityReplay("gemini-3-pro", "session-old", [{

--- a/tests/state-store-sweeper.test.ts
+++ b/tests/state-store-sweeper.test.ts
@@ -22,6 +22,12 @@ import {
   sweepDeadOcxStartProcessCache,
 } from "../src/config";
 import { STATE_STORE_REGISTRATIONS } from "../src/lib/state-store-registrations";
+import { readCodexAccountRecord, saveCodexAccountCredential } from "../src/codex/account-store";
+import {
+  clearPoolQuota401RecoveryForTests,
+  getLivePoolQuota401Recovery,
+  setPoolQuota401Recovery,
+} from "../src/codex/quota-401-recovery";
 import { getAccountSet, saveCredential } from "../src/oauth/store";
 import {
   clearAccountQuotaCache,
@@ -79,12 +85,14 @@ beforeEach(() => {
   resetAppOwnedMemoryForTests();
   clearResponseStateMemoryForTests();
   __resetAntigravityReplayCache();
+  clearPoolQuota401RecoveryForTests();
 });
 afterEach(() => {
   resetStateStoreSweeperForTests();
   resetAppOwnedMemoryForTests();
   clearResponseStateMemoryForTests();
   __resetAntigravityReplayCache();
+  clearPoolQuota401RecoveryForTests();
   setOcxStartProcessCacheForTests([]);
   setOcxStartProcessProbeForTests(null);
   if (previousSweeperHome === undefined) delete process.env.OPENCODEX_HOME;
@@ -109,6 +117,7 @@ describe("state-store sweeper", () => {
       "combo-warning-memos",
       "router-warning-memos",
       "codex-quota",
+      "codex-quota-401-recovery",
       "provider-quota-history",
       "codex-routing-health",
       "model-cache-history",
@@ -122,6 +131,32 @@ describe("state-store sweeper", () => {
       "oauth-flow-state",
       "ocx-start-process-cache",
     ]);
+  });
+
+  test("Codex quota 401 recovery rows are removed when their account leaves live config", () => {
+    saveCodexAccountCredential("swept-quota-account", {
+      accessToken: "swept-access",
+      refreshToken: "swept-refresh",
+      expiresAt: Date.now() + 3600_000,
+      chatgptAccountId: "acct-swept",
+    });
+    const generation = readCodexAccountRecord("swept-quota-account")!.generation;
+    setPoolQuota401Recovery("swept-quota-account", {
+      generation,
+      disposition: "spent",
+      retryAt: Date.now() + 300_000,
+    });
+    expect(getLivePoolQuota401Recovery("swept-quota-account", generation)).toBeDefined();
+
+    const registration = STATE_STORE_REGISTRATIONS
+      .find(candidate => candidate.name === "codex-quota-401-recovery")!;
+    registerStateStore(registration);
+    expect(reconcileStateGeneration(context(1, {
+      codexAccountIds: new Set(["swept-quota-account"]),
+    })).rowsRemoved).toBe(0);
+    expect(getLivePoolQuota401Recovery("swept-quota-account", generation)).toBeDefined();
+    expect(reconcileStateGeneration(context(2)).rowsRemoved).toBe(1);
+    expect(getLivePoolQuota401Recovery("swept-quota-account", generation)).toBeUndefined();
   });
 
   test("a sweeper tick expires continuation and Antigravity rows without store traffic", () => {


### PR DESCRIPTION
## Summary

- Recover stored Codex pool accounts when the account-list WHAM quota lookup rejects a bearer after a plan or credential transition: perform one generation-bounded refresh and replay WHAM once with the current credential.
- Share the canonical generation-fenced `needsReauth` state with routing. Only a terminal refresh-grant failure or structured terminal WHAM evidence asks the user to sign in again; transient transport, lock, and upstream failures remain retryable.
- Distinguish a committed refresh (`spent`) from a refresh that never committed (`retryable`), preserve the budget across replay failures, and allow a user-forced WHAM re-probe without repeating the token exchange.
- Preserve credential lineage across concurrent refresh, external replacement, delete/re-add, and same-millisecond writes; stale generations cannot quarantine or erase recovery state for their replacement.
- This extends the Responses/compact recovery contract from #2889 to the account-list quota path omitted there; it does not duplicate the request-path implementation.

Closes #3019.

## Verification

- `bun run typecheck` — passed on exact head `4ccc69516`.
- `bun scripts/privacy-scan.ts` — passed on exact head.
- `git diff --check` — passed on exact head.
- `tests/codex-auth-api.test.ts` — 207/207 passed in the affected-file run; after the final state-machine hardening, targeted current-delta runs passed 5/5 (79 assertions) and 3/3 (43 assertions).
- `tests/state-store-sweeper.test.ts` — 18/18 passed (63 assertions).
- `tests/codex-account-store.test.ts` — 43 tests completed their product assertions; one Windows fixture `afterEach` cleanup hit `EBUSY`, and the exact affected test rerun passed 1/1.
- `bun run test` — invoked once against the exact final diff as required. The repository-wide parallel wrapper reached its 900-second deadline after unrelated Windows ACL (`EICACLS`), fixture-lock (`EBUSY`), and existing 5-second integration timeouts. No failing assertion identified the changed WHAM recovery regressions; the affected suites above are green. The same broad failure path was not rerun.
- No GUI files changed, so a screenshot is not applicable.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No user-facing option, command, or configuration changed, so no documentation update is required.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Token handling, account identity, generation fences, stale-state behavior, and fail-closed defaults were reviewed; maintainer security review and sponsorship remain required.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
