### PR TITLE
docs(devlog): record the v2.37.0 release and the live #3022 verification

### DIFF
--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
@@ -107,3 +107,38 @@ genuine stable-fixed-point loop, `B=5000`/`R=4000` with the fallback receiving i
 reserved slice, and the shared ACL deadline reaching both hardeners. The review found
 one high defect: supersession reaches the state tracking but not the writer, so an
 abandoned writer can still publish to the filesystem and orphan a temp. Sent back.
+
+## v2.37.0 released — #3022 verified live
+
+The 5.6 fix is published and proven on the installed runtime, not just in CI.
+
+- npm `@bitkyc08/opencodex@2.37.0` on `latest`; `gitHead` = `54e2274cff231631c0ea2ff12574ff03829d5fe6`
+- tag `v2.37.0` and the GitHub release both point at that same commit
+- `main` = `54e2274cf` (promotion PR #3037), `dev` = `4180067b4` and an ancestor of it
+
+Both required gates passed on the exact release SHA as push events: Cross-platform CI
+and Service lifecycle. `enforce-target` fails on any promotion by construction —
+`ALLOWED_BASES` is `["dev"]` — which is why #3002 (v2.36.0) merged in the same state.
+
+Release-path proof, in order:
+
+1. The published tarball carries both changes:
+   `MEASURED_GATED_CLIENT_VERSION_MINIMUM = "0.144.0"` at `:88` and
+   `const usable = models !== null && models.size > 0` at `:472`.
+2. The global install had to be forced. `bun add -g` reused a cached 2.37.0 from
+   Aug 30 that predated the fix — same version string, old bytes. Worth remembering:
+   a version match is not a content match, and `grep` on the installed file is the
+   check that actually settles it.
+3. The running proxy was serving the primary checkout, which sat 4 commits behind
+   `dev` while reporting `version: 2.37.0`. So `/healthz` agreed with the release
+   and the code did not. Fast-forwarded the checkout and restarted onto the global
+   install (PID 57341, `~/.bun/install/global/.../@bitkyc08/opencodex`).
+4. On that runtime: `ocx models live --provider openai` lists `gpt-5.6-sol`,
+   `-terra` and `-luna` as native/enabled; `/v1/models` returns all three;
+   `/api/models` and `ocx export --client opencode --json` carry them too.
+
+That last point matters beyond #3022: the three surfaces #3023 names were checked on
+a warm roster and all carry the gated rows. #3023 is about what happens once
+`MODEL_ROSTER_TTL_MS` expires, so this is not a NOOP for it — but it does confirm
+the warm path is intact and the wp6 work is scoped to expiry, not to the rows
+themselves.


### PR DESCRIPTION
## Summary

Records the **v2.37.0** release and the live verification of #3022. Docs only, no source change.

The 5.6 fix is published and proven on the installed runtime rather than only in CI. npm `latest` is 2.37.0 with `gitHead` `54e2274cf`; the tag, the GitHub release and `main` all point at that same commit, and both required gates passed on it as push events.

Two things in the release path are written down because either one would have let a "released" claim stand on nothing:

- `bun add -g` reused a cached 2.37.0 built the previous day, from before the fix existed. The version string matched and the bytes did not. The check that actually settles it is grepping the installed file; `--force` fixed it.
- The running proxy was serving the primary checkout, which sat four commits behind `dev` while `/healthz` reported `version: 2.37.0`. So the health endpoint agreed with the release and the code did not.

After fast-forwarding and restarting onto the global install, `ocx models live --provider openai` lists `gpt-5.6-sol`, `-terra` and `-luna` as native and enabled, and `/v1/models`, `/api/models` and `ocx export --client opencode --json` all carry them.

That last part also bears on #3023: its three named surfaces are intact on a **warm** roster. #3023 is about what happens once `MODEL_ROSTER_TTL_MS` expires, so this is not a NOOP for it, but it does scope the remaining work to expiry rather than to the rows themselves.

## Verification

Docs only; nothing in the build, typecheck or test path reads from `devlog/`.

- Published tarball inspected: `MEASURED_GATED_CLIENT_VERSION_MINIMUM = "0.144.0"` and `const usable = models !== null && models.size > 0` both present
- `npm view @bitkyc08/opencodex dist-tags` → `latest: 2.37.0`
- Runtime checked against the global install, not a source checkout
- `bun run privacy:scan` is the gate that reads `devlog/`, and it passed on this content at `4180067b4`

## Checklist

- [x] Targets `dev`
- [x] No source change, so no regression test applies
- [x] No security or pre-disclosure material — this is release record for a public, already-fixed issue
- [x] No `gui` change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Recorded the successful release of version 2.37.0.
  - Documented verification that gated model listings appear consistently across command-line and API surfaces.
  - Confirmed the release package and running service use the updated model availability behavior.
  - Noted that the existing warm-path behavior remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->