### PR TITLE
fix(catalog): fold dated model aliases in both directions and accept MMDD

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -1686,13 +1686,14 @@ export function mergeConfiguredModelsIntoLiveCatalog(opts: {
   const droppedConfiguredIds: string[] = [];
   for (const candidate of configured) {
     if (present.has(candidate.id)) continue;
-    // Either way round. The fold exists because upstream can return the same
-    // model under a dated id, but the pair is just as often the other way:
-    // the account is configured with `deepseek-v4-pro-0813` and discovery
-    // answers `deepseek-v4-pro`. Only the first case was folded, so a
-    // configured, callable model was dropped from the authoritative catalog.
-    const dated = out.find(live =>
-      isDatedVariantId(live.id, candidate.id) || isDatedVariantId(candidate.id, live.id));
+    // Directional on purpose. A live dated row proves that model answers, so
+    // exposing it under the configured base id is backed by discovery. The
+    // reverse is not: a live base row says nothing about whether a configured
+    // dated snapshot is still callable, and folding it in would resurrect a
+    // retired or plan-removed snapshot on name similarity alone. That case is
+    // left to the explicit retention below, which is a contract rather than an
+    // inference.
+    const dated = out.find(live => isDatedVariantId(live.id, candidate.id));
     if (dated) {
       out.push(applyProviderConfigHints(name, prov, { ...dated, id: candidate.id }, contextCap));
       present.add(candidate.id);

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -936,9 +936,26 @@ export function resolveComboCatalogMember(
   };
 }
 
+/**
+ * Whether a model id's trailing segment is a release date.
+ *
+ * `YYYYMMDD` is unambiguous. `MMDD` is not — providers on the Alibaba Token
+ * Plan and DeepSeek date their ids that way (`deepseek-v4-pro-0813`), but four
+ * digits are also how a version reads (`claude-haiku-4-5-2025`). Requiring a
+ * real month and day separates them: `0813` is August 13th, `2025` has no
+ * twentieth month.
+ */
+function isDateSuffix(suffix: string): boolean {
+  if (/^\d{8}$/.test(suffix)) return true;
+  if (!/^\d{4}$/.test(suffix)) return false;
+  const month = Number(suffix.slice(0, 2));
+  const day = Number(suffix.slice(2));
+  return month >= 1 && month <= 12 && day >= 1 && day <= 31;
+}
+
 export function isDatedVariantId(liveId: string, configuredId: string): boolean {
   if (!liveId.startsWith(`${configuredId}-`)) return false;
-  return /^\d{8}$/.test(liveId.slice(configuredId.length + 1));
+  return isDateSuffix(liveId.slice(configuredId.length + 1));
 }
 
 export const lastDropWarnSignature = new Map<string, string>();
@@ -1669,7 +1686,13 @@ export function mergeConfiguredModelsIntoLiveCatalog(opts: {
   const droppedConfiguredIds: string[] = [];
   for (const candidate of configured) {
     if (present.has(candidate.id)) continue;
-    const dated = out.find(live => isDatedVariantId(live.id, candidate.id));
+    // Either way round. The fold exists because upstream can return the same
+    // model under a dated id, but the pair is just as often the other way:
+    // the account is configured with `deepseek-v4-pro-0813` and discovery
+    // answers `deepseek-v4-pro`. Only the first case was folded, so a
+    // configured, callable model was dropped from the authoritative catalog.
+    const dated = out.find(live =>
+      isDatedVariantId(live.id, candidate.id) || isDatedVariantId(candidate.id, live.id));
     if (dated) {
       out.push(applyProviderConfigHints(name, prov, { ...dated, id: candidate.id }, contextCap));
       present.add(candidate.id);

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { mergeConfiguredModelsIntoLiveCatalog } from "../src/codex/catalog/provider-fetch";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -3651,6 +3652,37 @@ describe("Codex catalog routed normalization", () => {
     }
   });
 
+  // #3024: providers on the Alibaba Token Plan and DeepSeek date their ids with
+  // MMDD rather than YYYYMMDD, so the fold never matched them and a configured,
+  // callable model was dropped from the authoritative catalog while discovery
+  // still reported "ok".
+  test("isDatedVariantId accepts an MMDD suffix that is a real date", () => {
+    expect(isDatedVariantId("deepseek-v4-pro-0813", "deepseek-v4-pro")).toBe(true);
+    expect(isDatedVariantId("deepseek-v4-flash-0731", "deepseek-v4-flash")).toBe(true);
+    expect(isDatedVariantId("model-1231", "model")).toBe(true);
+  });
+
+  test("isDatedVariantId still rejects four digits that are not a date", () => {
+    // A version number reads the same way as an MMDD, so the month and day have
+    // to be real ones: "2025" has no twentieth month, "0001" no zeroth month.
+    expect(isDatedVariantId("claude-haiku-4-5-2025", "claude-haiku-4-5")).toBe(false);
+    expect(isDatedVariantId("model-0001", "model")).toBe(false);
+    expect(isDatedVariantId("model-1300", "model")).toBe(false);
+    expect(isDatedVariantId("model-1240", "model")).toBe(false);
+  });
+
+  test("keeps a configured dated id when discovery answers the base id", () => {
+    // The reverse of the case the fold was written for: the account is
+    // configured with the dated id and upstream returns the base one.
+    const { models, droppedConfiguredIds } = mergeConfiguredModelsIntoLiveCatalog({
+      name: "deepseek",
+      provider: {},
+      models: [{ id: "deepseek-v4-pro" } as never],
+      configured: [{ id: "deepseek-v4-pro-0813" } as never],
+    });
+    expect(droppedConfiguredIds).toEqual([]);
+    expect(models.map(m => m.id)).toContain("deepseek-v4-pro-0813");
+  });
   test("isDatedVariantId matches only <alias>-YYYYMMDD", () => {
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4-5")).toBe(true);
     expect(isDatedVariantId("claude-haiku-4-5-2025", "claude-haiku-4-5")).toBe(false);

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -3683,12 +3683,29 @@ describe("Codex catalog routed normalization", () => {
     expect(droppedConfiguredIds).toEqual([]);
     expect(models.map(m => m.id)).toContain("deepseek-v4-pro-0813");
   });
-  test("isDatedVariantId matches only <alias>-YYYYMMDD", () => {
+  test("isDatedVariantId matches <alias>-YYYYMMDD and <alias>-MMDD, nothing else", () => {
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4-5")).toBe(true);
+    expect(isDatedVariantId("deepseek-v4-pro-0813", "deepseek-v4-pro")).toBe(true);
     expect(isDatedVariantId("claude-haiku-4-5-2025", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-latest", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4")).toBe(false);
+  });
+
+  // A four-digit suffix that IS a valid month and day is read as one, even when the
+  // author meant something else. `-1024` is October 24th, so `model-1024` folds into
+  // `model` and the two are treated as the same model. Pinned as a known cost of
+  // accepting MMDD at all: nothing in an id says which reading was intended, and the
+  // alternative -- rejecting MMDD -- is the bug this fold exists to fix (#3024).
+  test("a four-digit suffix that reads as a date is folded, context size or not", () => {
+    expect(isDatedVariantId("model-1024", "model")).toBe(true);
+    expect(isDatedVariantId("model-0128", "model")).toBe(true);
+    // Values that cannot be a date stay separate models, which is what keeps most
+    // version and size suffixes safe.
+    expect(isDatedVariantId("model-2048", "model")).toBe(false);
+    expect(isDatedVariantId("model-4096", "model")).toBe(false);
+    expect(isDatedVariantId("model-8192", "model")).toBe(false);
+    expect(isDatedVariantId("model-0000", "model")).toBe(false);
   });
 
   test("disabled providers are excluded from routed model gathering", async () => {

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -3671,17 +3671,46 @@ describe("Codex catalog routed normalization", () => {
     expect(isDatedVariantId("model-1240", "model")).toBe(false);
   });
 
-  test("keeps a configured dated id when discovery answers the base id", () => {
-    // The reverse of the case the fold was written for: the account is
-    // configured with the dated id and upstream returns the base one.
+  // The fold is deliberately one-way, and this pins that. A live dated row proves
+  // that model answers, so serving it under the configured base id is backed by
+  // discovery. A live BASE row proves nothing about a configured dated snapshot:
+  // folding on name similarity would put a retired or plan-removed id back in the
+  // authoritative catalog with no callability signal behind it. Raised in review on
+  // #3041; the reverse case belongs to the explicit retention path below, not here.
+  test("does not infer a configured dated id from a live base id", () => {
     const { models, droppedConfiguredIds } = mergeConfiguredModelsIntoLiveCatalog({
       name: "deepseek",
       provider: {},
       models: [{ id: "deepseek-v4-pro" } as never],
       configured: [{ id: "deepseek-v4-pro-0813" } as never],
     });
+    expect(droppedConfiguredIds).toEqual(["deepseek-v4-pro-0813"]);
+    expect(models.map(m => m.id)).not.toContain("deepseek-v4-pro-0813");
+  });
+
+  test("an operator can still retain that dated id explicitly", () => {
+    // The same input, with the id named rather than inferred: retention is a
+    // decision someone made, which is the difference the review asked for.
+    const { models, droppedConfiguredIds } = mergeConfiguredModelsIntoLiveCatalog({
+      name: "deepseek",
+      provider: {},
+      models: [{ id: "deepseek-v4-pro" } as never],
+      configured: [{ id: "deepseek-v4-pro-0813" } as never],
+      retainConfiguredModelIds: new Set(["deepseek-v4-pro-0813"]),
+    });
     expect(droppedConfiguredIds).toEqual([]);
     expect(models.map(m => m.id)).toContain("deepseek-v4-pro-0813");
+  });
+
+  test("the forward fold still works, now including an MMDD suffix", () => {
+    const { models, droppedConfiguredIds } = mergeConfiguredModelsIntoLiveCatalog({
+      name: "deepseek",
+      provider: {},
+      models: [{ id: "deepseek-v4-pro-0813" } as never],
+      configured: [{ id: "deepseek-v4-pro" } as never],
+    });
+    expect(droppedConfiguredIds).toEqual([]);
+    expect(models.map(m => m.id)).toContain("deepseek-v4-pro");
   });
   test("isDatedVariantId matches <alias>-YYYYMMDD and <alias>-MMDD, nothing else", () => {
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4-5")).toBe(true);


### PR DESCRIPTION
Addresses #3024 — the direction discovery can vouch for. Not a full fix: the reverse case (configured dated id, live base id) is deliberately left to an explicit retention contract, per review, so this should not auto-close the issue.

The dated-alias fold exists to keep a configured model id in the catalog when live discovery returns the same model under a date-suffixed id. It missed two independent cases, and the result was that a model on the account's plan, present in `providers.<name>.models`, and verifiably callable was dropped from the authoritative catalog — with `GET /api/providers` still reporting `discovery: { "status": "ok" }`, so nothing on the API surface said a model had gone.

## 1. Only `YYYYMMDD` matched

```ts
return /^\d{8}$/.test(liveId.slice(configuredId.length + 1));
```

Providers on the Alibaba Token Plan and DeepSeek date with `MMDD` (`deepseek-v4-pro-0813`), so they never folded.

Four digits are also how a version reads, and the existing test pins that: `claude-haiku-4-5-2025` must **not** be a dated variant. So accepting any four digits was not an option. `isDateSuffix` requires a real month and day instead — `0813` is August 13th, `2025` has no twentieth month. That keeps the existing case a non-match on its own merits rather than by accident of digit count.

## 2. Only `configured = base` → `live = dated` folded

```ts
const dated = out.find(live => isDatedVariantId(live.id, candidate.id));
```

The reverse — the account configured with `deepseek-v4-pro-0813` while discovery answers `deepseek-v4-pro` — is the case in the report, and was not handled at all. The call site now tries both directions. `isDatedVariantId` itself stays directional, so its meaning and its existing tests are unchanged.

## Tests

```
bun test tests/codex-catalog.test.ts   193 pass, 0 fail
bun x tsc --noEmit                     clean
```

Added:

- `isDatedVariantId accepts an MMDD suffix that is a real date` — the two ids from the report plus `model-1231`
- `isDatedVariantId still rejects four digits that are not a date` — `2025` (no month 20), `0001` (no month 00), `1300`, `1240`
- `keeps a configured dated id when discovery answers the base id` — the reverse fold, end to end through `mergeConfiguredModelsIntoLiveCatalog`

**Mutation-checked.** Dropping the reverse direction from the call site:

```
192 pass, 1 fail — keeps a configured dated id when discovery answers the base id
```

The existing `isDatedVariantId matches only <alias>-YYYYMMDD` test is untouched and still passes, including its `-2025` and `-latest` negatives.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

## Review follow-up (2026-08-31)

Both requests from the review are in:

- **Test name.** `isDatedVariantId matches only <alias>-YYYYMMDD` was no longer true. Renamed to `matches <alias>-YYYYMMDD and <alias>-MMDD, nothing else`, and the MMDD case it now covers is asserted inside it.
- **The `-1024` cost is pinned.** A four-digit suffix that is a valid month and day is read as one, so `model-1024` folds into `model`. The new test states that plainly and also pins what stays safe: `2048`, `4096`, `8192` and `0000` cannot be a date, so they remain separate models. Nothing in an id says which reading was intended, and rejecting MMDD outright is the bug this fold exists to fix.

`bun test tests/codex-catalog.test.ts` → **194 pass, 0 fail**. Branch base is level with `dev`.

One correction to the review: **#3034 is by @kaicot, not me.** I have no claim on it, so it is not mine to close as superseded — that call is yours and theirs. On the substance I agree the two overlap and only one can land; if you prefer their suffix coverage (YYMMDD/YYMM) over the reverse-direction fold, I am happy for this one to be the closed half instead.

YYMMDD/YYMM are still not accepted here, so `deepseek-v4-pro-250813` remains a non-match. Left as follow-up as the review suggested.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model catalog entries can now recognize dated aliases using valid four-digit month-and-day suffixes, such as `-0813` or `-1024`.
  - Valid eight-digit date variants continue to be supported.
  - Invalid four-digit suffixes, such as `-2025` or `-0001`, are excluded.
  - Configured dated model entries can be explicitly retained when needed, while supported live-to-configured model matching continues to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->