### PR TITLE
fix(catalog): advertise image input for modalities-declared sidecar rows

### DIFF
--- a/docs-site/src/content/docs/guides/sidecars.md
+++ b/docs-site/src/content/docs/guides/sidecars.md
@@ -123,8 +123,11 @@ failures after response headers have started are delivered as `response.failed` 
 
 ## Vision sidecar
 
-When the routed model is listed in its provider's `noVisionModels` and a request carries an image,
-opencodex describes each image **before** the main call and replaces it with text. When
+When the routed model is listed in its provider's `noVisionModels` — or declared text-only for
+that model via `modelInputModalities` — and a request carries an image, opencodex describes each
+image **before** the main call and replaces it with text. The model catalog advertises image input
+for every sidecar-covered model (combos advertise image when every member is covered), so clients
+such as the Codex app allow attachments instead of blocking them before the sidecar runs. When
 `visionSidecar.model` is absent or blank, the OpenAI execution path, Dashboard, and management API
 use the `gpt-5.4-mini` fallback. Startup still migrates an explicitly persisted legacy
 `gpt-5.4-mini` value to `gpt-5.6-luna`; that migration applies to a stored value, not to an absent

--- a/docs-site/src/content/docs/guides/sidecars.md
+++ b/docs-site/src/content/docs/guides/sidecars.md
@@ -126,8 +126,9 @@ failures after response headers have started are delivered as `response.failed` 
 When the routed model is listed in its provider's `noVisionModels` — or declared text-only for
 that model via `modelInputModalities` — and a request carries an image, opencodex describes each
 image **before** the main call and replaces it with text. The model catalog advertises image input
-for every sidecar-covered model (combos advertise image when every member is covered), so clients
-such as the Codex app allow attachments instead of blocking them before the sidecar runs. When
+for every sidecar-covered model. Combos advertise image only when every member is covered and
+`imageInput` is not disabled, so clients such as the Codex app allow attachments instead of
+blocking them before the sidecar runs. When
 `visionSidecar.model` is absent or blank, the OpenAI execution path, Dashboard, and management API
 use the `gpt-5.4-mini` fallback. Startup still migrates an explicitly persisted legacy
 `gpt-5.4-mini` value to `gpt-5.6-luna`; that migration applies to a stored value, not to an absent

--- a/docs-site/src/content/docs/guides/sidecars.md
+++ b/docs-site/src/content/docs/guides/sidecars.md
@@ -125,10 +125,12 @@ failures after response headers have started are delivered as `response.failed` 
 
 When the routed model is listed in its provider's `noVisionModels` — or declared text-only for
 that model via `modelInputModalities` — and a request carries an image, opencodex describes each
-image **before** the main call and replaces it with text. The model catalog advertises image input
-for every sidecar-covered model. Combos advertise image only when every member is covered and
-`imageInput` is not disabled, so clients such as the Codex app allow attachments instead of
-blocking them before the sidecar runs. When
+image **before** the main call and replaces it with text, provided a vision sidecar plan is
+available. Without an available plan the raw image is stripped rather than forwarded to a
+text-only backend. The model catalog advertises image input for every sidecar-covered model.
+Combos advertise image input only when every member is sidecar-covered and the combo's
+`imageInput` setting is not disabled, so clients such as the Codex app allow attachments instead
+of blocking them before the sidecar runs. When
 `visionSidecar.model` is absent or blank, the OpenAI execution path, Dashboard, and management API
 use the `gpt-5.4-mini` fallback. Startup still migrates an explicitly persisted legacy
 `gpt-5.4-mini` value to `gpt-5.6-luna`; that migration applies to a stored value, not to an absent
@@ -150,8 +152,8 @@ model field.
   remote `https` images are fetched by the OpenAI backend, not by the proxy.
 - `noVisionModels` matching ignores an Ollama-style `:size` suffix, so a `gpt-oss` entry also covers
   `gpt-oss:120b`.
