### PR TITLE
[WRONG BRANCH] fix(cli): don't shadow a live configured-port proxy on start; retry health probes past startup

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -12,7 +12,7 @@ import { CLI_COMMANDS } from "./registry";
 import { isValidProviderName } from "../config/provider-name";
 import type { CliHead } from "./root";
 import type { ReadyArgs } from "./ready";
-import type { LiveProxy } from "../server/proxy-liveness";
+import type { LivenessIo, LiveProxy } from "../server/proxy-liveness";
 import type { OcxConfig } from "../types";
 import { hasHelpFlag, printSubcommandUsage, printUsage } from "./help";
 import { setIntegrationEnabled, shouldSyncCodexOnStart } from "../codex/desired-state";
@@ -29,7 +29,7 @@ export interface CliDispatchDeps {
   command: string | undefined;
   head: CliHead;
   loadConfig: () => OcxConfig;
-  findLiveProxy: () => Promise<LiveProxy | null>;
+  findLiveProxy: (io?: LivenessIo) => Promise<LiveProxy | null>;
   probeHostname: (hostname: string | undefined) => string;
   waitForProxy: (timeoutMs?: number) => Promise<LiveProxy | null>;
   startArgv: (port?: number) => string[];
@@ -542,7 +542,12 @@ const commandRunners: Record<string, CommandRunner> = {
   health: async deps => {
     const healthArgs = deps.args.slice(1);
     const wantsHealthJson = healthArgs.includes("--json");
-    const live = await deps.findLiveProxy();
+    // A proxy that has only just bound can miss a single 750ms probe while its
+    // event loop is still settling startup work — the same just-started race the
+    // stop paths already cover with retries (#764). Retry here so `ocx health`
+    // run seconds after a service restart reports the live proxy instead of a
+    // false negative.
+    const live = await deps.findLiveProxy({ attempts: 3 });
     if (wantsHealthJson) {
       console.log(JSON.stringify({ ok: !!live, pid: live?.pid ?? null, port: live?.port ?? null }));
     } else {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -230,7 +230,13 @@ async function handleStart(options: { block?: boolean } = {}) {
   const present = process.env.OPENCODEX_API_AUTH_TOKEN?.trim();
   if (present) assertNotAdminToken(present);
   const requestedPort = parsePortOption();
-  const owner = await findProxyOwnerBeforeJournalRecovery();
+  // Always probe the configured port, even when both state files are absent. A
+  // fallback-port sibling overwrites the pid/runtime records on start and removes
+  // them on its own shutdown, so state-file absence alone proves nothing: without
+  // the probe, `start` shadowed a healthy configured-port proxy on an ephemeral
+  // port and re-pointed Codex/Grok config at that ephemeral copy, and the next
+  // sibling shutdown left no runtime record for discovery at all.
+  const owner = await findProxyOwnerBeforeJournalRecovery({ probeConfiguredPort: true });
   if (owner.live) {
     // Service-wrapper context (opencodex-service.cmd `:loop`): a healthy proxy from
     // ANY source means the requested port is already served. Exit 0 so the wrapper's

--- a/tests/cli-health-retry.test.ts
+++ b/tests/cli-health-retry.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { watchdogMs } from "./helpers/ci-watchdog";
+
+// Regression: `ocx health` probed once (750ms ceiling). A proxy that has only
+// just bound can leave that single probe timing out while startup work settles
+// the event loop, so the command reported ok:false seconds before the very same
+// proxy answered other commands. The health command now retries a bounded
+// number of times, matching the stop-path liveness posture (#764).
+const RUN_BUDGET_MS = watchdogMs(15_000);
+
+const cliPath = resolve(import.meta.dir, "../src/cli/index.ts");
+const roots: string[] = [];
+const servers: Server[] = [];
+
+/** Identity body after a deliberately slow first response: single-probe setups miss it. */
+function startLateFirstResponseProxy(port: number, firstResponseDelayMs: number): void {
+  let requests = 0;
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    requests += 1;
+    const respond = () => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        status: "ok",
+        service: "opencodex",
+        version: "0.0.0-test",
+        uptime: 1,
+        pid: process.pid,
+        port,
+      }));
+    };
+    if (requests === 1) setTimeout(respond, firstResponseDelayMs);
+    else respond();
+  });
+  servers.push(server);
+  server.listen(port, "127.0.0.1");
+}
+
+async function fixture(port: number) {
+  const root = mkdtempSync(join(tmpdir(), "ocx-health-retry-"));
+  roots.push(root);
+  const ocxHome = join(root, "ocx");
+  const home = join(root, "home");
+  const codexHome = join(root, "codex");
+  const runtime = join(root, "runtime");
+  for (const path of [ocxHome, home, codexHome, runtime]) mkdirSync(path, { recursive: true });
+  // No pid/runtime records: discovery must fall through to the configured port.
+  writeFileSync(join(ocxHome, "config.json"), JSON.stringify({
+    port,
+    hostname: "127.0.0.1",
+    codexAutoStart: false,
+    providers: {},
+    defaultProvider: "openai",
+  }));
+  return {
+    root,
+    env: {
+      HOME: home,
+      USERPROFILE: home,
+      CODEX_HOME: codexHome,
+      OPENCODEX_HOME: ocxHome,
+      XDG_RUNTIME_DIR: runtime,
+      NO_PROXY: "127.0.0.1,localhost",
+    } as Record<string, string>,
+  };
+}
+
+async function runHealth(fx: { root: string; env: Record<string, string> }): Promise<{ exitCode: number; stdout: string }> {
+  const child = Bun.spawn([process.execPath, cliPath, "health", "--json"], {
+    cwd: fx.root,
+    env: fx.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const completed = await Promise.race([
+    Promise.all([child.exited, new Response(child.stdout).text()]),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("CLI watchdog: ocx health --json")), RUN_BUDGET_MS)),
+  ]);
+  return { exitCode: completed[0], stdout: completed[1] };
+}
+
+afterEach(async () => {
+  while (servers.length) servers.pop()!.close();
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("ocx health against a proxy whose first probe response is slow", () => {
+  test("retries past a slow first response instead of reporting ok:false", async () => {
+    const port = await new Promise<number>((resolvePort, reject) => {
+      const server = createServer();
+      server.once("error", reject);
+      server.once("listening", () => {
+        const address = server.address();
+        const picked = typeof address === "object" && address ? address.port : 0;
+        server.close(() => (picked > 0 ? resolvePort(picked) : reject(new Error("no ephemeral port"))));
+      });
+      server.listen(0, "127.0.0.1");
+    });
+    // 1500ms first response: beyond the 750ms probe ceiling, so attempt 1 must
+    // time out and attempt 2 carry the answer.
+    startLateFirstResponseProxy(port, 1500);
+    const fx = await fixture(port);
+
+    const result = await runHealth(fx);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { ok: boolean; port: number };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.port).toBe(port);
+  }, RUN_BUDGET_MS);
+});

--- a/tests/cli-start-shadow-guard.test.ts
+++ b/tests/cli-start-shadow-guard.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:http";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { watchdogMs } from "./helpers/ci-watchdog";
+
+// Regression: `ocx start` skipped live-proxy discovery entirely when both state
+// files were absent, then hopped to an ephemeral port and re-pointed Codex at
+// the ephemeral copy. A fallback-port sibling produces exactly that precondition
+// on its own shutdown: it overwrites the pid/runtime records on start and
+// removes them when it exits, while the configured-port proxy keeps serving.
+const RUN_BUDGET_MS = watchdogMs(15_000);
+
+const cliPath = resolve(import.meta.dir, "../src/cli/index.ts");
+const roots: string[] = [];
+const children: Array<ReturnType<typeof Bun.spawn>> = [];
+
+function reserveLoopbackPort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.once("listening", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => (port > 0 ? resolvePort(port) : reject(new Error("no ephemeral port"))));
+    });
+    server.listen(0, "127.0.0.1");
+  });
+}
+
+async function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "ocx-start-shadow-"));
+  roots.push(root);
+  const codexHome = join(root, "codex");
+  const ocxHome = join(root, "ocx");
+  const home = join(root, "home");
+  const runtime = join(root, "runtime");
+  for (const path of [codexHome, ocxHome, home, runtime]) mkdirSync(path, { recursive: true });
+  const port = await reserveLoopbackPort();
+  // A FIXED configured port: the shadow bug is specifically that start never
+  // probes this port when the pid/runtime records are missing.
+  writeFileSync(join(ocxHome, "config.json"), JSON.stringify({
+    port,
+    hostname: "127.0.0.1",
+    codexAutoStart: false,
+    syncResumeHistory: false,
+    clientIntegrations: { codex: false, grok: false, "claude-desktop": false },
+    claudeCode: { systemEnv: false },
+    providers: {},
+    defaultProvider: "openai",
+  }));
+  const env: Record<string, string> = {
+    HOME: home,
+    USERPROFILE: home,
+    CODEX_HOME: codexHome,
+    OPENCODEX_HOME: ocxHome,
+    XDG_RUNTIME_DIR: runtime,
+    NO_PROXY: "127.0.0.1,localhost",
+  };
+  return { root, codexHome, ocxHome, port, pidPath: join(ocxHome, "ocx.pid"), runtimePath: join(ocxHome, "runtime-port.json"), env };
+}
+
+async function runCli(fx: Awaited<ReturnType<typeof fixture>>, argv: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([process.execPath, cliPath, ...argv], {
+    cwd: fx.root,
+    env: fx.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  children.push(child);
+  const completed = await Promise.race([
+    Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`CLI watchdog: ocx ${argv.join(" ")}`)), RUN_BUDGET_MS)),
+  ]);
+  return { exitCode: completed[0], stdout: completed[1], stderr: completed[2] };
+}
+
+async function startOwner(fx: Awaited<ReturnType<typeof fixture>>): Promise<ReturnType<typeof Bun.spawn>> {
+  const child = Bun.spawn([process.execPath, cliPath, "start", "--port", String(fx.port)], {
+    cwd: fx.root,
+    env: fx.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  children.push(child);
+  const deadline = Date.now() + RUN_BUDGET_MS;
+  for (;;) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for owner health");
+    try {
+      const response = await fetch(`http://127.0.0.1:${fx.port}/healthz`, { signal: AbortSignal.timeout(500) });
+      const body = await response.json() as { pid?: number };
+      if (response.ok && body.pid === child.pid) return child;
+    } catch { /* not listening yet */ }
+    await Bun.sleep(25);
+  }
+}
+
+/** Simulate a fallback-port sibling that already cleaned up its state files. */
+function removeStateFiles(fx: Awaited<ReturnType<typeof fixture>>): void {
+  for (const path of [fx.pidPath, fx.runtimePath]) {
+    if (existsSync(path)) unlinkSync(path);
+  }
+}
+
+afterEach(async () => {
+  for (const child of children) {
+    if (child.exitCode === null) child.kill("SIGTERM");
+  }
+  while (children.length) {
+    const child = children.pop()!;
+    if (child.exitCode === null) await child.exited;
+  }
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("start vs a healthy configured-port proxy with no state files", () => {
+  test("start refuses to shadow the live proxy and leaves no fallback instance", async () => {
+    const fx = await fixture();
+    const owner = await startOwner(fx);
+    try {
+      removeStateFiles(fx);
+
+      const start = await runCli(fx, ["start"]);
+      expect(start.exitCode).toBe(1);
+      expect(start.stderr).toContain("Proxy already running");
+      expect(start.stderr).toContain(`port ${fx.port}`);
+      // The pre-fix failure mode: an ephemeral-port hop plus a fresh instance.
+      expect(start.stderr).not.toContain("is busy; starting opencodex on");
+      expect(existsSync(fx.runtimePath)).toBe(false);
+      expect(existsSync(fx.pidPath)).toBe(false);
+
+      // The untouched owner is still the one serving.
+      const health = await fetch(`http://127.0.0.1:${fx.port}/healthz`, { signal: AbortSignal.timeout(500) });
+      const body = await health.json() as { pid?: number };
+      expect(body.pid).toBe(owner.pid);
+    } finally {
+      owner.kill("SIGTERM");
+      await owner.exited;
+    }
+  }, RUN_BUDGET_MS);
+});


### PR DESCRIPTION
## Summary

Two CLI reliability fixes for a duplicate-instance cascade observed in real use (macOS, v2.37.0, installed launchd service + interactive `ocx start` in the same home):

1. **`ocx start` skipped live-proxy discovery entirely when both `ocx.pid` and `runtime-port.json` were absent**, then shadowed a healthy configured-port proxy on an ephemeral port and re-pointed Codex/Grok config at that ephemeral copy. A fallback-port sibling produces exactly this precondition on its own shutdown: it overwrites the pid/runtime records on start, and removes them when it exits, while the configured-port proxy keeps serving. The next `start` shadows again — the cascade repeats on every restart. Observed downstream effects: two concurrent proxy instances, Codex config flip-flopping between ports, journal-restore warnings on every service start, and management-surface commands (`ocx account list`, `ocx claude` gateway model discovery) failing with "Proxy not reachable" while the installed service answered `/healthz` the whole time.

2. **`ocx health` probed exactly once.** A proxy that has only just bound can miss the single 750ms probe while its event loop is still settling startup work, so `ocx health --json` reported `{"ok":false}` seconds before the same proxy answered other commands. This is the same just-started race the stop paths already compensate for with retries (#764).

## Changes

- `handleStart` now passes `probeConfiguredPort: true` to `findProxyOwnerBeforeJournalRecovery`, mirroring `handleEnsure`. Cost on a genuinely cold start is one extra identity-checked `/healthz` probe (connection-refused returns immediately); the existing already-running refusal path absorbs the shadow case, including the `OCX_SERVICE=1` wrapper exit-0 behavior.
- The health command passes `attempts: 3` to discovery (bounded retries, same posture as the stop paths), and `CliDispatchDeps.findLiveProxy` is widened to accept an optional `LivenessIo`.

## Testing

- New `tests/cli-start-shadow-guard.test.ts`: a real owner serving on the configured port, pid/runtime records removed (the post-sibling-shutdown precondition) → `start` must refuse with "Proxy already running", must not hop to an ephemeral port, and must not write new state. **Fails before the fix, passes after.**
- New `tests/cli-health-retry.test.ts`: an identity-correct proxy whose first `/healthz` response is slower than the probe ceiling → `health --json` must report `ok:true`. **Fails before the fix, passes after.**
- `bun x tsc --noEmit` clean; `tests/proxy-liveness.test.ts`, `tests/cli-start-journal-order.test.ts`, `tests/cli-restart-health.test.ts`, `tests/stale-state-purge.test.ts` all green (92 tests); `bun scripts/privacy-scan.ts` passes.

No upstream issue exists for the start-shadow cascade as far as I could find (#618 covered status/doctor pid-file fallback; this is the start-path sibling plus the single-attempt health probe). Happy to split into two PRs or adjust scoping if preferred.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `health` checks by retrying liveness probes, reducing failures when a proxy is still starting or responds slowly.
  * Prevented `start` from launching a duplicate proxy when an existing healthy proxy is running on the configured port, even if local state information is unavailable.
  * Ensured startup preserves the existing proxy instead of switching to an unexpected fallback port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->