### PR TITLE
docs(devlog): record the wp6/wp5/wp4 entitlement stack outcome

### DIFF
--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/000_plan.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/000_plan.md
@@ -11,6 +11,16 @@ decade doc as one full PABCD cycle.
 | wp2 | #3023 roster TTL expiry drops entitled rows | `020` | 71/80 |
 | wp3 | #3011 Windows ACL spill stall (PR #3018 audit) | `030` | 71/80 |
 
+Three more work phases were born from audit blockers rather than from the frozen scan,
+so they are recorded here as audit-derived additions rather than as part of the original
+three-target scope:
+
+| wp | target | doc | origin |
+| --- | --- | --- | --- |
+| wp4 | entitlement diagnostic transport | `040` | split out of wp2 by audit round 1 (`004`, blocker 4) |
+| wp5 | tri-state entitlement authority | `050` | split out of wp1 by audit round 2 (`005`, blocker 1) |
+| wp6 | #3023 ensure-freshness implementation | `060` | wp2 closed as a planning cycle; its implementation is wp6 |
+
 ## Why this order
 
 wp1 is the stack base: it changes what `resolveCodexModelEntitlements` records

--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/060_wp6_ensure_freshness.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/060_wp6_ensure_freshness.md
@@ -1,0 +1,70 @@
+# wp6 — #3023: implement the audited ensure-freshness design
+
+Status: implemented, verified, landed via PR #3054.
+
+## What wp2 established and deliberately did not build
+
+wp2 closed as a planning cycle. Four audit rounds each found a real hole in the
+cross-answering behaviour, and the round-4 output was a flight key, not a patch:
+
+    (normalized candidate set, client version, mutation epoch, identity vector, workset)
+
+The reason wp2 did not implement is that the first three candidate designs each
+answered a caller from a flight that had been started for a *different* question.
+A memo keyed only on "are we logged in" cannot distinguish a roster derived
+before a credential swap from one derived after it, so a fresh entitlement and a
+revoked one both read as a hit.
+
+## The defect in observable terms
+
+`/api/models`, `/api/client-config` and `ocx export` share
+`listManagementModelRows`. The entitlement snapshot behind it carried an expiry
+but no binding to the credential state that produced it. Two consequences:
+
+1. After `MODEL_ROSTER_TTL_MS` elapsed, the surfaces kept answering from the
+   expired snapshot instead of re-deriving.
+2. When `auth.json` was replaced out of band, the snapshot stayed authoritative.
+   A newly entitled account saw the old roster; a logged-out account still saw
+   models it no longer had.
+
+## Implementation
+
+`src/codex/credential-mutation-epoch.ts` (new) holds a monotonic counter bumped
+at every credential mutation point — `account-store`, `main-account`,
+`native-profile-manager`. An entitlement snapshot records the epoch it was
+derived under. A read is a hit only when both the epoch and the expiry still
+match; otherwise it re-derives. Consumers move to the freshness-checked accessor
+(`server/management/model-rows.ts`, `sidecar/candidates.ts`).
+
+The logged-out result is memoized deliberately, because the dashboard polls this
+path ~24 times a minute and c-9 requires zero credential enumerations after the
+first.
+
+## Cost contract
+
+Steady state, nothing mutated and the snapshot live: **0** additional
+`accountCredentialSnapshot` calls, **0** token refreshes, **0** network
+requests. This is the property that makes the fix safe to put on a polling path.
+
+## Evidence
+
+Nine regressions written red-first against the unfixed code: steady-state
+credential reads, logged-out memo, memo invalidation on mutation,
+`/api/client-config` fetch count 1 vs 0, expired `/api/models`, real-handler
+`ocx export`, local epoch write during an in-flight derive, external
+`auth.json` replacement during an in-flight derive, and account B expiring
+during an A-only flight.
+
+The rejection-path tests are labelled characterization, not red-first. They
+describe behaviour that already held; calling them regressions would overstate
+what they prove.
+
+`ssh lidge` at exact head `6298fae32`: privacy scan clean, typecheck clean,
+full suite **16524 pass / 0 fail / 16 skip**, `EXIT=0`. 208 focused tests pass
+locally across the touched suites.
+
+## Residual
+
+The epoch is process-local. Two proxies sharing one `OPENCODEX_HOME` still
+observe each other only through the expiry, not the epoch. Not reachable in the
+supported single-proxy topology, and out of scope here.

--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
@@ -7,8 +7,10 @@ this train, so suite receipts name `lidge`.
 ## wp0 — roadmap (docs-only)
 
 - Status: closing.
-- Deliverable: 12 docs — `000` plan, `001`-`003` research, `004`-`006` audit
-  syntheses, `010`/`020`/`030`/`040`/`050` decade docs, `070` receipts.
+- Deliverable at the time wp0 closed: 12 docs — `000` plan, `001`-`003` research,
+  `004`-`006` audit syntheses, `010`/`020`/`030`/`040`/`050` decade docs, `070`
+  receipts. The unit now holds **14**: audit rounds 4-8 added `007`-`009`, and wp2's
+  implementation split out as `060`.
 - Branch: `codex/prio70-train-260831` at `903243d04`.
 - Research: three read-only `gpt-5.6-sol` high-effort lanes. Every load-bearing
   claim was re-verified in-tree by the main session before it entered a doc.
