### PR TITLE
fix(service): verify a scheduler path the console code page cannot carry

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -2037,7 +2037,14 @@ function windowsTaskTriggerScopeAcceptable(element: string, expectedUserId: stri
   if (userIdCount === 0) return true;
   if (userIdCount !== 1) return false;
   if (expectedUserId === undefined) return false;
-  return taskXmlDecodedValueEquals(element, "UserId", expectedUserId);
+  // Compared the same lossy way as Command and Arguments, and for the same reason:
+  // buildWindowsTaskXml writes the live account name here, so an account named outside
+  // the console code page comes back from `schtasks /query /xml` mangled and an exact
+  // comparison would reject a task that is in fact correctly scoped (#3064). The
+  // separator rule earns its keep on this field: a `DOMAIN\User` scope keeps its
+  // backslash verified literally, so a placeholder run can never swallow the domain and
+  // let another domain's account match.
+  return taskXmlDecodedPathEquals(element, "UserId", expectedUserId);
 }
 
 /** Validate the stable OpenCodex action, principal, settings, and logon trigger. */

--- a/src/service.ts
+++ b/src/service.ts
@@ -1935,6 +1935,46 @@ function taskXmlDecodedValueEquals(xml: string, tag: string, expected: string): 
   return taskXmlDecodeEntities(value).trim().toLowerCase() === expected.trim().toLowerCase();
 }
 