-- If description fails, the model receives a short processing-error marker. If no sidecar plan is
-  available, the raw image is stripped rather than forwarded to a text-only backend.
+- If description fails, the model receives a short processing-error marker. (Without an available
+  sidecar plan, no description is attempted — the raw image is stripped, as described above.)
 - `maxDescriptionsPerTurn` (default 8) limits new descriptions per main-model turn. Cache hits and
   same-turn duplicates do not consume it. Successful `data:` image descriptions are cached by
   backend, model, detail, image bytes, and message context — plus the reasoning effort on OpenAI

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -670,11 +670,16 @@ export function applyProviderConfigHints(name: string, prov: OcxProviderConfig, 
   const configuredMaxInput = configuredMaxInputTokens(prov, model.id);
   const configuredAutoCompact = configuredAutoCompactTokenLimit(prov, model.id);
   let inputModalities = configuredInputModalities(prov, model.id);
-  // Vision-sidecar coverage: `noVisionModels` marks models whose images the PROXY describes
-  // (src/vision/index.ts). The catalog must still advertise image input for them — the Codex app
+  // Vision-sidecar coverage mirrors isModelTextOnly (src/vision/index.ts): `noVisionModels` OR
+  // a `modelInputModalities` declaration excluding "image" both mean the PROXY describes images
+  // for this model at request time. The catalog must still advertise image input — the Codex app
   // gates attachments client-side on input_modalities, and a text-only entry would block images
-  // before the sidecar ever runs ("This model does not support image inputs").
-  if (modelInList(prov.noVisionModels, model.id)) {
+  // before the sidecar ever runs ("This model does not support image inputs"). Discovery-derived
+  // text-only rows stay untouched: the runtime predicate only reads these two config sources, so
+  // it would not convert those.
+  const sidecarCovered = modelInList(prov.noVisionModels, model.id)
+    || (Array.isArray(inputModalities) && inputModalities.length > 0 && !inputModalities.includes("image"));
+  if (sidecarCovered) {
     const base = inputModalities ?? model.inputModalities ?? ["text"];
     inputModalities = base.includes("image") ? [...base] : [...base, "image"];
   }
@@ -2141,7 +2146,15 @@ async function gatherRoutedModelsUncached(
       }
       : mergedWithHardBounds;
     const enrichedProvider = enrichedByName.get(cm.provider) ?? rawProvider;
-    if (enrichedProvider && modelInList(enrichedProvider.noVisionModels, mergedWithAutoCompact.id)) {
+    // Same vision-sidecar coverage rule as applyProviderConfigHints (isModelTextOnly parity):
+    // noVisionModels OR a text-only modelInputModalities declaration means the sidecar converts
+    // images at request time, so the custom row must advertise image input.
+    const declaredModalities = enrichedProvider
+      ? modelRecordValue(enrichedProvider.modelInputModalities, mergedWithAutoCompact.id)
+      : undefined;
+    if (enrichedProvider
+      && (modelInList(enrichedProvider.noVisionModels, mergedWithAutoCompact.id)
+        || (Array.isArray(declaredModalities) && declaredModalities.length > 0 && !declaredModalities.includes("image")))) {
       const current = mergedWithAutoCompact.inputModalities ?? ["text"];
       if (!current.includes("image")) {
         return { ...mergedWithAutoCompact, inputModalities: [...current, "image"] };

--- a/tests/catalog-vision-sidecar-modalities.test.ts
+++ b/tests/catalog-vision-sidecar-modalities.test.ts
@@ -48,6 +48,40 @@ describe("vision-sidecar catalog modalities", () => {
     expect(hinted.inputModalities).toEqual(["text", "image"]);
   });
 
+  test("modelInputModalities-declared text-only models advertise image without a noVisionModels entry", () => {
+    // Regression: isModelTextOnly (the RUNTIME sidecar gate) treats a text-only
+    // modelInputModalities declaration exactly like a noVisionModels entry, but the catalog hint
+    // pass only checked noVisionModels — so sidecar-covered models stayed advertised text-only
+    // and the Codex app blocked image paste before the sidecar could run.
+    const prov: OcxProviderConfig = {
+      adapter: "openai-chat",
+      baseUrl: "https://api.example/v1",
+      modelInputModalities: { "deepseek-chat": ["text"] },
+    };
+    const hinted = applyProviderConfigHints("azu-lab2", prov, { id: "deepseek-chat", provider: "azu-lab2" });
+    expect(hinted.inputModalities).toEqual(["text", "image"]);
+  });
+
+  test("modelInputModalities declaring image stays untouched (no duplication)", () => {
+    const prov: OcxProviderConfig = {
+      adapter: "openai-chat",
+      baseUrl: "https://api.example/v1",
+      modelInputModalities: { "glm-5.3": ["text", "image"] },
+    };
+    const hinted = applyProviderConfigHints("vdi", prov, { id: "glm-5.3", provider: "vdi" });
+    expect(hinted.inputModalities).toEqual(["text", "image"]);
+  });
+
+  test("discovery-derived text-only rows are NOT advertised image (the runtime would not convert them)", () => {
+    // Only the two config sources the runtime predicate reads (noVisionModels,
+    // modelInputModalities) may widen the catalog; a listing that merely reports
+    // ["text"] without either must stay text-only.
+    const hinted = applyProviderConfigHints("opencode-go", base, {
+      id: "listing-text-model", provider: "opencode-go", inputModalities: ["text"],
+    });
+    expect(hinted.inputModalities).toEqual(["text"]);
+  });
+
   test("MiMo token-plan sends only the Pro model through the sidecar (#1927)", () => {
     const canonical: OcxProviderConfig = {
       adapter: "openai-chat",
@@ -173,6 +207,39 @@ describe("vision-sidecar custom-model override (#349/#344)", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("a custom row whose modelId is declared text-only via modelInputModalities still advertises image", async () => {
+    // Same isModelTextOnly parity as the hint pass, applied to the custom-model override path:
+    // the registry/config text-only declaration covers the row at request time, so the catalog
+    // must let images through to the sidecar here too.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => { throw new Error("fetch should not be called"); }) as typeof fetch;
+    try {
+      const models = await gatherRoutedModels({
+        port: 10100,
+        defaultProvider: "text-sidecar-provider",
+        providers: {
+          "text-sidecar-provider": {
+            baseUrl: "https://text-sidecar.example/v1",
+            adapter: "openai-chat",
+            authMode: "key",
+            liveModels: false,
+            models: ["baseline-model"],
+            modelInputModalities: { "glm-5.2": ["text"] },
+          },
+        },
+        customModels: [
+          { id: "cm-4", provider: "text-sidecar-provider", modelId: "glm-5.2", displayName: "GLM 5.2", addedAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      });
+      const custom = models.find(m => m.provider === "text-sidecar-provider" && m.id === "glm-5.2");
+      expect(custom).toBeDefined();
+      expect(custom?.inputModalities).toEqual(["text", "image"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      clearModelCache("text-sidecar-provider");
+    }
+  });
 });
 
 describe("vision-capable provider models feed combo modalities", () => {
@@ -257,6 +324,31 @@ describe("vision-capable provider models feed combo modalities", () => {
     expect(prov.modelInputModalities?.["grok-4.5"]).toEqual(["text", "image"]);
     const hinted = applyProviderConfigHints("xai", prov, { provider: "xai", id: "grok-4.5" });
     expect(hinted.inputModalities).toEqual(["text", "image"]);
+  });
+
+  test("a combo of modelInputModalities-declared text-only members advertises image through the hints", () => {
+    // End-to-end shape of the /planners bug: every member is sidecar-covered via
+    // modelInputModalities (not noVisionModels). The hinted members all carry image, so the
+    // derived combo keeps image input instead of collapsing to text-only.
+    const memberFor = (provider: string, id: string): CatalogModel => applyProviderConfigHints(provider, {
+      adapter: "openai-chat",
+      baseUrl: `https://${provider}.example/v1`,
+      modelInputModalities: { [id]: ["text"] },
+    }, { id, provider, contextWindow: 200_000 });
+    const memberA = memberFor("azu-lab2", "deepseek-chat");
+    const memberB = memberFor("vdi", "glm-5.2");
+    const derived = deriveComboCatalogModel(
+      "planners",
+      {
+        targets: [
+          { provider: "azu-lab2", model: "deepseek-chat" },
+          { provider: "vdi", model: "glm-5.2" },
+        ],
+        defaultEffort: "high",
+      } as never,
+      [memberA, memberB],
+    );
+    expect(derived?.inputModalities).toEqual(["text", "image"]);
   });
 });
 

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -1061,7 +1061,9 @@ describe("combo catalog capability intersection", () => {
           liveModels: false,
           models: ["m2"],
           modelContextWindows: { m2: 128_000 },
-          modelInputModalities: { m2: ["text"] },
+          // No declaration: text-only by catalog default, NOT sidecar-covered. A declared
+          // text-only member would widen to image (isModelTextOnly parity) and the pair
+          // would no longer be disjoint.
         },
       },
       combos: {
@@ -1202,7 +1204,9 @@ describe("combo catalog capability intersection", () => {
       contextWindow: 128_000,
       contextCapped: false,
       maxInputTokens: 100_000,
-      inputModalities: ["text"],
+      // The text-only modelInputModalities declaration is sidecar-covered at runtime
+      // (isModelTextOnly), so the combo advertises image input like its member does.
+      inputModalities: ["text", "image"],
       reasoningEfforts: ["high"],
     });
     expect(rows.find(row => row.provider === "combo" && row.id === "nova-sol"))
@@ -1515,7 +1519,7 @@ describe("combo catalog capability intersection", () => {
           liveModels: false,
           models: ["m1"],
           modelContextWindows: { m1: 128_000 },
-          // Disjoint modalities with b → empty intersection (incompatible_modalities).
+          // Image-only member. An image-only declaration is not sidecar-covered.
           modelInputModalities: { m1: ["image"] },
         },
         b: {
@@ -1524,7 +1528,10 @@ describe("combo catalog capability intersection", () => {
           liveModels: false,
           models: ["m2"],
           modelContextWindows: { m2: 128_000 },
-          modelInputModalities: { m2: ["audio"] },
+          // No modality declaration: the member is text-only by catalog default and the
+          // sidecar does not cover it, so text and image stay genuinely disjoint
+          // (incompatible_modalities). A DECLARED text-only member would be widened to
+          // image (isModelTextOnly parity) and no longer be disjoint.
         },
       },
       combos: {
@@ -5335,7 +5342,9 @@ describe("Codex catalog routed normalization", () => {
     expect(models.find(m => m.id === "wide-model")).toMatchObject({
       contextWindow: 100_000,
       maxInputTokens: 100_000,
-      inputModalities: ["text"],
+      // Declared text-only modalities are sidecar-covered at runtime (isModelTextOnly),
+      // so the catalog advertises image on top of the configured base.
+      inputModalities: ["text", "image"],
     });
     expect(models.find(m => m.id === "small-model")?.contextWindow).toBe(64_000);
   });


### PR DESCRIPTION
## Summary

- Models whose provider declares them text-only via modelInputModalities are covered by the vision sidecar at runtime (isModelTextOnly, introduced in fde2a9537 / #1024), but both catalog advertise sites only checked noVisionModels. Those models — and every combo built from them — stayed advertised text-only in /v1/models, so the Codex app blocked image attachments client-side before the sidecar could describe them. This restores runtime/catalog parity: a non-vision model no longer needs a hand-edit on the noVisionModels list to accept images.
- applyProviderConfigHints and the custom-model override path now advertise image input for any model whose declared modelInputModalities exclude "image", mirroring isModelTextOnly. Discovery-derived text-only rows stay untouched (the runtime predicate does not convert those), declared-image rows are never duplicated, and combos inherit the fix through their hinted members (a combo advertises image when every member is sidecar-covered and imageInput is not disabled).
- Docs: the vision sidecar section in docs-site now names both coverage sources and the catalog advertise behavior.
- Three existing tests encoded the old catalog drift and were updated to the new semantics (native-alias capability limits, hard-failure combo omissions, context-cap lowering); new regressions cover the hint pass, the custom-model override, and combo derivation for modalities-declared members.

## Verification

- Rebased unchanged onto 71bd7bec6 (the 2.39.0 head produced by #3076). The intervening #2960 alias-display change in provider-fetch.ts is preserved verbatim alongside the modality hints (both sets of edits coexist in the rebased file; no manual conflict resolution was needed).
- bun test tests/catalog-vision-sidecar-modalities.test.ts — 19 pass on the rebased head, including the new regressions for the hint pass, the custom-model override, and combo derivation.
- bun run typecheck — clean on the rebased head.
- bun run privacy:scan — pass.
- bun test tests/codex-catalog.test.ts — 216 pass, 6 fail on the rebased head. The exact same 6 failures reproduce on pristine origin/dev (5cec0a33e) on this Windows host: the two combo-warn dedup expectations, bundled-catalog materialization, and the three #2465 preset routes (temp-file ENOENT race documented below). Pre-existing drift, untouched by this patch.
- Full local suite (bun run test): 318 failures, all timeouts in unrelated files under sustained machine load. Zero failures in codex-catalog.test.ts or catalog-vision-sidecar-modalities.test.ts beyond the pre-existing dev drift above. Suite terminated at 1498s by Bun's parallel-suite watchdog (consistent with the pre-existing "busy CPU" condition).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models supported by vision sidecars now advertise image input even when configured as text-only.
  * Combined model entries correctly indicate image support when covered by a vision sidecar.
  * Clients can submit image attachments to applicable custom and catalog-listed models.

* **Bug Fixes**
  * Corrected modality reporting to avoid missing or duplicate image support.
  * Preserved text-only reporting for models not covered by vision-sidecar support.
  * Improved handling when no sidecar plan is available by avoiding unnecessary descriptions and removing raw images.
