### PR TITLE
fix(catalog): recognize YYMMDD/MMDD/YYMM dated model id suffixes (#3024)

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -936,9 +936,70 @@ export function resolveComboCatalogMember(
   };
 }
 
+const DATED_VARIANT_YYYYMMDD = /^(\d{4})(\d{2})(\d{2})$/;
+const DATED_VARIANT_YYMMDD = /^(2\d)(\d{2})(\d{2})$/;
+const DATED_VARIANT_MMDD_OR_YYMM = /^(\d{2})(\d{2})$/;
+
+/** Whether a Gregorian year contains February 29th. */
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+/**
+ * Whether a month/day pair exists in the given year. Without a year, February 29th is
+ * accepted because it occurs in at least one calendar year.
+ */
+function isValidCalendarDate(year: number | undefined, month: number, day: number): boolean {
+  if (year !== undefined && (year < 1 || year > 9999)) return false;
+  if (month < 1 || month > 12 || day < 1) return false;
+  const daysInMonth = [
+    31, year === undefined || isLeapYear(year) ? 29 : 28, 31, 30, 31, 30,
+    31, 31, 30, 31, 30, 31,
+  ];
+  return day <= daysInMonth[month - 1]!;
+}
+
+/**
+ * Release-date suffixes providers actually publish: `YYYYMMDD` (`-20251001`), `YYMMDD`
+ * (`-260806`), `MMDD` (`-0813`) and `YYMM` (`-2512`). A `\d{8}`-only rule matched none of
+ * the dated ids on a real multi-provider install, so DeepSeek, Kimi, Mistral, Qwen and
+ * Solar aliases all fell through to `droppedConfiguredIds` (#3024).
+ *
+ * Calendar validation rejects impossible month-end and leap-day values as well as ordinary
+ * numeric suffixes such as `-2048`, `-4096` and `-8192`. `-1024` is the one irreducible
+ * collision — it is a valid `MMDD` (October 24th) — so it reads as dated. That is a known,
+ * accepted cost; the test table pins it so it cannot become a surprise later.
+ *
+ * Hyphenated ISO suffixes (`-2024-08-06`, `-05-06`) are deliberately out of scope: a
+ * hyphenated suffix is ambiguous against ordinary name segments and needs its own call.
+ */
+function isDatedVariantSuffix(suffix: string): boolean {
+  const yyyyMmDd = DATED_VARIANT_YYYYMMDD.exec(suffix);
+  if (yyyyMmDd) {
+    return isValidCalendarDate(
+      Number(yyyyMmDd[1]), Number(yyyyMmDd[2]), Number(yyyyMmDd[3]),
+    );
+  }
+
+  const yyMmDd = DATED_VARIANT_YYMMDD.exec(suffix);
+  if (yyMmDd) {
+    return isValidCalendarDate(
+      2000 + Number(yyMmDd[1]), Number(yyMmDd[2]), Number(yyMmDd[3]),
+    );
+  }
+
+  const mmDdOrYyMm = DATED_VARIANT_MMDD_OR_YYMM.exec(suffix);
+  if (!mmDdOrYyMm) return false;
+  const first = Number(mmDdOrYyMm[1]);
+  const second = Number(mmDdOrYyMm[2]);
+  return isValidCalendarDate(undefined, first, second)
+    || (first >= 20 && first <= 29 && second >= 1 && second <= 12);
+}
+
+/** Whether `liveId` is a supported dated release of the configured base id. */
 export function isDatedVariantId(liveId: string, configuredId: string): boolean {
   if (!liveId.startsWith(`${configuredId}-`)) return false;
-  return /^\d{8}$/.test(liveId.slice(configuredId.length + 1));
+  return isDatedVariantSuffix(liveId.slice(configuredId.length + 1));
 }
 
 export const lastDropWarnSignature = new Map<string, string>();

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -3651,12 +3651,66 @@ describe("Codex catalog routed normalization", () => {
     }
   });
 