+/**
+ * Compare a path Task Scheduler reported against the one we registered.
+ *
+ * `schtasks /query /tn X /xml` writes through the console code page when stdout
+ * is a pipe, not UTF-16, so a profile directory outside that code page is
+ * already mangled in the bytes we receive -- there is nothing left on our side
+ * to decode. A valid task therefore failed the Command/Arguments comparison and
+ * a successful elevated create was rolled back (#3064).
+ *
+ * When, and only when, the path we expect contains characters that transport
+ * could not carry, compare what it *could* carry: every run of non-ASCII on both
+ * sides collapses to one placeholder. A task pointing somewhere genuinely
+ * different still differs in its ASCII structure and still fails.
+ */
+export function taskXmlPathEquals(reported: string, expected: string): boolean {
+  const a = reported.trim().toLowerCase();
+  const b = expected.trim().toLowerCase();
+  if (a === b) return true;
+  if (!/[^\x00-\x7F]/.test(b)) return false;
+  // Match the expected path literally except where the code page could not carry
+  // it. What came back there depends on the conversion -- "?" per character,
+  // U+FFFD, or nothing at all -- so accept any run, but never one containing a
+  // path separator: every directory the path names is still verified, and a task
+  // pointing at a different folder or file still fails.
+  const pattern = b
+    .split(/([^\x00-\x7F]+)/)
+    .map((part, index) =>
+      index % 2 === 1 ? "[^\\\\/]*" : part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("");
+  return new RegExp(`^${pattern}$`).test(a);
+}
+
+function taskXmlDecodedPathEquals(xml: string, tag: string, expected: string): boolean {
+  if (taskXmlHasPrefixedTag(xml, tag)) return false;
+  if (taskXmlElementCount(xml, tag) !== 1) return false;
+  const value = new RegExp(`<${tag}(?:\\s[^>]*?)?>([^<]*)<\\/${tag}>`, "i").exec(xml)?.[1];
+  if (value === undefined) return false;
+  return taskXmlPathEquals(taskXmlDecodeEntities(value), expected);
+}
+
 function taskXmlOptionalValueEquals(xml: string, tag: string, expected: string): boolean {
   // Check the prefixed form first: treating `<t:Enabled>false</t:Enabled>` as an
   // omission would turn an explicitly disabled task into a healthy one.
@@ -2030,8 +2070,10 @@ function windowsTaskRegistrationBaseHealthy(
     // quotes we wrote as `&quot;` back to literal `"` on export, so an escaped
     // needle never matched and a healthy task read as permanently stale (#608).
     // Case-insensitive: elevated `schtasks /create` may rewrite System32 casing.
-    && taskXmlDecodedValueEquals(action, "Command", wscript)
-    && taskXmlDecodedValueEquals(action, "Arguments", `/b /nologo "${launcher}"`);
+    // Paths, not plain values: both live under the user profile, which schtasks
+    // cannot round-trip through the console code page when it is not ASCII (#3064).
+    && taskXmlDecodedPathEquals(action, "Command", wscript)
+    && taskXmlDecodedPathEquals(action, "Arguments", `/b /nologo "${launcher}"`);
 }
 
 /** Validate the security/lifecycle-critical fields of the registered scheduler task. */

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -583,6 +583,47 @@ describe("Windows service task", () => {
   });
 
 
+  // A scoped trigger names the installing account, and that name goes through the same
+  // code page as the paths do (CodeRabbit review on #3067).
+  test("accepts a scoped trigger whose account name the code page could not carry", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
+    const user = "MACHINE\\Người";
+    const xml = buildWindowsTaskXml("ignored.cmd", launcher, undefined, user)
+      .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+    expect(windowsTaskRegistrationHealthy(xml, wscript, launcher, user)).toBe(true);
+
+    for (const mangled of [
+      xml.replace("Người", "Ng??i"),
+      xml.replace("Người", "Ngi"),
+      xml.replace("Người", "Ng\uFFFDi"),
+    ]) expect(windowsTaskRegistrationHealthy(mangled, wscript, launcher, user)).toBe(true);
+  });
+
+  test("a scoped trigger for a different account is still rejected", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
+    const user = "MACHINE\\Người";
+    const xml = buildWindowsTaskXml("ignored.cmd", launcher, undefined, user)
+      .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+
+    // The relaxation must not reach across the domain separator: a placeholder run
+    // stands in for unrepresentable characters only, never for a `\`. Otherwise
+    // "OTHER\\admin" could match a scope that names this machine.
+    for (const other of [
+      "MACHINE\\Nguoi",
+      "OTHER\\Người",
+      "MACHINE\\Người\\sub",
+    ]) expect(windowsTaskRegistrationHealthy(xml, wscript, launcher, other)).toBe(false);
+
+    // And an ASCII account name keeps its exact comparison.
+    const ascii = "MACHINE\\installer";
+    const asciiXml = buildWindowsTaskXml("ignored.cmd", launcher, undefined, ascii)
+      .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+    expect(windowsTaskRegistrationHealthy(asciiXml, wscript, launcher, ascii)).toBe(true);
+    expect(windowsTaskRegistrationHealthy(asciiXml, wscript, launcher, "MACHINE\\installr")).toBe(false);
+  });
+
   // --- #3064: a non-ASCII profile path survives the schtasks code page --------
   test("accepts a registration whose path the schtasks code page could not carry", () => {
     const wscript = "C:\\Windows\\System32\\wscript.exe";

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 import * as serviceModule from "../src/service";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
-import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, stableLauncherEntry, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, uninstallSystemd, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy } from "../src/service";
+import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml, confirmServiceServing, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, launchdListenPort, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, serviceLogPath, serviceRetryCommand, serviceStartableFromTray, serviceStatusReport, serviceStatusSummary, stableLauncherEntry, startLaunchd, systemdListenPort, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, taskXmlPathEquals, uninstallSystemd, windowsListenPort, windowsTaskRegistrationHealthy, winswListenPort } from "../src/service";
 import type { ServiceDiagnostic } from "../src/service";
 import { definitionCarriesCredential, resolvedProxyEnv, writeServiceDefinitionFile } from "../src/service";
 import { buildWinswXml } from "../src/lib/winsw";
@@ -580,6 +580,61 @@ describe("Windows service task", () => {
       xml.replace(wscript, "C:\\Windows\\System32\\cmd.exe"),
       xml.replace(launcher, "C:\\Temp\\foreign.vbs"),
     ]) expect(windowsTaskRegistrationHealthy(mutated, wscript, launcher)).toBe(false);
