### PR TITLE
fix(history): resolve a rollout's session_meta by thread id

### DIFF
--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -549,7 +549,7 @@ function snapshotRolloutForRestore(entry: CodexHistoryBackupEntry): RestoreRollo
   if (identityBefore === null) {
     throw new CodexHistoryIntegrityError("history_backup_rollout_unrestorable");
   }
-  const latest = readLatestSessionMeta(entry.rolloutPath);
+  const latest = readLatestSessionMetaForId(entry.rolloutPath, entry.id);
   if (!latest
     || (!rolloutMatchesRestoreTuple(latest, entry, entry.modelProvider, entry.source)
       && !rolloutMatchesExpectedPostImage(latest, entry))) {
@@ -628,7 +628,7 @@ function assertRestoreReadback(
       || !rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)) {
       throw new CodexHistoryIntegrityError("history_backup_database_readback_mismatch");
     }
-    const latest = readLatestSessionMeta(entry.rolloutPath);
+    const latest = readLatestSessionMetaForId(entry.rolloutPath, entry.id);
     if (inspectFirstLineProvider(entry.rolloutPath, entry.id, entry.modelProvider) !== "current"
       || !latest
       || !rolloutMatchesRestoreTuple(latest, entry, entry.modelProvider, entry.source)) {
@@ -663,6 +663,19 @@ function parseSessionMetaLine(line: string): ParsedSessionMeta | null {
 export function readLatestSessionMeta(path: string): ParsedSessionMeta | null {
   const raw = readFileSync(path, "utf8");
   return readLatestSessionMetaFromText(raw);
+}
+
+/**
+ * Same fold as {@link readLatestSessionMeta}, restricted to this thread's own metadata.
+ *
+ * A forked/branched rollout appends the SOURCE thread's `session_meta` after its own, and the
+ * app discards any record whose payload id is not the canonical thread id (codex-rs
+ * `apply_session_meta_from_item`). Reading the last line regardless of id therefore answers
+ * with a foreign thread's provider, which is neither what the app honors nor what we may patch.
+ */
+function readLatestSessionMetaForId(path: string, expectedId: string): ParsedSessionMeta | null {
+  const raw = readFileSync(path, "utf8");
+  return readLatestSessionMetaForIdFromText(raw, expectedId);
 }
 
 function readLatestSessionMetaFromText(raw: string): ParsedSessionMeta | null {
@@ -875,18 +888,15 @@ function updateSessionMeta(
     return { changed: false, durableProvider: false, conflict: true };
   }
 
-  const latest = readLatestSessionMeta(path);
+  // Resolve by id. The app ignores `session_meta` lines whose payload id != the canonical
+  // thread id (codex-rs `apply_session_meta_from_item`), and a forked rollout trails the source
+  // session's metadata, so the last line is not necessarily this thread's. Patching that record
+  // would clone the wrong thread's meta into a line the app discards; skipping the file entirely
+  // left forked threads unroutable and, once routed, unrestorable.
+  const latest = readLatestSessionMetaForId(path, expectedId);
   if (!latest) return { changed: false, durableProvider: false };
   const record = latest.record;
 
-  // The app ignores `session_meta` lines whose payload id != the canonical thread id
-  // (codex-rs `apply_session_meta_from_item`). Forked rollouts can embed a source session's
-  // metadata, so an id-mismatched latest line means we'd be cloning the wrong thread's meta and
-  // appending a line the app would discard. Skip rather than write a no-op/misleading line.
-  const payloadId = record.payload.id;
-  if (typeof payloadId !== "string" || payloadId !== expectedId) {
-    return { changed: false, durableProvider: false };
-  }
   const latestProvider = typeof record.payload.model_provider === "string" && record.payload.model_provider
     ? record.payload.model_provider
     : "openai";

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -189,21 +189,27 @@ describe("Codex history provider sync", () => {
     expect(JSON.parse(before.split("\n")[0])).toEqual(JSON.parse(after.split("\n")[0]));
   });
 
-  test("does not append when the latest session_meta belongs to a different thread id", () => {
+  test("appends this thread's own session_meta when the latest one belongs to a different thread id", () => {
     const { dbPath, backupPath, rollout } = makeFixture();
     // Simulate a forked rollout whose trailing session_meta embeds a *different* thread's id.
-    appendFileSync(rollout, JSON.stringify({
+    const foreignLine = JSON.stringify({
       type: "session_meta",
       timestamp: "2026-01-02T00:00:00.000Z",
       payload: { id: "some-other-forked-thread", model_provider: "openai", cwd: "/tmp" },
-    }) + "\n");
+    });
+    appendFileSync(rollout, foreignLine + "\n");
     const before = readFileSync(rollout, "utf8");
 
     const result = syncCodexHistoryProvider("opencodex", dbPath, backupPath);
 
-    // DB row still flips, but the rollout is left untouched (no misleading append for a foreign id).
-    expect(result.files).toBe(0);
-    expect(readFileSync(rollout, "utf8")).toBe(before);
+    // The append describes THIS thread — never a clone of the foreign record, which the app
+    // would discard. Routing the row without the file left the pair unrestorable (#3026).
+    expect(result.files).toBe(1);
+    const after = readFileSync(rollout, "utf8");
+    expect(after.startsWith(before)).toBe(true);
+    expect(latestSessionMetaPayload(rollout)).toMatchObject({ id: "thread-1", model_provider: "opencodex" });
+    // The foreign thread's record is still there, exactly once, exactly as written.
+    expect(after.split("\n").filter(Boolean).filter(line => line === foreignLine)).toHaveLength(1);
     const db = new Database(dbPath);
     expect(db.query("SELECT model_provider FROM threads WHERE id = 'thread-1'").get()).toEqual({ model_provider: "opencodex" });
     db.close();
@@ -628,6 +634,69 @@ describe("Codex history provider sync", () => {
       .toMatchObject({ rows: 1, files: 1, failed: true, failureReason: "integrity" });
     expect(existsSync(fixture.backupPath)).toBe(true);
     expect(latestSessionMetaPayload(fixture.rollout).model_provider).toBe("custom");
+  });
+
+  test("consumes the manifest when a foreign-id session_meta lands after restore readback", () => {
+    const fixture = makeFixture();
+    syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath);
+    // The same last-moment race as the same-id case above, except the arriving record belongs
+    // to another thread. The app discards it, so it is not a newer decision to protect.
+    setBeforeHistoryBackupConsumeForTests(() => {
+      appendFileSync(fixture.rollout, JSON.stringify({
+        type: "session_meta",
+        timestamp: "2026-03-04T00:00:00.000Z",
+        payload: { id: "parent-thread", model_provider: "custom", source: "exec" },
+      }) + "\n");
+    });
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    expect(existsSync(fixture.backupPath)).toBe(false);
+  });
+
+  test("restores a forked rollout that trails its parent thread's session_meta", () => {
+    const fixture = makeFixture();
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+
+    // A forked/branched session appends the SOURCE thread's session_meta after its own.
+    // codex-rs `apply_session_meta_from_item` ignores a record whose payload id is not the
+    // canonical thread id, so this line is ordinary rollout content, not an integrity fault.
+    appendFileSync(fixture.rollout, JSON.stringify({
+      type: "session_meta",
+      timestamp: "2026-03-03T00:00:00.000Z",
+      payload: { id: "parent-thread", model_provider: "openai", source: "cli" },
+    }) + "\n");
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    const db = new Database(fixture.dbPath, { readonly: true });
+    expect(db.query("SELECT model_provider, source FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "openai", source: "vscode" });
+    db.close();
+    expect(latestSessionMetaPayload(fixture.rollout)).toMatchObject({
+      id: "thread-1",
+      model_provider: "openai",
+      source: "vscode",
+    });
+    expect(existsSync(fixture.backupPath)).toBe(false);
+  });
+
+  test("leaves a foreign trailing session_meta untouched while restoring its own", () => {
+    const fixture = makeFixture();
+    syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath);
+    const parentLine = JSON.stringify({
+      type: "session_meta",
+      timestamp: "2026-03-03T00:00:00.000Z",
+      payload: { id: "parent-thread", model_provider: "opencodex", source: "exec" },
+    });
+    appendFileSync(fixture.rollout, parentLine + "\n");
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    // The parent's record still says what it said: restore repairs this thread only.
+    const lines = readFileSync(fixture.rollout, "utf8").split("\n").filter(Boolean);
+    expect(lines.filter(line => line === parentLine)).toHaveLength(1);
   });
 
   test("reports applied permission progress when manifest finalization is denied", () => {


### PR DESCRIPTION
Fixes #3026.

## The pair that can never validate

A forked rollout trails its parent thread's `session_meta`. Three call sites folded the file with the id-agnostic `readLatestSessionMeta`, so all three answered with the **parent's** provider:

| site | consequence |
|---|---|
| `updateSessionMeta` (line 878) | id mismatch → skip the file entirely |
| `snapshotRolloutForRestore` (line 552) | `history_backup_rollout_postimage_mismatch` |
| `assertRestoreReadback` (line 631) | `history_backup_rollout_readback_mismatch` |

The reporter identified the two validators. The writer is the same defect on the write side, and it is where the unrecoverable state is *created*: routing flips the database row but skips the rollout, so the manifest records an entry whose file never received the OpenCodex post-image. Neither restore branch can match it, and `preflightRestoreTargets` is all-or-nothing — a handful of forked threads blocks every entry, `ocx stop` exits 1 on every invocation, and `ocx update` aborts at its gate. Nothing clears on retry.

Fixing only the validators does not restore a forked thread: the writer still skips, `requireDurableProvider` is unmet, and restore throws `history_backup_rollout_unrestorable`. I confirmed that by running it.

## The fix

Resolve the record by id at all three sites, via a `readLatestSessionMetaForId` wrapper around the `readLatestSessionMetaForIdFromText` already used by `compensateConcurrentSessionMetaAppend`.

For an unforked rollout the last record *is* this thread's, so behaviour is byte-identical. The file's identity stays anchored by `readFirstLineProviderValue` / `inspectFirstLineProvider`, which already require line 1 to carry `entry.id`.

## ⚠️ One existing test changed its expectation

`does not append when the latest session_meta belongs to a different thread id` asserted `files: 0` — the skip this PR removes. Its comment gives the reason: *"no misleading append for a foreign id"*. That concern was about **cloning the foreign record**, and resolving by id addresses it directly: we append this thread's own metadata, which the app honors, rather than a copy of a record it would discard.

I rewrote the test rather than delete it, and it is now strictly stronger — it pins the append's id, that the original bytes remain a prefix, and that the foreign line survives unchanged exactly once:

```ts
expect(latestSessionMetaPayload(rollout)).toMatchObject({ id: "thread-1", model_provider: "opencodex" });
expect(after.split("\n").filter(Boolean).filter(line => line === foreignLine)).toHaveLength(1);
```

Please look at this hunk first — it is the one judgement call in the PR. If you would rather keep forked rollouts unwritable, the alternative is to stop flipping the database row for them too, so no manifest entry is ever recorded; say the word and I will send that instead.

## Tests

Three new tests, plus the rewritten one:

- `restores a forked rollout that trails its parent thread's session_meta` — the reported end-to-end path
- `leaves a foreign trailing session_meta untouched while restoring its own`
- `consumes the manifest when a foreign-id session_meta lands after restore readback` — the last-moment race, via `setBeforeHistoryBackupConsumeForTests`. Its same-id sibling (`keeps the manifest when a newer same-id rollout provider lands after readback`) still fails closed, so the pair now pins both halves of that comment.

Each site was reverted individually to confirm the tests actually hold it:

| reverted site | result |
|---|---|
| `snapshotRolloutForRestore` | 2 fail |
| `assertRestoreReadback` | 1 fail |
| `updateSessionMeta` | 3 fail |

```
bun test tests/codex-history-provider.test.ts        48 pass, 0 fail
bun test tests/codex-history-*.test.ts \
     tests/codex-native-residue.test.ts \
     tests/history-migration-guardian.test.ts        168 pass, 2 skip, 0 fail
bun x tsc --noEmit                                   clean
```

Not reproduced on macOS — I am on Windows and built the forked rollout from the fixture instead. The defect is filesystem-agnostic.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollout restoration when session metadata from another thread or fork appears in the history.
  * Ensured the correct thread’s metadata is selected and restored.
  * Prevented unrelated metadata records from being incorrectly treated as integrity errors or overwritten.

* **Tests**
  * Added coverage for restoring rollouts with foreign or trailing session metadata records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->