### PR TITLE
fix(codex): refresh expired management entitlements

### DIFF
--- a/src/codex/account-store.ts
+++ b/src/codex/account-store.ts
@@ -12,6 +12,7 @@ import {
 } from "../config";
 import { assertNotRealHomeUnderTest } from "../lib/test-home-guard";
 import type { CodexAccountCredentialRecord, CodexAccountCredentials } from "../types";
+import { advanceCodexCredentialMutationEpoch } from "./credential-mutation-epoch";
 
 type LegacyCodexAccountStore = Record<string, CodexAccountCredentials>;
 type CodexAccountStore = Record<string, CodexAccountCredentialRecord>;
@@ -111,6 +112,11 @@ function persist(store: CodexAccountStore): void {
   atomicWriteFile(codexAccountsPath(), JSON.stringify(store, null, 2) + "\n");
 }
 
+function persistCredentialMutation(store: CodexAccountStore): void {
+  persist(store);
+  advanceCodexCredentialMutationEpoch();
+}
+
 function preservedValidationMetadata(record: CodexAccountCredentialRecord | undefined): Pick<
   CodexAccountCredentialRecord,
   "lastCodexValidatedAt" | "lastCodexValidationStatus" | "lastCodexValidationError"
@@ -142,7 +148,7 @@ export function saveCodexAccountCredential(id: string, cred: CodexAccountCredent
       replacedAt: current ? Date.now() : undefined,
       ...preservedValidationMetadata(current),
     };
-    persist(store);
+    persistCredentialMutation(store);
   });
 }
 
@@ -213,7 +219,7 @@ export function saveCodexAccountCredentialIfGeneration(
       replacedAt: current.replacedAt,
       ...preservedValidationMetadata(current),
     };
-    persist(store);
+    persistCredentialMutation(store);
     return true;
   });
 }
@@ -304,7 +310,7 @@ export function commitRefreshedCodexCredentialWithAliases(
         propagatedAliases.push({ id: aliasId, generation: aliasGeneration });
       }
     }
-    persist(store);
+    persistCredentialMutation(store);
     return { committed: true, propagatedAliases };
   });
 }
@@ -315,7 +321,7 @@ export function tombstoneCodexAccount(id: string): number {
     const current = store[id];
     const generation = (current?.generation ?? 0) + 1;
     store[id] = { generation, deletedAt: Date.now() };
-    persist(store);
+    persistCredentialMutation(store);
     return generation;
   });
 }

--- a/src/codex/credential-mutation-epoch.ts
+++ b/src/codex/credential-mutation-epoch.ts
@@ -1,0 +1,11 @@
+let credentialMutationEpoch = 0;
+
+/** Process-local fence advanced after every OpenCodex-owned credential publication. */
+export function codexCredentialMutationEpoch(): number {
+  return credentialMutationEpoch;
+}
+
+export function advanceCodexCredentialMutationEpoch(): number {
+  credentialMutationEpoch += 1;
+  return credentialMutationEpoch;
+}

--- a/src/codex/main-account.ts
+++ b/src/codex/main-account.ts
@@ -18,6 +18,7 @@ import { atomicWriteFile, resolveWriteTarget } from "../config/atomic-write";
 import { resolveCodexHomeDir } from "./home";
 import { assertNotRealCodexHomeUnderTest } from "../lib/test-home-guard";
 import { clearAccountNeedsReauth } from "./account-runtime-state";
+import { advanceCodexCredentialMutationEpoch } from "./credential-mutation-epoch";
 
 export { MAIN_CODEX_ACCOUNT_ID } from "./account-id";
 
@@ -160,6 +161,7 @@ function persistRefreshedMainAuthJson(
       validateBeforeRename: () => assertMainAuthJsonSnapshotUnchanged(expected),
     },
   );
+  advanceCodexCredentialMutationEpoch();
   return { accessToken, chatgptAccountId };
 }
 

--- a/src/codex/model-entitlements.ts
+++ b/src/codex/model-entitlements.ts
@@ -921,6 +921,18 @@ export function resetCodexModelEntitlementCacheForTests(): void {
   runtimeVersionMemo = null;
 }
 
+/** Test-only snapshot for proving publication fences, which cache lookup intentionally masks. */
+export function codexEntitlementNegativeMemoForTests(
+  accountId: string,
+): Readonly<{
+  credentialIdentity: string | null;
+  mutationEpoch: number;
+  expiresAt: number;
+}> | null {
+  const memo = negativeCredentialMemo.get(accountId);
+  return memo ? { ...memo } : null;
+}
+
 /**
  * Test-only seam for the memoized tier-2 read.
  *

--- a/src/codex/model-entitlements.ts
+++ b/src/codex/model-entitlements.ts
@@ -13,6 +13,7 @@ import { ACCOUNT_GATED_NATIVE_OPENAI_MODELS } from "./catalog/native-models";
 import { loadPersistedCodexRuntime } from "./runtime";
 import { codexRuntimeStateEpoch } from "./runtime";
 import upstreamModelsSnapshot from "./data/upstream-models.json";
+import { codexCredentialMutationEpoch } from "./credential-mutation-epoch";
 
 const CODEX_MODELS_ENDPOINT = "https://chatgpt.com/backend-api/codex/models";
 
@@ -230,6 +231,7 @@ function memoizedPersistedRuntimeVersion(
   return selected;
 }
 const MODEL_ROSTER_FAILURE_TTL_MS = 15_000;
+const MODEL_ROSTER_NEGATIVE_CREDENTIAL_TTL_MS = 5_000;
 const MODEL_ROSTER_TIMEOUT_MS = 8_000;
 const MODEL_ROSTER_MAX_BYTES = 2 * 1024 * 1024;
 const MODEL_ROSTER_CACHE_MAX = 64;
@@ -309,10 +311,39 @@ export interface CodexModelEntitlementResolveOptions {
   readonly credentialSnapshot?: typeof accountCredentialSnapshot;
   /** Accounts whose credentials must not be read while another lifecycle owns them. */
   readonly excludeAccountIds?: ReadonlySet<string>;
+  /** Ensure-only fence; ordinary request resolvers retain their established flight identity. */
+  readonly credentialMutationEpoch?: number;
+}
+
+export interface CodexEntitlementFreshnessOptions extends Pick<
+  CodexModelEntitlementResolveOptions,
+  | "clientVersion"
+  | "credentialSnapshot"
+  | "fetcher"
+  | "loadPersistedRuntime"
+  | "nativeMainRefreshDependencies"
+  | "now"
+  | "signal"
+> {
+  readonly waitMs?: number;
 }
 
 const accountModelsCache = new Map<string, CachedAccountModels>();
 const accountModelsFlights = new Map<string, Promise<CachedAccountModels>>();
