### PR TITLE
fix(codex): make entitlement authority tri-state

### DIFF
--- a/src/codex/catalog/sync.ts
+++ b/src/codex/catalog/sync.ts
@@ -35,6 +35,7 @@ import { codexAccountNamespaceEntries, isMainCodexAccountTarget } from "../accou
 import { MAIN_CODEX_ACCOUNT_ID } from "../main-account";
 import {
   availableAccountGatedNativeModels,
+  codexModelEntitlementStateForAccount,
   isCodexModelEntitlementSnapshotCurrent,
   resolveCodexModelEntitlements,
   type CodexModelEntitlementSnapshot,
@@ -1613,10 +1614,10 @@ function writeRetainedCatalogSync({
     ? new Map([...accountBoundNativeOpenAiSlugsBySelector(config, observedAccountNativeEntries)].map(([selector, slugs]) => {
       const target = accountTargets.get(selector);
       const accountId = target && isMainCodexAccountTarget(target) ? MAIN_CODEX_ACCOUNT_ID : target;
-      const entitled = accountId ? modelEntitlements.modelsByAccount.get(accountId) : undefined;
-      const confirmed = accountId ? modelEntitlements.confirmedAccountIds.has(accountId) : false;
       return [selector, slugs.filter(slug => (
-        !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug) || (confirmed && entitled?.has(slug) === true)
+        !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug)
+        || (accountId !== undefined
+          && codexModelEntitlementStateForAccount(modelEntitlements, accountId, slug) === "granted")
       ))] as const;
     }))
     : new Map<string, readonly string[]>();

--- a/src/codex/convergence.ts
+++ b/src/codex/convergence.ts
@@ -73,6 +73,7 @@ import { codexAccountNamespaceEntries, isMainCodexAccountTarget } from "./accoun
 import { MAIN_CODEX_ACCOUNT_ID } from "./main-account";
 import {
   availableAccountGatedNativeModels,
+  codexModelEntitlementStateForAccount,
   isCodexModelEntitlementSnapshotCurrent,
   resolveCodexModelEntitlements,
   type CodexModelEntitlementSnapshot,
@@ -277,10 +278,10 @@ function prepareCatalog(
     ? new Map([...accountBoundNativeOpenAiSlugsBySelector(config, observedAccountNativeEntries)].map(([selector, slugs]) => {
       const target = accountTargets.get(selector);
       const accountId = target && isMainCodexAccountTarget(target) ? MAIN_CODEX_ACCOUNT_ID : target;
-      const entitled = accountId ? modelEntitlements.modelsByAccount.get(accountId) : undefined;
-      const confirmed = accountId ? modelEntitlements.confirmedAccountIds.has(accountId) : false;
       return [selector, slugs.filter(slug => (
-        !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug) || (confirmed && entitled?.has(slug) === true)
+        !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug)
+        || (accountId !== undefined
+          && codexModelEntitlementStateForAccount(modelEntitlements, accountId, slug) === "granted")
       ))] as const;
     }))
     : new Map<string, readonly string[]>();

--- a/src/codex/model-entitlements.ts
+++ b/src/codex/model-entitlements.ts
@@ -89,6 +89,20 @@ export function deriveGatedClientVersionFloor(
 const MEASURED_GATED_CLIENT_VERSION_MINIMUM = "0.144.0";
 
 /**
+ * Lowest versions measured to return each account-gated model when the account owns it.
+ *
+ * This is deliberately independent of the bundled upstream snapshot. The snapshot still
+ * records 0.142.2 for sol/terra/luna, while live measurements show that upstream omits them
+ * below 0.144.0. Daybreak has no snapshot row or independent minimum, so its omission remains
+ * authoritative instead of inheriting a guessed floor from another model.
+ */
+export const ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS: ReadonlyMap<string, string> = new Map([
+  ["gpt-5.6-sol", MEASURED_GATED_CLIENT_VERSION_MINIMUM],
+  ["gpt-5.6-terra", MEASURED_GATED_CLIENT_VERSION_MINIMUM],
+  ["gpt-5.6-luna", MEASURED_GATED_CLIENT_VERSION_MINIMUM],
+]);
+
+/**
  * Fallback when the snapshot records no usable gated floor.
  *
  * Not every gated slug carries a `minimal_client_version` — `gpt-daybreak-blue-latest` has no
@@ -285,9 +299,12 @@ interface CachedAccountModels {
 
 export interface CodexModelEntitlementSnapshot {
   readonly modelsByAccount: ReadonlyMap<string, ReadonlySet<string>>;
+  readonly clientVersionByAccount: ReadonlyMap<string, string>;
   readonly confirmedAccountIds: ReadonlySet<string>;
   readonly credentialIdentities: ReadonlyMap<string, string>;
 }
+
+export type CodexModelEntitlementState = "granted" | "denied" | "unknown";
 
 export interface CodexModelEntitlementResolveOptions {
   readonly fetcher?: typeof fetch;
@@ -501,10 +518,16 @@ async function fetchAccountModels(
     // that as authoritative is exactly how 2.36.0 denied sol/terra/luna to accounts that own
     // them (#3022). No usable rows means unconfirmed, on the 15s failure TTL, asked again.
     const usable = models !== null && models.size > 0;
+    const hasUnknownGatedAbsence = usable && [...ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS]
+      .some(([modelId, minimum]) => (
+        !models.has(modelId) && compareClientVersions(clientVersion, minimum) < 0
+      ));
     return {
       credentialIdentity: credential.credentialIdentity,
       clientVersion,
-      expiresAt: now + (usable ? MODEL_ROSTER_TTL_MS : MODEL_ROSTER_FAILURE_TTL_MS),
+      expiresAt: now + (usable && !hasUnknownGatedAbsence
+        ? MODEL_ROSTER_TTL_MS
+        : MODEL_ROSTER_FAILURE_TTL_MS),
       models: models ?? new Set(),
       confirmed: usable,
     };
@@ -823,9 +846,42 @@ export async function resolveCodexModelEntitlements(
   })));
   return {
     modelsByAccount: new Map(results.map(({ credential, result }) => [credential.accountId, result.models])),
+    clientVersionByAccount: new Map(results.map(({ credential, result }) => (
+      [credential.accountId, result.clientVersion]
+    ))),
     confirmedAccountIds: new Set(results.flatMap(({ credential, result }) => result.confirmed ? [credential.accountId] : [])),
     credentialIdentities: new Map(results.map(({ credential }) => [credential.accountId, credential.credentialIdentity])),
   };
+}
+
+function codexModelEntitlementStateForRoster(
+  models: ReadonlySet<string> | undefined,
+  confirmed: boolean,
+  clientVersion: string | undefined,
+  modelId: string,
+): CodexModelEntitlementState {
+  if (!models || !confirmed) return "unknown";
+  // Positive evidence is authoritative regardless of which client version asked for it.
+  if (models.has(modelId)) return "granted";
+  const minimum = ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS.get(modelId);
+  if (minimum && (!clientVersion || compareClientVersions(clientVersion, minimum) < 0)) {
+    return "unknown";
+  }
+  return "denied";
+}
+
+/** Per-account tri-state authority. Positive projections admit only `granted`. */
+export function codexModelEntitlementStateForAccount(
+  snapshot: CodexModelEntitlementSnapshot,
+  accountId: string,
+  modelId: string,
+): CodexModelEntitlementState {
+  return codexModelEntitlementStateForRoster(
+    snapshot.modelsByAccount.get(accountId),
+    snapshot.confirmedAccountIds.has(accountId),
+    snapshot.clientVersionByAccount?.get(accountId),
+    modelId,
+  );
 }
 
 /** Fail-closed entitlement check for a Direct request's own forwarded ChatGPT credential. */
@@ -844,7 +900,12 @@ export async function isDirectCallerEntitledToCodexModel(
     options.now ?? Date.now(),
     clientVersion,
   );
-  return result.confirmed && result.models.has(modelId);
+  return codexModelEntitlementStateForRoster(
+    result.models,
+    result.confirmed,
+    result.clientVersion,
+    modelId,
+  ) === "granted";
 }
 
 export function entitledCodexAccountIdsForModel(
@@ -852,8 +913,10 @@ export function entitledCodexAccountIdsForModel(
   modelId: string | undefined,
 ): ReadonlySet<string> | undefined {
   if (!modelId || !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(modelId)) return undefined;
-  return new Set([...snapshot.modelsByAccount].flatMap(([accountId, models]) => (
-    snapshot.confirmedAccountIds.has(accountId) && models.has(modelId) ? [accountId] : []
+  return new Set([...snapshot.modelsByAccount.keys()].flatMap(accountId => (
+    codexModelEntitlementStateForAccount(snapshot, accountId, modelId) === "granted"
+      ? [accountId]
+      : []
   )));
 }
 
@@ -862,10 +925,9 @@ export function availableAccountGatedNativeModels(
   eligibleAccountIds?: ReadonlySet<string>,
 ): ReadonlySet<string> {
   return new Set([...ACCOUNT_GATED_NATIVE_OPENAI_MODELS].filter(modelId => (
-    [...snapshot.modelsByAccount].some(([accountId, models]) => (
+    [...snapshot.modelsByAccount.keys()].some(accountId => (
       (!eligibleAccountIds || eligibleAccountIds.has(accountId))
-      && snapshot.confirmedAccountIds.has(accountId)
-      && models.has(modelId)
+      && codexModelEntitlementStateForAccount(snapshot, accountId, modelId) === "granted"
     ))
   )));
 }
@@ -890,9 +952,13 @@ export function cachedAvailableAccountGatedNativeModels(
       (!eligibleAccountIds || eligibleAccountIds.has(accountIdOfCacheKey(accountId)))
       && !accountIdOfCacheKey(accountId).startsWith(DIRECT_CALLER_ACCOUNT_PREFIX)
       && (version === null || entry.clientVersion === version)
-      && entry.confirmed
       && entry.expiresAt > now
-      && entry.models.has(modelId)
+      && codexModelEntitlementStateForRoster(
+        entry.models,
+        entry.confirmed,
+        entry.clientVersion,
+        modelId,
+      ) === "granted"
     ))
   )));
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -66,6 +66,7 @@ import { codexAccountNamespaceEntries, isMainCodexAccountTarget } from "../codex
 import { MAIN_CODEX_ACCOUNT_ID } from "../codex/main-account";
 import {
   availableAccountGatedNativeModels,
+  codexModelEntitlementStateForAccount,
   resolveCodexModelEntitlements,
 } from "../codex/model-entitlements";
 export {
@@ -1211,10 +1212,10 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
           ? new Map([...accountBoundNativeOpenAiSlugsBySelector(config)].map(([selector, slugs]) => {
             const target = accountTargets.get(selector);
             const accountId = target && isMainCodexAccountTarget(target) ? MAIN_CODEX_ACCOUNT_ID : target;
-            const entitled = accountId ? modelEntitlements.modelsByAccount.get(accountId) : undefined;
-            const confirmed = accountId ? modelEntitlements.confirmedAccountIds.has(accountId) : false;
             return [selector, slugs.filter(slug => (
-              !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug) || (confirmed && entitled?.has(slug) === true)
+              !ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(slug)
+              || (accountId !== undefined
+                && codexModelEntitlementStateForAccount(modelEntitlements, accountId, slug) === "granted")
             ))] as const;
           }))
           : new Map<string, readonly string[]>();

--- a/tests/codex-model-entitlements.test.ts
+++ b/tests/codex-model-entitlements.test.ts
@@ -3,8 +3,10 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS,
   availableAccountGatedNativeModels,
   cachedAvailableAccountGatedNativeModels,
+  codexModelEntitlementStateForAccount,
   composeGatedClientVersionFloorForTests,
   compareClientVersionsForTests,
   codexEntitlementNegativeMemoForTests,
@@ -20,6 +22,7 @@ import {
   resolveCodexModelEntitlements,
   seedCodexModelEntitlementsForTests,
   type CodexModelEntitlementCredentialSnapshot,
+  type CodexModelEntitlementState,
 } from "../src/codex/model-entitlements";
 import {
   forceRefreshMainAccountToken,
@@ -52,6 +55,14 @@ function roster(...slugs: string[]): Response {
   return Response.json({
     models: slugs.map(slug => ({ slug, supported_in_api: true, visibility: "list" })),
   });
+}
+
+function projectedEntitlementState(
+  snapshot: Awaited<ReturnType<typeof resolveCodexModelEntitlements>>,
+  accountId: string,
+  modelId: string,
+): CodexModelEntitlementState {
+  return codexModelEntitlementStateForAccount(snapshot, accountId, modelId);
 }
 
 function deferred<T = void>(): {
@@ -212,6 +223,126 @@ describe("Codex account model entitlements", () => {
     expect([...cachedAvailableAccountGatedNativeModels(1_000)]).toContain(DAYBREAK);
   });
 
+});
+
+describe("tri-state entitlement authority", () => {
+  const directHeaders = (): Headers => new Headers({
+    authorization: "Bearer tri-state-caller",
+    "chatgpt-account-id": "tri-state-account",
+  });
+
+  test("an omitted gated slug below its minimum is unknown and uses the failure TTL", async () => {
+    let fetches = 0;
+    const backend = (async () => {
+      fetches += 1;
+      return roster("gpt-5.5");
+    }) as typeof fetch;
+
+    expect(await isDirectCallerEntitledToCodexModel(directHeaders(), SOL, {
+      fetcher: backend,
+      now: 1_000,
+      clientVersion: "0.140.0",
+    })).toBe(false);
+    expect(await isDirectCallerEntitledToCodexModel(directHeaders(), SOL, {
+      fetcher: backend,
+      now: 15_999,
+      clientVersion: "0.140.0",
+    })).toBe(false);
+    expect(fetches).toBe(1);
+    expect(await isDirectCallerEntitledToCodexModel(directHeaders(), SOL, {
+      fetcher: backend,
+      now: 16_001,
+      clientVersion: "0.140.0",
+    })).toBe(false);
+    expect(fetches).toBe(2);
+
+    const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
+      credentials: [credential("main")],
+      fetcher: (async () => roster("gpt-5.5")) as typeof fetch,
+      now: 20_000,
+      clientVersion: "0.140.0",
+    });
+    expect(snapshot.clientVersionByAccount.get("main")).toBe("0.140.0");
+    expect(projectedEntitlementState(snapshot, "main", SOL)).toBe("unknown");
+    expect(entitledCodexAccountIdsForModel(snapshot, SOL)?.size).toBe(0);
+    expect(availableAccountGatedNativeModels(snapshot).has(SOL)).toBe(false);
+  });
+
+  test("an omitted gated slug at its minimum is denied", async () => {
+    const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
+      credentials: [credential("main")],
+      fetcher: (async () => roster("gpt-5.5")) as typeof fetch,
+      now: 1_000,
+      clientVersion: "0.144.0",
+    });
+
+    expect(projectedEntitlementState(snapshot, "main", SOL)).toBe("denied");
+    expect(entitledCodexAccountIdsForModel(snapshot, SOL)?.size).toBe(0);
+    expect(availableAccountGatedNativeModels(snapshot).has(SOL)).toBe(false);
+  });
+
+  test("a present gated slug below its minimum is granted", async () => {
+    const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
+      credentials: [credential("main")],
+      fetcher: (async () => roster("gpt-5.5", SOL)) as typeof fetch,
+      now: 1_000,
+      clientVersion: "0.140.0",
+    });
+
+    expect(projectedEntitlementState(snapshot, "main", SOL)).toBe("granted");
+    expect([...entitledCodexAccountIdsForModel(snapshot, SOL)!]).toEqual(["main"]);
+    expect(availableAccountGatedNativeModels(snapshot).has(SOL)).toBe(true);
+  });
+
+  test("Daybreak omission remains denied without a known minimum", async () => {
+    expect(ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS.get(SOL)).toBe("0.144.0");
+    expect(ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS.has(DAYBREAK)).toBe(false);
+
+    for (const clientVersion of ["0.140.0", "0.200.0"]) {
+      const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
+        credentials: [credential(`main-${clientVersion}`)],
+        fetcher: (async () => roster("gpt-5.5")) as typeof fetch,
+        now: 1_000,
+        clientVersion,
+      });
+      expect(projectedEntitlementState(snapshot, `main-${clientVersion}`, DAYBREAK)).toBe("denied");
+      expect(entitledCodexAccountIdsForModel(snapshot, DAYBREAK)?.size).toBe(0);
+      expect(availableAccountGatedNativeModels(snapshot).has(DAYBREAK)).toBe(false);
+    }
+  });
+
+  test("CHARACTERIZATION: no positive projection returns a gated slug absent from the roster", async () => {
+    const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
+      credentials: [credential("main")],
+      fetcher: (async () => roster("gpt-5.5")) as typeof fetch,
+      now: 1_000,
+      clientVersion: "0.140.0",
+    });
+    expect(entitledCodexAccountIdsForModel(snapshot, SOL)?.size).toBe(0);
+    expect(availableAccountGatedNativeModels(snapshot).has(SOL)).toBe(false);
+
+    seedCodexModelEntitlementsForTests("main", ["gpt-5.5"], 1_000, "0.140.0");
+    expect(cachedAvailableAccountGatedNativeModels(1_001, undefined, "0.140.0").has(SOL))
+      .toBe(false);
+    expect(await isDirectCallerEntitledToCodexModel(directHeaders(), SOL, {
+      fetcher: (async () => roster("gpt-5.5")) as typeof fetch,
+      now: 1_000,
+      clientVersion: "0.140.0",
+    })).toBe(false);
+  });
+
+  test("CHARACTERIZATION: an unconfirmed roster cannot grant a present gated slug", () => {
+    const snapshot = {
+      modelsByAccount: new Map([["main", new Set([SOL])]]),
+      clientVersionByAccount: new Map([["main", "0.140.0"]]),
+      confirmedAccountIds: new Set<string>(),
+      credentialIdentities: new Map([["main", "test:main"]]),
+    };
+
+    expect(projectedEntitlementState(snapshot, "main", SOL)).toBe("unknown");
+    expect(entitledCodexAccountIdsForModel(snapshot, SOL)?.size).toBe(0);
+    expect(availableAccountGatedNativeModels(snapshot).has(SOL)).toBe(false);
+  });
 });
 
 describe("ensureCodexEntitlementFreshness", () => {


### PR DESCRIPTION
## Summary

#3022 happened because a roster fetched under a too-low `client_version` came back without the gated GPT-5.6 rows, and their **absence was recorded as a decided denial**. PR #3035 fixed that instance by asking under a measured `0.144.0`. It does not survive the next upstream bump: when the gated minimum moves to `0.148.0`, a version that was correct yesterday silently produces confirmed negatives again.

This removes the class rather than the instance. Absence is only evidence when the question was capable of producing the answer.

- `src/codex/model-entitlements.ts` — an explicit per-model minimum source, a `clientVersionByAccount` map carrying the answering version into the snapshot, and a `granted`/`denied`/`unknown` boundary.
- `src/codex/catalog/sync.ts`, `src/codex/convergence.ts`, `src/server/index.ts` — the three selector projections now require exactly `granted`.

Four rules hold together:

1. Positive evidence is never version-tested. A returned row is a grant no matter which version asked.
2. A gated slug omitted from a roster fetched **below** its minimum is `unknown`: not exposed, and not cached as a five-minute denial. It takes the 15-second failure TTL so recovery is prompt.
3. The same slug omitted **at or above** the minimum is `denied`, because the question was capable.
4. `gpt-daybreak-blue-latest` has no row in `upstream-models.json`, therefore no minimum, therefore keeps omission-as-denial at every version. It is not handed a guess.

**Fail-closed is preserved.** The projections still return only `granted`. `unknown` exists so it can be reported and so it expires quickly, never so it can widen exposure.

## Verification

Five regressions, all on genuinely gated slugs — an earlier draft asserted on `gpt-5.5`, which is not in `ACCOUNT_GATED_NATIVE_OPENAI_MODELS` and was therefore vacuous.

Red-first, each driven against the unfixed code: below-minimum omission TTL `Expected 2 / Received 1`; at-minimum omission `Expected "denied" / Received undefined`; below-minimum positive row `Expected "granted" / Received undefined`; explicit minimum source `Expected "0.144.0" / Received undefined`. The fail-closed absent-row invariant is labeled characterization, not claimed as red.

One widening bug was caught and fixed during implementation: an unconfirmed present row briefly returned `granted` instead of `unknown`. Independent review reproduced it by reordering the presence check ahead of the confirmation gate and confirmed the guard test catches it.

Independent review verified the caller census directly: five `entitledCodexAccountIdsForModel` sites, six `availableAccountGatedNativeModels`, two cached-projection calls. No raw grant projection remains. No cross-account, expired-entry, missing-minimum, or unknown-as-granted path was found.

Focused suites: 103 pass / 0 fail across entitlements, convergence selectors, and native model toggle. `bun run typecheck` clean. Full Linux suite at this exact head is running and will be reported before merge.

## Checklist

- [x] Tests added, driven red-first
- [x] `bun run typecheck` passes
- [x] `bun run privacy:scan` passes
- [x] Targets `dev`
- [x] No user-facing surface change, so no docs update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved availability checks for account-gated native models.
  - Models are now shown only when the selected account has confirmed access.
  - Prevented models from being incorrectly denied when entitlement information may be outdated due to client-version differences.
  - Improved handling of uncertain entitlement status to avoid prematurely hiding newly available models.
- **Tests**
  - Added coverage for entitlement states, version compatibility, missing models, and unconfirmed access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->