### PR TITLE
chore(release): move dev to 2.38.0 after the v2.37.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Moves `dev` from `2.37.0` to `2.38.0` now that `v2.37.0` is published.

`scripts/release.ts` runs only on `main`/`preview` and `release.yml` ends at the GitHub release, so nothing advances `dev`. The moment a release publishes, `dev` carries an already-released version and `tests/release-version-line.test.ts` fails on `dev` **and on every PR opened against it** — inherited red a contributor cannot fix from their own diff.

Observed exactly that on `origin/dev` = `cdaf2649e`:

```
package.json version 2.37.0 equals release tag v2.37.0, but this commit is not the
one that tag names. The tree claims an already-published version: publishing is
refused as a duplicate. Bump package.json.
```

Version chosen by the helper rather than by hand:

```
$ bun scripts/bump-dev-version.ts 2.37.0 package.json
{"changed":true,"version":"2.38.0","reason":"2.37.0 is a stable release, so dev moves to the next minor 2.38.0"}
```

## Why this is a manual PR this time

`.github/workflows/dev-version-bump.yml` exists to open this PR automatically on `release: published`. It did not fire for v2.37.0, and its own header explains why: a `release` event resolves the workflow file from the **default branch**, and the workflow only reached `main` in this very promotion. It is installed on `main` now, so v2.38.0 onward should be automatic. This is the documented re-drive path — run `bump-dev-version.ts` locally and open the PR normally — not a workaround.

## Verification

```
$ bun test tests/release-version-line.test.ts
3 pass / 0 fail
```

Red before this change on the same tree, green after. One line in `package.json`; no source change.

## Checklist

- [x] Targets `dev`
- [x] The failing test is the regression, and it flips red to green
- [x] Version decided by `scripts/bump-dev-version.ts`, not chosen by hand
- [x] No `gui` change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application to version 2.38.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->