### PR TITLE
fix(responses): strip Codex-private item metadata

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -237,6 +237,30 @@ function stripCanonicalOnlyToolFields(body: unknown, includeCapabilityGated: boo
 }
 
 /**
+ * Codex keeps this ChatGPT-internal item metadata when its configured provider name is `openai`.
+ * Loopback OpenCodex injection intentionally retains that provider identity for history continuity,
+ * even when the proxy ultimately routes the request to a public Responses destination. Those
+ * destinations reject the private field as an unknown `input[*]` parameter, so remove it at the
+ * noncanonical boundary without mutating the caller-owned raw body.
+ */
+function stripInternalChatMessageMetadataPassthrough(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!isPlainObject(item) || !Object.hasOwn(item, "internal_chat_message_metadata_passthrough")) {
+      return item;
+    }
+    changed = true;
+    const next = { ...item };
+    delete next.internal_chat_message_metadata_passthrough;
+    return next;
+  });
+
+  return changed ? { ...body, input } : body;
+}
+
+/**
  * When `store` is false, the upstream API does not persist response items. Any item ID
  * forwarded in `input` is then interpreted as a reference to a stored item that does not
  * exist, producing a 404. Strip all item IDs in this case — `call_id` pairing is unaffected.
@@ -2102,6 +2126,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       // a strict parser rejects the whole request over it (#930).
       outBody = backfillWebSearchQueries(outBody);
       if (!isCanonicalOpenAiForwardProvider(provider)) {
+        outBody = stripInternalChatMessageMetadataPassthrough(outBody);
         outBody = promoteClientLoadedTools(outBody);
       }
       if (!isCanonicalOpenAiForwardProvider(provider)) {

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -122,6 +122,80 @@ test("noncanonical pool-required providers use only their configured static cred
   expect(request.headers.session_id).toBeUndefined();
 });
 
+test("noncanonical Responses destinations strip Codex-private item metadata", () => {
+  const rawBody = {
+    model: "openai/gpt-5.6-sol",
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "ping" }],
+        internal_chat_message_metadata_passthrough: { turn_id: "turn-1" },
+      },
+      {
+        type: "function_call",
+        name: "lookup",
+        arguments: "{}",
+        call_id: "call-1",
+        internal_chat_message_metadata_passthrough: { turn_id: "turn-1" },
+      },
+    ],
+  };
+
+  for (const configuredProvider of [
+    {
+      adapter: "openai-responses",
+      baseUrl: "https://gateway.example/v1",
+      authMode: "key" as const,
+      apiKey: "test-key",
+    },
+    {
+      adapter: "openai-responses",
+      baseUrl: "https://gateway.example/v1",
+      authMode: "forward" as const,
+    },
+  ]) {
+    const request = createResponsesPassthroughAdapter(configuredProvider).buildRequest({
+      modelId: rawBody.model,
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: rawBody,
+    }, { headers: new Headers() });
+    const body = JSON.parse(request.body) as { input: Record<string, unknown>[] };
+
+    expect(body.input.every(item => !("internal_chat_message_metadata_passthrough" in item)))
+      .toBe(true);
+  }
+
+  expect(rawBody.input.every(item => "internal_chat_message_metadata_passthrough" in item))
+    .toBe(true);
+});
+
+test("canonical ChatGPT forward preserves Codex-private item metadata", () => {
+  const request = createResponsesPassthroughAdapter(provider).buildRequest({
+    modelId: "gpt-5.6-sol",
+    context: { messages: [] },
+    stream: true,
+    options: {},
+    _rawBody: {
+      model: "gpt-5.6-sol",
+      input: [{
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "ping" }],
+        internal_chat_message_metadata_passthrough: { turn_id: "turn-1" },
+      }],
+    },
+  }, { headers: new Headers({ authorization: "Bearer token" }) });
+  const body = JSON.parse(request.body) as {
+    input: { internal_chat_message_metadata_passthrough?: unknown }[];
+  };
+
+  expect(body.input[0].internal_chat_message_metadata_passthrough)
+    .toEqual({ turn_id: "turn-1" });
+});
+
 test("passthrough serialized-body observation releases after the request settles", () => {
   const budget = createTranslatorBudget();
   const request = createResponsesPassthroughAdapter(provider).buildRequest({


### PR DESCRIPTION
## Summary

- Strip Codex's ChatGPT-internal `internal_chat_message_metadata_passthrough` field from Responses input items before forwarding to noncanonical destinations.
- Preserve the field for canonical ChatGPT forwarding and avoid mutating the caller-owned raw request body.
- Cover custom gateway model IDs such as `openai/gpt-5.6-sol`, where Codex retains its built-in OpenAI provider identity before OpenCodex routes the request.
- Addresses the proxy-side compatibility gap described in openai/codex#30161.

## Verification

- `bun test tests/openai-responses-passthrough.test.ts` — 115 pass, 0 fail.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `bun run test` — 16,533 pass, 14 skip; three unrelated 5-second load-sensitive timeouts under the local parallel run. Each timed-out assertion passed when rerun serially with a diagnostic timeout (10–30 seconds).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Not needed: no user-facing configuration or UI change.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed internal metadata from requests sent through routed Responses destinations.
  * Preserved the original request body without modification.
  * Retained private metadata for the canonical ChatGPT route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->