-  test("isDatedVariantId matches only <alias>-YYYYMMDD", () => {
+  test("isDatedVariantId matches only <alias>-<date>", () => {
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4-5")).toBe(true);
     expect(isDatedVariantId("claude-haiku-4-5-2025", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-latest", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4")).toBe(false);
+  });
+
+  // Real ids from a multi-provider install. A `\d{8}`-only rule matched none of them, so
+  // every one of these aliases dropped out of the authoritative live catalog (#3024).
+  test.each([
+    ["YYYYMMDD", "claude-haiku-4-5-20251001", "claude-haiku-4-5"],
+    ["YYYYMMDD leap day", "acme-model-20240229", "acme-model"],
+    ["YYMMDD", "solar-pro4-260806", "solar-pro4"],
+    ["YYMMDD", "syn-pro-251021", "syn-pro"],
+    ["YYMMDD leap day", "acme-model-240229", "acme-model"],
+    ["MMDD", "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4-pro"],
+    ["MMDD", "moonshotai/kimi-k2-0905", "moonshotai/kimi-k2"],
+    ["MMDD", "openai/gpt-3.5-turbo-0613", "openai/gpt-3.5-turbo"],
+    ["MMDD leap day", "acme-model-0229", "acme-model"],
+    ["YYMM", "mistralai/mistral-large-2407", "mistralai/mistral-large"],
+    ["YYMM", "qwen/qwen3-235b-a22b-2507", "qwen/qwen3-235b-a22b"],
+  ])("folds a %s dated variant: %s", (_format, liveId, configuredId) => {
+    expect(isDatedVariantId(liveId, configuredId)).toBe(true);
+  });
+
+  test.each([
+    ["a version number", "mistralai/mistral-medium-3-5", "mistralai/mistral-medium-3"],
+    ["a context size", "openai/gpt-3.5-turbo-16k", "openai/gpt-3.5-turbo"],
+    ["a variant name", "qwen/qwen3-coder-30b-a3b-instruct", "qwen/qwen3-coder"],
+    ["a batch lane of a dated id", "deepseek/deepseek-v4-pro-0813:batch", "deepseek/deepseek-v4-pro"],
+    ["a bare year", "acme-model-2025", "acme-model"],
+    ["an impossible YYMM", "acme-model-1301", "acme-model"],
+    ["a non-leap YYYYMMDD", "acme-model-20250229", "acme-model"],
+    ["a non-leap YYMMDD", "acme-model-250229", "acme-model"],
+    ["an impossible YYYYMMDD month-end", "acme-model-20240431", "acme-model"],
+    ["an impossible YYMMDD month-end", "acme-model-240431", "acme-model"],
+    ["an impossible MMDD month-end", "acme-model-0431", "acme-model"],
+    // Hyphenated ISO is ambiguous against ordinary name segments; out of scope for now.
+    ["a hyphenated ISO date", "openai/gpt-4o-2024-08-06", "openai/gpt-4o"],
+    ["a hyphenated MM-DD", "google/gemini-2.5-pro-preview-05-06", "google/gemini-2.5-pro-preview"],
+  ])("does not fold %s: %s", (_label, liveId, configuredId) => {
+    expect(isDatedVariantId(liveId, configuredId)).toBe(false);
+  });
+
+  test.each(["2048", "4096", "8192"])("a %s context suffix is not a date", suffix => {
+    expect(isDatedVariantId(`acme-model-${suffix}`, "acme-model")).toBe(false);
+  });
+
+  // Known, accepted cost of allowing MMDD: October 24th is a real date, so a `-1024`
+  // context suffix is indistinguishable from one. No month/day tightening can exclude it.
+  test("a -1024 suffix reads as MMDD and is accepted", () => {
+    expect(isDatedVariantId("acme-model-1024", "acme-model")).toBe(true);
+  });
+
+  // The fold stays one-directional: a configured id the provider no longer lists must not
+  // be retained on the strength of a format match alone (#1690 is the explicit opt-in for
+  // that). `deepseek-v4-pro-0813` configured against a live `deepseek-v4-pro` stays dropped.
+  test("does not fold configured=dated against live=base", () => {
+    expect(isDatedVariantId("deepseek-v4-pro", "deepseek-v4-pro-0813")).toBe(false);
   });
 
   test("disabled providers are excluded from routed model gathering", async () => {


### PR DESCRIPTION
Fixes the safely-fixable half of #3024, in the scope you picked (widen the suffix format, keep the fold one-directional) with the `YY = 2\d` tightening from your review.

## Summary

`isDatedVariantId` only accepted an 8-digit `YYYYMMDD` suffix, so the dated-alias fold in `mergeConfiguredModelsIntoLiveCatalog` never fired for providers that publish shorter release dates. Enumerating every numeric-suffixed id pair on a real multi-provider install, the `\d{8}` rule matched **0 of 26** — so DeepSeek, Kimi, Mistral, Qwen and Solar aliases all fell through to `droppedConfiguredIds` even when a live row for the same model was present.

This widens the suffix to the formats upstreams actually publish, behind a calendar guard:

| Format | Example | Before | After |
|---|---|---|---|
| `YYYYMMDD` | `claude-haiku-4-5-20251001` | yes | yes |
| `YYMMDD` | `solar-pro4-260806`, `syn-pro-251021` | no | yes |
| `MMDD` | `deepseek-v4-pro-0813`, `kimi-k2-0905`, `gpt-3.5-turbo-0613` | no | yes |
| `YYMM` | `mistral-large-2407`, `qwen3-235b-a22b-2507` | no | yes |
| `YYYY-MM-DD` | `gpt-4o-2024-08-06` | no | no (out of scope) |
| `MM-DD` | `gemini-2.5-pro-preview-05-06` | no | no (out of scope) |

The matcher now parses and validates real calendar dates. `YYYYMMDD` and `YYMMDD` apply Gregorian leap-year rules, `MMDD` is accepted only when the date occurs in at least one calendar year, and `YYMM` remains restricted to the 2020s. Impossible values such as `20250229`, `250229`, and `0431` are rejected. Ordinary numeric suffixes `-2048`, `-4096`, and `-8192` remain rejected. `-1024` is still the one irreducible collision because October 24th is a real date; an explicit regression test documents that accepted cost.

Two things this deliberately does **not** do:

- **The fold stays one-directional** (`configured=base` → `live=dated`). A configured id the provider no longer lists must not be retained on the strength of a format match alone — the fold has no callability signal, and #1690 is the right place for an explicit operator allow-list. This means `alibaba-token-plan-intl/deepseek-v4-pro-0813`, the id that opened #3024, **is still dropped**. That is the deliberate call from your review, not an oversight.
- **No change to `shouldRetainConfiguredProviderModel` or the `retainModels` path**, so this does not touch or conflict with the #1690 train (#2860 / #2122).

The 8-digit path is intentionally stricter than the historical bare `\d{8}` rule: impossible calendar dates no longer fold. This follows the review decision and is covered by month-end and leap-day regression tests.

## Verification

Revalidated after rebasing onto the then-current `dev` commit `44b4de39d` on Windows 11 with Bun 1.4.0:

```
bun test tests/codex-catalog.test.ts  # 251 pass, 0 fail
bun run typecheck                      # exit 0
bun run privacy:scan                   # Privacy scan passed
git diff --check upstream/dev...HEAD   # exit 0
```

The CodeRabbit finding is covered by explicit valid/invalid leap-day and month-end cases for `YYYYMMDD`, `YYMMDD`, and `MMDD`.

The repository-wide `bun run test` continued making progress but reached the runner's 900-second Windows limit. Failures observed outside this catalog change were Windows ACL/temporary-directory locking and existing 5-second integration-test timeouts. As a control, the Kiro file that failed with `EBUSY` in the parallel suite passed alone (15 pass, 0 fail). `responses-state.test.ts` still fails alone when its ACL-backed spill path is unavailable on this D: volume. I am therefore leaving the local-all-green readiness box unticked and treating GitHub CI as the authority, as requested in review.

Tests remain table-driven in the existing `isDatedVariantId` section. Added calendar regressions include valid `20240229` / `240229` / `0229`, invalid `20250229` / `250229`, and invalid April 31 values in all applicable widths.

## Checklist
- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing docs describe this fold; the rationale lives in the JSDoc on the pattern.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Pure predicate change; no auth, network, or config surface touched. `bun run privacy:scan` passes.)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of dated model aliases using multiple date formats.
  * Prevented valid aliases from being incorrectly excluded from configured model listings.
  * Continued rejecting version numbers, context sizes, invalid dates, and unrelated suffixes.

* **Tests**
  * Expanded coverage for supported date formats and edge cases, including the accepted `-1024` suffix behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->