### PR TITLE
feat(management): expose OpenAI entitlement status

### DIFF
--- a/gui/src/models-groups.ts
+++ b/gui/src/models-groups.ts
@@ -8,6 +8,17 @@ export type ProviderDiscoverySummary =
       httpStatus?: never;
     };
 
+export type ProviderEntitlementSummary =
+  | { status: "unavailable" }
+  | { status: "fresh" }
+  | { status: "unconfirmed-empty" }
+  | {
+      status: "failed";
+      reason: "http-error" | "timeout" | "unparseable";
+      httpStatus?: number;
+    }
+  | { status: "expired-refresh-in-flight" };
+
 export interface ConfiguredProviderSummary {
   name: string;
   authMode?: string;
@@ -17,6 +28,7 @@ export interface ConfiguredProviderSummary {
   contextWindow?: number;
   modelContextWindows?: Record<string, number>;
   discovery?: ProviderDiscoverySummary;
+  entitlement?: ProviderEntitlementSummary;
 }
 
 export interface ProviderModelGroup<Row> {
@@ -37,6 +49,7 @@ export interface ProviderModelGroup<Row> {
   contextWindow?: number;
   modelContextWindows?: Record<string, number>;
   discovery?: ProviderDiscoverySummary;
+  entitlement?: ProviderEntitlementSummary;
 }
 
 export function buildProviderModelGroups<Row extends { provider: string; native?: boolean }>(
@@ -73,6 +86,7 @@ export function buildProviderModelGroups<Row extends { provider: string; native?
         contextWindow: configured?.contextWindow,
         modelContextWindows: configured?.modelContextWindows,
         discovery: configured?.discovery,
+        entitlement: configured?.entitlement,
       };
     })
     .sort((a, b) => {

--- a/gui/src/models-groups.ts
+++ b/gui/src/models-groups.ts
@@ -12,10 +12,11 @@ export type ProviderEntitlementSummary =
   | { status: "unavailable" }
   | { status: "fresh" }
   | { status: "unconfirmed-empty" }
+  | { status: "failed"; reason: "http-error"; httpStatus: number }
   | {
       status: "failed";
-      reason: "http-error" | "timeout" | "unparseable";
-      httpStatus?: number;
+      reason: "network-error" | "timeout" | "unparseable";
+      httpStatus?: never;
     }
   | { status: "expired-refresh-in-flight" };
 

--- a/gui/tests/models-native-group-controls.test.ts
+++ b/gui/tests/models-native-group-controls.test.ts
@@ -23,6 +23,16 @@ test("a provider with no native rows is not a native group", () => {
   expect(groups[0]!.nativeProviderGroup).toBe(false);
 });
 
+test("the native provider group carries the additive entitlement diagnostic", () => {
+  const entitlement = { status: "failed", reason: "timeout" } as const;
+  const groups = buildProviderModelGroups(
+    [nativeRow("gpt-5.6-sol")],
+    [{ name: "openai", entitlement }],
+  );
+
+  expect(groups[0]!.entitlement).toEqual(entitlement);
+});
+
 test("the native card keeps sorting first once a custom row joins it", () => {
   const groups = buildProviderModelGroups(
     [{ provider: "anthropic", id: "opus", native: false }, nativeRow("gpt-5.6-sol"), customRow("gpt-5.4")],

--- a/src/codex/model-entitlements.ts
+++ b/src/codex/model-entitlements.ts
@@ -284,6 +284,23 @@ export interface CodexModelEntitlementCredentialSnapshot {
   readonly credentialIdentity: string;
 }
 
+export type CodexModelEntitlementProvenance =
+  | { readonly kind: "parsed-empty" }
+  | { readonly kind: "http-error"; readonly httpStatus?: number }
+  | { readonly kind: "timeout" }
+  | { readonly kind: "unparseable" };
+
+export type CodexModelEntitlementStatus =
+  | { readonly status: "unavailable" }
+  | { readonly status: "fresh" }
+  | { readonly status: "unconfirmed-empty" }
+  | {
+      readonly status: "failed";
+      readonly reason: Exclude<CodexModelEntitlementProvenance["kind"], "parsed-empty">;
+      readonly httpStatus?: number;
+    }
+  | { readonly status: "expired-refresh-in-flight" };
+
 interface CachedAccountModels {
   readonly credentialIdentity: string;
   /**
@@ -295,6 +312,7 @@ interface CachedAccountModels {
   readonly expiresAt: number;
   readonly models: ReadonlySet<string>;
   readonly confirmed: boolean;
+  readonly provenance?: CodexModelEntitlementProvenance;
 }
 
 export interface CodexModelEntitlementSnapshot {
@@ -483,6 +501,26 @@ function parseAccountModels(text: string): ReadonlySet<string> | null {
   }
 }
 
+function unconfirmedAccountModels(
+  credential: CodexModelEntitlementCredentialSnapshot,
+  clientVersion: string,
+  now: number,
+  provenance: CodexModelEntitlementProvenance,
+): CachedAccountModels {
+  return {
+    credentialIdentity: credential.credentialIdentity,
+    clientVersion,
+    expiresAt: now + MODEL_ROSTER_FAILURE_TTL_MS,
+    models: new Set(),
+    confirmed: false,
+    provenance,
+  };
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
+
 async function fetchAccountModels(
   credential: CodexModelEntitlementCredentialSnapshot,
   fetcher: typeof fetch,
@@ -507,9 +545,19 @@ async function fetchAccountModels(
       maxBytes: MODEL_ROSTER_MAX_BYTES,
       fatalUtf8: true,
     });
-    const models = response.ok && body.displaySafe && !body.truncated
-      ? parseAccountModels(body.text)
-      : null;
+    if (!response.ok) {
+      return unconfirmedAccountModels(credential, clientVersion, now, {
+        kind: "http-error",
+        httpStatus: response.status,
+      });
+    }
+    if (!body.displaySafe || body.truncated) {
+      return unconfirmedAccountModels(credential, clientVersion, now, { kind: "unparseable" });
+    }
+    const models = parseAccountModels(body.text);
+    if (models === null) {
+      return unconfirmedAccountModels(credential, clientVersion, now, { kind: "unparseable" });
+    }
     // A roster is a confirmation only when it lists something usable. `models` is a Set, and an
     // empty Set is truthy, so `models !== null` used to call `{"models":[]}` — and a response
     // whose every row was hidden or api-disabled — a confirmed answer, and lock it in for the
@@ -517,28 +565,28 @@ async function fetchAccountModels(
     // account asked under too old a client version answers with no gated rows, and treating
     // that as authoritative is exactly how 2.36.0 denied sol/terra/luna to accounts that own
     // them (#3022). No usable rows means unconfirmed, on the 15s failure TTL, asked again.
-    const usable = models !== null && models.size > 0;
-    const hasUnknownGatedAbsence = usable && [...ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS]
+    const usable = models.size > 0;
+    if (!usable) {
+      return unconfirmedAccountModels(credential, clientVersion, now, { kind: "parsed-empty" });
+    }
+    const hasUnknownGatedAbsence = [...ACCOUNT_GATED_NATIVE_MODEL_MINIMUM_CLIENT_VERSIONS]
       .some(([modelId, minimum]) => (
         !models.has(modelId) && compareClientVersions(clientVersion, minimum) < 0
       ));
     return {
       credentialIdentity: credential.credentialIdentity,
       clientVersion,
-      expiresAt: now + (usable && !hasUnknownGatedAbsence
+      expiresAt: now + (!hasUnknownGatedAbsence
         ? MODEL_ROSTER_TTL_MS
         : MODEL_ROSTER_FAILURE_TTL_MS),
-      models: models ?? new Set(),
-      confirmed: usable,
+      models,
+      confirmed: true,
     };
-  } catch {
-    return {
-      credentialIdentity: credential.credentialIdentity,
-      clientVersion,
-      expiresAt: now + MODEL_ROSTER_FAILURE_TTL_MS,
-      models: new Set(),
-      confirmed: false,
-    };
+  } catch (error) {
+    const provenance = isTimeoutError(error) || isTimeoutError(controller.signal.reason)
+      ? { kind: "timeout" } as const
+      : { kind: "http-error" } as const;
+    return unconfirmedAccountModels(credential, clientVersion, now, provenance);
   } finally {
     clearTimeout(timer);
   }
@@ -798,6 +846,48 @@ export async function ensureCodexEntitlementFreshness(
   } catch {
     // The shared management boundary must degrade to the last confirmed fail-closed projection.
   }
+}
+
+export function getCodexModelEntitlementStatus(
+  config: Pick<OcxConfig, "codexAccounts">,
+  now = Date.now(),
+  clientVersion?: string | null,
+): CodexModelEntitlementStatus {
+  const version = resolveCodexEntitlementClientVersion(clientVersion);
+  const accounts = candidateAccountIds(config).flatMap(accountId => {
+    const credentialIdentity = currentCredentialIdentity(accountId);
+    return credentialIdentity ? [{ accountId, credentialIdentity }] : [];
+  });
+  if (accounts.length === 0) return { status: "unavailable" };
+
+  const entries = accounts.map(({ accountId, credentialIdentity }) => ({
+    accountId,
+    credentialIdentity,
+    entry: accountModelsCache.get(cacheKeyFor(accountId, version)),
+  }));
+  if (entries.some(({ accountId, credentialIdentity, entry }) => (
+    entry
+    && entry.credentialIdentity === credentialIdentity
+    && entry.expiresAt <= now
+    && accountModelsFlights.has(`${accountId}\u0000${credentialIdentity}\u0000${version}`)
+  ))) return { status: "expired-refresh-in-flight" };
+
+  const live = entries.flatMap(({ credentialIdentity, entry }) => (
+    entry && entry.credentialIdentity === credentialIdentity && entry.expiresAt > now ? [entry] : []
+  ));
+  const failed = live.find(entry => entry.provenance && entry.provenance.kind !== "parsed-empty");
+  if (failed?.provenance?.kind === "http-error") {
+    return failed.provenance.httpStatus === undefined
+      ? { status: "failed", reason: "http-error" }
+      : { status: "failed", reason: "http-error", httpStatus: failed.provenance.httpStatus };
+  }
+  if (failed?.provenance?.kind === "timeout") return { status: "failed", reason: "timeout" };
+  if (failed?.provenance?.kind === "unparseable") return { status: "failed", reason: "unparseable" };
+  if (live.some(entry => entry.provenance?.kind === "parsed-empty")) {
+    return { status: "unconfirmed-empty" };
+  }
+  if (live.some(entry => entry.confirmed)) return { status: "fresh" };
+  return { status: "unavailable" };
 }
 
 /**

--- a/src/codex/model-entitlements.ts
+++ b/src/codex/model-entitlements.ts
@@ -540,17 +540,17 @@ async function fetchAccountModels(
       redirect: "error",
       signal: controller.signal,
     });
-    const body = await readBoundedResponseBody(response, {
-      signal: controller.signal,
-      maxBytes: MODEL_ROSTER_MAX_BYTES,
-      fatalUtf8: true,
-    });
     if (!response.ok) {
       return unconfirmedAccountModels(credential, clientVersion, now, {
         kind: "http-error",
         httpStatus: response.status,
       });
     }
+    const body = await readBoundedResponseBody(response, {
+      signal: controller.signal,
+      maxBytes: MODEL_ROSTER_MAX_BYTES,
+      fatalUtf8: true,
+    });
     if (!body.displaySafe || body.truncated) {
       return unconfirmedAccountModels(credential, clientVersion, now, { kind: "unparseable" });
     }
@@ -865,13 +865,16 @@ export function getCodexModelEntitlementStatus(
     credentialIdentity,
     entry: accountModelsCache.get(cacheKeyFor(accountId, version)),
   }));
+  const hasFlight = (accountId: string, credentialIdentity: string): boolean => {
+    const prefix = `${accountId}\u0000${credentialIdentity}\u0000${version}`;
+    return [...accountModelsFlights.keys()].some(key => key === prefix || key.startsWith(`${prefix}\u0000`));
+  };
   if (entries.some(({ accountId, credentialIdentity, entry }) => (
     entry
     && entry.credentialIdentity === credentialIdentity
     && entry.expiresAt <= now
-    && accountModelsFlights.has(`${accountId}\u0000${credentialIdentity}\u0000${version}`)
+    && hasFlight(accountId, credentialIdentity)
   ))) return { status: "expired-refresh-in-flight" };
-
   const live = entries.flatMap(({ credentialIdentity, entry }) => (
     entry && entry.credentialIdentity === credentialIdentity && entry.expiresAt > now ? [entry] : []
   ));

--- a/src/codex/model-entitlements.ts
+++ b/src/codex/model-entitlements.ts
@@ -375,6 +375,9 @@ interface NegativeCredentialMemo {
 interface EntitlementEnsureFlight {
   readonly startedAt: number;
   readonly promise: Promise<void>;
+  readonly clientVersion: string;
+  readonly identityVector: ReadonlyMap<string, string | null>;
+  readonly workset: readonly string[];
 }
 
 const negativeCredentialMemo = new Map<string, NegativeCredentialMemo>();
@@ -836,7 +839,7 @@ export async function ensureCodexEntitlementFreshness(
       }).finally(() => {
         if (entitlementEnsureFlights.get(key) === created) entitlementEnsureFlights.delete(key);
       });
-      created = { startedAt, promise };
+      created = { startedAt, promise, clientVersion, identityVector, workset };
       entitlementEnsureFlights.set(key, created);
       flight = created;
     }
@@ -865,15 +868,18 @@ export function getCodexModelEntitlementStatus(
     credentialIdentity,
     entry: accountModelsCache.get(cacheKeyFor(accountId, version)),
   }));
-  const hasFlight = (accountId: string, credentialIdentity: string): boolean => {
-    const prefix = `${accountId}\u0000${credentialIdentity}\u0000${version}`;
-    return [...accountModelsFlights.keys()].some(key => key === prefix || key.startsWith(`${prefix}\u0000`));
+  const hasRefreshFlight = (accountId: string, credentialIdentity: string): boolean => {
+    return [...entitlementEnsureFlights.values()].some(flight => (
+      flight.clientVersion === version
+      && flight.identityVector.get(accountId) === credentialIdentity
+      && flight.workset.includes(accountId)
+    ));
   };
   if (entries.some(({ accountId, credentialIdentity, entry }) => (
     entry
     && entry.credentialIdentity === credentialIdentity
     && entry.expiresAt <= now
-    && hasFlight(accountId, credentialIdentity)
+    && hasRefreshFlight(accountId, credentialIdentity)
   ))) return { status: "expired-refresh-in-flight" };
   const live = entries.flatMap(({ credentialIdentity, entry }) => (
     entry && entry.credentialIdentity === credentialIdentity && entry.expiresAt > now ? [entry] : []

--- a/src/codex/model-entitlements.ts
+++ b/src/codex/model-entitlements.ts
@@ -286,7 +286,8 @@ export interface CodexModelEntitlementCredentialSnapshot {
 
 export type CodexModelEntitlementProvenance =
   | { readonly kind: "parsed-empty" }
-  | { readonly kind: "http-error"; readonly httpStatus?: number }
+  | { readonly kind: "http-error"; readonly httpStatus: number }
+  | { readonly kind: "network-error" }
   | { readonly kind: "timeout" }
   | { readonly kind: "unparseable" };
 
@@ -294,10 +295,11 @@ export type CodexModelEntitlementStatus =
   | { readonly status: "unavailable" }
   | { readonly status: "fresh" }
   | { readonly status: "unconfirmed-empty" }
+  | { readonly status: "failed"; readonly reason: "http-error"; readonly httpStatus: number }
   | {
       readonly status: "failed";
-      readonly reason: Exclude<CodexModelEntitlementProvenance["kind"], "parsed-empty">;
-      readonly httpStatus?: number;
+      readonly reason: Exclude<CodexModelEntitlementProvenance["kind"], "parsed-empty" | "http-error">;
+      readonly httpStatus?: never;
     }
   | { readonly status: "expired-refresh-in-flight" };
 
@@ -588,7 +590,7 @@ async function fetchAccountModels(
   } catch (error) {
     const provenance = isTimeoutError(error) || isTimeoutError(controller.signal.reason)
       ? { kind: "timeout" } as const
-      : { kind: "http-error" } as const;
+      : { kind: "network-error" } as const;
     return unconfirmedAccountModels(credential, clientVersion, now, provenance);
   } finally {
     clearTimeout(timer);
@@ -884,12 +886,12 @@ export function getCodexModelEntitlementStatus(
   const live = entries.flatMap(({ credentialIdentity, entry }) => (
     entry && entry.credentialIdentity === credentialIdentity && entry.expiresAt > now ? [entry] : []
   ));
+  // Deliberate failure-first aggregation keeps a partial Pool refresh failure visible.
   const failed = live.find(entry => entry.provenance && entry.provenance.kind !== "parsed-empty");
   if (failed?.provenance?.kind === "http-error") {
-    return failed.provenance.httpStatus === undefined
-      ? { status: "failed", reason: "http-error" }
-      : { status: "failed", reason: "http-error", httpStatus: failed.provenance.httpStatus };
+    return { status: "failed", reason: "http-error", httpStatus: failed.provenance.httpStatus };
   }
+  if (failed?.provenance?.kind === "network-error") return { status: "failed", reason: "network-error" };
   if (failed?.provenance?.kind === "timeout") return { status: "failed", reason: "timeout" };
   if (failed?.provenance?.kind === "unparseable") return { status: "failed", reason: "unparseable" };
   if (live.some(entry => entry.provenance?.kind === "parsed-empty")) {

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -53,6 +53,7 @@ import { codexAccountNamespaceProviderCollisionError } from "../../codex/account
 import { clearThreadAccountMap } from "../../codex/routing";
 import { primeCodexPoolQuotas } from "../../codex/auth-api";
 import { clearModelCache, getProviderDiscoveryStatus } from "../../codex/model-cache";
+import { getCodexModelEntitlementStatus } from "../../codex/model-entitlements";
 import { DEFAULT_PROVIDER_CONTEXT_CAP, globalContextCapValue, providerContextCap, providerContextCaps, setAllProviderContextCaps, setGlobalContextCapValue, setProviderContextCap } from "../../providers/context-cap";
 import { modelAutoCompactTokenLimitsConfigError } from "../../providers/auto-compact-budget";
 import { resolveCodexHomeDir } from "../../codex/home";
@@ -474,6 +475,9 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       codexAccountMode: providerCodexAccountMode(name, p),
       ...(name === "xai" ? { xaiResponsesOptInState: xaiResponsesOptInState(p) } : {}),
       discovery: p.liveModels === false ? undefined : getProviderDiscoveryStatus(name),
+      ...(name === "openai" && isCanonicalOpenAiForwardProvider(p)
+        ? { entitlement: getCodexModelEntitlementStatus(config) }
+        : {}),
     })));
   }
 

--- a/tests/codex-model-entitlements.test.ts
+++ b/tests/codex-model-entitlements.test.ts
@@ -145,6 +145,51 @@ describe("Codex account model entitlements", () => {
     }
   });
 
+  test("reports an expired roster while its refresh remains in flight", async () => {
+    const isolated = installIsolatedCodexHome("ocx-entitlement-in-flight-");
+    const accountId = "pool-in-flight";
+    const config = {
+      codexAccounts: [{ id: accountId, email: "pool-in-flight@example.test", isMain: false }],
+    };
+    let releaseRefresh: ((response: Response) => void) | undefined;
+    let refresh: ReturnType<typeof resolveCodexModelEntitlements> | undefined;
+    try {
+      saveCodexAccountCredential(accountId, {
+        accessToken: "in-flight-access",
+        refreshToken: "in-flight-refresh",
+        expiresAt: Date.now() + 60_000,
+        chatgptAccountId: "chatgpt-in-flight",
+      });
+      const generation = readCodexAccountRecord(accountId)!.generation;
+      const storedCredential: CodexModelEntitlementCredentialSnapshot = {
+        accountId,
+        accessToken: "in-flight-access",
+        chatgptAccountId: "chatgpt-in-flight",
+        credentialIdentity: `pool:${generation}:chatgpt-in-flight`,
+      };
+      await resolveCodexModelEntitlements(config, {
+        credentials: [storedCredential],
+        fetcher: (async () => roster(SOL)) as typeof fetch,
+        now: 1_000,
+        clientVersion: TEST_CLIENT_VERSION,
+      });
+
+      const pendingResponse = new Promise<Response>(resolve => { releaseRefresh = resolve; });
+      refresh = resolveCodexModelEntitlements(config, {
+        credentials: [storedCredential],
+        fetcher: (async () => pendingResponse) as typeof fetch,
+        now: 301_001,
+        clientVersion: TEST_CLIENT_VERSION,
+      });
+      expect(getCodexModelEntitlementStatus(config, 301_001, TEST_CLIENT_VERSION))
+        .toEqual({ status: "expired-refresh-in-flight" });
+    } finally {
+      releaseRefresh?.(roster(SOL));
+      await refresh;
+      isolated.restore();
+    }
+  });
+
   test("keeps account-gated models scoped to the authenticated account roster", async () => {
     const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
       credentials: [credential("main"), credential("secondary")],

--- a/tests/codex-model-entitlements.test.ts
+++ b/tests/codex-model-entitlements.test.ts
@@ -145,51 +145,6 @@ describe("Codex account model entitlements", () => {
     }
   });
 
-  test("reports an expired roster while its refresh remains in flight", async () => {
-    const isolated = installIsolatedCodexHome("ocx-entitlement-in-flight-");
-    const accountId = "pool-in-flight";
-    const config = {
-      codexAccounts: [{ id: accountId, email: "pool-in-flight@example.test", isMain: false }],
-    };
-    let releaseRefresh: ((response: Response) => void) | undefined;
-    let refresh: ReturnType<typeof resolveCodexModelEntitlements> | undefined;
-    try {
-      saveCodexAccountCredential(accountId, {
-        accessToken: "in-flight-access",
-        refreshToken: "in-flight-refresh",
-        expiresAt: Date.now() + 60_000,
-        chatgptAccountId: "chatgpt-in-flight",
-      });
-      const generation = readCodexAccountRecord(accountId)!.generation;
-      const storedCredential: CodexModelEntitlementCredentialSnapshot = {
-        accountId,
-        accessToken: "in-flight-access",
-        chatgptAccountId: "chatgpt-in-flight",
-        credentialIdentity: `pool:${generation}:chatgpt-in-flight`,
-      };
-      await resolveCodexModelEntitlements(config, {
-        credentials: [storedCredential],
-        fetcher: (async () => roster(SOL)) as typeof fetch,
-        now: 1_000,
-        clientVersion: TEST_CLIENT_VERSION,
-      });
-
-      const pendingResponse = new Promise<Response>(resolve => { releaseRefresh = resolve; });
-      refresh = resolveCodexModelEntitlements(config, {
-        credentials: [storedCredential],
-        fetcher: (async () => pendingResponse) as typeof fetch,
-        now: 301_001,
-        clientVersion: TEST_CLIENT_VERSION,
-      });
-      expect(getCodexModelEntitlementStatus(config, 301_001, TEST_CLIENT_VERSION))
-        .toEqual({ status: "expired-refresh-in-flight" });
-    } finally {
-      releaseRefresh?.(roster(SOL));
-      await refresh;
-      isolated.restore();
-    }
-  });
-
   test("keeps account-gated models scoped to the authenticated account roster", async () => {
     const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
       credentials: [credential("main"), credential("secondary")],
@@ -531,6 +486,48 @@ describe("ensureCodexEntitlementFreshness", () => {
       credentialIdentity: `main:${parsed.tokens.account_id}`,
     };
   };
+
+  test("reports an expired roster during outer-flight credential acquisition", async () => {
+    const accountId = "pool-outer-flight";
+    const config = poolConfig(accountId);
+    savePoolCredential(accountId, "outer-flight");
+    const baseOptions = {
+      clientVersion: TEST_CLIENT_VERSION,
+      fetcher: (async () => roster(SOL)) as typeof fetch,
+    };
+    await ensureCodexEntitlementFreshness(config, {
+      ...baseOptions,
+      waitMs: 1_000,
+      now: 1_000,
+      credentialSnapshot: storedCredentialSnapshot,
+    });
+
+    const credentialReadStarted = deferred();
+    const releaseCredentialRead = deferred();
+    const blockedCredentialSnapshot = async (
+      candidateAccountId: string,
+    ): Promise<CodexModelEntitlementCredentialSnapshot | null> => {
+      if (candidateAccountId !== accountId) return null;
+      credentialReadStarted.resolve();
+      await releaseCredentialRead.promise;
+      return storedCredentialSnapshot(candidateAccountId);
+    };
+    const refreshOptions = {
+      ...baseOptions,
+      waitMs: 0,
+      now: 301_001,
+      credentialSnapshot: blockedCredentialSnapshot,
+    };
+    try {
+      await ensureCodexEntitlementFreshness(config, refreshOptions);
+      await credentialReadStarted.promise;
+      expect(getCodexModelEntitlementStatus(config, 301_001, TEST_CLIENT_VERSION))
+        .toEqual({ status: "expired-refresh-in-flight" });
+    } finally {
+      releaseCredentialRead.resolve();
+      await ensureCodexEntitlementFreshness(config, { ...refreshOptions, waitMs: 1_000 });
+    }
+  });
 
   test("a fresh ensure uses identity reads but performs zero full credential snapshots or network calls", async () => {
     savePoolCredential("pool-fresh", "fresh");

--- a/tests/codex-model-entitlements.test.ts
+++ b/tests/codex-model-entitlements.test.ts
@@ -116,6 +116,11 @@ describe("Codex account model entitlements", () => {
           expected: { status: "failed", reason: "http-error", httpStatus: 503 },
         },
         {
+          name: "network-error",
+          fetcher: (async () => { throw new TypeError("connection refused"); }) as typeof fetch,
+          expected: { status: "failed", reason: "network-error" },
+        },
+        {
           name: "timeout",
           fetcher: (async () => { throw new DOMException("timed out", "TimeoutError"); }) as typeof fetch,
           expected: { status: "failed", reason: "timeout" },
@@ -140,6 +145,37 @@ describe("Codex account model entitlements", () => {
           testCase.name,
         ).toEqual(testCase.expected);
       }
+    } finally {
+      isolated.restore();
+    }
+  });
+
+  test("default entitlement status uses the same client-version cache key as resolution", async () => {
+    const isolated = installIsolatedCodexHome("ocx-entitlement-default-version-");
+    const accountId = "pool-default-version";
+    const config = {
+      codexAccounts: [{ id: accountId, email: "pool-default-version@example.test", isMain: false }],
+    };
+    try {
+      saveCodexAccountCredential(accountId, {
+        accessToken: "default-version-access",
+        refreshToken: "default-version-refresh",
+        expiresAt: Date.now() + 60_000,
+        chatgptAccountId: "chatgpt-default-version",
+      });
+      const generation = readCodexAccountRecord(accountId)!.generation;
+      await resolveCodexModelEntitlements(config, {
+        credentials: [{
+          accountId,
+          accessToken: "default-version-access",
+          chatgptAccountId: "chatgpt-default-version",
+          credentialIdentity: `pool:${generation}:chatgpt-default-version`,
+        }],
+        fetcher: (async () => roster(SOL)) as typeof fetch,
+        now: 1_000,
+      });
+
+      expect(getCodexModelEntitlementStatus(config, 1_001)).toEqual({ status: "fresh" });
     } finally {
       isolated.restore();
     }

--- a/tests/codex-model-entitlements.test.ts
+++ b/tests/codex-model-entitlements.test.ts
@@ -14,6 +14,7 @@ import {
   ensureCodexEntitlementFreshness,
   entitledCodexAccountIdsForModel,
   GATED_MODEL_CLIENT_VERSION_FLOOR,
+  getCodexModelEntitlementStatus,
   isDirectCallerEntitledToCodexModel,
   isUsableCodexClientVersion,
   memoizeRuntimeVersionForTests,
@@ -35,6 +36,8 @@ import {
 import { clearCodexRuntimeResolveCache, loadPersistedCodexRuntime } from "../src/codex/runtime";
 import { ACCOUNT_GATED_NATIVE_OPENAI_MODELS } from "../src/codex/catalog/native-models";
 import upstreamModelsSnapshot from "../src/codex/data/upstream-models.json";
+import { readCodexAccountRecord, saveCodexAccountCredential } from "../src/codex/account-store";
+import { installIsolatedCodexHome } from "./helpers/isolated-codex-home";
 
 const TEST_CLIENT_VERSION = "0.146.0";
 const DAYBREAK = "gpt-daybreak-blue-latest";
@@ -77,6 +80,71 @@ function deferred<T = void>(): {
 beforeEach(() => resetCodexModelEntitlementCacheForTests());
 
 describe("Codex account model entitlements", () => {
+  test("keeps parsed-empty distinct from refresh failures end to end", async () => {
+    const isolated = installIsolatedCodexHome("ocx-entitlement-provenance-");
+    const accountId = "pool-provenance";
+    const config = {
+      codexAccounts: [{ id: accountId, email: "pool-provenance@example.test", isMain: false }],
+    };
+    try {
+      saveCodexAccountCredential(accountId, {
+        accessToken: "provenance-access",
+        refreshToken: "provenance-refresh",
+        expiresAt: Date.now() + 60_000,
+        chatgptAccountId: "chatgpt-provenance",
+      });
+      const generation = readCodexAccountRecord(accountId)!.generation;
+      const storedCredential: CodexModelEntitlementCredentialSnapshot = {
+        accountId,
+        accessToken: "provenance-access",
+        chatgptAccountId: "chatgpt-provenance",
+        credentialIdentity: `pool:${generation}:chatgpt-provenance`,
+      };
+      const cases: Array<{
+        name: string;
+        fetcher: typeof fetch;
+        expected: Record<string, unknown>;
+      }> = [
+        {
+          name: "parsed-empty",
+          fetcher: (async () => Response.json({ models: [] })) as typeof fetch,
+          expected: { status: "unconfirmed-empty" },
+        },
+        {
+          name: "http-error",
+          fetcher: (async () => new Response("upstream failed", { status: 503 })) as typeof fetch,
+          expected: { status: "failed", reason: "http-error", httpStatus: 503 },
+        },
+        {
+          name: "timeout",
+          fetcher: (async () => { throw new DOMException("timed out", "TimeoutError"); }) as typeof fetch,
+          expected: { status: "failed", reason: "timeout" },
+        },
+        {
+          name: "unparseable",
+          fetcher: (async () => new Response("not-json")) as typeof fetch,
+          expected: { status: "failed", reason: "unparseable" },
+        },
+      ];
+
+      for (const testCase of cases) {
+        resetCodexModelEntitlementCacheForTests();
+        await resolveCodexModelEntitlements(config, {
+          credentials: [storedCredential],
+          fetcher: testCase.fetcher,
+          now: 1_000,
+          clientVersion: TEST_CLIENT_VERSION,
+        });
+        expect(
+          getCodexModelEntitlementStatus(config, 1_001, TEST_CLIENT_VERSION),
+          testCase.name,
+        ).toEqual(testCase.expected);
+      }
+    } finally {
+      isolated.restore();
+    }
+  });
+
   test("keeps account-gated models scoped to the authenticated account roster", async () => {
     const snapshot = await resolveCodexModelEntitlements({ codexAccounts: [] }, {
       credentials: [credential("main"), credential("secondary")],

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -3,7 +3,7 @@ import { managementFetch as fetch, ManagementRequest as Request } from "./helper
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { saveCodexAccountCredential } from "../src/codex/account-store";
+import { readCodexAccountRecord, saveCodexAccountCredential } from "../src/codex/account-store";
 import { getTrackedCodexWebSocketCountForAccount } from "../src/codex/websocket-registry";
 import { clearAccountNeedsReauth, clearAccountQuota, getAccountQuota, isAccountNeedsReauth, markAccountNeedsReauth, updateAccountQuota } from "../src/codex/auth-api";
 import {
@@ -32,7 +32,12 @@ import { handleManagementAPI } from "../src/server/management-api";
 import { providerManagementConfigError } from "../src/server/auth-cors";
 import { providerEmptyToolOutputConfigError } from "../src/config/provider-validation";
 import { providerServiceTierConfigError, withProviderServiceTierDTO } from "../src/server/management/provider-capability-config";
-import { clearModelCache, markProviderDiscoveryFailed } from "../src/codex/model-cache";
+import { clearModelCache, markProviderDiscoveryFailed, markProviderDiscoveryOk } from "../src/codex/model-cache";
+import {
+  resetCodexModelEntitlementCacheForTests,
+  resolveCodexModelEntitlements,
+  type CodexModelEntitlementCredentialSnapshot,
+} from "../src/codex/model-entitlements";
 import type { OcxConfig } from "../src/types";
 import { fakeChatGptJwt } from "./helpers/fake-chatgpt-jwt";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
@@ -686,6 +691,77 @@ describe("provider management validation", () => {
       expect(providers.find(provider => provider.name === "not-attempted"))
         .not.toHaveProperty("discovery");
     } finally {
+      clearModelCache();
+    }
+  });
+
+  test("provider discovery stays ok while entitlement status changes independently", async () => {
+    const accountId = "pool-entitlement-diagnostic";
+    const now = Date.now();
+    const liveConfig: OcxConfig = {
+      port: 10100,
+      defaultProvider: "openai",
+      providers: poolProviders(),
+      codexAccounts: [{
+        id: accountId,
+        email: "pool-entitlement-diagnostic@example.test",
+        isMain: false,
+      }],
+    };
+    saveCodexAccountCredential(accountId, {
+      accessToken: "entitlement-diagnostic-access",
+      refreshToken: "entitlement-diagnostic-refresh",
+      expiresAt: now + 60_000,
+      chatgptAccountId: "chatgpt-entitlement-diagnostic",
+    });
+    const generation = readCodexAccountRecord(accountId)!.generation;
+    const storedCredential: CodexModelEntitlementCredentialSnapshot = {
+      accountId,
+      accessToken: "entitlement-diagnostic-access",
+      chatgptAccountId: "chatgpt-entitlement-diagnostic",
+      credentialIdentity: `pool:${generation}:chatgpt-entitlement-diagnostic`,
+    };
+    const readOpenAi = async (config: OcxConfig): Promise<Record<string, unknown>> => {
+      const requestUrl = new URL("http://127.0.0.1/api/providers");
+      const response = await handleManagementAPI(new Request(requestUrl), requestUrl, config);
+      const providers = await response!.json() as Array<Record<string, unknown>>;
+      return providers.find(provider => provider.name === "openai")!;
+    };
+
+    markProviderDiscoveryOk("openai", 1);
+    try {
+      await resolveCodexModelEntitlements(liveConfig, {
+        credentials: [storedCredential],
+        fetcher: (async () => Response.json({ models: [{
+          slug: "gpt-5.6-sol",
+          supported_in_api: true,
+          visibility: "list",
+        }] })) as typeof fetch,
+        now,
+      });
+      expect(await readOpenAi(liveConfig)).toMatchObject({
+        discovery: { status: "ok" },
+        entitlement: { status: "fresh" },
+      });
+
+      resetCodexModelEntitlementCacheForTests();
+      await resolveCodexModelEntitlements(liveConfig, {
+        credentials: [storedCredential],
+        fetcher: (async () => new Response("upstream failed", { status: 503 })) as typeof fetch,
+        now,
+      });
+      expect(await readOpenAi(liveConfig)).toMatchObject({
+        discovery: { status: "ok" },
+        entitlement: { status: "failed", reason: "http-error", httpStatus: 503 },
+      });
+
+      resetCodexModelEntitlementCacheForTests();
+      expect(await readOpenAi({ ...liveConfig, codexAccounts: [] })).toMatchObject({
+        discovery: { status: "ok" },
+        entitlement: { status: "unavailable" },
+      });
+    } finally {
+      resetCodexModelEntitlementCacheForTests();
       clearModelCache();
     }
   });


### PR DESCRIPTION
> **Stacked on #3057** (`codex/wp5-tristate-work`). Retarget to `dev` once the parent lands.

## Summary

While entitled rows were missing in #3023, `GET /api/providers` still reported `discovery: {"status":"ok"}`. The reporter read that as the proxy lying about its own state.

It was not lying — it was answering a different question. `discovery` is written by routed-provider discovery and entitlement resolution never touches it, so routed discovery genuinely was ok. The real problem is that **nothing anywhere reported entitlement freshness**, so an operator had no way to tell "this account owns nothing" from "we could not ask".

Two ordered changes:

**Provenance first.** The parsed-empty success path and the catch path both produced `{models: new Set(), confirmed: false}` — byte-identical cache entries. Nothing downstream could distinguish an empty roster from a network failure. Provenance is now a discriminated field: `parsed-empty` | `http-error` | `timeout` | `unparseable`. Without this, reporting the two states separately would have been a fabricated distinction.

**Then the diagnostic.** An additive `entitlement` sibling on `GET /api/providers` for canonical OpenAI, with a matching GUI contract type. States: `unavailable`, `fresh`, `unconfirmed-empty`, `failed`, `expired-refresh-in-flight`.

Three constraints held deliberately:

- `discovery` is not overloaded. It is legitimately `ok` at the same moment entitlement is `failed`, and erasing that would repeat the original defect in a new field.
- `GET /api/models` keeps its bare-array shape, because `gui/src/pages/Models.tsx` and `src/cli/export-command.ts` both depend on it.
- There is no "confirmed genuinely empty" state. The roster contract carries no completeness marker, so the system cannot honestly distinguish an account owning nothing from an unusable empty answer. `unconfirmed-empty` says only what is known.

## Verification

Red-first: missing `getCodexModelEntitlementStatus` export; `Expected entitlement {status:"fresh"} / Received no entitlement field`; GUI `Expected {status:"failed", reason:"timeout"} / Received undefined`; `Expected {status:"expired-refresh-in-flight"} / Received {status:"unavailable"}`.

The required regression holds `discovery: ok` constant while entitlement moves through `fresh`, `failed` and `unavailable`. Independent review reproduced the red by deleting only the entitlement projection and confirmed `discovery` stayed `ok` — the independence of the two fields is the entire point of this phase.

One correction came out of the stack rebase: `expired-refresh-in-flight` originally observed the inner `accountModelsFlights`, but #3054's outer `entitlementEnsureFlights` begins before credential acquisition. During slow acquisition the diagnostic would have reported `unavailable` when the truthful answer was `expired-refresh-in-flight` — exactly the dishonest-status class this phase exists to remove. Rewired to the outer flight with a regression driven through `ensureCodexEntitlementFreshness`.

Focused: 126 pass / 0 fail across entitlements and provider validation, GUI grouping 8 pass, `bun run typecheck` clean, GUI production build succeeds. Full Linux suite at the exact head will be reported before merge.

The diagnostic is read-only: grant projection still requires confirmed evidence and model membership, and provenance never widens exposure.

## Checklist

- [x] Tests added, driven red-first
- [x] `bun run typecheck` passes
- [x] `bun run privacy:scan` passes
- [x] Stacked on an open PR per the stacked-child workflow
- [x] No GUI visual change (contract type only), so no screenshot applies




## On the UI screenshot requirement

The gate asks for a screenshot because `gui/` is touched. There is nothing to screenshot: this change renders no pixels.

The entire GUI diff is 24 added lines across two files, and every one of them is a type declaration or a field passthrough:

```
gui/src/models-groups.ts                       | 14 ++++++++++++++
gui/tests/models-native-group-controls.test.ts | 10 ++++++++++
```

In `gui/src/models-groups.ts`: a new `ProviderEntitlementSummary` union type, an optional `entitlement?` field on `ConfiguredProviderSummary` and `ProviderModelGroup`, and one line in `buildProviderModelGroups` copying `configured?.entitlement` through to the group. No component, no JSX, no styling, no layout, and no string that reaches the screen. The remaining 10 lines are a unit test asserting that passthrough.

The field is plumbed now so the backend contract and the GUI type cannot drift apart. Whatever renders it later is a separate change, and that one will carry a screenshot.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added entitlement status details to provider information, including fresh, unavailable, expired, and failure states.
  - Added diagnostic reasons for entitlement failures, such as network errors, timeouts, HTTP errors, and invalid responses.
  - Provider model groups now retain entitlement information for display and inspection.

- **Bug Fixes**
  - Improved reporting when model rosters are empty, expired, or being refreshed.
  - Provider discovery status now remains independent from model entitlement status.

- **Tests**
  - Added coverage for entitlement status transitions, failure reasons, cache behavior, and provider data propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->