### PR TITLE
fix(update): gate the update on the proxy being down, not on stop's exit code

### DIFF
--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -27,6 +27,26 @@ export function historyRestoreIncomplete(configDir = getConfigDir()): boolean {
   }
 }
 
+/**
+ * Whether the update may replace the package once `ocx stop` has returned, and
+ * whether its exit status is worth mentioning.
+ *
+ * The only precondition the update has is that nothing is still serving —
+ * package replacement cannot run under a live proxy. But `ocx stop` does more
+ * than stop the proxy: it also restores Codex resume-history and reverts
+ * environment ownership, and it reports a non-zero status when any of that
+ * fails. A busy history DB is ordinary on Windows, so reading the status as the
+ * gate aborted updates whose proxy had already stopped cleanly, leaving nothing
+ * on the port and the old version installed (#3008).
+ */
+export function classifyStopForUpdate(outcome: {
+  status: number | null;
+  proxyStillUp: boolean;
+}): { proceed: false } | { proceed: true; stopStatus: number | null } {
+  if (outcome.proxyStillUp) return { proceed: false };
+  return { proceed: true, stopStatus: outcome.status === 0 ? null : outcome.status };
+}
+
 export const PKG = "@bitkyc08/opencodex";
 const HERE = dirname(fileURLToPath(import.meta.url)); // .../opencodex/src/update
 
@@ -256,7 +276,11 @@ export async function runUpdate(): Promise<void> {
       windowsHide: true,
     });
     if (stopStdio === "pipe") logSpawnOutput("", stop);
-    if (stop.status !== 0 || readPid() || readRuntimePort()) {
+    const stopOutcome = classifyStopForUpdate({
+      status: stop.status,
+      proxyStillUp: Boolean(readPid() || readRuntimePort()),
+    });
+    if (!stopOutcome.proceed) {
       if (trayWasRunning) {
         try {
           const { startWindowsTray } = await import("../tray/windows");
@@ -265,6 +289,11 @@ export async function runUpdate(): Promise<void> {
       }
       console.error("⚠️  Could not stop the running proxy; aborting the update. Run 'ocx stop' and retry.");
       process.exit(1);
+    }
+    if (stopOutcome.stopStatus !== null) {
+      console.warn(
+        `⚠️  'ocx stop' exited ${stopOutcome.stopStatus}, but the proxy is stopped; continuing the update.`,
+      );
     }
     if (historyRestoreIncomplete()) {
       console.warn(

--- a/tests/update-stop-classification.test.ts
+++ b/tests/update-stop-classification.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { classifyStopForUpdate } from "../src/update/index";
+
+/**
+ * #3008: a dashboard update aborted after `ocx stop` had already stopped the
+ * proxy, because resume-history restoration exited non-zero and the update read
+ * the stop command's status as its gate. The port was left with no listener and
+ * the old package still installed.
+ */
+describe("classifyStopForUpdate", () => {
+  test("proceeds when the proxy is down, even if stop reported failure", () => {
+    expect(classifyStopForUpdate({ status: 1, proxyStillUp: false })).toEqual({
+      proceed: true,
+      stopStatus: 1,
+    });
+  });
+
+  test("reports no status to warn about when stop succeeded", () => {
+    expect(classifyStopForUpdate({ status: 0, proxyStillUp: false })).toEqual({
+      proceed: true,
+      stopStatus: null,
+    });
+  });
+
+  test("refuses while a proxy is still up, whatever stop reported", () => {
+    // Replacing package files under a live proxy leaves it executing mixed
+    // old/new code, so this is the one condition that must still abort.
+    expect(classifyStopForUpdate({ status: 0, proxyStillUp: true })).toEqual({ proceed: false });
+    expect(classifyStopForUpdate({ status: 1, proxyStillUp: true })).toEqual({ proceed: false });
+  });
+
+  test("treats a signal-killed stop as non-fatal once the proxy is down", () => {
+    // spawnSync reports status null when the child died from a signal.
+    expect(classifyStopForUpdate({ status: null, proxyStillUp: false })).toEqual({
+      proceed: true,
+      stopStatus: null,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3008.

A dashboard update aborted **after** `ocx stop` had already stopped the proxy, because resume-history restoration exited non-zero. The reported end state was the bad one: nothing on the configured port, runtime state cleared, old package still installed.

## Why the status was the wrong gate

`ocx stop` does more than stop the proxy. `handleStop` also reverts environment ownership and calls `restoreSharedClientStateAfterStop()`, and any of those setting `stopFailed` produces `process.exitCode = 1`. A Codex history DB held busy by the app is an ordinary Windows condition, so a clean proxy shutdown can still exit 1.

The update read that status:

```ts
if (stop.status !== 0 || readPid() || readRuntimePort()) { ...abort... }
```

Its only real precondition is that nothing is still serving — package replacement under a live proxy leaves the running server dynamic-importing a mix of old and new modules, which is what the comment above that block already says. History restoration has no bearing on it.

There is a second symptom in the same lines: the resume-history warning immediately below the guard could not be reached on this path, because the condition it warns about had already aborted the update. It was written for exactly this case.

## What changed

`classifyStopForUpdate` decides both things and is exported for testing, next to `historyRestoreIncomplete`, which this file already exports for the same reason:

- **abort only while a proxy is still up** — the condition that actually blocks replacement
- **report a non-zero stop status as a warning** rather than swallowing it, so a failed teardown is still visible

The tray restore and `process.exit(1)` on a genuine still-running proxy are unchanged.

## Tests

`tests/update-stop-classification.test.ts`, 4 cases:

- proceeds when the proxy is down even though stop reported failure — the reported bug
- nothing to warn about when stop succeeded
- still refuses while a proxy is up, whatever stop reported (both status values)
- a signal-killed stop (`status: null` from `spawnSync`) is not treated as a numeric failure

```
bun test update-job update-transactional update-npm-invocation update-stop-classification
72 pass, 0 fail

bun x tsc --noEmit   clean
```

I did not add a case to `tests/update-stop-first.test.ts`; it drives real proxies, and the decision this changes is a pure one.

## Not in this PR

#3009 came out of the same recovery session, but it is `src/service.ts` and a different failure point — the review on that issue asked to keep the two apart. It is up separately.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updates now continue when the proxy is confirmed stopped, even if the stop command reports a failure or is interrupted.
  * Updates still stop safely when the proxy remains active.
  * A warning is shown when stopping the proxy reports an issue but the proxy is no longer running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->