@@ -143,10 +145,11 @@ a warm roster and all carry the gated rows. #3023 is about what happens once
 the warm path is intact and the wp6 work is scoped to expiry, not to the rows
 themselves.
 
-## wp3 — LANDED (pending merge of PR #3044)
+## wp3 — LANDED
 
 #3011 fixed by carrying Ingwannu's `aec717722` and closing the shutdown boundary it
-opened. His commit is the base of the branch, unmodified and credited.
+opened. His commit is the base of the branch, unmodified and credited. PR #3044 is
+merged into `dev` as `e5d588669`.
 
 Five review rounds, each returning FAIL until the last, and every finding was a real
 defect rather than a style note. Worth recording as a sequence, because each fix

--- a/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
+++ b/devlog/_plan/260831_prio70_entitlement_and_spill_train/070_outcome.md
@@ -191,3 +191,57 @@ rather than by editing the version by hand.
 
 Residual risk: a real Windows host is still needed for NTFS unlink semantics and
 `icacls` timeout behaviour while a path is held.
+
+## wp6 / wp5 / wp4 — the entitlement stack (landed 260831)
+
+Three phases landed as a dependency-ordered stack on top of the spill work.
+
+**wp6 (#3054, `0844dc9a9`) closed #3023.** A credential mutation epoch binds an
+entitlement snapshot to the credential state that produced it; a read is a hit
+only when both epoch and expiry still match. Steady state stays free: 0 extra
+credential snapshots, 0 token refreshes, 0 network calls on the ~24/min polling
+path.
+
+The review round that mattered was the second one. The first submission's two
+race regressions returned *usable* credentials, so they never reached the
+negative-memo publication fence at all — **deleting the epoch and identity fences
+left both tests green.** A third test could not distinguish absence-observation
+time from settlement time. The implementation was correct; the tests guarding its
+riskiest lines were worthless. Three replacements were driven red by removing
+each fence in turn, and the reviewer reproduced every red independently rather
+than trusting the report.
+
+**wp5 (#3057) removes the #3022 class, not its instance.** wp1 fixed the current
+failure by asking under a measured `0.144.0`. wp5 makes absence evidence only
+when the question was capable of producing an answer: below-minimum omission is
+`unknown` on the 15s failure TTL, at-or-above omission is `denied`, a present row
+is `granted` regardless of version, and `gpt-daybreak-blue-latest` — which has no
+row in `upstream-models.json` — keeps omission-as-denial rather than being handed
+a guessed minimum. Projections still return only `granted`; that is what keeps
+the gate fail-closed. One widening bug surfaced during implementation (an
+unconfirmed present row briefly read as `granted`) and the guard test now pins it.
+
+**wp4 (#3058) answers the part of #3023 that was never about rows.** The reporter
+saw `discovery: {"status":"ok"}` beside missing models and read it as the proxy
+lying. It was answering a different question, and nothing reported entitlement
+freshness at all. Provenance had to come first: the parsed-empty path and the
+catch path produced byte-identical cache entries, so reporting them as two states
+would have been the same fabrication in a new field.
+
+### Two CI defects found along the way
+
+Neither was ours, and both were real.
+
+`shutdown cleanup failure still persists unrelated response state` used a real
+80ms wall-clock fallback reserve. Drain expiry is forced by an `icacls` gate and
+is deterministic; the reserve was not. Under load it expired first, terminalizing
+the unrelated response into a `spill-failed` tombstone. Measured on Linux at
+`origin/dev`: eight parallel runs of that single test spanned **2.08s to 109.38s**,
+and a six-way run reproduced the failure 1-in-6. Fixed in #3055 by sizing the
+reserve so it can never be the thing that runs out; 10/10 parallel runs pass
+afterwards, the longest at 45.51s.
+
+`Unix install rejects delayed detached redispatch` failed once on macOS CI and
+passed on rerun and on three local macOS runs. It pairs a 1500ms observation
+window with a fixed `time.sleep(0.5)` in a forked child, which is thin on a slow
+runner. Recorded rather than fixed: it has not reproduced.


### PR DESCRIPTION
## Summary

Records the closing state of the 260831 priority-70+ train's entitlement stack. Docs only - no runtime, test, or build path reads from devlog/.

- 060_wp6_ensure_freshness.md - the wp6 decade doc for #3023: the conditional ensure at the shared entry point, the bounded negative memo for the logged-out case, and the flight key as it grew across eight audit rounds to (candidate set, client version, mutation epoch, identity vector, workset).
- 070_outcome.md - receipts for wp6 (#3054), wp5 tri-state authority (#3057) and wp4 entitlement diagnostic (#3058), plus the two CI-only test defects found alongside them.

## Verification

- bun test tests/repo-hygiene.test.ts -> 12 pass / 0 fail. That is the focused file covering a tracked devlog/ change (no-gitlink and tracked-devlog assertions).
- No source, test, config, or GUI file is touched, so no other focused set applies.
- Branch rebased onto dev at 5cec0a33e before pushing; head is b1f55b807.

## Checklist

- [x] Targets dev
- [x] No source behavior change, so no regression test is required
- [x] No user-facing behavior change, so no docs-site/ update is required
- [x] No credentials, request bodies, or account identifiers added
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added implementation notes for entitlement freshness and credential-change handling.
  * Documented clearer entitlement status outcomes: unknown, denied, and granted.
  * Added documentation on cache-entry provenance and related CI findings.
  * Updated the planning and outcome records with newly completed work phases and audit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->