### PR TITLE
[WRONG BRANCH] chore(release): move preview to 2.39.0-preview.20260831

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.38.0-preview.20260831",
+  "version": "2.39.0-preview.20260831",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Cross-platform CI went red on `preview` right after the v2.38.0 promotion, on `macos` and `test 1/4`. One assertion, in both:

```
(fail) release version line > the in-tree version is never behind a released one
```

Every other check on that run passed.

The cause is ordering, not a defect. The preview promotion was prepared as `2.38.0-preview.20260831` while `2.38.0` was still unpublished, which was correct at the time. Publishing the stable `2.38.0` immediately afterwards consumed that core, and a prerelease of an already-released version is by definition behind it.

Move the preview line to the next unconsumed core, `2.39.0-preview.20260831`, matching `dev`'s move to `2.39.0` in #3076.

## Verification

`bun test tests/release-version-line.test.ts` — 3 pass / 0 fail.

## Note

`enforce-target` fails on any PR not targeting `dev`; that applies here as it does to promotion PRs.

## Checklist

- [x] Version-line test passes
- [x] Only `package.json` touched
- [x] Consistent with the `dev` bump in #3076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version `2.39.0-preview.20260831`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->