### PR TITLE
docs(devlog): close wp2 planning after four audit rounds and record the wp3 review

### DIFF
--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/008_audit_round5_wp2_plan.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/008_audit_round5_wp2_plan.md
@@ -1,0 +1,86 @@
+# 008 — audit round 5: wp2 plan re-audit after wp1 landed
+
+Auditor: sol-high subagent, read-only, run against `codex/prio70-train-260831` at
+`1b6b36b96` (wp1 merged into the branch). Verdict **FAIL** — five substantive
+corrections plus a stale-citation sweep. All are folded into `020`.
+
+## Findings
+
+1. **Citations shifted by wp1** (+45 lines or so in `model-entitlements.ts`).
+   `:223` → `:323-325`; `:455` → `:524-526`, `:542-552`; `:500-506` → `:556-563`;
+   `:539-550` → `:391-419`, `:592-602`; `:630` → `:686-693`; expiry `:509` → `:673`.
+   Also `auth-api.ts:2015` → `:2016`, `server/index.ts:1155` → `:1158-1164`,
+   `export-command.ts:169` → `:181`, `sidecar/candidates.ts:29` → `:35-40`.
+   Still valid: `account-store.ts:131`, `model-rows.ts:50`,
+   `model-routes.ts:352-354`, `Models.tsx:402-417`.
+
+2. **"Zero credential validation in the steady state" is unachievable as written.**
+   The cache key is `(accountId, clientVersion)` (`:323-325`), but freshness also
+   compares `credentialIdentity` (`:517-522`), and obtaining the current identity
+   reads `auth.json` or the account store (`:378-389`). A pure cache read would need
+   a cross-process credential-generation signal that does not exist. Redefined
+   target: **zero token refresh and zero network**, via an identity-only read, with
+   the full `accountCredentialSnapshot` (`:391-419`) reserved for entries that are
+   missing, stale, or identity-mismatched.
+
+3. **The invalidation hook list was incomplete**, and one entry was wrong.
+   `auth-api.ts:2015` is the branch, not the save (`:2016`), and hooking it misses
+   new-account login at `:546`. Also required: pool CAS refresh
+   (`account-store.ts:195-218`, called at `:705`, `:790`), owner/alias refresh
+   (`:252-309`, called at `:858`), deletion/tombstone (`:312-320` via
+   `account-lifecycle.ts:158`), and main-token refresh
+   (`main-account.ts:133-163`, `:219`). External replacement of
+   `~/.codex/auth.json` cannot be hooked at all, so a bounded identity probe has to
+   remain. Active-account switch (`auth-api.ts:1630-1641`) is config-only and needs
+   no clear. One cycle-free mutation epoch at every successful commit and tombstone,
+   rather than a hook per call site.
+
+4. **Awaiting in `listManagementModelRows` is structurally safe; rejecting is not.**
+   The function is already async, every production caller awaits it, and
+   `nativeModelRows` stays synchronous (`src/codex/catalog/metadata.ts:414`). But a
+   rejection degrades sidecar to auth slots (`src/sidecar/candidates.ts:35-61`) and
+   makes client-config answer 503 (`model-routes.ts:393-409`). The ensure must be
+   non-throwing at its boundary, with a regression for each of those two outcomes.
+
+5. **The 8-second figure is not a total bound.** `MODEL_ROSTER_TIMEOUT_MS` starts
+   inside the roster fetch (`:438-445`); credential refresh can spend 30 seconds
+   first (`main-account.ts:188-190`, `account-store.ts:743-746`). And flight dedup
+   begins only *after* credential enumeration (`:524-552`), so abandoning a wait
+   avoids duplicate roster fetches but not repeated credential work. The whole
+   ensure operation has to be deduplicated, with the deadline anchored to the
+   flight's start.
+
+6. **Three of the four regression claims were false reds.** Fresh-zero-refetch,
+   TTL+1-single-fetch, and unconfirmed-failure-caching are already green through
+   `:517-552`, and the empty/all-filtered 15s behaviour is already covered by wp1's
+   own tests (`tests/codex-model-entitlements.test.ts:672-749`). The genuine wp2
+   reds are the **credential-read count** and the **logged-out negative memo**. The
+   `/api/models` and client-config assertions are red only if the fixture supplies a
+   usable credential and upstream roster — and client-config's expected fetch count
+   of 1 is red because the current count is **0**, which is the defect itself. The
+   CLI case is red only after its stub (`tests/cli-export-command.test.ts:51-57`) is
+   replaced with the real handler. Baseline across the four files: 93 pass, 0 fail.
+
+7. wp1 removed the concept the plan still named: there is no "confirmed-empty
+   entry" any more (`:465-478`). The correct noun is "an empty or all-filtered
+   **unconfirmed** entry within `MODEL_ROSTER_FAILURE_TTL_MS`".
+
+## Open question — settled
+
+The plan's default (wait out the refresh) is wrong, and my proposed flat 3s
+per-waiter deadline was also wrong: sequential sidecar calls
+(`src/server/management/config-routes.ts:589-593`) would accumulate up to 6s.
+
+**Decision.** One whole-ensure flight carrying `{ startedAt, promise }`, caught
+fail-closed, and **never aborted by a management timeout** — the upstream work
+always runs to completion so the cache is populated for the next caller.
+
+- Sidecar candidate paths join with a **0 ms** wait. They never stall; they read
+  whatever is already cached.
+- `/api/models`, `/api/client-config`, integrations and `ocx export` wait up to
+  **3000 ms**, measured from the flight's original `startedAt` rather than from each
+  waiter's own arrival.
+
+That keeps the useful one-shot window for `ocx export` — which is the surface
+#3023 actually reported — while a dashboard poll never stalls and converges within
+one 5s cycle.

