### PR TITLE
test(shutdown): give the launcher startup wait room on a loaded runner

### DIFF
--- a/tests/shutdown-launcher.test.ts
+++ b/tests/shutdown-launcher.test.ts
@@ -107,7 +107,11 @@ describe.skipIf(!runnable)("ocx launcher graceful shutdown", () => {
         child.on("exit", () => { exited = true; });
 
         // 1. Proxy comes up + injected the Codex config (Design B root override on loopback).
-        const up = await waitUntil(() => healthy(port), 20_000);
+        // Startup is a cold `node bin/ocx.mjs start` spawn, and this file runs three of them
+        // back to back. On a loaded runner the 20s ceiling was the failure: observed failures
+        // land at 20061ms and 20168ms, i.e. the budget itself, not a hang. Startup time is not
+        // what any assertion here is about — the teardown behaviour after the signal is.
+        const up = await waitUntil(() => healthy(port), 90_000);
         expect(up).toBe(true);
         expect(existsSync(join(home, "ocx.pid"))).toBe(true);
         const injected = readFileSync(codexConfig, "utf8");
@@ -131,7 +135,9 @@ describe.skipIf(!runnable)("ocx launcher graceful shutdown", () => {
         expect(existsSync(join(home, "runtime-port.json"))).toBe(false);
         expect(readFileSync(codexConfig, "utf8")).not.toContain("opencodex");
       },
-      45_000,
+      // Raised with the startup budget above: a 45s per-test ceiling could not contain a
+      // 90s wait, so the two have to move together or the wait is decorative.
+      130_000,
     );
   }
 });

--- a/tests/shutdown-launcher.test.ts
+++ b/tests/shutdown-launcher.test.ts
@@ -91,7 +91,11 @@ describe.skipIf(!runnable)("ocx launcher graceful shutdown", () => {
         writeFileSync(codexConfig, 'model = "gpt-5.1"\n');
 
         const child = spawn("node", [BIN_OCX, "start", "--port", String(port)], {
-          stdio: "ignore",
+          // Captured rather than discarded: when this test fails in CI it fails on
+          // `expect(up).toBe(true)` with no evidence at all, which cost a full
+          // investigation cycle. The launcher's own output is the only thing that
+          // can distinguish a slow start from a refused one.
+          stdio: ["ignore", "pipe", "pipe"],
           env: {
             ...process.env,
             HOME: identity.homeDir,
@@ -102,6 +106,9 @@ describe.skipIf(!runnable)("ocx launcher graceful shutdown", () => {
           },
         });
         spawned.push(child);
+        let launcherOutput = "";
+        child.stdout?.on("data", chunk => { launcherOutput += chunk; });
+        child.stderr?.on("data", chunk => { launcherOutput += chunk; });
 
         let exited = false;
         child.on("exit", () => { exited = true; });
@@ -112,6 +119,9 @@ describe.skipIf(!runnable)("ocx launcher graceful shutdown", () => {
         // land at 20061ms and 20168ms, i.e. the budget itself, not a hang. Startup time is not
         // what any assertion here is about — the teardown behaviour after the signal is.
         const up = await waitUntil(() => healthy(port), 90_000);
+        if (!up) {
+          console.error(`launcher never became healthy on port ${port}; its output was:\n${launcherOutput || "(nothing)"}`);
+        }
         expect(up).toBe(true);
         expect(existsSync(join(home, "ocx.pid"))).toBe(true);
         const injected = readFileSync(codexConfig, "utf8");

--- a/tests/shutdown-launcher.test.ts
+++ b/tests/shutdown-launcher.test.ts
@@ -120,7 +120,17 @@ describe.skipIf(!runnable)("ocx launcher graceful shutdown", () => {
         // what any assertion here is about — the teardown behaviour after the signal is.
         const up = await waitUntil(() => healthy(port), 90_000);
         if (!up) {
-          console.error(`launcher never became healthy on port ${port}; its output was:\n${launcherOutput || "(nothing)"}`);
+          // A launcher that produced NO output for the whole wait did not start slowly; it
+          // never got far enough to print its banner. The observed macOS case looks exactly
+          // like that, and the next case in the same file then came up in 820ms — so the
+          // machine was not busy. The remaining suspect is the port: freePort() binds :0,
+          // reads the number, then closes, so anything on the runner can take that port in
+          // the gap before the proxy binds it.
+          console.error(
+            `launcher never became healthy on port ${port} after ${Math.round(90_000 / 1000)}s`
+            + `; exited=${exited}`
+            + `; its output was:\n${launcherOutput || "(nothing)"}`,
+          );
         }
         expect(up).toBe(true);
         expect(existsSync(join(home, "ocx.pid"))).toBe(true);


### PR DESCRIPTION
## What this PR now is

Two things, and I want to be precise about which one is a fix and which one is evidence.

**1. The 20s startup budget was itself the failure — fixed.** The three signal cases each cold-spawn `node bin/ocx.mjs start` and wait on `/healthz`, back to back in one file. The wait was capped at 20s and the per-test ceiling at 45s. Observed failures landed at **20061ms** and **20168ms**: the budget, not a hang. Raised to 90s and 130s; they must move together or the longer wait is decorative. Reproduced 1-in-3 on Linux at `origin/dev`; after the change, 12 sequential and 6 parallel runs all green.

**2. A second, distinct cause exists on macOS — instrumented, not fixed.** This is the honest part.

The test discarded the launcher's output (`stdio: "ignore"`), so a startup failure surfaced as `expect(up).toBe(true)` / `Received: false` and nothing else. That is what made this expensive to chase. Now stdout, stderr and the child's exit state are captured and printed when the health wait expires.

It paid off immediately. Two macOS CI failures on this branch report:

```
launcher never became healthy on port 49939 after 90s; exited=false; its output was:
(nothing)
```

That narrows it considerably:

- Not a slow machine — the *next* case in the same file came up in 820ms.
- Not a crash — `exited=false`, the process is alive the whole time.
- Not a port collision — a failed bind would print an error and exit.
- Not the budget — it consumed the full 90s and produced no banner.

An alive, silent launcher is blocked before it reaches its first write. I did not find which call, and I am not going to guess and label a guess a fix. It did not reproduce on Linux across 12 sequential runs, 6 parallel runs, and 8 direct launcher spawns (all healthy in 589-796ms), which fits a macOS-specific path — the `claimOwnedServiceHome` fixture writes a `LaunchAgents` plist on darwin and a `service-state.json` ownership claim, so a service-manager probe is the first place I would look next.

## Why land this anyway

It strictly improves the situation. One real cause is removed and proven. The remaining one now produces a diagnosable failure instead of a bare `Received: false`, which is the difference between a five-minute triage and the multi-hour one this took. Nothing here touches product code.

## Verification

- Before: 1 failure in 3 isolated Linux runs at `origin/dev` (`0844dc9a9`), failing at exactly 20s.
- After: 12 sequential + 6 parallel Linux runs, 3 pass / 0 fail each.
- `bun test tests/shutdown-launcher.test.ts` locally: 3 pass / 0 fail. `bun run typecheck` clean.
- macOS CI still fails on this branch, for the second cause described above, with the new diagnostic attached.

## Checklist

- [x] Test-only change; no product code touched
- [x] Reproduced before, verified after, for the cause that is fixed
- [x] Unresolved cause stated plainly rather than papered over
- [x] Targets `dev`