+
+interface NegativeCredentialMemo {
+  readonly credentialIdentity: string | null;
+  readonly mutationEpoch: number;
+  readonly expiresAt: number;
+}
+
+interface EntitlementEnsureFlight {
+  readonly startedAt: number;
+  readonly promise: Promise<void>;
+}
+
+const negativeCredentialMemo = new Map<string, NegativeCredentialMemo>();
+const entitlementEnsureFlights = new Map<string, EntitlementEnsureFlight>();
 
 /**
  * Cache key. The roster is version-specific, so the version has to be part of the identity —
@@ -513,6 +544,7 @@ async function modelsForCredential(
   fetcher: typeof fetch,
   now: number,
   clientVersion: string,
+  credentialMutationEpoch?: number,
 ): Promise<CachedAccountModels> {
   const cached = accountModelsCache.get(cacheKeyFor(credential.accountId, clientVersion));
   if (
@@ -521,7 +553,8 @@ async function modelsForCredential(
     && cached.expiresAt > now
   ) return cached;
 
-  const flightKey = `${credential.accountId}\u0000${credential.credentialIdentity}\u0000${clientVersion}`;
+  const flightKey = `${credential.accountId}\u0000${credential.credentialIdentity}\u0000${clientVersion}`
+    + (credentialMutationEpoch === undefined ? "" : `\u0000${credentialMutationEpoch}`);
   const existing = accountModelsFlights.get(flightKey);
   if (existing) return existing;
 
@@ -541,7 +574,11 @@ async function modelsForCredential(
   }
   const flight = fetchAccountModels(credential, fetcher, now, clientVersion)
     .then(result => {
-      if (currentCredentialIdentity(credential.accountId) === credential.credentialIdentity) {
+      if (
+        currentCredentialIdentity(credential.accountId) === credential.credentialIdentity
+        && (credentialMutationEpoch === undefined
+          || codexCredentialMutationEpoch() === credentialMutationEpoch)
+      ) {
         boundedCacheSet(credential.accountId, result);
       }
       return result;
@@ -560,6 +597,184 @@ function candidateAccountIds(config: Pick<OcxConfig, "codexAccounts">): string[]
       .filter(isSelectableCodexPoolAccount)
       .map(account => account.id),
   ];
+}
+
+function normalizedCandidateAccountIds(config: Pick<OcxConfig, "codexAccounts">): string[] {
+  return [...new Set(candidateAccountIds(config))].sort();
+}
+
+function freshNegativeCredentialMemo(
+  accountId: string,
+  credentialIdentity: string | null,
+  mutationEpoch: number,
+  now: number,
+): boolean {
+  const memo = negativeCredentialMemo.get(accountId);
+  if (
+    memo
+    && memo.credentialIdentity === credentialIdentity
+    && memo.mutationEpoch === mutationEpoch
+    && memo.expiresAt > now
+  ) return true;
+  if (memo) negativeCredentialMemo.delete(accountId);
+  return false;
+}
+
+function boundedNegativeCredentialMemoSet(accountId: string, memo: NegativeCredentialMemo): void {
+  negativeCredentialMemo.delete(accountId);
+  negativeCredentialMemo.set(accountId, memo);
+  for (const oldest of [...negativeCredentialMemo.keys()].slice(0, Math.max(
+    0,
+    negativeCredentialMemo.size - MODEL_ROSTER_CACHE_MAX,
+  ))) negativeCredentialMemo.delete(oldest);
+}
+
+function needsEntitlementRefresh(
+  accountId: string,
+  credentialIdentity: string | null,
+  clientVersion: string,
+  mutationEpoch: number,
+  now: number,
+): boolean {
+  const cached = accountModelsCache.get(cacheKeyFor(accountId, clientVersion));
+  if (cached && cached.credentialIdentity !== credentialIdentity) {
+    invalidateCodexModelEntitlementsForAccount(accountId);
+  } else if (cached && cached.expiresAt > now) {
+    return false;
+  }
+  return !freshNegativeCredentialMemo(accountId, credentialIdentity, mutationEpoch, now);
+}
+
+function entitlementEnsureFlightKey(
+  candidateAccountIds: readonly string[],
+  clientVersion: string,
+  mutationEpoch: number,
+  identityVector: readonly (readonly [string, string | null])[],
+  workset: readonly string[],
+): string {
+  return JSON.stringify([candidateAccountIds, clientVersion, mutationEpoch, identityVector, workset]);
+}
+
+async function refreshCodexEntitlementWorkset(
+  config: Pick<OcxConfig, "codexAccounts">,
+  workset: readonly string[],
+  identityVector: ReadonlyMap<string, string | null>,
+  clientVersion: string,
+  mutationEpoch: number,
+  options: CodexEntitlementFreshnessOptions,
+): Promise<void> {
+  const credentialSnapshot = options.credentialSnapshot ?? accountCredentialSnapshot;
+  const observations = await Promise.all(workset.map(async accountId => {
+    const credential = await credentialSnapshot(accountId, options);
+    return {
+      accountId,
+      credential,
+      absenceObservedAt: options.now ?? Date.now(),
+    };
+  }));
+  const credentials = observations.flatMap(observation => observation.credential
+    ? [observation.credential]
+    : []);
+  if (credentials.length > 0) {
+    await resolveCodexModelEntitlements(config, {
+      ...options,
+      clientVersion,
+      credentialMutationEpoch: mutationEpoch,
+      credentials,
+    });
+  }
+
+  for (const observation of observations) {
+    if (observation.credential) continue;
+    const capturedIdentity = identityVector.get(observation.accountId) ?? null;
+    if (codexCredentialMutationEpoch() !== mutationEpoch) continue;
+    if ((currentCredentialIdentity(observation.accountId) ?? null) !== capturedIdentity) continue;
+    boundedNegativeCredentialMemoSet(observation.accountId, {
+      credentialIdentity: capturedIdentity,
+      mutationEpoch,
+      expiresAt: observation.absenceObservedAt + MODEL_ROSTER_NEGATIVE_CREDENTIAL_TTL_MS,
+    });
+  }
+}
+
+function waitForEntitlementEnsureFlight(
+  flight: EntitlementEnsureFlight,
+  waitMs: number,
+): Promise<void> {
+  const remaining = Math.max(0, waitMs - Math.max(0, Date.now() - flight.startedAt));
+  if (remaining === 0) return Promise.resolve();
+  return new Promise(resolve => {
+    const timer = setTimeout(resolve, remaining);
+    void flight.promise.then(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+/**
+ * Refreshes only missing, expired, or credential-mismatched local entitlement entries.
+ * Management deadlines bound the wait, not the upstream work, so a timed-out poll still warms
+ * the cache for the first poll after the shared flight settles.
+ */
+export async function ensureCodexEntitlementFreshness(
+  config: Pick<OcxConfig, "codexAccounts">,
+  options: CodexEntitlementFreshnessOptions = {},
+): Promise<void> {
+  try {
+    const now = options.now ?? Date.now();
+    const clientVersion = resolveCodexEntitlementClientVersion(
+      options.clientVersion,
+      options.loadPersistedRuntime ?? loadPersistedCodexRuntime,
+    );
+    const candidates = normalizedCandidateAccountIds(config);
+    const mutationEpoch = codexCredentialMutationEpoch();
+    const identityEntries = candidates.map(accountId => (
+      [accountId, currentCredentialIdentity(accountId) ?? null] as const
+    ));
+    const identityVector = new Map(identityEntries);
+    const workset = candidates.filter(accountId => needsEntitlementRefresh(
+      accountId,
+      identityVector.get(accountId) ?? null,
+      clientVersion,
+      mutationEpoch,
+      now,
+    ));
+    if (workset.length === 0) return;
+
+    const key = entitlementEnsureFlightKey(
+      candidates,
+      clientVersion,
+      mutationEpoch,
+      identityEntries,
+      workset,
+    );
+    let flight = entitlementEnsureFlights.get(key);
+    if (!flight) {
+      const startedAt = Date.now();
+      let created!: EntitlementEnsureFlight;
+      const promise = refreshCodexEntitlementWorkset(
+        config,
+        workset,
+        identityVector,
+        clientVersion,
+        mutationEpoch,
+        options,
+      ).catch(() => {
+        // Entitlement discovery is fail-closed: callers project only confirmed cache entries.
+      }).finally(() => {
+        if (entitlementEnsureFlights.get(key) === created) entitlementEnsureFlights.delete(key);
+      });
+      created = { startedAt, promise };
+      entitlementEnsureFlights.set(key, created);
+      flight = created;
+    }
+    const requestedWaitMs = options.waitMs ?? 3_000;
+    const waitMs = Number.isFinite(requestedWaitMs) ? Math.max(0, requestedWaitMs) : 0;
+    await waitForEntitlementEnsureFlight(flight, waitMs);
+  } catch {
+    // The shared management boundary must degrade to the last confirmed fail-closed projection.
+  }
 }
 
 /**
@@ -598,7 +813,13 @@ export async function resolveCodexModelEntitlements(
       .filter((value): value is CodexModelEntitlementCredentialSnapshot => value !== null);
   const results = await Promise.all(credentials.map(async credential => ({
     credential,
-    result: await modelsForCredential(credential, fetcher, now, clientVersion),
+    result: await modelsForCredential(
+      credential,
+      fetcher,
+      now,
+      clientVersion,
+      options.credentialMutationEpoch,
+    ),
   })));
   return {
     modelsByAccount: new Map(results.map(({ credential, result }) => [credential.accountId, result.models])),
@@ -695,6 +916,8 @@ export function invalidateCodexModelEntitlementsForAccount(accountId: string | n
 export function resetCodexModelEntitlementCacheForTests(): void {
   accountModelsCache.clear();
   accountModelsFlights.clear();
+  negativeCredentialMemo.clear();
+  entitlementEnsureFlights.clear();
   runtimeVersionMemo = null;
 }
 
@@ -717,9 +940,10 @@ export function seedCodexModelEntitlementsForTests(
   models: readonly string[],
   now = Date.now(),
   clientVersion = "0.146.0",
+  credentialIdentity = `test:${accountId}`,
 ): void {
   boundedCacheSet(accountId, {
-    credentialIdentity: `test:${accountId}`,
+    credentialIdentity,
     clientVersion,
     expiresAt: now + MODEL_ROSTER_TTL_MS,
     models: new Set(models),

--- a/src/codex/native-profile-manager.ts
+++ b/src/codex/native-profile-manager.ts
@@ -67,6 +67,7 @@ import {
   type NativeProfilePublic,
   type NativeProfileSwitchJournalV1,
 } from "./native-profile-types";
+import { advanceCodexCredentialMutationEpoch } from "./credential-mutation-epoch";
 import {
   NATIVE_STAGE_HEARTBEAT_INTERVAL_MS,
   NativeProfileStageStore,
@@ -1307,6 +1308,7 @@ export class NativeProfileManager {
         await this.atomicWrite(this.context.authPath, target.text);
         const observedTarget = this.verifyWrittenEnvelope(target.digest, targetProfile.identityHash, key);
         observedTarget.raw.fill(0);
+        advanceCodexCredentialMutationEpoch();
         await this.onSwitchBoundary("auth-replaced");
         journal.phase = "auth-replaced";
         await this.writeJournal(journal);
@@ -1335,6 +1337,7 @@ export class NativeProfileManager {
           await this.atomicWrite(this.context.authPath, source!.text);
           const restored = this.verifyWrittenEnvelope(source!.digest, nativeIdentityHash(key!.key, source!.accountId), key!);
           restored.raw.fill(0);
+          advanceCodexCredentialMutationEpoch();
           await this.writeVault(beforeVault);
           this.removeJournal();
         } catch {
@@ -1449,6 +1452,7 @@ export class NativeProfileManager {
         await this.atomicWrite(this.context.authPath, sourceEnvelope.text);
         const restored = this.verifyWrittenEnvelope(sourceEnvelope.digest, journal.sourceIdentityHash, key);
         restored.raw.fill(0);
+        advanceCodexCredentialMutationEpoch();
         if (!rollbackVaultPublished) await this.writeVault(rollbackVault);
         this.applyTransition(current.envelope.accountId, sourceEnvelope.accountId);
         this.removeJournal();

--- a/src/server/management/model-rows.ts
+++ b/src/server/management/model-rows.ts
@@ -25,6 +25,7 @@ import { providerContextCap } from "../../providers/context-cap";
 import { isVisionReasoningEffort } from "../../reasoning-effort";
 import { routedSlug, slugEquals } from "../../providers/slug-codec";
 import type { OcxConfig } from "../../types";
+import { ensureCodexEntitlementFreshness } from "../../codex/model-entitlements";
 import { fetchAllModels } from "./shared";
 
 /**
@@ -47,8 +48,16 @@ export type ManagementModelRow = Partial<CatalogModel> & {
  * models the GUI's Models tab shows — including this function's `disabled` computation,
  * which the export core (src/clients/config-export.ts) deliberately does not perform.
  */
