### PR TITLE
fix(cursor): retry pre-header discovery eof

### DIFF
--- a/src/adapters/cursor/live-models.ts
+++ b/src/adapters/cursor/live-models.ts
@@ -262,6 +262,7 @@ async function fetchCursorUsableModelsHttp2Once(opts: CursorUsableModelsOptions)
     req.on("error", () => close({ ok: false, error: "transport", detail: "HTTP/2 request failed" }));
     req.on("end", () => {
       if (bodyRejected) return;
+      if (status === 0) return close({ ok: false, error: "transport", detail: "HTTP/2 response ended before headers" });
       if (status === 401 || status === 403) {
         return close({ ok: false, error: "auth", detail: `HTTP ${status}` });
       }

--- a/tests/cursor-hardening.test.ts
+++ b/tests/cursor-hardening.test.ts
@@ -424,6 +424,25 @@ describe("Cursor discovery bounded retry", () => {
     expect(result).toEqual({ ok: true, models: ["gpt-5.5-high"] });
   });
 
+  test("retries an HTTP/2 stream that ends before response headers", async () => {
+    const body = toBinary(GetUsableModelsResponseSchema, create(GetUsableModelsResponseSchema, {
+      models: [create(ModelDetailsSchema, { modelId: "gpt-5.5-high" })],
+    }));
+    let requests = 0;
+    const result = await withDiscoveryServer(stream => {
+      requests += 1;
+      if (requests === 1) {
+        stream.close(http2.constants.NGHTTP2_NO_ERROR);
+        return;
+      }
+      stream.respond({ ":status": 200, "content-type": "application/proto" });
+      stream.end(body);
+    }, baseUrl => fetchCursorUsableModels({ apiKey: "test-token", baseUrl }));
+
+    expect(requests).toBe(2);
+    expect(result).toEqual({ ok: true, models: ["gpt-5.5-high"] });
+  });
+
   test("does not retry deterministic auth failures", async () => {
     let requests = 0;
     const result = await withDiscoveryServer(stream => {


### PR DESCRIPTION
## Summary

Fix Cursor live model discovery when an HTTP/2 stream ends before response headers. The adapter now classifies status-less EOF as a transient transport failure, so the existing bounded retry can recover without changing completed HTTP-status, authentication, decode, or empty-response handling.

Closes #3051

## Verification

- `bun test tests/cursor-hardening.test.ts` (42 pass)
- `PATH="/Users/terrytan/.nvm/versions/node/v24.3.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" bun run test:changed` (9637 pass, 3 skip)
- `PATH="/Users/terrytan/.nvm/versions/node/v24.3.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" bun run typecheck`
- `PATH="/Users/terrytan/.nvm/versions/node/v24.3.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" bun run privacy:scan`
- `PATH="/Users/terrytan/.nvm/versions/node/v24.3.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" bun run test` (exit 0; parallel phase 16345 pass, 12 skip)
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (internal transport resilience; no user-facing configuration change).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; no credential or auth behavior changed.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model discovery reliability when an HTTP/2 connection closes before response headers are received.
  * Automatically retries the discovery request once and successfully loads available models when the connection recovers.

* **Tests**
  * Added coverage for bounded retry behavior during interrupted model discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->