--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/009_audit_rounds6to8_wp2_and_wp3_review.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/009_audit_rounds6to8_wp2_and_wp3_review.md
@@ -1,0 +1,84 @@
+# 009 — audit rounds 6-8: wp2 plan, and the wp3 implementation review
+
+Two independent sol-high reviewers, both read-only. Recorded together because they
+ran concurrently.
+
+## wp2 plan — rounds 6, 7 and 8 (all FAIL, all folded into `020`)
+
+**Round 6.**
+
+1. The whole-ensure flight was underspecified: a bare `{ startedAt, promise }` can
+   cross-answer different candidate sets, client versions or credential epochs, while
+   the per-entry dedup it wraps is keyed by account, identity and version
+   (`:524-552`). Fixed by giving the flight a real key.
+2. The mutation-hook set was still incomplete: `native-profile-manager.ts:1307`,
+   `:1335`, `:1449` write canonical `auth.json` during switch, rollback and recovery
+   (transitions at `:1318`, `:1453`). These are OpenCodex's own writes, so they belong
+   in the epoch.
+3. The two wait policies could not be expressed by `ensureCodexEntitlementFreshness(config)`
+   as written, because sidecar reaches the same `listManagementModelRows`
+   (`src/sidecar/candidates.ts:40`). Needs an options path.
+4. The credential-read regression was **false-green**: "zero token refreshes and zero
+   fetches" is already satisfied today while the full credential snapshot still runs
+   (`:592-601`). Must assert zero `accountCredentialSnapshot` calls.
+5. The negative-memo TTL was never pinned, and "converges within one 5s cycle"
+   contradicted the acknowledged 30s credential refresh.
+
+**Round 7.**
+
+1. The epoch alone cannot fence external `auth.json` writers — the document says so
+   itself — so a caller holding a new identity could still join an old-identity
+   flight. The flight key now carries the identity vector
+   `(accountId, credentialIdentity | null)`.
+2. The negative memo could still be published against a login that landed mid-flight.
+   Publication is now fenced on the captured identity vector, and expiry is measured
+   from the **absence observation**, not from settlement — a flight that spent 30s in
+   a credential refresh must not hand out evidence that is treated as 5s fresh.
+
+**Round 8 (final).**
+
+The key still omitted the **workset**. Candidate set, version, epoch and identities
+can be unchanged while an entry expires mid-flight: a flight that started when B was
+fresh refreshes only A, B expires, a second caller computes the same key and joins,
+and the resolver's `now` is fixed from flight start (`:586`) so B stays a cache hit
+(`:517-522`). `ocx export` — the surface #3023 actually reported — then returns short
+rows having refreshed nothing. The key now includes normalized
+`needsRefreshAccountIds`, or joining requires a subset relationship.
+
+wp2 is planned but **not implemented**. The document is now implementable; the work
+itself is the next cycle.
+
+## wp3 implementation review — FAIL, one high finding
+
+Reviewed commit `135f22932` (on top of Ingwannu's `aec717722`).
+
+**Confirmed correct, no change needed:** drain ordering before the 2 MiB snapshot
+exclusion (`state.ts:1236-1247` vs `:1133`); the stable-fixed-point loop with no bare
+`Promise.race` (`:443-450`); the budget split `B=5000`/`R=4000` with the fallback
+receiving `R`; the shared ACL deadline reaching both the directory and temp hardeners
+(`spill-store.ts:197-227`, `:440-452`); test 2c's six `icacls` calls and its
+max-timeout assertion, which would genuinely detect a fresh 30s window. No
+MUST-NOT-CHANGE violation, no payload or token logging.
+
+**HIGH — the abandoned writer can still publish, and can orphan a temp.** The async
+writer creates and fills its temp *before* awaiting file ACL hardening
+(`spill-store.ts:505-511`). At cap expiry the fallback marks the job cancelled and
+drops its tracking (`state.ts:417-422`) but takes no ownership of that temp; the drain
+returns (`:446-448`) and shutdown exits (`management-api.ts:278-280`,
+`cli/index.ts:365-370`). A resuming writer publishes *first* (`spill-store.ts:515-529`)
+and only then hits the cancellation check (`state.ts:257-260`). State overwrite
+prevention is airtight; filesystem publication and cleanup are merely narrow. The
+commit's own test encoded the violation as expected, asserting **two** publications
+(`tests/responses-state.test.ts:999-1000`).
+
+**MEDIUM — the fixed point has no regression behind it.** The shutdown tests queue a
+single job (`:823-891`), so a one-shot tail await would pass them. The loop is right;
+nothing proves it stays right.
+
+Both sent back for repair before wp3 lands.
+
+## Residual risk carried
+
+A real Windows host is still needed to prove NTFS inheritance, `icacls` timeout
+behaviour, and unlink semantics while `icacls` holds a path. Everything above was
+exercised through the repository's injected Windows/ACL runners.

--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/020_wp2_roster_ttl_refresh.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/020_wp2_roster_ttl_refresh.md
@@ -17,18 +17,19 @@ enters the real resolver **only** for credential/version entries that are missin
 or past their own deadline. It must treat as cached answers:
 
 - a confirmed roster inside `MODEL_ROSTER_TTL_MS`;
-- a confirmed-empty entry (after wp1, unconfirmed with the 15s TTL);
+- an empty or all-filtered UNCONFIRMED entry within `MODEL_ROSTER_FAILURE_TTL_MS` (wp1
+  removed the confirmed-empty case entirely, `:465-478`);
 - an unconfirmed failure entry inside `MODEL_ROSTER_FAILURE_TTL_MS`.
 
 It must reuse the existing per-account/version keys and in-flight deduplication
-(`:223`, `:455`) so concurrent pollers collapse into one upstream fetch.
+(`:323-325`, `:524-526`, `:542-552`) so concurrent pollers collapse into one upstream fetch.
 
 ### Amendment after audit round 1 (`004`, blocker 2): the logged-out hole
 
 "Refresh entries that are missing" **misses forever** when there is no credential.
-`MAIN_CODEX_ACCOUNT_ID` is always a candidate (`:500-506`), but
+`MAIN_CODEX_ACCOUNT_ID` is always a candidate (`:556-563`), but
 `accountCredentialSnapshot` returns null without one, so the account is filtered
-out before any cache entry is created (`:539-550`). Nothing is ever cached, so
+out before any cache entry is created (`:391-419`, `:592-602`). Nothing is ever cached, so
 every poll re-enters the full resolver — ~24 times/minute, which is precisely the
 cost this cycle forbids.
 
@@ -43,39 +44,90 @@ against a naive implementation.
 ### The memo needs an invalidation hook (audit round 2 — `005`)
 
 Credential commits do not invalidate entitlement state today
-(`src/codex/account-store.ts:131`, `src/codex/auth-api.ts:2015`,
-`src/codex/model-entitlements.ts:630`). So a negative memo means a **fresh login
+(`src/codex/account-store.ts:131`, `src/codex/auth-api.ts:2016`,
+`src/codex/model-entitlements.ts:686-693`). So a negative memo means a **fresh login
 stays invisible until the memo expires** — the user logs in and the dashboard still
 shows nothing.
 
 Two requirements, both testable:
 
-1. **Pin the TTL explicitly** and keep it short. It bounds how stale a successful
-   login can look, so it is a UX number, not an implementation detail.
-2. **Clear the memo on known credential writes.** The account-store and auth-api
-   commit points above are the hooks. Regression: log in, then the very next ensure
-   sees the credential without waiting out the TTL.
+1. **TTL pinned at 5000 ms.** It bounds how stale a successful login can look, so it
+   is a UX number rather than an implementation detail, and it is written here so a
+   later change has to argue with a number instead of a vibe.
+2. **Clear the memo on every credential write.** Regression: log in, then the very
+   next ensure sees the credential without waiting out the TTL.
 
-Without (2) this cycle fixes a missing-rows bug by introducing a different
+### The full hook set (audit round 5 — `008`, finding 3)
+
+Round 2's two hooks were not enough, and one was misidentified.
+`src/codex/auth-api.ts:2015` is the *branch*; the save is `:2016`, and hooking that
+line still misses new-account login at `:546`. The complete set of local credential
+mutations:
+
+- `src/codex/account-store.ts:131` — the commit primitive (correctly identified).
+- `src/codex/auth-api.ts:2016` and `:546` — existing-account save and new-account
+  login.
+- `src/codex/account-store.ts:195-218` — pool CAS refresh, called at `:705`, `:790`.
+- `src/codex/account-store.ts:252-309` — owner/alias refresh, called at `:858`.
+- `src/codex/account-store.ts:312-320` — deletion and tombstone, via
+  `src/codex/account-lifecycle.ts:158`.
+- `src/codex/main-account.ts:133-163` and `:219` — main-token refresh.
+- `src/codex/native-profile-manager.ts:1307`, `:1335`, `:1449` — canonical
+  `auth.json` writes during native-profile switch, rollback and recovery, with the
+  successful transitions at `:1318` and `:1453`. Added after audit round 6
+  (finding 2): these are OpenCodex's own writes, not external ones, so they belong in
+  the epoch rather than being left to the identity probe. Regression: a credential
+  write that lands **during** an in-flight ensure must not be masked by that flight's
+  result.
+
+`src/codex/auth-api.ts:1630-1641` (active-account switch) is config-only and needs
+**no** memo clear.
+
+Two consequences for the design:
+
+1. **One cycle-free mutation epoch**, incremented at every successful commit and
+   tombstone, rather than a clear-call bolted onto each of the eight call sites.
+   Eight hooks is eight chances to miss one, and the miss is silent.
+2. **A bounded identity probe has to remain.** External replacement of
+   `~/.codex/auth.json` — another Codex process, a manual edit, `codex login` outside
+   this proxy — cannot be hooked at all. The memo can be cheap, but it cannot be
+   authoritative.
+
+Without this, the cycle fixes a missing-rows bug by shipping a different
 missing-rows bug.
 
 ## Change 2 — await it from the shared entry point
 
 `src/server/management/model-rows.ts:50`, `listManagementModelRows`: await the
 ensure in parallel with `fetchAllModels`, before `nativeModelRows` — the shape
-`/v1/models` already uses (`src/server/index.ts:1155`).
+`/v1/models` already uses (`src/server/index.ts:1158-1164`).
+
+The two wait policies cannot be expressed by a bare call (audit round 6, finding 3):
+sidecar reaches this very function (`src/sidecar/candidates.ts:40`), so the waiting
+policy has to be a parameter of the entry point rather than a property of the
+ensure.
 
 ```ts
-const [routed] = await Promise.all([fetchAllModels(config), ensureCodexEntitlementFreshness(config)]);
+export async function listManagementModelRows(
+  config: OcxConfig,
+  options: { entitlementWaitMs?: number } = {},
+): Promise<ManagementModelRow[]> {
+  const [routed] = await Promise.all([
+    fetchAllModels(config),
+    ensureCodexEntitlementFreshness(config, { waitMs: options.entitlementWaitMs ?? 3_000 }),
+  ]);
 ```
+
+Sidecar passes `{ entitlementWaitMs: 0 }`; `/api/models`, `/api/client-config`,
+integrations and `ocx export` take the 3000 ms default.
 
 This repairs all three reported surfaces at once because they funnel here:
 `/api/models` directly, `/api/client-config` via `loadExportModels`, and
 `ocx export` by requesting `/api/models` over HTTP
-(`src/cli/export-command.ts:169`).
+(`src/cli/export-command.ts:181`).
 
 **Failure must not throw.** A rejection here would degrade sidecar candidates
-(`src/sidecar/candidates.ts:29`) and could turn client-config into a 503. The
+(`src/sidecar/candidates.ts:35-40`) and could turn client-config into a 503. The
 ensure resolves with a bounded fail-closed result; the rows stay short, which is
 the honest outcome, and Change 3 makes that visible.
 
@@ -85,10 +137,17 @@ The dashboard reaches this entry point ~24 times/minute (`/api/sidecar-settings`
 every 5s, computing vision and web-search candidates independently), ~30 with the
 Models page open. Polls pause on a hidden document.
 
-So the ensure must be a **cache read** in the steady state: no credential
-enumeration, no allocation of a resolver context, no network. Measured target:
-with a fresh roster, repeated calls perform zero fetches and no credential
-validation. That assertion is a test, not a hope.
+So the ensure must be a **cache read** in the steady state. Corrected after audit
+round 5 (`008`, finding 2): "no credential validation" is not achievable as stated.
+The cache key is `(accountId, clientVersion)` (`:323-325`) but freshness also
+compares `credentialIdentity` (`:517-522`), and reading the current identity means
+touching `auth.json` or the account store (`:378-389`). A pure cache read would
+need a cross-process credential-generation signal that does not exist.
+
+Measured target, restated honestly: **zero token refresh and zero network** with a
+fresh roster. An identity-only read is permitted; the full
+`accountCredentialSnapshot` (`:391-419`) is reserved for entries that are missing,
+stale, or identity-mismatched. That assertion is a test, not a hope.
 
 ## Change 3 — moved out of this cycle
 
@@ -103,31 +162,140 @@ The honest diagnostic therefore needs its own endpoint decision, which is a desi
 question, not a line of code. It is now **wp4** (`040`). wp2 is the refresh fix and
 nothing else.
 
-## Regressions (each driven red first)
+## Regressions
 
-- `tests/codex-model-entitlements.test.ts` — fresh repeated ensure -> zero
-  refetches; at TTL+1 concurrent callers -> exactly one; failed refresh stays
-  unconfirmed with no retry for 15s.
+> Corrected after audit round 5 (`008`, finding 6). Three of the four original
+> claims were false reds — already green through `:517-552` and wp1's own tests at
+> `tests/codex-model-entitlements.test.ts:672-749`. Baseline across the four files
+> is 93 pass / 0 fail, so a claim of "red today" has to be earned per case.
+
+**Genuine reds (the wp2 defect itself):**
+
+- `tests/codex-model-entitlements.test.ts` — **credential-read count**: after priming,
+  repeated ensures perform **zero `accountCredentialSnapshot` calls**. Corrected after
+  audit round 6 (finding 4): asserting only "zero token refreshes and zero fetches"
+  is false-green, because the current resolver already satisfies it while still
+  invoking the full credential snapshot (`:592-601`). Identity-only reads are
+  permitted and counted separately.
+- `tests/codex-model-entitlements.test.ts` — **logged-out negative memo**: repeated
+  ensures with no credential perform exactly one credential enumeration, not one per
+  call. Red against a naive "refresh what is missing" implementation, which never
+  caches the absence and so re-enters the resolver ~24 times a minute.
+- `tests/codex-model-entitlements.test.ts` — **memo invalidation**: after a
+  credential write, the very next ensure sees it without waiting out the memo TTL.
+- `tests/management-client-config-route.test.ts` — entitlement fetch count is **1**.
+  Red because the current count is **0**: the shared entry point never resolves
+  entitlements at all, which is the defect.
 - `tests/native-model-toggle.test.ts` — expired confirmed roster, `/api/models`
-  still lists sol/terra/luna. Red today.
-- `tests/management-client-config-route.test.ts` — same fixture; OpenCode map holds
-  the GPT-5.6 entries; entitlement fetch count is 1.
-- `tests/cli-export-command.test.ts` — repoint its fake proxy at the real
-  `/api/models` handler. Its stubbed rows currently bypass the defective boundary,
-  so today's green is vacuous for this defect.
+  still lists sol/terra/luna. Red **only if** the fixture supplies a usable
+  credential and an upstream roster; without both, it is vacuous.
+- `tests/cli-export-command.test.ts` — red **only after** its stub proxy
+  (`tests/cli-export-command.test.ts:51-57`) is repointed at the real `/api/models`
+  handler and the assertion names the gated ids. The stubbed rows bypass the
+  defective boundary entirely, so today's green proves nothing about this defect.
 
+**Already green — do not claim as proof:** fresh repeated ensure yielding zero
+refetches, TTL+1 collapsing to exactly one fetch, and an unconfirmed failure entry
+surviving 15s. All three hold today through `:517-552`.
+
+**Rejection regressions (audit round 5, finding 4):** the ensure must not throw at
+its boundary. One case for sidecar degrading to auth slots
+(`src/sidecar/candidates.ts:35-61`) and one for client-config answering 503
+(`src/server/management/model-routes.ts:393-409`) — both must be unreachable via a
+failed ensure.
 ## Must not change
 
-The expiry check (`:509`) — serving expired grants breaks fail-closed revocation.
+The expiry check (`:673`) — serving expired grants breaks fail-closed revocation.
 `/v1/models` authorization or version behaviour. Per-account/version keys.
 Synchronous `nativeModelRows` must stay synchronous.
 
-## Open question to settle during P
+## Open question — SETTLED (audit rounds 5 and 6, `008`)
 
-Whether a stale management request waits out the 8s entitlement timeout or returns
-immediately with short rows. Serving stale rows is inconsistent with the current
-posture, so the default is to wait — but 8s on a dashboard poll is its own problem.
+The draft default (wait out the refresh) is wrong, and a flat per-waiter 3s
+deadline is also wrong: the sequential sidecar calls at
+`src/server/management/config-routes.ts:589-593` would accumulate up to 6s.
 
-Note the shape of the risk: the wait only happens on the *first* poll after expiry,
-because in-flight deduplication collapses the rest. Resolve before B and record the
-decision here.
+**One whole-ensure flight**, caught fail-closed, and **never aborted by a management
+timeout** — the upstream work always runs to completion so the cache is warm for the
+next caller. Deduplicating the *whole* ensure matters because roster-fetch dedup
+begins only after credential enumeration (`:524-552`), so abandoning a wait would
+otherwise repeat the credential work.
+
+### The flight needs an identity, not just a timestamp (audit rounds 6 and 7)
+
+A bare `{ startedAt, promise }` can cross-answer: two callers with different
+candidate sets, different client versions, or a credential change in between would
+join a flight that is not answering their question. The existing per-entry dedup is
+keyed by account, credential identity and version (`:524-526`), and the whole-ensure
+flight must not be weaker than the thing it wraps.
+
+The mutation epoch alone is **not** sufficient (audit round 7, finding 1). External
+`auth.json` writers cannot advance it — that is stated a few sections up and it is
+exactly the gap: a caller that has already observed a new identity would otherwise
+join an old-identity flight, which the per-entry dedup would never have allowed.
+
+So the flight key is:
+
+**(normalized candidate set, client version, mutation epoch, identity vector)**
+
+where the identity vector is the normalized list of
+`(accountId, credentialIdentity | null)` observed by the joining caller. The
+identity-only read that the cost bound already permits is what produces it, so this
+costs nothing extra: the caller has the vector in hand before it decides to join.
+
+### The key must also carry the workset (audit round 8, final blocker)
+
+Candidate set, version, epoch and identities can all be unchanged while an **entry
+expires mid-flight**. Concretely: a flight starts when account B is still fresh and
+so refreshes only A; B then expires; a second caller computes an identical key,
+joins, and the resolver's `now` is still fixed from the flight's start
+(`src/codex/model-entitlements.ts:586`), so B remains a cache hit (`:517-522`). The
+one-shot caller — `ocx export`, the surface #3023 reported — returns short rows
+having refreshed nothing.
+
+So the key includes the normalized **`needsRefreshAccountIds`** workset, or joining
+is permitted only when the new caller's workset is a **subset** of the running
+flight's. Overlap is already deduplicated one level down by the per-account flights
+(`:524-552`), so the stricter rule costs at most one extra credential pass and never
+an extra roster fetch.
+
+Regression: B expires while an A-only ensure flight is running; the next caller must
+refresh B rather than joining and reporting stale-short rows.
+### Negative-memo publication is fenced on identity, not just epoch (round 7, finding 2)
+
+An epoch fence alone still lets an external login during a flight receive a freshly
+published 5000 ms negative memo once that flight settles. Two requirements:
+
+1. **Fence publication on the captured identity vector.** A settling flight may
+   publish "no credential for X" only if X's identity is still what the flight
+   observed when it started. Otherwise it discards the memo and lets the next caller
+   re-ask.
+2. **Measure expiry from the absence observation, not from settlement.** A flight
+   that spent 30s in a credential refresh must not then hand out a memo that is
+   treated as 5000 ms fresh; its evidence is already 30s old.
+
+Regressions, both genuinely red: a **local epoch write during an in-flight ensure**,
+and an **external `auth.json` replacement during an in-flight ensure**. The second
+is the one an epoch-only design silently fails.
+
+### Wait policy
+
+- Sidecar candidate paths join with a **0 ms** wait: they never stall, they read
+  what is already cached.
+- `/api/models`, `/api/client-config`, integrations and `ocx export` wait up to
+  **3000 ms**, measured from the flight's original start rather than from each
+  waiter's arrival.
+
+`MODEL_ROSTER_TIMEOUT_MS` (8s) is **not** a total bound and must not be treated as
+one: it starts inside the roster fetch (`:438-445`), and credential refresh can
+spend 30s before that (`src/codex/main-account.ts:188-190`,
+`src/codex/account-store.ts:743-746`). The 3000 ms ceiling is what the management
+surfaces actually observe; the work behind it may outlive that ceiling.
+
+### Convergence, stated accurately (audit round 6, finding 5)
+
+Not "within one 5s poll cycle" — that contradicts the 30s credential refresh and 8s
+roster bound above. The honest statement: a management surface converges on **the
+first poll after the background flight settles**. With a warm credential that is
+usually the next poll; with a cold credential refresh it can be several. The
+guarantee this cycle makes is that **no poll stalls**, not that every poll is fresh.

--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
@@ -63,3 +63,47 @@ the real output of wp0:
 
 - Status: pending.
 - Receipt: _pending_
+
+## wp1 — CLOSED (shipped)
+
+`#3022` is fixed on `dev`. PR #3035 squash-merged as `4bdc0f6fb`.
+
+Two defects, one file (`src/codex/model-entitlements.ts`): the gated client-version
+floor derived `0.142.2` from the bundled snapshot when upstream only returns the
+gpt-5.6 rows at `0.144.0` and above, and an empty roster was recorded as a
+confirmation because an empty `Set` is truthy. The floor is now composed as
+`max(derived, measured, fallback)`, and a roster with no usable rows is unconfirmed
+on the 15s failure TTL.
+
+Eight regressions, each driven red against the unfixed source. Reverting both changes
+produces exactly six failures in `tests/codex-model-entitlements.test.ts` and one in
+`tests/claude-models-discovery.test.ts`; restoring returns 37/37. One existing
+assertion was intentionally flipped (an all-filtered roster is no longer "confirmed"),
+and one existing mock was corrected — it gated at minor `>= 142`, which is precisely
+why the suite never caught the regression.
+
+Verified on `ssh lidge` at the exact pushed head `1b6b36b96`: privacy scan passed,
+typecheck clean, full suite **16510 pass / 0 fail / 16 skip**, `EXIT=0`. Repo CI green
+across all four test shards, Windows, macOS, keyring, npm-global and the gates.
+
+## wp2 — CLOSED as a planning cycle; implementation is wp6
+
+Four audit rounds, four correctness holes, all in the same place: what a deduplicated
+ensure is allowed to answer for. The flight key grew from a bare timestamp to
+`(candidate set, client version, mutation epoch, identity vector, workset)`, one term
+per round, each added because a reviewer produced a concrete cross-answering sequence.
+
+Round 8's is the one worth remembering: every other term can be unchanged while an
+entry expires mid-flight, so a second caller joins a flight that will never refresh
+the account it came to refresh, and `ocx export` — the surface #3023 actually
+reported — returns short rows having refreshed nothing.
+
+wp2 does not claim an implementation, because there is none. It is registered as wp6.
+
+## wp3 — repair in flight
+
+The drain itself is right: correct ordering before the 2 MiB snapshot exclusion, a
+genuine stable-fixed-point loop, `B=5000`/`R=4000` with the fallback receiving its
+reserved slice, and the shared ACL deadline reaching both hardeners. The review found
+one high defect: supersession reaches the state tracking but not the writer, so an
+abandoned writer can still publish to the filesystem and orphan a temp. Sent back.


### PR DESCRIPTION
## Summary

Planning and audit records for the priority-70+ train. **Docs only — no source change.**

wp1 (#3022) already landed as #3035. This carries the record of what the audits changed, and closes wp2 (#3023) as a *planning* cycle rather than claiming an implementation that does not exist.

**wp2 took four audit rounds, and every one found a correctness hole in the same place:** what a deduplicated ensure operation is allowed to answer for. The flight key grew one term per round.

- Round 5: a bare `{ startedAt, promise }` cross-answers different candidate sets, versions and credential epochs, while the per-entry dedup it wraps is keyed by account, identity and version.
- Round 6: the mutation-hook set missed `native-profile-manager.ts` writes; the credential-read regression was false-green (already satisfied today while the full credential snapshot still runs); the two wait policies could not be expressed without an options path, since sidecar reaches the same entry point.
- Round 7: a mutation epoch cannot fence *external* `auth.json` writers, so a caller holding a new identity could still join an old-identity flight. Negative-memo publication is now fenced on the captured identity vector, and expiry is measured from the absence observation rather than settlement.
- Round 8: the key still omitted the **workset**. Every other term can be unchanged while an entry expires mid-flight, so a second caller joins a flight that will never refresh the account it came to refresh — and `ocx export`, the surface #3023 actually reported, returns short rows having refreshed nothing.

Final design: one whole-ensure flight keyed by `(candidate set, client version, mutation epoch, identity vector, workset)`, caught fail-closed and never aborted by a management timeout, with sidecar joining at 0 ms and the management surfaces waiting up to 3000 ms measured from the flight's start. `MODEL_ROSTER_TIMEOUT_MS` is explicitly **not** a total bound, because credential refresh can spend 30s before the roster fetch begins.

Three regressions the earlier draft claimed as red are now marked already-green, and the "zero credential validation" target is restated as zero token refresh and zero network — a pure cache read is unachievable without a cross-process credential-generation signal.

wp2's implementation is registered as **wp6** rather than folded in here.

Also records the **wp3** (#3011 / PR #3018) implementation review, which returned FAIL: the drain, budget split and ordering are correct, but supersession reached the state tracking and not the writer, so an abandoned writer could still publish to the filesystem and orphan a temp. That work is still in repair and is not part of this PR.

## Verification

Docs only; nothing in the build, typecheck or test path reads from `devlog/`. Verified anyway on Linux at `origin/dev` = `4bdc0f6fb` (which carries wp1):

- `bun run typecheck` — clean
- `bun test tests/codex-model-entitlements.test.ts tests/claude-models-discovery.test.ts` — 37 pass / 0 fail
- `bun run privacy:scan` — passed (it does read `devlog/`, which is the point of a public devlog)

## Checklist

- [x] Targets `dev`
- [x] No source change, so no regression test applies
- [x] `bun run privacy:scan` clean — relevant here because it is the gate that reads `devlog/`
- [x] No security material: this is planning and audit record for defects with public issues, no pre-disclosure content
- [x] No `gui` change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access to account-gated models by enforcing the measured minimum client version.
  - Empty or filtered model rosters are now treated as unconfirmed and retried sooner, reducing temporary missing-model results.
  - Preserved gated model visibility when no client version is supplied or stored.

- **Tests**
  - Added coverage for client-version compatibility, roster retry behavior, and gated-model discovery across API surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->