### PR TITLE
fix(cursor): namespace bare client tools on the wire

### DIFF
--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -56,6 +56,7 @@ import {
   cursorToolsForActivePrompt,
   buildCursorToolGuidanceSystemNote,
   buildCursorToolDefinitions,
+  cursorToolWireName,
   cursorRequestHasShellAlias,
   CURSOR_SHELL_ALIAS_SYSTEM_NOTE,
   OCX_RESPONSES_TOOL_PROVIDER,
@@ -1091,7 +1092,9 @@ function toolCallStep(
 ): Uint8Array {
   const args: Record<string, Uint8Array> = {};
   for (const [key, value] of Object.entries(part.arguments ?? {})) args[key] = argBytes(value);
-  const toolName = namespacedToolName(part.namespace, part.name);
+  // Replay the same provider-isolated identity advertised in this request. Returned calls are
+  // restored to the client name, so transcript parts carry the client name again on the next turn.
+  const toolName = cursorToolWireName(part);
   const decodedResult = result ? decodeResultParts(result) : undefined;
   const serialize = (maxImages: number): Uint8Array => toBinary(ConversationStepSchema, create(ConversationStepSchema, {
     message: {

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -170,8 +170,10 @@ function cursorToolChoiceMatches(
     }
     return tool.name === choiceName || cursorToolWireName(tool) === choiceName;
   }
-  if (tool.name === choiceName || cursorToolWireName(tool) === choiceName) return true;
-  return cursorToolChoiceAliases(tool).includes(choiceName);
+  if (tool.name === choiceName) return true;
+  if (cursorToolChoiceAliases(tool).includes(choiceName)) return true;
+  return cursorToolWireName(tool) === choiceName
+    && !catalog.some(candidate => candidate.name === choiceName);
 }
 
 export function isBareCodexShellBridgeTool(tool: Pick<OcxTool, "namespace" | "name">): boolean {

--- a/src/adapters/cursor/tool-definitions.ts
+++ b/src/adapters/cursor/tool-definitions.ts
@@ -12,6 +12,7 @@ export const CODEX_SHELL_COMMAND_TOOL = "shell_command";
 export const CODEX_UNIFIED_EXEC_TOOL = "exec";
 export const CODEX_WAIT_TOOL = "wait";
 export const CODEX_APPLY_PATCH_TOOL = "apply_patch";
+export const CODEX_TOOL_SEARCH_TOOL = "tool_search";
 export const CURSOR_EDIT_FILE_TOOL = "edit_file";
 export const CURSOR_MULTI_EDIT_TOOL = "multi_edit";
 export const CURSOR_STRUCTURED_EDIT_TOOLS = [CURSOR_EDIT_FILE_TOOL, CURSOR_MULTI_EDIT_TOOL] as const;
@@ -320,8 +321,37 @@ export function cursorRequestAdvertisesStructuredEdits(
   return cursorStructuredEditTools(tools, toolChoice).length > 0;
 }
 
+const CURSOR_CLIENT_TOOL_WIRE_PREFIX = "ocx_client_";
+const CURSOR_PROXY_OWNED_BARE_TOOL_NAMES = new Set([
+  CODEX_UNIFIED_EXEC_TOOL,
+  CODEX_WAIT_TOOL,
+  CODEX_EXEC_COMMAND_TOOL,
+  CODEX_SHELL_COMMAND_TOOL,
+  CODEX_APPLY_PATCH_TOOL,
+  CURSOR_EDIT_FILE_TOOL,
+  CURSOR_MULTI_EDIT_TOOL,
+  CODEX_TOOL_SEARCH_TOOL,
+]);
+
+/** Avoid collisions with Cursor's private bare-tool namespace. */
+function isCursorBareClientToolWireAliased(
+  tool: Pick<OcxTool, "namespace" | "name">,
+): boolean {
+  return !tool.namespace
+    && !CURSOR_PROXY_OWNED_BARE_TOOL_NAMES.has(tool.name);
+}
+
 export function cursorToolWireName(tool: Pick<OcxTool, "namespace" | "name">): string {
+  if (isCursorBareClientToolWireAliased(tool)) {
+    return `${CURSOR_CLIENT_TOOL_WIRE_PREFIX}${tool.name}`;
+  }
   return namespacedToolName(tool.namespace, tool.name);
+}
+
+function clientSemanticToolNameFromCursorWire(name: string): string {
+  return name.startsWith(CURSOR_CLIENT_TOOL_WIRE_PREFIX)
+    ? name.slice(CURSOR_CLIENT_TOOL_WIRE_PREFIX.length)
+    : name;
 }
 
 /**
@@ -591,7 +621,7 @@ function quotedNames(names: readonly string[]): string {
 }
 
 function advertisedCoversNeighbor(wireNames: readonly string[], neighbor: (typeof NEIGHBOR_AGENT_TOOL_NAMES)[number]): boolean {
-  const advertised = new Set(wireNames.map(name => name.toLowerCase()));
+  const advertised = new Set(wireNames.map(name => clientSemanticToolNameFromCursorWire(name).toLowerCase()));
   if (advertised.has(neighbor.toLowerCase())) return true;
   return NEIGHBOR_AGENT_TOOL_ALIASES[neighbor].some(alias => advertised.has(alias.toLowerCase()));
 }
@@ -602,7 +632,7 @@ function unavailableNeighborAgentToolNames(wireNames: readonly string[]): string
 
 function discoveryToolLabel(wireNames: readonly string[]): string | undefined {
   const labels: string[] = [];
-  if (wireNames.includes("tool_search")) labels.push("`tool_search`");
+  if (wireNames.includes(CODEX_TOOL_SEARCH_TOOL)) labels.push(`\`${CODEX_TOOL_SEARCH_TOOL}\``);
   if (wireNames.some(name => name.startsWith("mcp__"))) labels.push("MCP");
   if (wireNames.some(name => /resource/i.test(name))) labels.push("resource discovery");
   return labels.length > 0 ? labels.join(", ") : undefined;

--- a/tests/cursor-blob.test.ts
+++ b/tests/cursor-blob.test.ts
@@ -827,6 +827,7 @@ describe("Cursor blob handshake", () => {
     expect(tool.case).toBe("mcpToolCall");
     if (tool.case === "mcpToolCall") {
       expect(tool.value.args?.toolCallId).toBe("ocxc1e_");
+      expect(tool.value.args?.toolName).toBe("ocx_client_read_file");
       expect(tool.value.result?.result.case).toBe("success");
       if (tool.value.result?.result.case === "success") {
         const content = tool.value.result.result.value.content[0]?.content;

--- a/tests/cursor-eof-terminal.test.ts
+++ b/tests/cursor-eof-terminal.test.ts
@@ -235,8 +235,8 @@ describe("Cursor clean-EOF terminal gate", () => {
 
   test("clean Connect END_STREAM preserves a drained client-tool terminal before its grace timer", async () => {
     await withH2Server(respondWith([
-      toolCallStartedFrame("call_client_1", "echo_a"),
-      clientToolArgsFrame("call_client_1", "echo_a", "A"),
+      toolCallStartedFrame("call_client_1", "ocx_client_echo_a"),
+      clientToolArgsFrame("call_client_1", "ocx_client_echo_a", "A"),
       cleanConnectEndFrame(),
     ]), async baseUrl => {
       const { messages, failure } = await drain(baseUrl, runRequest(ECHO_TOOL));
@@ -250,8 +250,8 @@ describe("Cursor clean-EOF terminal gate", () => {
 
   test("clean Connect END_STREAM keeps a later open sibling fail-closed after a client-tool drain", async () => {
     await withH2Server(respondWith([
-      toolCallStartedFrame("call_client_2", "echo_a"),
-      clientToolArgsFrame("call_client_2", "echo_a", "A"),
+      toolCallStartedFrame("call_client_2", "ocx_client_echo_a"),
+      clientToolArgsFrame("call_client_2", "ocx_client_echo_a", "A"),
       toolCallStartedFrame("call_open_2", "apply_patch"),
       cleanConnectEndFrame(),
     ]), async baseUrl => {

--- a/tests/cursor-hardening.test.ts
+++ b/tests/cursor-hardening.test.ts
@@ -748,8 +748,8 @@ describe("Cursor live transport unexpected EOF", () => {
                   case: "mcpToolCall",
                   value: create(McpToolCallSchema, {
                     args: create(McpArgsSchema, {
-                      name: "get_time",
-                      toolName: "get_time",
+                      name: "ocx_client_get_time",
+                      toolName: "ocx_client_get_time",
                       toolCallId: "call_1",
                       providerIdentifier: "opencodex-responses",
                     }),

--- a/tests/cursor-http1-transport.test.ts
+++ b/tests/cursor-http1-transport.test.ts
@@ -404,8 +404,8 @@ describe("Cursor HTTP/1.1 compatibility transport", () => {
                   case: "mcpToolCall",
                   value: create(McpToolCallSchema, {
                     args: create(McpArgsSchema, {
-                      name: "get_time",
-                      toolName: "get_time",
+                      name: "ocx_client_get_time",
+                      toolName: "ocx_client_get_time",
                       toolCallId: "call_1",
                       providerIdentifier: "opencodex-responses",
                     }),

--- a/tests/cursor-live-transport.test.ts
+++ b/tests/cursor-live-transport.test.ts
@@ -18,6 +18,7 @@ import {
   setBackgroundShellRuntimeForTests,
 } from "../src/adapters/cursor/native-exec-shell";
 import { BackgroundShellSpawnArgsSchema, ExecServerMessageSchema } from "../src/adapters/cursor/gen/agent_pb";
+import type { CursorProtobufEventState } from "../src/adapters/cursor/protobuf-events";
 
 class TransportFakeChild extends EventEmitter {
   readonly stdin = new PassThrough();
@@ -339,21 +340,24 @@ describe("Cursor live transport context estimate wiring (#373)", () => {
   async function captureOpen(request: Record<string, unknown>): Promise<{
     encoded: Uint8Array | undefined;
     estimate: number | undefined;
+    state: CursorProtobufEventState | undefined;
   }> {
     const transport = makeTransport();
     const internals = transport as unknown as {
       open(
         encodedRequest: Uint8Array,
         signal: AbortSignal | undefined,
-        state: { estimatedInputTokens?: number },
+        state: CursorProtobufEventState,
         ...rest: unknown[]
       ): void;
     };
     let encoded: Uint8Array | undefined;
     let estimate: number | undefined;
+    let capturedState: CursorProtobufEventState | undefined;
     internals.open = (encodedRequest, _signal, state) => {
       encoded = encodedRequest;
       estimate = state.estimatedInputTokens;
+      capturedState = state;
       throw new Error("stop-after-open");
     };
 
@@ -361,7 +365,7 @@ describe("Cursor live transport context estimate wiring (#373)", () => {
       for await (const _ of transport.run(request as never)) { /* not reached */ }
     } catch { /* open() throws by design */ }
     transport.close?.();
-    return { encoded, estimate };
+    return { encoded, estimate, state: capturedState };
   }
 
   const baseRequest = {
@@ -394,5 +398,22 @@ describe("Cursor live transport context estimate wiring (#373)", () => {
     // Still no checkpoint was ever observed (open() aborts before any frame), so the
     // estimate stays on. This pins the condition rather than the tracker's contents.
     expect(first).toBeGreaterThan(0);
+  });
+
+  test("wire-isolated freeform tools keep client-name validation and return mapping", async () => {
+    const { state } = await captureOpen({
+      ...baseRequest,
+      conversationId: "c-wire-freeform",
+      tools: [{
+        name: "script",
+        description: "Run a script",
+        parameters: {},
+        freeform: true,
+      }],
+    });
+
+    expect(state?.clientToolNames?.has("ocx_client_script")).toBe(true);
+    expect(state?.freeformToolNames?.has("script")).toBe(true);
+    expect(state?.cursorToolNameMap?.get("ocx_client_script")).toBe("script");
   });
 });

--- a/tests/cursor-protobuf-events.test.ts
+++ b/tests/cursor-protobuf-events.test.ts
@@ -123,6 +123,84 @@ describe("Cursor protobuf tool-call events", () => {
     ]);
   });
 