+  });
+
+
+  // --- #3064: a non-ASCII profile path survives the schtasks code page --------
+  test("accepts a registration whose path the schtasks code page could not carry", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Người\\.opencodex\\service-launcher.vbs";
+    const xml = buildWindowsTaskXml("ignored.cmd", launcher).replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+    expect(windowsTaskRegistrationHealthy(xml, wscript, launcher)).toBe(true);
+
+    // What `schtasks /query /tn X /xml` actually hands back when stdout is a pipe:
+    // its output goes through the console code page, so characters outside it are
+    // already replaced before we read a single byte.
+    for (const mangled of [
+      xml.replace("Người", "Ng??i"),
+      xml.replace("Người", "Ngi"),
+      xml.replace("Người", "Ng\uFFFDi"),
+    ]) expect(windowsTaskRegistrationHealthy(mangled, wscript, launcher)).toBe(true);
+  });
+
+  test("still rejects a foreign path even when the expected one is non-ASCII", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Người\\.opencodex\\service-launcher.vbs";
+    const xml = buildWindowsTaskXml("ignored.cmd", launcher).replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+    for (const mutated of [
+      xml.replace(launcher, "C:\\Temp\\foreign.vbs"),
+      xml.replace(launcher, "C:\\Users\\Người\\.opencodex\\other-launcher.vbs"),
+      xml.replace(launcher, "C:\\Users\\Người\\.evil\\service-launcher.vbs"),
+      xml.replace(wscript, "C:\\Windows\\System32\\cmd.exe"),
+    ]) expect(windowsTaskRegistrationHealthy(mutated, wscript, launcher)).toBe(false);
+  });
+
+  test("an ASCII path is compared exactly, with no relaxation", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
+    const xml = buildWindowsTaskXml("ignored.cmd", launcher).replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+    // A single character off must still fail: nothing about an ASCII path is
+    // unrepresentable, so there is nothing to forgive.
+    expect(windowsTaskRegistrationHealthy(xml.replace("\\Test\\", "\\Tost\\"), wscript, launcher)).toBe(false);
+    expect(windowsTaskRegistrationHealthy(xml.replace("service-launcher", "service-launcherr"), wscript, launcher)).toBe(false);
+  });
+
+  test("the path comparison forgives only unrepresentable characters", () => {
+    expect(taskXmlPathEquals("C:\\Users\\Người\\x.vbs", "C:\\Users\\Người\\x.vbs")).toBe(true);
+    expect(taskXmlPathEquals("C:\\Users\\Ng??i\\x.vbs", "C:\\Users\\Người\\x.vbs")).toBe(true);
+    // Case-insensitive, matching the exact comparison it replaces.
+    expect(taskXmlPathEquals("c:\\users\\ng??i\\x.vbs", "C:\\Users\\Người\\x.vbs")).toBe(true);
+    // ASCII differences are never forgiven, on either side of the mangled run.
+    expect(taskXmlPathEquals("C:\\Users\\Ng??i\\y.vbs", "C:\\Users\\Người\\x.vbs")).toBe(false);
+    expect(taskXmlPathEquals("D:\\Users\\Ng??i\\x.vbs", "C:\\Users\\Người\\x.vbs")).toBe(false);
+    // The forgiven run may never swallow a path separator: a task pointing at a
+    // different directory must not slip through as "unrepresentable".
+    expect(taskXmlPathEquals("C:\\Users\\Ng\\evil\\i\\x.vbs", "C:\\Users\\Người\\x.vbs")).toBe(false);
+    // An entirely ASCII expectation gets no relaxation at all.
+    expect(taskXmlPathEquals("C:\\Users\\A?c\\x.vbs", "C:\\Users\\Abc\\x.vbs")).toBe(false);
   });
 
   // --- #432: Task Scheduler omits schema defaults when exporting ---------------


### PR DESCRIPTION
Fixes #3064.

## The conversion is schtasks', not ours

I could not confirm the proposed cause, so I measured it. Two experiments, both on Windows 11 + Bun 1.3.14:

**1. `runFile()` does not apply a code-page conversion.** It already reads with `encoding: "buffer"`, and under Bun the two spawn APIs are byte-identical. Against a UTF-16LE fixture containing `Người`:

```
execFileSync  isBuffer = true  len = 162  first8 = ff fe 3c 00 3f 00 78 00
Bun.spawnSync                  len = 162  first8 = ff fe 3c 00 3f 00 78 00
IDENTICAL BYTES = true
```

Both decode to `…<Arguments>C:\Users\Người\launcher.js</Arguments>…` intact. So `Bun.spawnSync` + `decodeSchtasksOutput()` would change nothing.

**2. `schtasks` itself converts when stdout is not a console.** Querying a real registered task with output redirected:

```
xml bytes: 5437
first 16 : 3c 3f 78 6d 6c 20 76 65 72 73 69 6f 6e 3d 22 31     ("<?xml version=\"1")
UTF-16LE : False
```

No BOM, no UTF-16 — 8-bit console-code-page bytes. (Worth noting on its own: `decodeSchtasksOutput`'s comment says `/query /xml` emits UTF-16LE. That is true from a console; through a pipe it is not, at least on 11 24H2.) A profile path outside that code page is therefore already destroyed in the bytes we receive, and no decoder on our side can bring it back.

That is why the install rolls back: `windowsTaskRegistrationHealthy` ends with

```ts
&& taskXmlDecodedValueEquals(action, "Command", wscript)
&& taskXmlDecodedValueEquals(action, "Arguments", `/b /nologo "${launcher}"`)
```

and `launcher` lives under the profile directory. Every other check in that function is ASCII and survives.

## The fix

Those two comparisons become `taskXmlDecodedPathEquals`, which matches the expected path literally **except** across a run the code page could not carry. There, anything is accepted — `"?"` per character, `U+FFFD`, or nothing at all — but **never a path separator**, so every directory the path names is still verified and a task pointing at a different folder or file still fails.

An all-ASCII path takes the relaxation not at all: `if (!/[^\x00-\x7F]/.test(expected)) return false`. Nothing in it is unrepresentable, so there is nothing to forgive, and a one-character difference still fails.

### What this trades

This does weaken the check, narrowly: within one path segment, a non-ASCII run is no longer compared character by character, so a segment differing *only* inside that run would now pass. I judged that better than the alternatives — the information needed for an exact comparison does not reach the process, and rolling back every valid install on such a machine is a hard failure. If you would rather verify these two values against the on-disk document we registered (`windowsTaskXmlPath()`, already used as a fallback when the query is empty), that is a clean alternative and I am happy to send it instead.

## Tests

Four tests in `tests/service.test.ts`, next to the existing registration-health cases:

- a registration whose path was mangled three different ways (`Ng??i`, `Ngi`, `Ng\uFFFDi`) is accepted
- a foreign path is still rejected with a non-ASCII expectation — different drive-relative folder, different file name, a sibling `.evil` directory, a different `Command`
- an ASCII path is still compared exactly (`\Test\` → `\Tost\` fails, `service-launcher` → `service-launcherr` fails)
- `taskXmlPathEquals` directly: exact, mangled, case-insensitive, ASCII differences on either side of the run, no relaxation for an ASCII expectation, and a run that tries to swallow a path separator

| mutation | result |
|---|---|
| revert to the exact comparison | 2 failed |
| let the forgiven run cross a path separator | 1 failed |

```
bun test tests/service.test.ts     138 pass, 0 fail
bun x tsc --noEmit                 clean
```

I do not have a non-ASCII profile directory here, so I have **not** reproduced `ocx service install` end to end. What I did measure is the two facts the diagnosis rests on — that both spawn APIs return identical bytes, and that `schtasks /xml` through a pipe is code-page text, not UTF-16.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Task Scheduler registration checks for paths and account names containing non-ASCII characters.
  * Valid task registrations are no longer incorrectly rejected when console encoding alters unsupported characters.
  * Path validation continues to enforce structure, separators, safe interpreters, and case-insensitive matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
