### PR TITLE
chore(release): move dev to 2.39.0 after the v2.38.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

`dev` was left carrying `2.38.0`, the version just published to npm. `tests/release-version-line.test.ts` asserts the in-tree version is never behind a released one, so this fails on `dev` itself and on every PR opened against it until it is fixed.

`bun scripts/bump-dev-version.ts 2.38.0 package.json` chose `2.39.0`:

```json
{"changed":true,"version":"2.39.0","reason":"2.38.0 is a stable release, so dev moves to the next minor 2.39.0"}
```

That follows the documented rule: a published stable consumes its core, so `dev` moves to the next minor. A published prerelease would instead have left `dev` on that same core.

`dev-version-bump.yml` did not fire on its own. On a `release` event GitHub resolves the workflow from the default branch, and it only reached `main` in the v2.37.0 promotion, so the automatic path has not had a release to act on yet. Same manual step as #3045 after v2.37.0.

## Verification

`bun test tests/release-version-line.test.ts` — 3 pass / 0 fail.

## Checklist

- [x] Version chosen by the script, not by hand
- [x] Version-line test passes
- [x] Targets `dev`
- [x] No other file touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.39.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->