-export async function listManagementModelRows(config: OcxConfig): Promise<ManagementModelRow[]> {
-  const models = await fetchAllModels(config);
+export async function listManagementModelRows(
+  config: OcxConfig,
+  options: { entitlementWaitMs?: number } = {},
+): Promise<ManagementModelRow[]> {
+  const [models] = await Promise.all([
+    fetchAllModels(config),
+    ensureCodexEntitlementFreshness(config, {
+      waitMs: options.entitlementWaitMs ?? 3_000,
+    }),
+  ]);
   const disabled = new Set(config.disabledModels ?? []);
   // Native GPT passthrough rows lead (provider "openai", bare-slug namespaced ids): sourced
   // from the static supported set so a disabled model stays listed and re-enableable.

--- a/src/sidecar/candidates.ts
+++ b/src/sidecar/candidates.ts
@@ -37,7 +37,7 @@ export async function pickerVisibleSidecarCandidates(
   auth: SidecarAuthState,
 ): Promise<SidecarCandidate[]> {
   let rows: Awaited<ReturnType<typeof listManagementModelRows>> = [];
-  try { rows = await listManagementModelRows(config); } catch { rows = []; }
+  try { rows = await listManagementModelRows(config, { entitlementWaitMs: 0 }); } catch { rows = []; }
   const byKey = new Map<string, SidecarCandidate>();
   for (const row of rows) {
     if (row.disabled === true) continue;

--- a/tests/cli-export-command.test.ts
+++ b/tests/cli-export-command.test.ts
@@ -8,11 +8,13 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { handleExportCommand, exportModelsFromProxyRows } from "../src/cli/export-command";
+import { resetCodexModelEntitlementCacheForTests } from "../src/codex/model-entitlements";
+import { handleManagementAPI } from "../src/server/management-api";
 import type { OcxConfig } from "../src/types";
 
 const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
@@ -61,6 +63,19 @@ function fakeProxy(rows: unknown = ROWS) {
   return { port: server.port, baseUrl: `http://127.0.0.1:${server.port}` };
 }
 
+function managementProxy(managementConfig: OcxConfig) {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      return await handleManagementAPI(req, url, managementConfig)
+        ?? new Response("not found", { status: 404 });
+    },
+  });
+  servers.push(server);
+  return { port: server.port, baseUrl: `http://127.0.0.1:${server.port}` };
+}
+
 function tempDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "ocx-export-"));
   tempDirs.push(dir);
@@ -86,6 +101,7 @@ afterEach(() => {
   console.error = originalError;
   for (const server of servers.splice(0)) server.stop(true);
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  resetCodexModelEntitlementCacheForTests();
 });
 
 /** console.log adds exactly one newline per call; this is the byte stream a shell sees. */
