### PR TITLE
docs(maintainers): correct the claim that this repository is unprotected

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,8 +305,11 @@ repository CI; a maintainer has to — so the gate never disproves it; a new
 push still resets every box. A disproved claim unticks the matching box and
 keeps the PR a draft.
 Authors with repository push permission skip the ancestry heuristic only. As with approval requirements in
-[`MAINTAINERS.md`](./MAINTAINERS.md), this is enforced by convention until
-branch protection is configured.
+[`MAINTAINERS.md`](./MAINTAINERS.md), the ancestry heuristic is a CI check
+rather than a branch rule. The branches themselves are protected: `dev`,
+`main`, and `preview` each carry an active ruleset requiring a reviewed pull
+request and blocking force-pushes and deletion, so a direct push to `dev` is
+rejected regardless of `--no-verify`.
 
 [`MAINTAINERS.md`](./MAINTAINERS.md) is authoritative for review and merge
 policy (approvals, CI requirements, security review, promotion). This file

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -52,8 +52,8 @@ when a maintainer steps down.
   a new push still resets every box. A disproved claim unticks the matching
   box and keeps the PR a draft.
   Authors with repository push permission skip the ancestry heuristic only. As
-  with the approval requirement above, this is enforced by convention until
-  branch protection is configured (see the note under the change log).
+  with the approval requirement above, this part is enforced by convention;
+  the ruleset does not check ancestry (see the note under the change log).
 - A pull request requires approval from at least one maintainer and successful required CI checks
   before merge.
 - Authors do not approve their own pull requests.
@@ -160,11 +160,21 @@ Adding or removing a maintainer requires:
   and release automation keep the two owners already listed for those paths, so
   this addition does not widen the review surface for them.
 
-  CODEOWNERS requests reviews rather than enforcing them — no branch protection
-  rule is configured on this repository, so code-owner approval is a convention
-  here, not a gate. The same is true of the approval requirement in the review
-  and merge policy above. Widening the security boundary, or enforcing either
-  of these through branch protection, is a separate decision.
+  Code-owner approval and the maintainer-approval requirement above are both
+  enforced, not conventions. `dev`, `main`, and `preview` each carry an active
+  repository ruleset — the classic `/branches/{branch}/protection` endpoint
+  returns 404 for them, which is why this file long described the repository as
+  unprotected. `Protect dev` (id 20763889) requires a pull request with one
+  approving review, code-owner review, and extra approval for unattributed
+  changes, and it blocks deletion and non-fast-forward pushes. Allowed merge
+  methods are merge and squash; rebase merges are off.
+
+  The one carve-out is that the `maintain`/`admin` repository role holds a
+  `pull_request` bypass, so an owner can merge without the approval the rules
+  otherwise require. That is a bypass, not an exemption: "Authors do not approve
+  their own pull requests" above still governs, and an owner who uses the bypass
+  should record it on the pull request rather than leave it to be inferred from
+  a merge timestamp. Widening the security boundary is a separate decision.
 
 ## Security reports
 


### PR DESCRIPTION
## Summary

`MAINTAINERS.md` stated that no branch protection rule is configured on this
repository, and concluded that code-owner approval and the maintainer-approval
requirement are "a convention here, not a gate". `AGENTS.md` repeated the same
claim. Both are inaccurate: `dev`, `main`, and `preview` each carry an active
repository ruleset. `Protect dev` (id 20763889) requires a pull request with one
approving review, code-owner review, and extra approval for unattributed
changes, and blocks deletion and non-fast-forward pushes.

The mistake was an easy one to make and worth recording: rulesets do not appear
in the classic `/branches/{branch}/protection` endpoint, which returns 404 for
all three branches, so verifying the old way confirmed the sentence.

Two consequences were being mis-stated. A reader was told a direct push to `dev`
would land, when it is rejected regardless of `--no-verify`. And the
`maintain`/`admin` role's `pull_request` bypass was undocumented, so an owner
merge that skips the approval requirement read as the documented normal case
rather than an exercised bypass. The note now names it a bypass rather than an
exemption and asks that its use be recorded on the pull request.

The ancestry heuristic genuinely is convention, since it is a CI check rather
than a branch rule, so that sentence is narrowed instead of reversed.

Found by an adversarial pre-merge audit of the #3047-#3050 stack (HIGH-1).
Docs only; no runtime or workflow code changes.

## Verification

- `gh api repos/lidge-jun/opencodex/rulesets` and `.../rulesets/20763889` to read
  the live enforcement state and parameters that this text now describes.
- `bun x tsc --noEmit` clean.
- `bun test tests/assert-mergeable-review.test.ts tests/ci-workflows.test.ts
  tests/repo-hygiene.test.ts tests/codex-prompt-text-probe.test.ts
  tests/bump-dev-version.test.ts tests/codex-prompt-route.test.ts` gives
  270 pass / 0 fail (these are the suites that read these two documents).
- `bun run privacy:scan` passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated branch policy guidance to reflect active protections for `dev`, `main`, and `preview`.
  * Clarified that direct pushes, force-pushes, and branch deletion are restricted.
  * Documented pull request review requirements, permitted merge methods, and approved administrative exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->