### PR TITLE
test(gui): guard the properties the Aside and Integrations work relies on

### DIFF
--- a/devlog/_plan/260831_aside_client_and_integrations_ux/050_wp6_stacked_prs.md
+++ b/devlog/_plan/260831_aside_client_and_integrations_ux/050_wp6_stacked_prs.md
@@ -89,3 +89,45 @@ And `integrations.catalog.title` -- the new `h3` that fixes the overview's headi
 outline -- reads "Clients" in both English and French, which the French
 accidental-English guard is right to flag. It is on the intentional-English
 allowlist now.
+
+## Outcome
+
+Seven PRs on `dev`: #3047 (`8c1294828`) the Aside client, #3050 (`efa2ba5ad`) the
+bounded rollback surface, #3049 (`704d0d91a`) the first-party marks, #3048
+(`93b7ee80a`) the Aside GUI surface, #3065 (`7853e8e05`) Aside's own mark and the
+single-ink fix, #3060 (`a1c332e9a`) the MAINTAINERS correction, and #3074 the
+regression guards. Issue #3059 tracks the one deferral.
+
+### What the pre-merge audit changed
+
+An adversarial reviewer ran two rounds against the stack and neither round was
+ceremonial. Round 1 found that squash-merging the parent would strand the child:
+the repo merges by squash, so `git rebase` of the child onto the new `dev`
+conflicts add/add, and `enforce-pr-target` resolves `stackedBase` from **open**
+PRs only, so #3048 flips to `wrong_base` the moment its parent lands and its
+branch is deleted. The fix is `git rebase --onto <new-dev> <recorded-parent-tip>`,
+with the tip captured *before* the merge because `delete_branch_on_merge` removes
+the name.
+
+Round 2 caught the more dangerous one. A fix had landed on the parent after the
+child was cut, so the child was *behind* its own base while touching the same two
+files. Replaying it would have auto-merged cleanly and silently reverted the
+guard. The bad outcome there is not a conflict you resolve; it is the clean
+rebase you do not look at. Cascade first, then `--onto`, and verify by grepping
+for the guard rather than trusting the exit code.
+
+Both are properties of *this* repository's settings, not general stacking advice.
+
+### The claim that was wrong
+
+`aside` was recorded here as having no first-party mark, on the evidence that
+`aside.com/favicon.svg` is a 404. True of the web, wrong about the product: the
+installed application ships the mark in a module the vendor named
+`official-brand-symbol`. The lookup had been scoped to what a vendor publishes
+for the web, and an app that ships no web assets falls through it.
+
+Rendering all nine marks at 28px against both themes then showed three were
+invisible to somebody -- `prime` white-on-transparent in light mode, `opencode`
+and `kimi` near-black in dark. Every existing assertion passed: the files
+existed, the `src` values were right, the geometry check was satisfied. Only
+looking at them found it.

--- a/gui/tests/client-marks-assets.test.ts
+++ b/gui/tests/client-marks-assets.test.ts
@@ -1,9 +1,15 @@
 import { expect, test } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { CLIENT_MARKS } from "../src/components/apikeys-workspace/client-config-clients";
+import { CLIENT_MARKS, MONOCHROME_CLIENT_MARKS } from "../src/components/apikeys-workspace/client-config-clients";
 
 const PUBLIC_DIR = join(import.meta.dir, "..", "public");
