### PR TITLE
test(responses): stop the shutdown-cleanup reserve from expiring under load

### DIFF
--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -1217,7 +1217,12 @@ describe("Responses previous_response_id state", () => {
 
   test("shutdown cleanup failure still persists unrelated response state and reports failure", async () => {
     setPlatformForTests("win32");
-    setResponseSpillShutdownBudgetForTests({ totalMs: 120, fallbackReserveMs: 80 });
+    // The drain must expire, but the fallback reserve must NOT: this test asserts that a
+    // cleanup failure still persists unrelated state. Under load the previous 80ms reserve
+    // could itself expire, terminalizing `resp_cleanup_unrelated` into a tombstone and
+    // failing the replay assertion. The gate below — not the clock — is what forces drain
+    // expiry, so the reserve is sized to never be the thing that runs out.
+    setResponseSpillShutdownBudgetForTests({ totalMs: 30_120, fallbackReserveMs: 30_000 });
     let release!: () => void;
     let entered!: () => void;
     let tempHardenFinished!: () => void;


### PR DESCRIPTION
## Summary

`Responses previous_response_id state > shutdown cleanup failure still persists unrelated response state and reports failure` is flaky on loaded runners. It failed `test 2/4` on two consecutive CI runs for PR #3054, a branch that does not touch `src/responses/` at all.

The test forces the shutdown drain to expire by holding an `icacls` gate open, then injects an `unlink` failure during cleanup, and asserts that an unrelated small response still replays afterwards. Drain expiry is driven by the gate, which is deterministic. The **fallback reserve** was not: `fallbackReserveMs: 80` is a real wall-clock value measured with `Date.now()` in `fallbackPendingResponseSpills`.

On a loaded runner that 80ms window can expire before the unrelated response finishes persisting. When it does, `terminalizeExhaustedShutdownFallback` converts `resp_cleanup_unrelated` into a `spill-failed` tombstone, and the replay assertion fails with the raw request echoed back instead of the stored input and output.

This is a test defect, not a product defect. The drain and fallback budgets behave correctly; the test was asserting a real-time property it did not intend to assert.

## The fix

Size the reserve so it cannot be the thing that runs out (`totalMs: 30_120, fallbackReserveMs: 30_000`). The gate still forces the drain to expire, the cleanup failure is still injected, and the unrelated response must still replay. Every assertion is unchanged.

## Verification

Reproduced first, on a Linux host at `origin/dev` (`7c68768ca`), before changing anything:

- 8 parallel runs of this single test ranged from **2.08s to 109.38s** wall time.
- A 6-way parallel run reproduced the failure **1 in 6**.
- CI hit it on `test 2/4` twice in a row on PR #3054.

After the fix, at `883faf0d9` on the same host: **10 parallel runs, 10 pass, 0 fail**, with individual run times spread from 5.47s to 45.51s. The longest run is now over 500x the old reserve and still passes.

Focused suite locally: `bun test tests/responses-state.test.ts` — **130 pass / 0 fail / 364 assertions**.

## Checklist

- [x] Tests updated for the changed behavior
- [x] No product code changed
- [x] Targets `dev`
- [x] Docs unaffected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved shutdown cleanup test reliability by allowing drain expiration to be controlled explicitly.
  * Added clarification ensuring unrelated response state is preserved and correctly reported as a tombstone when cleanup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->