@@ -102,6 +118,68 @@ async function run(args: string[], extra: { baseUrl: string; config?: OcxConfig 
 }
 
 describe("ocx export --json (accept criterion 1)", () => {
+  test("the real /api/models handler refreshes expired GPT-5.6 entitlements before export", async () => {
+    const oldOcxHome = process.env.OPENCODEX_HOME;
+    const oldCodexHome = process.env.CODEX_HOME;
+    const originalFetch = globalThis.fetch;
+    const root = tempDir();
+    const codexHome = join(root, "codex");
+    mkdirSync(codexHome, { recursive: true });
+    process.env.OPENCODEX_HOME = join(root, "opencodex");
+    process.env.CODEX_HOME = codexHome;
+    writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+      tokens: { access_token: "export-token", account_id: "export-main" },
+    }));
+    let entitlementFetches = 0;
+    globalThis.fetch = (async input => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.hostname === "chatgpt.com" && url.pathname === "/backend-api/codex/models") {
+        entitlementFetches += 1;
+        return Response.json({ models: [
+          { slug: "gpt-5.6-sol", supported_in_api: true, visibility: "list" },
+          { slug: "gpt-5.6-terra", supported_in_api: true, visibility: "list" },
+          { slug: "gpt-5.6-luna", supported_in_api: true, visibility: "list" },
+        ] });
+      }
+      return originalFetch(input);
+    }) as typeof fetch;
+    try {
+      const managementConfig = config({
+        defaultProvider: "openai",
+        providers: {
+          openai: {
+            adapter: "openai-responses",
+            baseUrl: "https://chatgpt.com/backend-api/codex",
+            authMode: "forward",
+            liveModels: false,
+            models: [],
+          },
+        },
+      });
+      const proxy = managementProxy(managementConfig);
+      const result = await run(["--client", "opencode", "--json"], {
+        baseUrl: proxy.baseUrl,
+        config: managementConfig,
+      });
+      expect(result.code).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        provider: Record<string, { models: Record<string, unknown> }>;
+      };
+      expect(entitlementFetches).toBe(1);
+      expect(Object.keys(parsed.provider.opencodex!.models)).toEqual(expect.arrayContaining([
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+      ]));
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (oldOcxHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = oldOcxHome;
+      if (oldCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = oldCodexHome;
+    }
+  });
+
   test("stdout parses as JSON with zero extra bytes, for both clients", async () => {
     const proxy = fakeProxy();
     for (const client of ["opencode", "pi"] as const) {

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -89,6 +89,41 @@ describe("codex-account-store CRUD", () => {
     expect(readCodexAccountRecord("wrapped")).toMatchObject({ credential: cred, generation: 1 });
   });
 
+  test("every successful credential commit and tombstone advances one shared mutation epoch", async () => {
+    const {
+      commitRefreshedCodexCredentialWithAliases,
+      markCodexAccountValidated,
+      readCodexAccountRecord,
+      saveCodexAccountCredential,
+      saveCodexAccountCredentialIfGeneration,
+      tombstoneCodexAccount,
+    } = await import("../src/codex/account-store");
+    const { codexCredentialMutationEpoch } = await import("../src/codex/credential-mutation-epoch");
+    const first = { accessToken: "epoch-a", refreshToken: "epoch-r-a", expiresAt: Date.now() + 3600_000, chatgptAccountId: "epoch-account" };
+    const second = { ...first, accessToken: "epoch-b", refreshToken: "epoch-r-b" };
+    const third = { ...second, accessToken: "epoch-c", refreshToken: "epoch-r-c" };
+    const start = codexCredentialMutationEpoch();
+
+    saveCodexAccountCredential("epoch", first);
+    expect(codexCredentialMutationEpoch()).toBe(start + 1);
+
+    markCodexAccountValidated("epoch");
+    expect(codexCredentialMutationEpoch()).toBe(start + 1);
+
+    const firstGeneration = readCodexAccountRecord("epoch")!.generation;
+    expect(saveCodexAccountCredentialIfGeneration("epoch", firstGeneration, second)).toBe(true);
+    expect(codexCredentialMutationEpoch()).toBe(start + 2);
+    expect(saveCodexAccountCredentialIfGeneration("epoch", firstGeneration, first)).toBe(false);
+    expect(codexCredentialMutationEpoch()).toBe(start + 2);
+
+    const secondGeneration = readCodexAccountRecord("epoch")!.generation;
+    expect(commitRefreshedCodexCredentialWithAliases("epoch", secondGeneration, third).committed).toBe(true);
+    expect(codexCredentialMutationEpoch()).toBe(start + 3);
+
+    tombstoneCodexAccount("epoch");
+    expect(codexCredentialMutationEpoch()).toBe(start + 4);
+  });
+
   test("remove credential deletes entry", async () => {
     const { saveCodexAccountCredential, removeCodexAccountCredential, getCodexAccountCredential, listCodexAccountIds, readCodexAccountRecord } = await import("../src/codex/account-store");
     saveCodexAccountCredential("temp", { accessToken: "t", refreshToken: "r", expiresAt: 0, chatgptAccountId: "c" });

--- a/tests/codex-main-account-refresh.test.ts
+++ b/tests/codex-main-account-refresh.test.ts
@@ -6,6 +6,7 @@ import {
   getValidMainAccountToken,
   setMainAuthJsonBeforeRenameHookForTests,
 } from "../src/codex/main-account";
+import { codexCredentialMutationEpoch } from "../src/codex/credential-mutation-epoch";
 
 let home: string;
 let previousCodexHome: string | undefined;
@@ -46,6 +47,7 @@ describe("native main token refresh", () => {
       targetDuringPublish = readFileSync(authPath, "utf8");
     });
 
+    const epochBefore = codexCredentialMutationEpoch();
     const token = await getValidMainAccountToken({
       refreshToken: async refreshToken => {
         expect(refreshToken).toBe("old-refresh");
@@ -70,6 +72,7 @@ describe("native main token refresh", () => {
       },
     });
     expect(readdirSync(home).filter(name => name.includes(".tmp"))).toEqual([]);
+    expect(codexCredentialMutationEpoch()).toBe(epochBefore + 1);
   });
 
   test("refuses to overwrite an external auth writer after refresh", async () => {
@@ -90,6 +93,7 @@ describe("native main token refresh", () => {
     });
     setMainAuthJsonBeforeRenameHookForTests(() => writeFileSync(authPath, external));
 
+    const epochBefore = codexCredentialMutationEpoch();
     await expect(getValidMainAccountToken({
       refreshToken: async () => ({
         access: "new-access",
@@ -101,6 +105,7 @@ describe("native main token refresh", () => {
 
     expect(readFileSync(authPath, "utf8")).toBe(external);
     expect(readdirSync(home).filter(name => name.includes(".tmp"))).toEqual([]);
+    expect(codexCredentialMutationEpoch()).toBe(epochBefore);
   });
 
   test("refresh failure leaves the original auth file byte-identical", async () => {

--- a/tests/codex-model-entitlements.test.ts
+++ b/tests/codex-model-entitlements.test.ts
@@ -7,6 +7,7 @@ import {
   cachedAvailableAccountGatedNativeModels,
   composeGatedClientVersionFloorForTests,
   compareClientVersionsForTests,
+  codexEntitlementNegativeMemoForTests,
   deriveGatedClientVersionFloor,
   ensureCodexEntitlementFreshness,
   entitledCodexAccountIdsForModel,
@@ -391,6 +392,127 @@ describe("ensureCodexEntitlementFreshness", () => {
     });
     expect(credentialReads).toBe(2);
     expect(fetches).toBe(1);
+  });
+
+  test("a local write after absence observation fences stale negative-memo publication by epoch", async () => {
+    writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+      tokens: {
+        access_token: "access-publication-local",
+        refresh_token: "refresh-publication-local",
+        account_id: "chatgpt-publication-local",
+      },
+    }));
+    savePoolCredential("pool-publication-local-blocker", "publication-local-blocker");
+    const siblingFetchStarted = deferred();
+    const releaseSiblingFetch = deferred();
+    const initial = ensureCodexEntitlementFreshness(
+      poolConfig("pool-publication-local-blocker"),
+      {
+        waitMs: 60_000,
+        now: 26_000,
+        clientVersion: TEST_CLIENT_VERSION,
+        credentialSnapshot: async accountId => accountId === MAIN_CODEX_ACCOUNT_ID
+          ? null
+          : storedCredentialSnapshot(accountId),
+        fetcher: (async () => {
+          siblingFetchStarted.resolve();
+          await releaseSiblingFetch.promise;
+          return roster(SOL);
+        }) as typeof fetch,
+      },
+    );
+
+    await siblingFetchStarted.promise;
+    await forceRefreshMainAccountToken("access-publication-local", {
+      refreshToken: async () => ({
+        access: "access-publication-local-new",
+        refresh: "refresh-publication-local-new",
+        expires: Date.now() + 60 * 60_000,
+        accountId: "chatgpt-publication-local",
+      }),
+    });
+    releaseSiblingFetch.resolve();
+    await initial;
+
+    expect(codexEntitlementNegativeMemoForTests(MAIN_CODEX_ACCOUNT_ID)).toBeNull();
+  });
+
+  test("an external replacement after absence observation fences stale negative-memo publication by identity", async () => {
+    writeMainAuth("publication-external-old");
+    savePoolCredential("pool-publication-external-blocker", "publication-external-blocker");
+    const siblingFetchStarted = deferred();
+    const releaseSiblingFetch = deferred();
+    const initial = ensureCodexEntitlementFreshness(
+      poolConfig("pool-publication-external-blocker"),
+      {
+        waitMs: 60_000,
+        now: 27_000,
+        clientVersion: TEST_CLIENT_VERSION,
+        credentialSnapshot: async accountId => accountId === MAIN_CODEX_ACCOUNT_ID
+          ? null
+          : storedCredentialSnapshot(accountId),
+        fetcher: (async () => {
+          siblingFetchStarted.resolve();
+          await releaseSiblingFetch.promise;
+          return roster(SOL);
+        }) as typeof fetch,
+      },
+    );
+
+    await siblingFetchStarted.promise;
+    writeMainAuth("publication-external-new");
+    releaseSiblingFetch.resolve();
+    await initial;
+
+    expect(codexEntitlementNegativeMemoForTests(MAIN_CODEX_ACCOUNT_ID)).toBeNull();
+  });
+
+  test("a delayed sibling fetch preserves negative-memo expiry from the absence observation", async () => {
+    savePoolCredential("pool-publication-delay-blocker", "publication-delay-blocker");
+    const originalNow = Date.now;
+    const siblingFetchStarted = deferred();
+    const releaseSiblingFetch = deferred();
+    let credentialReads = 0;
+    let wallNow = 10_000;
+    Date.now = () => wallNow;
+    try {
+      const options = {
+        waitMs: 60_000,
+        clientVersion: TEST_CLIENT_VERSION,
+        credentialSnapshot: async (accountId: string) => {
+          if (accountId === MAIN_CODEX_ACCOUNT_ID) {
+            credentialReads += 1;
+            return null;
+          }
+          return storedCredentialSnapshot(accountId);
+        },
+        fetcher: (async () => {
+          siblingFetchStarted.resolve();
+          await releaseSiblingFetch.promise;
+          return roster(SOL);
+        }) as typeof fetch,
+      };
+      const initial = ensureCodexEntitlementFreshness(
+        poolConfig("pool-publication-delay-blocker"),
+        options,
+      );
+      await siblingFetchStarted.promise;
+
+      wallNow = 40_000;
+      releaseSiblingFetch.resolve();
+      await initial;
+
+      expect(codexEntitlementNegativeMemoForTests(MAIN_CODEX_ACCOUNT_ID)?.expiresAt).toBe(15_000);
+      wallNow = 40_001;
+      await ensureCodexEntitlementFreshness(poolConfig("pool-publication-delay-blocker"), {
+        ...options,
+        waitMs: 1_000,
+      });
+      expect(credentialReads).toBe(2);
+    } finally {
+      Date.now = originalNow;
+      releaseSiblingFetch.resolve();
+    }
   });
 
   test("a local credential write during a flight cannot mask the replacement", async () => {

--- a/tests/codex-model-entitlements.test.ts
+++ b/tests/codex-model-entitlements.test.ts
@@ -1,10 +1,14 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   availableAccountGatedNativeModels,
   cachedAvailableAccountGatedNativeModels,
   composeGatedClientVersionFloorForTests,
   compareClientVersionsForTests,
   deriveGatedClientVersionFloor,
+  ensureCodexEntitlementFreshness,
   entitledCodexAccountIdsForModel,
   GATED_MODEL_CLIENT_VERSION_FLOOR,
   isDirectCallerEntitledToCodexModel,
@@ -16,7 +20,14 @@ import {
   seedCodexModelEntitlementsForTests,
   type CodexModelEntitlementCredentialSnapshot,
 } from "../src/codex/model-entitlements";
-import { MAIN_CODEX_ACCOUNT_ID } from "../src/codex/main-account";
+import {
+  forceRefreshMainAccountToken,
+  MAIN_CODEX_ACCOUNT_ID,
+} from "../src/codex/main-account";
+import {
+  readCodexAccountRecord,
+  saveCodexAccountCredential,
+} from "../src/codex/account-store";
 import { clearCodexRuntimeResolveCache, loadPersistedCodexRuntime } from "../src/codex/runtime";
 import { ACCOUNT_GATED_NATIVE_OPENAI_MODELS } from "../src/codex/catalog/native-models";
 import upstreamModelsSnapshot from "../src/codex/data/upstream-models.json";
@@ -40,6 +51,15 @@ function roster(...slugs: string[]): Response {
   return Response.json({
     models: slugs.map(slug => ({ slug, supported_in_api: true, visibility: "list" })),
   });
+}
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(settle => { resolve = settle; });
+  return { promise, resolve };
 }
 
 beforeEach(() => resetCodexModelEntitlementCacheForTests());
@@ -191,6 +211,400 @@ describe("Codex account model entitlements", () => {
     expect([...cachedAvailableAccountGatedNativeModels(1_000)]).toContain(DAYBREAK);
   });
 
+});
+
+describe("ensureCodexEntitlementFreshness", () => {
+  const originalOpenCodexHome = process.env.OPENCODEX_HOME;
+  const originalCodexHome = process.env.CODEX_HOME;
+  let root = "";
+  let codexHome = "";
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "ocx-entitlement-freshness-"));
+    codexHome = join(root, "codex");
+    mkdirSync(codexHome, { recursive: true });
+    process.env.OPENCODEX_HOME = join(root, "opencodex");
+    process.env.CODEX_HOME = codexHome;
+  });
+
+  afterEach(() => {
+    if (originalOpenCodexHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = originalOpenCodexHome;
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
+    rmSync(root, { recursive: true, force: true });
+    resetCodexModelEntitlementCacheForTests();
+  });
+
+  const poolConfig = (...ids: string[]) => ({
+    codexAccounts: ids.map(id => ({ id, email: `${id}@example.test`, isMain: false })),
+  });
+
+  const savePoolCredential = (accountId: string, suffix: string): void => {
+    saveCodexAccountCredential(accountId, {
+      accessToken: `access-${suffix}`,
+      refreshToken: `refresh-${suffix}`,
+      expiresAt: Date.now() + 60 * 60_000,
+      chatgptAccountId: `chatgpt-${suffix}`,
+    });
+  };
+
+  const storedCredentialSnapshot = async (
+    accountId: string,
+  ): Promise<CodexModelEntitlementCredentialSnapshot | null> => {
+    if (accountId === MAIN_CODEX_ACCOUNT_ID) return null;
+    const record = readCodexAccountRecord(accountId);
+    if (!record?.credential || record.deletedAt != null) return null;
+    return {
+      accountId,
+      accessToken: record.credential.accessToken,
+      chatgptAccountId: record.credential.chatgptAccountId,
+      credentialIdentity: `pool:${record.generation}:${record.credential.chatgptAccountId}`,
+    };
+  };
+
+  const writeMainAuth = (suffix: string): void => {
+    writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+      tokens: {
+        access_token: `access-${suffix}`,
+        account_id: `chatgpt-${suffix}`,
+      },
+    }));
+  };
+
+  const mainCredentialSnapshot = async (
+    accountId: string,
+  ): Promise<CodexModelEntitlementCredentialSnapshot | null> => {
+    if (accountId !== MAIN_CODEX_ACCOUNT_ID) return null;
+    const parsed = JSON.parse(readFileSync(join(codexHome, "auth.json"), "utf8")) as {
+      tokens: { access_token: string; account_id: string };
+    };
+    return {
+      accountId,
+      accessToken: parsed.tokens.access_token,
+      chatgptAccountId: parsed.tokens.account_id,
+      credentialIdentity: `main:${parsed.tokens.account_id}`,
+    };
+  };
+
+  test("a fresh ensure uses identity reads but performs zero full credential snapshots or network calls", async () => {
+    savePoolCredential("pool-fresh", "fresh");
+    let credentialReads = 0;
+    let fetches = 0;
+    const options = {
+      waitMs: 1_000,
+      now: 1_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: async (accountId: string) => {
+        credentialReads += 1;
+        return storedCredentialSnapshot(accountId);
+      },
+      fetcher: (async () => { fetches += 1; return roster(SOL, TERRA, LUNA); }) as typeof fetch,
+    };
+
+    await ensureCodexEntitlementFreshness(poolConfig("pool-fresh"), options);
+    expect(credentialReads).toBe(2);
+    expect(fetches).toBe(1);
+
+    credentialReads = 0;
+    await ensureCodexEntitlementFreshness(poolConfig("pool-fresh"), { ...options, now: 1_001 });
+    expect(credentialReads).toBe(0);
+    expect(fetches).toBe(1);
+  });
+
+  test("logged-out polls memoize the missing credential for exactly the bounded window", async () => {
+    let credentialReads = 0;
+    const options = {
+      waitMs: 1_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: async () => { credentialReads += 1; return null; },
+    };
+
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, { ...options, now: 10_000 });
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, { ...options, now: 14_999 });
+    expect(credentialReads).toBe(1);
+
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, { ...options, now: 15_001 });
+    expect(credentialReads).toBe(2);
+  });
+
+  test("a credential commit invalidates a negative memo before the next ensure", async () => {
+    let poolReads = 0;
+    let fetches = 0;
+    const snapshot = async (accountId: string) => {
+      if (accountId === "pool-login") poolReads += 1;
+      return storedCredentialSnapshot(accountId);
+    };
+    const options = {
+      waitMs: 1_000,
+      now: 20_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: snapshot,
+      fetcher: (async () => { fetches += 1; return roster(SOL); }) as typeof fetch,
+    };
+
+    await ensureCodexEntitlementFreshness(poolConfig("pool-login"), options);
+    expect(poolReads).toBe(1);
+    expect(fetches).toBe(0);
+
+    savePoolCredential("pool-login", "new-login");
+    await ensureCodexEntitlementFreshness(poolConfig("pool-login"), options);
+    expect(poolReads).toBe(2);
+    expect(fetches).toBe(1);
+  });
+
+  test("a same-identity main-token write invalidates a failed credential memo by epoch", async () => {
+    writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+      tokens: {
+        access_token: "access-memo-same",
+        refresh_token: "refresh-memo-same",
+        account_id: "chatgpt-memo-same",
+      },
+    }));
+    let credentialReads = 0;
+    let fetches = 0;
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, {
+      waitMs: 1_000,
+      now: 25_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: async () => { credentialReads += 1; return null; },
+    });
+    expect(credentialReads).toBe(1);
+
+    await forceRefreshMainAccountToken("access-memo-same", {
+      refreshToken: async () => ({
+        access: "access-memo-same-new",
+        refresh: "refresh-memo-same-new",
+        expires: Date.now() + 60 * 60_000,
+        accountId: "chatgpt-memo-same",
+      }),
+    });
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, {
+      waitMs: 1_000,
+      now: 25_001,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: async accountId => {
+        credentialReads += 1;
+        return mainCredentialSnapshot(accountId);
+      },
+      fetcher: (async () => { fetches += 1; return roster(SOL); }) as typeof fetch,
+    });
+    expect(credentialReads).toBe(2);
+    expect(fetches).toBe(1);
+  });
+
+  test("a local credential write during a flight cannot mask the replacement", async () => {
+    savePoolCredential("pool-local-race", "old");
+    const firstFetchStarted = deferred();
+    const releaseFirstFetch = deferred();
+    let fetches = 0;
+    const fetcher = (async () => {
+      fetches += 1;
+      if (fetches === 1) {
+        firstFetchStarted.resolve();
+        await releaseFirstFetch.promise;
+      }
+      return roster(SOL);
+    }) as typeof fetch;
+    const config = poolConfig("pool-local-race");
+    const options = {
+      waitMs: 0,
+      now: 30_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: storedCredentialSnapshot,
+      fetcher,
+    };
+
+    await ensureCodexEntitlementFreshness(config, options);
+    await firstFetchStarted.promise;
+    savePoolCredential("pool-local-race", "replacement");
+    await ensureCodexEntitlementFreshness(config, { ...options, waitMs: 1_000 });
+    expect(fetches).toBe(2);
+
+    releaseFirstFetch.resolve();
+    await ensureCodexEntitlementFreshness(config, { ...options, waitMs: 1_000 });
+    expect(fetches).toBe(2);
+  });
+
+  test("a same-identity main-token write cannot join its pre-write roster flight", async () => {
+    writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+      tokens: {
+        access_token: "access-same-identity",
+        refresh_token: "refresh-same-identity",
+        account_id: "chatgpt-same-identity",
+      },
+    }));
+    const firstFetchStarted = deferred();
+    const releaseFirstFetch = deferred();
+    let fetches = 0;
+    const fetcher = (async () => {
+      fetches += 1;
+      if (fetches === 1) {
+        firstFetchStarted.resolve();
+        await releaseFirstFetch.promise;
+      }
+      return roster(SOL);
+    }) as typeof fetch;
+    const options = {
+      waitMs: 0,
+      now: 35_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: mainCredentialSnapshot,
+      fetcher,
+    };
+
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, options);
+    await firstFetchStarted.promise;
+    await forceRefreshMainAccountToken("access-same-identity", {
+      refreshToken: async () => ({
+        access: "access-same-identity-new",
+        refresh: "refresh-same-identity-new",
+        expires: Date.now() + 60 * 60_000,
+        accountId: "chatgpt-same-identity",
+      }),
+    });
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, { ...options, waitMs: 1_000 });
+    expect(fetches).toBe(2);
+
+    releaseFirstFetch.resolve();
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, { ...options, waitMs: 1_000 });
+    expect(fetches).toBe(2);
+  });
+
+  test("an external auth.json replacement during a flight starts a new identity flight", async () => {
+    writeMainAuth("external-old");
+    const firstFetchStarted = deferred();
+    const releaseFirstFetch = deferred();
+    let fetches = 0;
+    const fetcher = (async () => {
+      fetches += 1;
+      if (fetches === 1) {
+        firstFetchStarted.resolve();
+        await releaseFirstFetch.promise;
+      }
+      return roster(SOL);
+    }) as typeof fetch;
+    const options = {
+      waitMs: 0,
+      now: 40_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: mainCredentialSnapshot,
+      fetcher,
+    };
+
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, options);
+    await firstFetchStarted.promise;
+    writeMainAuth("external-new");
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, { ...options, waitMs: 1_000 });
+    expect(fetches).toBe(2);
+
+    releaseFirstFetch.resolve();
+    await ensureCodexEntitlementFreshness({ codexAccounts: [] }, { ...options, waitMs: 1_000 });
+    expect(fetches).toBe(2);
+  });
+
+  test("an account expiring during an A-only flight is added to a distinct workset", async () => {
+    savePoolCredential("pool-work-b", "work-b");
+    const counts = new Map<string, number>();
+    let holdA = false;
+    const aFetchStarted = deferred();
+    let bRefreshStarted = false;
+    const releaseA = deferred();
+    const fetcher = (async (_input, init) => {
+      const accountId = new Headers(init?.headers).get("chatgpt-account-id") ?? "";
+      counts.set(accountId, (counts.get(accountId) ?? 0) + 1);
+      if (accountId === "chatgpt-work-a" && holdA) {
+        aFetchStarted.resolve();
+        await releaseA.promise;
+      }
+      if (accountId === "chatgpt-work-b" && (counts.get(accountId) ?? 0) === 2) {
+        bRefreshStarted = true;
+      }
+      return roster(SOL);
+    }) as typeof fetch;
+    const baseOptions = {
+      waitMs: 1_000,
+      clientVersion: TEST_CLIENT_VERSION,
+      credentialSnapshot: storedCredentialSnapshot,
+      fetcher,
+    };
+
+    await ensureCodexEntitlementFreshness(poolConfig("pool-work-b"), {
+      ...baseOptions,
+      now: 1_000,
+    });
+    expect(counts.get("chatgpt-work-b")).toBe(1);
+
+    savePoolCredential("pool-work-a", "work-a");
+    holdA = true;
+    await ensureCodexEntitlementFreshness(poolConfig("pool-work-a", "pool-work-b"), {
+      ...baseOptions,
+      waitMs: 0,
+      now: 300_999,
+    });
+    await aFetchStarted.promise;
+
+    await ensureCodexEntitlementFreshness(poolConfig("pool-work-a", "pool-work-b"), {
+      ...baseOptions,
+      waitMs: 0,
+      now: 301_001,
+    });
+    for (let i = 0; i < 10 && !bRefreshStarted; i += 1) await Promise.resolve();
+    expect(bRefreshStarted).toBe(true);
+    expect(counts.get("chatgpt-work-b")).toBe(2);
+
+    releaseA.resolve();
+    await ensureCodexEntitlementFreshness(poolConfig("pool-work-a", "pool-work-b"), {
+      ...baseOptions,
+      now: 301_001,
+    });
+    expect(counts.get("chatgpt-work-a")).toBe(1);
+    expect(counts.get("chatgpt-work-b")).toBe(2);
+  });
+
+  test("a late waiter spends only the flight's remaining management wait budget", async () => {
+    savePoolCredential("pool-wait", "wait");
+    const originalNow = Date.now;
+    const fetchStarted = deferred();
+    const releaseFetch = deferred();
+    let wallNow = 1_000;
+    Date.now = () => wallNow;
+    try {
+      const options = {
+        waitMs: 0,
+        now: 50_000,
+        clientVersion: TEST_CLIENT_VERSION,
+        credentialSnapshot: storedCredentialSnapshot,
+        fetcher: (async () => {
+          fetchStarted.resolve();
+          await releaseFetch.promise;
+          return roster(SOL);
+        }) as typeof fetch,
+      };
+      await ensureCodexEntitlementFreshness(poolConfig("pool-wait"), options);
+      await fetchStarted.promise;
+
+      wallNow = 5_000;
+      let lateWaiterSettled = false;
+      const lateWaiter = ensureCodexEntitlementFreshness(poolConfig("pool-wait"), {
+        ...options,
+        waitMs: 3_000,
+      }).then(() => { lateWaiterSettled = true; });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(lateWaiterSettled).toBe(true);
+
+      releaseFetch.resolve();
+      await lateWaiter;
+      await ensureCodexEntitlementFreshness(poolConfig("pool-wait"), {
+        ...options,
+        waitMs: 1_000,
+      });
+    } finally {
+      Date.now = originalNow;
+      releaseFetch.resolve();
+    }
+  });
 });
 
 describe("entitlement client version (#2886)", () => {

--- a/tests/management-client-config-route.test.ts
+++ b/tests/management-client-config-route.test.ts
@@ -1,6 +1,9 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  GATED_MODEL_CLIENT_VERSION_FLOOR,
   resetCodexModelEntitlementCacheForTests,
   seedCodexModelEntitlementsForTests,
 } from "../src/codex/model-entitlements";
@@ -28,7 +31,31 @@ import { catalogConvergenceFactory } from "./helpers/catalog-convergence";
  */
 const REAL_LOOKING_KEY = "ocx_live_9f3c7a2b41d84e6fa05c8e17b3d92764";
 
-afterEach(() => resetCodexModelEntitlementCacheForTests());
+const originalOpenCodexHome = process.env.OPENCODEX_HOME;
+const originalCodexHome = process.env.CODEX_HOME;
+let entitlementTestRoot = "";
+let entitlementCodexHome = "";
+
+beforeAll(() => {
+  entitlementTestRoot = mkdtempSync(join(tmpdir(), "ocx-client-config-entitlement-"));
+  entitlementCodexHome = join(entitlementTestRoot, "codex");
+  mkdirSync(entitlementCodexHome, { recursive: true });
+  process.env.OPENCODEX_HOME = join(entitlementTestRoot, "opencodex");
+  process.env.CODEX_HOME = entitlementCodexHome;
+});
+
+afterAll(() => {
+  if (originalOpenCodexHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = originalOpenCodexHome;
+  if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = originalCodexHome;
+  rmSync(entitlementTestRoot, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  resetCodexModelEntitlementCacheForTests();
+  rmSync(join(entitlementCodexHome, "auth.json"), { force: true });
+});
 
 interface ClientConfigEnvelope {
   client: string;
@@ -196,7 +223,16 @@ describe("GET /api/client-config", () => {
   }, 15_000);
 
   test("DSH response keeps management reasoning metadata in the rc.6 model map", async () => {
-    seedCodexModelEntitlementsForTests("main", ["gpt-5.6-luna"]);
+    writeFileSync(join(entitlementCodexHome, "auth.json"), JSON.stringify({
+      tokens: { access_token: "dsh-token", account_id: "dsh-main" },
+    }));
+    seedCodexModelEntitlementsForTests(
+      "main",
+      ["gpt-5.6-luna"],
+      Date.now(),
+      GATED_MODEL_CLIENT_VERSION_FLOOR,
+      "main:dsh-main",
+    );
     const response = await clientConfigApi(baseConfig(), "?client=dsh");
     expect(response.status).toBe(200);
     const body = await response.json() as ClientConfigEnvelope;
@@ -213,6 +249,57 @@ describe("GET /api/client-config", () => {
       xhigh: "xhigh",
       max: "max",
     });
+  }, 15_000);
+
+  test("an expired management roster is refreshed once before client-config is projected", async () => {
+    writeFileSync(join(entitlementCodexHome, "auth.json"), JSON.stringify({
+      tokens: { access_token: "client-config-token", account_id: "client-config-account" },
+    }));
+    const originalFetch = globalThis.fetch;
+    let entitlementFetches = 0;
+    globalThis.fetch = (async input => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.hostname === "chatgpt.com" && url.pathname === "/backend-api/codex/models") {
+        entitlementFetches += 1;
+        return Response.json({ models: [
+          { slug: "gpt-5.6-sol", supported_in_api: true, visibility: "list" },
+          { slug: "gpt-5.6-terra", supported_in_api: true, visibility: "list" },
+          { slug: "gpt-5.6-luna", supported_in_api: true, visibility: "list" },
+        ] });
+      }
+      return originalFetch(input);
+    }) as typeof fetch;
+    try {
+      const config = baseConfig({
+        providers: {
+          ...baseConfig().providers,
+          openai: { authMode: "forward", liveModels: false, models: [] },
+        },
+      });
+      const response = await clientConfigApi(config, "?client=opencode");
+      expect(response.status).toBe(200);
+      const body = await response.json() as ClientConfigEnvelope;
+      const models = (body.config as OpencodeGeneratedConfig).provider[OPENCODE_PROVIDER_ID].models;
+      expect(entitlementFetches).toBe(1);
+      expect(Object.keys(models)).toEqual(expect.arrayContaining([
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+      ]));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, 15_000);
+
+  test("an entitlement ensure rejection cannot turn client-config into a 503", async () => {
+    const config = baseConfig();
+    Object.defineProperty(config, "codexAccounts", {
+      get() { throw new Error("entitlement identity unavailable"); },
+      configurable: true,
+    });
+
+    const response = await clientConfigApi(config, "?client=opencode");
+    expect(response.status).toBe(200);
   }, 15_000);
 
   test("MCode response carries catalog context and its usable reasoning ladder", async () => {

--- a/tests/native-model-toggle.test.ts
+++ b/tests/native-model-toggle.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   accountBoundNativeOpenAiSlugs,
   accountBoundNativeDisplayName,
@@ -26,6 +29,7 @@ import { NATIVE_GPT56_CONTEXT_WINDOW, NATIVE_GPT56_OPT_IN_CONTEXT_WINDOW, native
 import type { OcxConfig } from "../src/types";
 import { ACCOUNT_GATED_NATIVE_OPENAI_MODELS } from "../src/codex/catalog/native-models";
 import {
+  GATED_MODEL_CLIENT_VERSION_FLOOR,
   resetCodexModelEntitlementCacheForTests,
   seedCodexModelEntitlementsForTests,
 } from "../src/codex/model-entitlements";
@@ -664,37 +668,117 @@ describe("native GPT model toggles (bare slugs in disabledModels)", () => {
   });
 
   test("management API surfaces: /api/models leads with native rows; subagent available drops disabled bare slugs", async () => {
-    resetCodexModelEntitlementCacheForTests();
-    const config = makeConfig({ disabledModels: ["gpt-5.6-sol"] });
+    const oldOcxHome = process.env.OPENCODEX_HOME;
+    const oldCodexHome = process.env.CODEX_HOME;
+    const root = mkdtempSync(join(tmpdir(), "ocx-native-model-management-"));
+    const codexHome = join(root, "codex");
+    mkdirSync(codexHome, { recursive: true });
+    process.env.OPENCODEX_HOME = join(root, "opencodex");
+    process.env.CODEX_HOME = codexHome;
+    try {
+      resetCodexModelEntitlementCacheForTests();
+      const config = makeConfig({ disabledModels: ["gpt-5.6-sol"] });
 
-    const modelsRes = await handleManagementAPI(
-      new Request("http://localhost/api/models"), new URL("http://localhost/api/models"), config,
-    );
-    const rows = await modelsRes!.json() as Array<{ namespaced: string; native?: boolean; disabled: boolean }>;
-    const nativeRows = rows.filter(r => r.native);
-    expect(nativeRows.map(r => r.namespaced)).toEqual(
-      NATIVE_OPENAI_MODELS.filter(slug => !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug)),
-    );
+      const modelsRes = await handleManagementAPI(
+        new Request("http://localhost/api/models"), new URL("http://localhost/api/models"), config,
+      );
+      const rows = await modelsRes!.json() as Array<{ namespaced: string; native?: boolean; disabled: boolean }>;
+      const nativeRows = rows.filter(r => r.native);
+      expect(nativeRows.map(r => r.namespaced)).toEqual(
+        NATIVE_OPENAI_MODELS.filter(slug => !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug)),
+      );
 
-    // A confirmed roster makes the gated rows selectable again; a bare disable still wins.
-    seedCodexModelEntitlementsForTests("main", ["gpt-5.6-sol"]);
-    const confirmedRes = await handleManagementAPI(
-      new Request("http://localhost/api/models"), new URL("http://localhost/api/models"), config,
-    );
-    const confirmedRows = (await confirmedRes!.json() as Array<{ namespaced: string; native?: boolean; disabled: boolean }>)
-      .filter(r => r.native);
-    expect(confirmedRows.map(r => r.namespaced)).toContain("gpt-5.6-sol");
-    expect(confirmedRows.find(r => r.namespaced === "gpt-5.6-sol")?.disabled).toBe(true);
-    // Native rows lead the response so the GUI pins the group first.
-    expect(rows[0]?.native).toBe(true);
+      // A confirmed roster makes the gated rows selectable again; a bare disable still wins.
+      writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+        tokens: { access_token: "toggle-token", account_id: "toggle-main" },
+      }));
+      seedCodexModelEntitlementsForTests(
+        "main",
+        ["gpt-5.6-sol"],
+        Date.now(),
+        GATED_MODEL_CLIENT_VERSION_FLOOR,
+        "main:toggle-main",
+      );
+      const confirmedRes = await handleManagementAPI(
+        new Request("http://localhost/api/models"), new URL("http://localhost/api/models"), config,
+      );
+      const confirmedRows = (await confirmedRes!.json() as Array<{ namespaced: string; native?: boolean; disabled: boolean }>)
+        .filter(r => r.native);
+      expect(confirmedRows.map(r => r.namespaced)).toContain("gpt-5.6-sol");
+      expect(confirmedRows.find(r => r.namespaced === "gpt-5.6-sol")?.disabled).toBe(true);
+      // Native rows lead the response so the GUI pins the group first.
+      expect(rows[0]?.native).toBe(true);
 
-    const subRes = await handleManagementAPI(
-      new Request("http://localhost/api/subagent-models"), new URL("http://localhost/api/subagent-models"), config,
+      const subRes = await handleManagementAPI(
+        new Request("http://localhost/api/subagent-models"), new URL("http://localhost/api/subagent-models"), config,
+      );
+      const sub = await subRes!.json() as { available: string[] };
+      // Bare disabled slugs flow through the existing namespaced-string filter automatically.
+      expect(sub.available).not.toContain("gpt-5.6-sol");
+      expect(sub.available).toContain("gpt-5.6-terra");
+    } finally {
+      if (oldOcxHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = oldOcxHome;
+      if (oldCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = oldCodexHome;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("an expired confirmed roster is refreshed before /api/models projects native rows", async () => {
+    const oldOcxHome = process.env.OPENCODEX_HOME;
+    const oldCodexHome = process.env.CODEX_HOME;
+    const originalFetch = globalThis.fetch;
+    const root = mkdtempSync(join(tmpdir(), "ocx-native-model-expired-"));
+    const codexHome = join(root, "codex");
+    mkdirSync(codexHome, { recursive: true });
+    process.env.OPENCODEX_HOME = join(root, "opencodex");
+    process.env.CODEX_HOME = codexHome;
+    writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+      tokens: { access_token: "expired-token", account_id: "expired-main" },
+    }));
+    seedCodexModelEntitlementsForTests(
+      "main",
+      ["gpt-5.6-sol"],
+      1_000,
+      GATED_MODEL_CLIENT_VERSION_FLOOR,
+      "main:expired-main",
     );
-    const sub = await subRes!.json() as { available: string[] };
-    // Bare disabled slugs flow through the existing namespaced-string filter automatically.
-    expect(sub.available).not.toContain("gpt-5.6-sol");
-    expect(sub.available).toContain("gpt-5.6-terra");
+    let entitlementFetches = 0;
+    globalThis.fetch = (async input => {
+      const url = new URL(input instanceof globalThis.Request ? input.url : String(input));
+      if (url.hostname === "chatgpt.com" && url.pathname === "/backend-api/codex/models") {
+        entitlementFetches += 1;
+        return Response.json({ models: [
+          { slug: "gpt-5.6-sol", supported_in_api: true, visibility: "list" },
+          { slug: "gpt-5.6-terra", supported_in_api: true, visibility: "list" },
+          { slug: "gpt-5.6-luna", supported_in_api: true, visibility: "list" },
+        ] });
+      }
+      return originalFetch(input);
+    }) as typeof fetch;
+    try {
+      const response = await handleManagementAPI(
+        new Request("http://localhost/api/models"),
+        new URL("http://localhost/api/models"),
+        makeConfig(),
+      );
+      const rows = await response!.json() as Array<{ namespaced: string; native?: boolean }>;
+      const nativeIds = rows.filter(row => row.native).map(row => row.namespaced);
+      expect(entitlementFetches).toBe(1);
+      expect(nativeIds).toEqual(expect.arrayContaining([
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+      ]));
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (oldOcxHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = oldOcxHome;
+      if (oldCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = oldCodexHome;
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 import { ManagementRequest as Request } from "./helpers/management-auth";

--- a/tests/native-profile-manager.test.ts
+++ b/tests/native-profile-manager.test.ts
@@ -14,6 +14,7 @@ import {
   type NativeEnvelopeSnapshot,
 } from "../src/codex/native-profile-store";
 import { NativeProfileError, type NativeProfileKey, type NativeProfileKeyProvider } from "../src/codex/native-profile-types";
+import { codexCredentialMutationEpoch } from "../src/codex/credential-mutation-epoch";
 
 const roots: string[] = [];
 
@@ -1027,6 +1028,7 @@ describe("native main profile transactions", () => {
   test("automatic recovery reports an externally refreshed target", async () => {
     const f = await enrolledFixture();
     await leavePendingJournal(f);
+    const epochBefore = codexCredentialMutationEpoch();
     const refreshed = envelope("account-target", "target-refreshed-auto");
     writeFileSync(f.manager.context.authPath, refreshed);
     expect(await f.manager.recover(false)).toMatchObject({
@@ -1036,6 +1038,7 @@ describe("native main profile transactions", () => {
       restartRequired: true,
     });
     expect(readFileSync(f.manager.context.authPath, "utf8")).toBe(refreshed);
+    expect(codexCredentialMutationEpoch()).toBe(epochBefore);
   });
 
   // The manager can spend up to 5 s acquiring its SQLite transaction lock.
@@ -1055,6 +1058,7 @@ describe("native main profile transactions", () => {
     expect(vaultText).not.toContain("account-target");
     expect(() => readFileSync(join(f.stage.stagingCodexHome, "auth.json"))).toThrow();
 
+    const epochBefore = codexCredentialMutationEpoch();
     const switched = await f.manager.switch("work", true);
     expect(switched.restartRequired).toBe(true);
     expect(readFileSync(join(f.codexHome, "auth.json"), "utf8")).toBe(f.target);
@@ -1067,6 +1071,7 @@ describe("native main profile transactions", () => {
       "account-source->account-target",
       "account-target->account-source",
     ]);
+    expect(codexCredentialMutationEpoch()).toBe(epochBefore + 2);
   }, 10_000);
 
   // This rollback case uses the same encrypted-vault and SQLite setup as the
@@ -1084,6 +1089,7 @@ describe("native main profile transactions", () => {
         return atomic(path, content);
       },
     });
+    const epochBefore = codexCredentialMutationEpoch();
     let caught: unknown;
     try { await failing.switch("work", true); } catch (error) { caught = error; }
     expect(caught).toBeInstanceOf(NativeProfileError);
@@ -1091,6 +1097,7 @@ describe("native main profile transactions", () => {
     expect(readFileSync(join(f.codexHome, "auth.json"), "utf8")).toBe(f.source);
     expect((await failing.doctor()).recoveryPending).toBe(false);
     expect((await failing.list()).activeProfileId).toBe(f.sourceProfile.id);
+    expect(codexCredentialMutationEpoch()).toBe(epochBefore + 1);
   }, 10_000);
 
   test("rollback verification failure retains the encrypted recovery journal and never claims success", async () => {
@@ -1255,6 +1262,7 @@ describe("native main profile transactions", () => {
     await leavePendingJournal(f);
     const refreshedTarget = envelope("account-target", "target-refreshed");
     writeFileSync(f.manager.context.authPath, refreshedTarget);
+    const epochBefore = codexCredentialMutationEpoch();
 
     const result = await f.manager.recover(true, true);
 
@@ -1280,6 +1288,7 @@ describe("native main profile transactions", () => {
     );
     try { expect(decrypted.text).toBe(refreshedTarget); } finally { decrypted.raw.fill(0); key!.key.fill(0); }
     expect(f.transitions).toEqual(["account-target->account-source"]);
+    expect(codexCredentialMutationEpoch()).toBe(epochBefore + 1);
   });
 
   test("rollback preservation failure leaves refreshed target auth untouched and journaled", async () => {

--- a/tests/sidecar-candidates.test.ts
+++ b/tests/sidecar-candidates.test.ts
@@ -6,6 +6,7 @@ import * as modelRowsModule from "../src/server/management/model-rows";
 let accountSets: Record<string, { accounts: Array<{ id: string; needsReauth?: boolean }>; activeAccountId?: string }> = {};
 let usableCodexAccounts: Set<string> = new Set();
 let managementRows: Array<Record<string, unknown>> | Error = [];
+let entitlementWaitMs: number | undefined;
 
 mock.module("../src/oauth/store", () => ({
   ...storeModule,
@@ -17,7 +18,8 @@ mock.module("../src/codex/account-usability", () => ({
 }));
 mock.module("../src/server/management/model-rows", () => ({
   ...modelRowsModule,
-  listManagementModelRows: async () => {
+  listManagementModelRows: async (_config: unknown, options?: { entitlementWaitMs?: number }) => {
+    entitlementWaitMs = options?.entitlementWaitMs;
     if (managementRows instanceof Error) throw managementRows;
     return managementRows;
   },
@@ -40,6 +42,7 @@ afterEach(() => {
   accountSets = {};
   usableCodexAccounts = new Set();
   managementRows = [];
+  entitlementWaitMs = undefined;
 });
 
 function loginBoth(): void {
@@ -82,6 +85,7 @@ describe("pickerVisibleSidecarCandidates", () => {
     const cfg = config({ providers: { openai: forward, claude: anthropicOAuth } });
     const all = await pickerVisibleSidecarCandidates(cfg, resolveSidecarAuth(cfg));
     expect(all.map(c => c.id).sort()).toEqual(["claude-haiku-4-5", "gpt-5.6-luna"]);
+    expect(entitlementWaitMs).toBe(0);
   });
 
   test("no logins and empty catalog -> empty set", async () => {


### PR DESCRIPTION
## Summary

`/api/models`, `/api/client-config`, and `ocx export` served a Codex model roster from a cached entitlement snapshot that could outlive the credentials it was derived from. Once the snapshot's TTL elapsed, or once the underlying `auth.json` was replaced out of band, the management surfaces kept answering from stale state: a freshly entitled account still saw the old roster, and a logged-out account still saw models it no longer had.

This adds an explicit credential mutation epoch so an entitlement snapshot is bound to the credential state that produced it, and re-derives on expiry instead of serving the stale copy.

- `src/codex/credential-mutation-epoch.ts` (new) — a monotonic epoch bumped on every credential mutation, local or external.
- `src/codex/model-entitlements.ts` — snapshots now carry `(epoch, expiry)`; a read whose epoch or expiry no longer matches re-derives rather than returning the memo. Logged-out state is memoized so the steady state stays free of extra credential reads.
- `src/codex/account-store.ts`, `src/codex/main-account.ts`, `src/codex/native-profile-manager.ts` — bump the epoch at each mutation point.
- `src/server/management/model-rows.ts`, `src/sidecar/candidates.ts` — consume the freshness-checked accessor.

Steady state is unchanged: 0 additional `accountCredentialSnapshot` calls, 0 token refreshes, 0 network requests when nothing has mutated and the snapshot is live.

Closes #3023

## Verification

- 9 regression tests written red-first against the unfixed code: steady-state credential reads, logged-out memo, memo invalidation on mutation, `/api/client-config` fetch count (1 vs 0), expired `/api/models`, real-handler `ocx export`, local epoch write during an in-flight derive, external `auth.json` replacement during an in-flight derive, and account B expiring during an A-only flight. The rejection-path tests are labeled characterization, not red-first.
- 208 focused tests pass locally across the touched suites.
- Full verification on a Linux host at this exact head (`6298fae32`): `bun run privacy:scan`, `bun run typecheck`, `bun run test` — **16524 pass / 0 fail / 16 skip, exit 0**.

## Checklist

- [x] Tests added or updated for the changed behavior
- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run privacy:scan` passes
- [x] Targets `dev`
- [x] Docs unaffected (no user-facing surface or flag changes)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model listings and exported configurations now automatically refresh expired entitlement data.
  - Management views briefly wait for entitlement updates to show current model availability.
  - Credential changes trigger timely refreshes of related models and entitlements.

- **Bug Fixes**
  - Prevented stale model availability after credential updates.
  - Improved resilience when entitlement refreshes fail, allowing management responses to complete normally.
  - Kept sidecar model discovery responsive by avoiding unnecessary entitlement wait time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->