+  test("maps a provider-isolated Cursor client-tool alias back to Claude Desktop's bare tool name", () => {
+    const state = createCursorProtobufEventState({
+      clientToolNames: ["ocx_client_read"],
+      toolSchemas: new Map([[
+        "ocx_client_read",
+        { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+      ]]),
+      cursorToolNameMap: new Map([["ocx_client_read", "read"]]),
+    });
+    const toolCall = mcpToolCall("ocx_client_read", { path: "README.md" });
+
+    expect(mapCursorProtobufServerMessage(interaction({
+      case: "toolCallCompleted",
+      value: create(ToolCallCompletedUpdateSchema, { callId: "call_read", modelCallId: "model_read", toolCall }),
+    }), state)).toEqual([
+      { type: "tool_call_start", id: "call_read", name: "read" },
+      { type: "tool_call_delta", arguments: "{\"path\":\"README.md\"}" },
+      { type: "tool_call_end", id: "call_read" },
+    ]);
+  });
+
+  test("rejects malformed freeform arguments after restoring a provider-isolated alias", () => {
+    const state = createCursorProtobufEventState({
+      clientToolNames: ["ocx_client_script"],
+      freeformToolNames: ["script"],
+      cursorToolNameMap: new Map([["ocx_client_script", "script"]]),
+    });
+    const toolCall = mcpToolCall("ocx_client_script", { wrong_key: "not a wrapper" });
+
+    expect(mapCursorProtobufServerMessage(interaction({
+      case: "toolCallCompleted",
+      value: create(ToolCallCompletedUpdateSchema, {
+        callId: "call_bad_freeform", modelCallId: "model_bad_freeform", toolCall,
+      }),
+    }), state)).toEqual([
+      { type: "error", message: "script call had invalid freeform arguments; expected {input:string}" },
+    ]);
+    expect(state.openToolCalls.has("call_bad_freeform")).toBe(false);
+    expect(state.completedToolCalls.has("call_bad_freeform")).toBe(true);
+  });
+
+  test("keeps an aliased partial freeform wrapper open for native arguments", () => {
+    const state = createCursorProtobufEventState({
+      clientToolNames: ["ocx_client_script"],
+      freeformToolNames: ["script"],
+      cursorToolNameMap: new Map([["ocx_client_script", "script"]]),
+    });
+    const toolCall = mcpToolCall("ocx_client_script", {});
+
+    expect(mapCursorProtobufServerMessage(interaction({
+      case: "toolCallStarted",
+      value: create(ToolCallStartedUpdateSchema, {
+        callId: "call_partial_alias", modelCallId: "model_partial_alias", toolCall,
+      }),
+    }), state)).toEqual([]);
+    expect(mapCursorProtobufServerMessage(interaction({
+      case: "partialToolCall",
+      value: create(PartialToolCallUpdateSchema, {
+        callId: "call_partial_alias",
+        modelCallId: "model_partial_alias",
+        toolCall,
+        argsTextDelta: '{"inpu',
+      }),
+    }), state)).toEqual([]);
+    expect(mapCursorProtobufServerMessage(interaction({
+      case: "toolCallCompleted",
+      value: create(ToolCallCompletedUpdateSchema, {
+        callId: "call_partial_alias", modelCallId: "model_partial_alias", toolCall,
+      }),
+    }), state)).toEqual([]);
+    expect(state.openToolCalls.get("call_partial_alias")).toMatchObject({
+      name: "script",
+      args: '{"inpu',
+      awaitingNativeArgs: true,
+    });
+    expect(state.completedToolCalls.has("call_partial_alias")).toBe(false);
+  });
+
   test("keeps genuine run_shell tool name when no exec_command alias was advertised", () => {
     const state = createCursorProtobufEventState({
       clientToolNames: ["run_shell"],

--- a/tests/cursor-tool-definitions.test.ts
+++ b/tests/cursor-tool-definitions.test.ts
@@ -64,6 +64,20 @@ describe("Cursor tool definitions", () => {
     }
   });
 
+  test("prefers a semantic tool name over a generated client wire alias", () => {
+    const tools: OcxTool[] = [
+      { name: "read", description: "Read", parameters: {} },
+      { name: "ocx_client_read", description: "Literal client-prefixed tool", parameters: {} },
+    ];
+
+    expect(buildCursorToolDefinitions(tools, { name: "ocx_client_read" }).map(tool => tool.toolName))
+      .toEqual(["ocx_client_ocx_client_read"]);
+    expect(buildCursorToolDefinitions(tools, { mode: "required", allowedTools: ["ocx_client_read"] }).map(tool => tool.toolName))
+      .toEqual(["ocx_client_ocx_client_read"]);
+    expect(buildCursorToolDefinitions(tools, { name: "read" }).map(tool => tool.toolName))
+      .toEqual(["ocx_client_read"]);
+  });
+
   test("advertises bare exec_command with compact native exec schema", () => {
     const tool: OcxTool = {
       name: "exec_command",

--- a/tests/cursor-tool-definitions.test.ts
+++ b/tests/cursor-tool-definitions.test.ts
@@ -40,6 +40,30 @@ describe("Cursor tool definitions", () => {
     expect(toJson(ValueSchema, fromBinary(ValueSchema, defs[0]!.inputSchema))).toEqual(tool.parameters);
   });
 
+  test("isolates ordinary bare client identities without renaming proxy-owned or namespaced tools", () => {
+    expect(cursorToolWireName({ name: "read" })).toBe("ocx_client_read");
+    expect(cursorToolWireName({ name: "ocx_client_read" })).toBe("ocx_client_ocx_client_read");
+    expect(cursorToolWireName({ name: "read", namespace: "mcp__workspace" })).toBe("mcp__workspace__read");
+    const bare: OcxTool = { name: "read", description: "Read", parameters: {} };
+    expect(buildCursorToolDefinitions([bare], { name: "read" }).map(tool => tool.toolName))
+      .toEqual(["ocx_client_read"]);
+    expect(buildCursorToolDefinitions([bare], { name: "ocx_client_read" }).map(tool => tool.toolName))
+      .toEqual(["ocx_client_read"]);
+
+    for (const name of [
+      "exec",
+      "wait",
+      "exec_command",
+      "shell_command",
+      "apply_patch",
+      "edit_file",
+      "multi_edit",
+      "tool_search",
+    ]) {
+      expect(cursorToolWireName({ name })).toBe(name);
+    }
+  });
+
   test("advertises bare exec_command with compact native exec schema", () => {
     const tool: OcxTool = {
       name: "exec_command",
@@ -255,7 +279,7 @@ describe("Cursor tool definitions", () => {
     expect(cursorToolsForActivePrompt(tools, "Use any 10 tools including MCP resources")?.map(tool => cursorToolWireName(tool))).toEqual([
       "exec_command",
       "tool_search",
-      "list_mcp_resources",
+      "ocx_client_list_mcp_resources",
     ]);
   });
 
@@ -408,7 +432,7 @@ describe("Cursor tool definitions", () => {
     expect(note).toBeDefined();
     if (!note) throw new Error("Expected Cursor tool guidance note");
 
-    expect(note).toContain("available tool names are exactly `exec_command`, `Glob`");
+    expect(note).toContain("available tool names are exactly `exec_command`, `ocx_client_Glob`");
     expect(note).toContain("This turn does not expose neighboring-agent tool names `Read`, `Grep`, `Bash`, `LS`");
     expect(note).not.toContain("`Read`, `Grep`, `Glob`, `Bash`, `LS`");
   });
@@ -425,7 +449,7 @@ describe("Cursor tool definitions", () => {
     expect(note).toBeDefined();
     if (!note) throw new Error("Expected Cursor tool guidance note");
 
-    expect(note).toContain("available tool names are exactly `exec_command`, `read`, `find`, `bash`");
+    expect(note).toContain("available tool names are exactly `exec_command`, `ocx_client_read`, `ocx_client_find`, `ocx_client_bash`");
     expect(note).toContain("This turn does not expose neighboring-agent tool names `Grep`, `LS`");
     expect(note).not.toContain("`Read`");
     expect(note).not.toContain("`Glob`");


### PR DESCRIPTION
## Summary

- Fix Claude Desktop requests through the Cursor provider that could fail with an empty completion/HTTP 502 when client-owned bare tool names collided with Cursor's private tool namespace. The same account and model worked through Codex's Responses path, showing this was a tool-mapping interoperability bug rather than a subscription-entitlement failure.
- Namespace bare client-owned Cursor tools as `ocx_client_<name>` on the provider wire to avoid collisions with Cursor's private bare-tool namespace.
- Preserve existing wire names for proxy-owned tools (`exec`, `wait`, `exec_command`, `shell_command`, `apply_patch`, `edit_file`, `multi_edit`, and `tool_search`) and map aliased calls back to their original client names before emitting responses.
- Reuse the same provider-isolated alias for structured replay, with focused regression coverage for declarations, call mapping, freeform validation, stream completion, and both Cursor transports.
- Non-blocking P2 follow-up: text-only external replay continues to display the semantic client tool name while native structured replay uses the wire alias; `composer-2.5` can exercise both replay shapes. This patch intentionally leaves that presentation-level consistency question out of scope because call routing already uses the mapped identity.

## Verification

- `bun run prepush` (through the installed pre-push hook) — passed, including typecheck, the full test suite (`16,350` pass, `12` skip, `0` fail, plus every serial suite), and the privacy scan.
- `bun test tests/update-stop-first.test.ts` — `15` pass, `0` fail.
- `bun test tests/shutdown-launcher.test.ts` — `3` pass, `0` fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cursor tool-call replay and completion handling for client-provided tools.
  * Prevented naming conflicts by consistently isolating client tools with an `ocx_client_` prefix.
  * Improved handling of incomplete or malformed freeform tool arguments.
  * Preserved correct tool identities and results across live connections, reconnects, and clean connection endings.

* **Tests**
  * Expanded coverage for tool discovery, replay, streaming events, and transport edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->