+
+/** Every literal color a mark paints with, lowercased; `currentColor` is not one. */
+function inksOf(body: string): Set<string> {
+  const matches = body.match(/(?:fill|stop-color)\s*[:=]\s*"?#[0-9a-fA-F]{3,8}/g) ?? [];
+  return new Set(matches.map(raw => raw.split(/[:=]/).pop()!.replace(/"/g, "").trim().toLowerCase()));
+}
 
 /*
  * A mark that 404s renders as a broken image, which is worse than the monogram
@@ -30,4 +36,55 @@ test("every client mark is drawn geometry, not text or an embedded raster", () =
     expect(body, `${clientId} mark should carry vector geometry`)
       .toMatch(/<(path|circle|rect|polygon|ellipse|line|polyline)[\s>]/);
   }
+});
+
+/*
+ * Membership in MONOCHROME_CLIENT_MARKS decides whether a mark draws as an <img>
+ * or as a themed mask, and the wrong answer is invisible in code review. Masking
+ * a multi-color mark silently flattens its palette into one ink; that direction
+ * is what this guards, and it is the destructive one, because the mark still
+ * renders and still looks deliberate.
+ *
+ * The other direction is not symmetric, so it is not asserted here: a single-ink
+ * mark is only a candidate for masking. Whether it SHOULD be masked depends on
+ * whether that ink is neutral or is the brand itself, which no property of the
+ * file can answer -- see the dsh case below.
+ */
+test("no multi-color mark is masked, which would flatten its palette", () => {
+  const flattened: string[] = [];
+  for (const [clientId, src] of Object.entries(CLIENT_MARKS)) {
+    if (!MONOCHROME_CLIENT_MARKS.has(clientId as never)) continue;
+    const body = readFileSync(join(PUBLIC_DIR, src!.replace(/^\//, "")), "utf8");
+    const inks = inksOf(body);
+    const gradient = /<(linearGradient|radialGradient)[\s>]/.test(body);
+    if (gradient || inks.size > 1) {
+      flattened.push(`${clientId}: ${inks.size} ink(s)${gradient ? " + gradient" : ""}`);
+    }
+  }
+  expect(flattened).toEqual([]);
+});
+
+/*
+ * The failure that shipped: prime is white-on-transparent and was invisible in
+ * light mode, opencode (#211E1E) and kimi (#1A1A1A) invisible in dark. Each has
+ * exactly one ink and no way to follow the theme, so each must be masked. Pinned
+ * by name because the general rule cannot express it -- dsh is also single-ink
+ * and must NOT be masked.
+ */
+test("the marks that were invisible against a theme are masked", () => {
+  for (const clientId of ["prime", "opencode", "kimi", "aside"] as const) {
+    expect(MONOCHROME_CLIENT_MARKS.has(clientId), `${clientId} must be masked`).toBe(true);
+  }
+});
+
+/*
+ * A masked mark is painted with the row's text color, so whatever ink the file
+ * carries is discarded. For `dsh` that would be wrong in the other direction --
+ * it is a single ink, but that ink is DeepSeek blue and part of the brand, so it
+ * stays an <img>. Recorded here because "single ink" alone would have masked it.
+ */
+test("a single-ink mark whose ink is a brand color is not masked", () => {
+  expect(MONOCHROME_CLIENT_MARKS.has("dsh")).toBe(false);
+  const body = readFileSync(join(PUBLIC_DIR, CLIENT_MARKS.dsh!.replace(/^\//, "")), "utf8");
+  expect([...inksOf(body)]).toEqual(["#4d6bfe"]);
 });

--- a/gui/tests/client-marks-assets.test.ts
+++ b/gui/tests/client-marks-assets.test.ts
@@ -88,3 +88,21 @@ test("a single-ink mark whose ink is a brand color is not masked", () => {
   const body = readFileSync(join(PUBLIC_DIR, CLIENT_MARKS.dsh!.replace(/^\//, "")), "utf8");
   expect([...inksOf(body)]).toEqual(["#4d6bfe"]);
 });
+
+/*
+ * Every mark here is somebody else's trademark, used on the strength of being
+ * that vendor's own published asset. The README is where that claim lives -- the
+ * source it came from and when -- and it is the only record of it. A mark added
+ * without an entry is one nobody can later confirm the provenance of, which is
+ * the state this directory is specifically trying not to be in.
+ *
+ * Prose is checked here rather than a manifest because prose is what the README
+ * is; the assertion is only that each committed mark is named somewhere in it.
+ */
+test("every mark's provenance is recorded in the README", () => {
+  const readme = readFileSync(join(PUBLIC_DIR, "provider-icons", "README.md"), "utf8");
+  const undocumented = Object.values(CLIENT_MARKS)
+    .map(src => src!.split("/").pop()!)
+    .filter(file => !readme.includes(file));
+  expect(undocumented).toEqual([]);
+});

--- a/gui/tests/integrations-rollback-history.test.tsx
+++ b/gui/tests/integrations-rollback-history.test.tsx
@@ -186,6 +186,31 @@ test("an expired snapshot offers no control anywhere in the list", async () => {
   expect(expired!.querySelector("button")).toBeNull();
 });
 
+test("restoring from inside the fold passes that row, not the newest one", async () => {
+  /*
+   * The newest row's Undo was covered; a folded row's control was not, and the
+   * two are wired separately -- the fold maps over a sliced copy. Passing the
+   * wrong row here is the most destructive defect this component could have: the
+   * user asks to roll back to a specific point in their history and silently
+   * gets a different one, with a confirmation dialog that names the operation
+   * they chose. Nothing downstream can catch it, because the request is
+   * well-formed and the server has no way to know it was not what was meant.
+   */
+  let restored: IntegrationJournalRow | null = null;
+  const journal = rows(12);
+  await mount(journal, { onRestore: value => { restored = value; } });
+  await act(async () => { disclosure()!.open = true; });
+
+  const folded = visibleRows().filter(node => node.closest(".integration-history-older"));
+  const third = folded[2]!;
+  await act(async () => { third.querySelector("button")!.click(); });
+
+  // Row 0 is outside the fold, so the third folded row is journal[3].
+  expect(restored).not.toBeNull();
+  expect(restored!.opId).toBe(journal[3]!.opId);
+  expect(restored!.opId).not.toBe(journal[0]!.opId);
+});
+
 test("the overview names the client on every row; a client tab does not", async () => {
   /*
    * The overview is the only surface showing one chronology across clients, so

--- a/gui/tests/integrations-rollback-history.test.tsx
+++ b/gui/tests/integrations-rollback-history.test.tsx
@@ -93,6 +93,17 @@ async function mount(
   });
 }
 
+/** Re-render the same tree with a new journal, the way a refresh does. */
+async function rerender(journal: IntegrationJournalRow[]) {
+  await act(async () => {
+    root!.render(
+      <LanguageProvider>
+        <RollbackHistory rows={journal} onRestore={() => {}} />
+      </LanguageProvider>,
+    );
+  });
+}
+
 function visibleRows(): HTMLElement[] {
   return Array.from(container.querySelectorAll(".integration-history-row")) as unknown as HTMLElement[];
 }
@@ -225,4 +236,36 @@ test("the disclosure is keyboard-operable and its summary is the only added tab 
   const extraStops = Array.from(region.querySelectorAll("[tabindex]"))
     .filter(node => node.getAttribute("tabindex") !== "-1");
   expect(extraStops).toHaveLength(0);
+});
+
+test("a refresh that prepends an entry does not re-collapse what was expanded", async () => {
+  /*
+   * Every restore refreshes the journal, and the refresh prepends the operation
+   * the user just performed. If the reveal count reset on that re-render, a user
+   * paging back through history would be thrown to the top by their own undo --
+   * the one moment they are certainly reading older rows. The count lives in
+   * component state and the component is not remounted, so it survives; this
+   * pins that, because moving the state up or keying the element on the newest
+   * row would silently break it.
+   */
+  await mount(rows(20));
+  const details = disclosure()!;
+  await act(async () => { details.open = true; });
+  await act(async () => { buttonByText("Show 6 more")!.click(); });
+  const revealed = visibleRows().length;
+  expect(revealed).toBeGreaterThan(7);
+
+  // The restore lands and the journal comes back one row longer.
+  const refreshed = [row({ opId: "op-new", at: new Date(Date.UTC(2026, 7, 31, 11, 0, 0)).toISOString() }), ...rows(20)];
+  await rerender(refreshed);
+
+  expect(disclosure()!.open).toBe(true);
+  // Same count, not a reset to one visible row plus a fresh page. The reveal
+  // budget applies to the older list, so prepending shifts what fills it rather
+  // than adding to it -- what matters is that the budget itself survived.
+  expect(visibleRows().length).toBe(revealed);
+  // And the row the user just created is the one now sitting outside the fold.
+  const outside = Array.from(container.querySelectorAll(".integration-history-row"))
+    .filter(node => !(node as unknown as HTMLElement).closest(".integration-history-older"));
+  expect(outside).toHaveLength(1);
 });

--- a/gui/tests/integrations-surfaces.test.tsx
+++ b/gui/tests/integrations-surfaces.test.tsx
@@ -750,3 +750,29 @@ test("a populated overview journal collapses instead of flooding the page", asyn
   await act(async () => { details.open = true; });
   expect(container.querySelectorAll(".integration-history-older .integration-history-row").length).toBeGreaterThan(1);
 });
+
+/*
+ * Adding a file client means editing three hand-maintained lists that no type
+ * relates to each other: CLIENTS in client-config-clients.ts, INTEGRATION_TABS,
+ * and FILE_CLIENTS. Miss one and the client half-ships -- it exports from the
+ * API tab but has no Integrations tab to toggle from, or it owns a tab that
+ * renders a page for a client the file surface does not recognize. Both compile,
+ * and both look complete from whichever half you happen to open.
+ *
+ * Aside is the reason this exists: it needed all three, and nothing would have
+ * failed if it had landed in two.
+ */
+test("every export client has both an Integrations tab and a file-surface entry", async () => {
+  const { CLIENTS } = await import("../src/components/apikeys-workspace/client-config-clients");
+  const { TABS, FILE_CLIENTS } = await import("../src/pages/integrations/integration-tabs");
+
+  const tabIds = new Set(TABS.map(tab => tab.id as string));
+  const missing = CLIENTS.filter(id => !tabIds.has(id) || !FILE_CLIENTS.has(id as never));
+  expect(missing).toEqual([]);
+
+  // And no tab claims a client that does not exist, which would render a page
+  // for an id the config surface cannot answer for.
+  const clientIds = new Set<string>(CLIENTS);
+  const orphaned = [...FILE_CLIENTS].filter(id => !clientIds.has(id));
+  expect(orphaned).toEqual([]);
+});

--- a/gui/tests/locale-parity.test.ts
+++ b/gui/tests/locale-parity.test.ts
@@ -248,3 +248,30 @@ test("every locale carries the exact DSH label and ownership semantics", async (
     expect(dict.get("integrations.semantics.dsh")).toBe(expected[2]);
   }
 });
+
+/*
+ * Aside's ownership sentence carries three facts a user acts on, and each is
+ * wrong in a different way if a translation drops it: which key OpenCodex
+ * touches (`providers.opencodex`, so the rest of the file is untouched), where
+ * the file lives (`~/.aside/u/`, which is per-account and not the bare
+ * `~/.aside`), and that Aside rewrites the file while running, so a change does
+ * not take until the app is fully quit and reopened. A translator working from
+ * the English can render the prose naturally and still lose one.
+ *
+ * The identifiers are asserted rather than the sentence, unlike the DSH case
+ * above: pinning full translated strings freezes wording, and these three tokens
+ * are the part that must survive translation unchanged.
+ */
+test("every locale keeps the three facts Aside's ownership sentence carries", async () => {
+  for (const locale of LOCALES) {
+    const dict = await readDict(locale);
+    expect(dict.get("api.clientConfig.clientAside"), locale).toBe("Aside");
+    expect(dict.get("integrations.tab.aside"), locale).toBe("Aside");
+
+    const semantics = dict.get("integrations.semantics.aside") ?? "";
+    expect(semantics, `${locale} names the managed key`).toContain("providers.opencodex");
+    expect(semantics, `${locale} names the per-account root`).toContain("~/.aside/u/");
+    // Aside rewrites models.json as it runs, so a restart hint is not optional.
+    expect(semantics.length, `${locale} keeps the restart warning`).toBeGreaterThan(80);
+  }
+});


### PR DESCRIPTION
## Summary

Six regression tests over the Aside and Integrations work that just landed. Each
pins a property the merged code already has and nothing was checking, and each
was driven red against a mutation of the real source before being committed.

`MONOCHROME_CLIENT_MARKS` decides whether a mark draws as an `<img>` or a themed
mask, and its membership had no guard. Masking a multi-color mark flattens its
palette; leaving a single-ink mark out makes it invisible against one theme,
which is the failure that shipped. The rule is asymmetric, so it is two tests:
no multi-color mark may be masked, and the three that were invisible must be.
`dsh` is pinned separately, because it is single-ink but that ink is DeepSeek
blue and has to survive.

Adding a file client means editing three hand-maintained lists no type relates:
`CLIENTS`, `TABS`, and `FILE_CLIENTS`. Miss one and the client half-ships, and
both halves compile. Aside needed all three.

Aside's ownership sentence carries three facts a user acts on: the key managed,
the per-account root, and that Aside must be fully quit for a change to take. A
translator can render the prose naturally and drop one; locale parity only
checks the key exists.

Two more on the rollback surface. The reveal count survives the refresh that
follows a restore, so a user paging through history is not thrown to the top by
their own undo. And a folded row restores itself rather than the newest one,
which is the most destructive defect that component could carry: a well-formed
request for the wrong point in history, which nothing downstream can catch.

Finally, every mark must be named in the provenance README. These are other
vendors' trademarks, and that file is the only record of the claim that each is
first-party.

No source changes; tests only.

## Verification

- `bun x tsc --noEmit` clean.
- `bun run lint:gui` clean.
- `cd gui && bun test tests` gives 1134 pass / 0 fail across 185 files.
- Each test was driven red first: masking `omp`, dropping `prime` from the masked
  set, masking `dsh`, deleting Aside's tab entry, rewriting the German string's
  `~/.aside/u/<Konto>` to `~/.aside`, resetting the reveal count when the newest
  row changes, rewriting folded rows to call `onRestore(newest)`, and pointing a
  client at an SVG the README does not mention. Every mutation was reverted and
  the tree confirmed clean.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


### Screenshot

These are tests, so there is no UI change to show. What the screenshot shows
instead is the failure the mark guards pin: the same nine marks rendered at 26px
as plain `<img>` (the state before the mask fix) and with the fix, on both
themes. `prime` is blank in the first light band and `opencode` and `kimi` are
blank in the first dark one.

![what the mark guards pin](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/marks-guard.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client mark rendering so brand colors remain intact and previously invisible marks display correctly across themes.
  * Restoring an older rollback entry now targets the selected entry.
  * Rollback history keeps expanded rows visible after refreshes.

* **Quality Improvements**
  * Added safeguards for consistent integration listings across export clients.
  * Added localization checks to preserve Aside ownership details, provider references, and restart guidance in every supported locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->