### PR TITLE
fix(responses): strip OpenAI-internal input metadata before routing upstream

### DIFF
--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -1,5 +1,6 @@
 import type { Server } from "bun";
 import { bridgeToResponsesSSE, buildResponseJSON, formatErrorResponse, type ResponsesTerminalStatus } from "../../bridge";
+import { stripOpenAiInternalRequestMetadata } from "./internal-request-metadata";
 import {
   getConfigPath,
   multiAgentGuidanceEnabled,
@@ -487,6 +488,7 @@ export async function handleResponsesCompact(
   let body: unknown;
   try {
     body = await readJsonRequestBody(req);
+    stripOpenAiInternalRequestMetadata(body);
   } catch (err) {
     return decodeRequestErrorResponse(err, "responses-compact");
   }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -7,6 +7,7 @@ import {
   backfillResponsesFieldsJson,
 } from "./responses-field-backfill";
 import { checkInputAdmission } from "./input-admission";
+import { stripOpenAiInternalRequestMetadata } from "./internal-request-metadata";
 import { nativeContextLimits } from "../../codex/catalog";
 import { describeUpstreamConnectFailure } from "./upstream-error";
 import {
@@ -2609,6 +2610,7 @@ async function handleResponsesInner(
     }
     return decodeRequestErrorResponse(err, "responses");
   }
+  stripOpenAiInternalRequestMetadata(body);
   const comboId = !options.comboAttempt ? comboIdFromRawBody(body, config) : null;
   if (comboId && Object.hasOwn(config.combos ?? {}, comboId)) {
     options.onRequestBodyRead?.();
@@ -2629,6 +2631,7 @@ async function handleResponsesInner(
     copyPreviousResponseReplayProvenance(options.comboReplaySnapshot.sourceBody, body);
   } else {
     body = expandPreviousResponseInput(body, inboundClientThreadId);
+    stripOpenAiInternalRequestMetadata(body);
     if (previousResponseScopeMismatch(body)) {
       console.warn("[opencodex] dropped a previous_response_id with a mismatched client task scope; continuing fresh");
     }

--- a/src/server/responses/internal-request-metadata.ts
+++ b/src/server/responses/internal-request-metadata.ts
@@ -1,0 +1,23 @@
+/**
+ * OpenAI-backend-only request metadata strip.
+ *
+ * codex >= 0.151 attaches `internal_chat_message_metadata_passthrough` (content_item_kinds) to
+ * Responses input items when the configured provider name is "openai" — codex-rs
+ * core/src/client.rs only clears it for `!is_openai()` providers. opencodex reuses the built-in
+ * openai provider via `openai_base_url`, so the field arrives here; routed upstreams (Joybuilder
+ * etc.) whitelist parameters strictly and reject it with 400 `unknown_parameter`
+ * ('input[0].internal_chat_message_metadata_passthrough.content_item_kinds').
+ *
+ * Mirror the codex-rs non-openai normalization at the proxy boundary: a flat loop over `input`,
+ * matching `build_responses_request`'s own stripping, so combo/chat/anthropic replays and the
+ * compact endpoint are all covered without touching per-provider forwarding code.
+ */
+export function stripOpenAiInternalRequestMetadata(body: unknown): void {
+  const input = (body as { input?: unknown } | undefined)?.input;
+  if (!Array.isArray(input)) return;
+  for (const item of input) {
+    if (item && typeof item === "object") {
+      delete (item as Record<string, unknown>).internal_chat_message_metadata_passthrough;
+    }
+  }
+}

--- a/tests/openai-internal-request-metadata.test.ts
+++ b/tests/openai-internal-request-metadata.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { stripOpenAiInternalRequestMetadata } from "../src/server/responses/internal-request-metadata";
+
+describe("stripOpenAiInternalRequestMetadata", () => {
+  test("strips passthrough metadata from message items", () => {
+    const body = {
+      model: "cov-x/gpt-5",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hi" }],
+          internal_chat_message_metadata_passthrough: {
+            content_item_kinds: ["input_text"],
+          },
+        },
+      ],
+    };
+    stripOpenAiInternalRequestMetadata(body);
+    const item = body.input[0] as Record<string, unknown>;
+    expect(item.internal_chat_message_metadata_passthrough).toBeUndefined();
+    // Other fields must survive intact.
+    expect(item.type).toBe("message");
+    expect(item.role).toBe("user");
+    expect(item.content).toEqual([{ type: "input_text", text: "hi" }]);
+  });
+
+  test("strips from every item in a mixed request", () => {
+    const body = {
+      input: [
+        { type: "message", role: "user", content: [], internal_chat_message_metadata_passthrough: {} },
+        { type: "reasoning", summary: [], internal_chat_message_metadata_passthrough: { scratch_pad: "x" } },
+        { type: "function_call", name: "exec", arguments: "{}", call_id: "c1" },
+        { type: "function_call_output", call_id: "c1", output: "ok" },
+      ],
+    };
+    stripOpenAiInternalRequestMetadata(body);
+    for (const item of body.input) {
+      expect((item as Record<string, unknown>).internal_chat_message_metadata_passthrough).toBeUndefined();
+    }
+  });
+
+  test("preserves other metadata fields on the same item", () => {
+    const body = {
+      input: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [],
+          internal_chat_message_metadata_passthrough: {},
+          extra_content: { gemini: { thought_signature: "sig-123" } },
+          id: "msg_1",
+        },
+      ],
+    };
+    stripOpenAiInternalRequestMetadata(body);
+    const item = body.input[0] as Record<string, unknown>;
+    expect(item.internal_chat_message_metadata_passthrough).toBeUndefined();
+    expect(item.extra_content).toEqual({ gemini: { thought_signature: "sig-123" } });
+    expect(item.id).toBe("msg_1");
+  });
+
+  test("no-op when the field is absent", () => {
+    const body = {
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "ok" }] }],
+    };
+    expect(() => stripOpenAiInternalRequestMetadata(body)).not.toThrow();
+    expect((body.input[0] as Record<string, unknown>).content).toEqual([
+      { type: "input_text", text: "ok" },
+    ]);
+  });
+
+  test("tolerates malformed input without throwing", () => {
+    expect(() => stripOpenAiInternalRequestMetadata(null)).not.toThrow();
+    expect(() => stripOpenAiInternalRequestMetadata(undefined)).not.toThrow();
+    expect(() => stripOpenAiInternalRequestMetadata({})).not.toThrow();
+    expect(() => stripOpenAiInternalRequestMetadata({ input: "not-an-array" })).not.toThrow();
+    expect(() =>
+      stripOpenAiInternalRequestMetadata({ input: [null, "x", 42, undefined] }),
+    ).not.toThrow();
+  });
+
+  test("leaves items unchanged when body.input is absent or empty", () => {
+    const body = { model: "m", input: [] };
+    stripOpenAiInternalRequestMetadata(body);
+    expect(body.input).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Starting with Codex **0.151.0-alpha** (shipped to Codex Desktop users on 2026-08-30), the client attaches an OpenAI-backend-only field to Responses input items:

```
internal_chat_message_metadata_passthrough: { content_item_kinds: [...] }
```

Codex intentionally keeps this field for providers whose name is `openai` (`codex-rs core/src/client.rs` strips it only for `!is_openai()` providers). Because opencodex occupies the built-in OpenAI provider slot via `openai_base_url`, the field arrives at opencodex and is forwarded **verbatim** to routed upstreams. Strict-upstream providers reject the unknown parameter and the turn fails:

```
Provider error 400: {
  "error": {
    "message": "Unknown parameter: 'input[0].internal_chat_message_metadata_passthrough.content_item_kinds'.",
    "type": "invalid_request_error",
    "code": "unknown_parameter"
  }
}
```

Confirmed on `combo/joy-openai` and `gpt-5.6-sol`; every turn (not just resumed sessions) fails with 400.

## Fix

Mirror the `!is_openai()` stripping rule at the proxy boundary by adding a single helper and calling it at every point where a Responses request body is read or rewritten:

- **New** `src/server/responses/internal-request-metadata.ts` — `stripOpenAiInternalRequestMetadata(body)`: flat loop over `body.input[]` deleting `internal_chat_message_metadata_passthrough`, matching `codex-rs`'s own normalization for non-OpenAI providers.
- `src/server/responses/core.ts` — **2 call sites**:
  1. After `readJsonRequestBody(...)` (covers direct POST, combo children, and the WebSocket bridge).
  2. After `expandPreviousResponseInput(...)` (covers the previous-response replay path).
- `src/server/responses/compact.ts` — **1 call site** after its own `readJsonRequestBody(req)` (compact bodies are re-serialized via `JSON.stringify({ ...compactBody, model })`, which previously leaked the field).

Only this one field is stripped. `encrypted_function_args` (also cleared by codex-rs for non-OpenAI) is left untouched because routed upstreams either accept it or never see it; if a future provider starts rejecting it, the same helper is the right place to add the deletion.

## Verification

- **Unit tests**: `bun test tests/openai-internal-request-metadata.test.ts` — 6/6 pass:
  - strips from message items, preserving every other field
  - strips from every item in a mixed request (message/reasoning/function_call/function_call_output)
  - coexists with `extra_content.gemini.thought_signature` and other metadata
  - no-op when the field is absent
  - tolerates `null` / non-array / malformed `input` without throwing
- **Type check**: `bun x tsc --noEmit` — clean (exit 0).
- **End-to-end**: sent a direct POST to a local 2.36.0 proxy carrying the failing field — before the patch it reproduced the exact upstream 400; after the patch the same request returns `status=completed` with a valid completion. Confirmed in Codex Desktop 0.151.0-alpha.7.2 that the previously failing session (combo/joy-openai) now completes turns end-to-end.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented internal request metadata from being sent to upstream providers that reject unknown fields.
  * Improved compatibility with strict Responses API endpoints, avoiding related 400 errors.
  * Preserved all other request content while safely handling malformed or incomplete input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->