### PR TITLE
feat(gui): put the client's logo on every Integrations surface

### DIFF
--- a/gui/src/components/ClientMark.tsx
+++ b/gui/src/components/ClientMark.tsx
@@ -1,0 +1,56 @@
+/**
+ * One brand mark, one decision about how to paint it.
+ *
+ * The rule this centralizes is the one that was already got wrong once: a
+ * single-ink logo drawn as an <img> is invisible against one of the two themes,
+ * so it has to be drawn as a CSS mask tinted with the surrounding text color
+ * instead. That decision was inline in ClientConfigRow, which was fine while
+ * exactly one surface drew marks. Four surfaces do now, and four copies of a
+ * ternary whose wrong branch renders nothing at all is how the bug comes back.
+ *
+ * Marks are decorative here. Every call site puts one beside a text label that
+ * already names the client, so the mark contributes nothing to the accessible
+ * name and must not try: an <img alt={label}> next to a visible label makes a
+ * screen reader say it twice.
+ */
+import { MASKED_MARKS } from "./integration-marks";
+
+export default function ClientMark({
+  src,
+  label,
+  size = 20,
+  className,
+}: {
+  /** Asset path, or null for a client with no committed mark. */
+  src: string | null;
+  /** Only the first character is drawn, as the monogram fallback. */
+  label: string;
+  size?: number;
+  className?: string;
+}) {
+  const classes = className ? `client-mark ${className}` : "client-mark";
+  // Concatenated rather than interpolated: the i18n lint reads a template
+  // literal with a bare unit as user-facing copy, and a CSS length is not that.
+  const style = { "--client-mark-size": String(size) + "px" } as React.CSSProperties;
+  if (!src) {
+    return (
+      <span className={`${classes} client-mark--monogram`} style={style} aria-hidden="true">
+        {label.slice(0, 1)}
+      </span>
+    );
+  }
+  if (MASKED_MARKS.has(src)) {
+    return (
+      <span
+        className={`${classes} client-mark--mask`}
+        style={{ ...style, maskImage: `url(${src})`, WebkitMaskImage: `url(${src})` }}
+        aria-hidden="true"
+      />
+    );
+  }
+  return (
+    <span className={`${classes} client-mark--img`} style={style} aria-hidden="true">
+      <img src={src} alt="" width={size} height={size} />
+    </span>
+  );
+}

--- a/gui/src/components/apikeys-workspace/ClientConfigRow.tsx
+++ b/gui/src/components/apikeys-workspace/ClientConfigRow.tsx
@@ -7,7 +7,8 @@
  */
 import { useCallback, useEffect, useState } from "react";
 import { useT } from "../../i18n/shared";
-import { CLIENT_LABEL_KEYS, CLIENT_MARKS, MONOCHROME_CLIENT_MARKS, type ClientConfigEnvelope, type ExportClientId } from "./client-config-clients";
+import ClientMark from "../ClientMark";
+import { CLIENT_LABEL_KEYS, CLIENT_MARKS, type ClientConfigEnvelope, type ExportClientId } from "./client-config-clients";
 
 export default function ClientConfigRow({
   client,
@@ -77,7 +78,6 @@ export default function ClientConfigRow({
 
   const label = t(CLIENT_LABEL_KEYS[client]);
   const mark = CLIENT_MARKS[client];
-  const monochrome = MONOCHROME_CLIENT_MARKS.has(client);
   // The server renders the client's own format; re-serializing as JSON here
   // would hand a TOML or YAML client bytes its parser cannot read.
   const json = data?.text ?? "";
@@ -88,12 +88,14 @@ export default function ClientConfigRow({
 
   return (
     <li className="awi-clientconfig-row">
-      <span className="awi-clientconfig-mark" aria-hidden="true">
-        {mark
-          ? monochrome
-            ? <span className="awi-clientconfig-mark-mask" style={{ maskImage: `url(${mark})`, WebkitMaskImage: `url(${mark})` }} />
-            : <img src={mark} alt="" width={20} height={20} />
-          : <span className="awi-clientconfig-monogram">{label.slice(0, 1)}</span>}
+      {/*
+        The img-versus-mask decision moved to ClientMark, which four surfaces now
+        share. It was inline here while this was the only surface drawing marks;
+        four copies of a ternary whose wrong branch renders nothing is how the
+        invisible-logo bug would come back.
+      */}
+      <span className="awi-clientconfig-mark">
+        <ClientMark src={mark ?? null} label={label} size={20} />
       </span>
 
       <span className="awi-clientconfig-identity">

--- a/gui/src/components/integration-marks.ts
+++ b/gui/src/components/integration-marks.ts
@@ -1,0 +1,83 @@
+/**
+ * The mark for every row the Integrations page can show, and the set of assets
+ * that must be drawn as a themed mask rather than an image.
+ *
+ * Why this is not just `CLIENT_MARKS`: the Integrations page reaches four rows
+ * that are not export clients at all -- Codex CLI routing, Claude Code, Claude
+ * Desktop and the Grok fence. Those ids live in a different namespace that
+ * happens to overlap on the string "claude", so one map keyed by
+ * `OverviewClientId` is the only shape that can serve the page.
+ *
+ * `MASKED_MARKS` is keyed by ASSET PATH, deliberately, where
+ * `MONOCHROME_CLIENT_MARKS` is keyed by client id. `kimi-color.svg` is reachable
+ * both as a provider icon and as a client mark; a path-keyed set cannot mask it
+ * on one surface and leave it unmasked on another, which is exactly the
+ * inconsistency a second id-keyed set would invite.
+ */
+import { CLIENT_MARKS, MONOCHROME_CLIENT_MARKS, type ExportClientId } from "./apikeys-workspace/client-config-clients";
+import type { OverviewClientId } from "../pages/integrations/overview-clients";
+
+/**
+ * The four rows with no export client behind them.
+ *
+ * Codex takes the OpenAI mark because Codex CLI ships no mark of its own and
+ * OpenAI publishes it. Claude Desktop shares Claude's: they are one brand and
+ * two surfaces, and inventing a distinct mark for the desktop app would imply a
+ * distinction that does not exist.
+ */
+const NATIVE_MARKS: Record<Exclude<OverviewClientId, ExportClientId>, string> = {
+  codex: "/provider-icons/openai.svg",
+  claude: "/provider-icons/claude-color.svg",
+  claudeDesktop: "/provider-icons/claude-color.svg",
+  grok: "/provider-icons/grok.svg",
+};
+
+/**
+ * Every Integrations row to its mark. Exhaustive over `OverviewClientId`, so a
+ * client added to the page without an asset decision is a compile error rather
+ * than a silent monogram.
+ *
+ * A value may still be null: that is the honest answer for a client whose
+ * vendor publishes nothing usable, and `ClientMark` renders a monogram for it.
+ * Today none are, which `integration-marks.test.ts` pins.
+ */
+export const INTEGRATION_MARKS: Record<OverviewClientId, string | null> = {
+  ...NATIVE_MARKS,
+  opencode: CLIENT_MARKS.opencode ?? null,
+  pi: CLIENT_MARKS.pi ?? null,
+  omp: CLIENT_MARKS.omp ?? null,
+  hermes: CLIENT_MARKS.hermes ?? null,
+  openclaw: CLIENT_MARKS.openclaw ?? null,
+  kimi: CLIENT_MARKS.kimi ?? null,
+  gajae: CLIENT_MARKS.gajae ?? null,
+  dsh: CLIENT_MARKS.dsh ?? null,
+  mcode: CLIENT_MARKS.mcode ?? null,
+  zcode: CLIENT_MARKS.zcode ?? null,
+  prime: CLIENT_MARKS.prime ?? null,
+  aside: CLIENT_MARKS.aside ?? null,
+};
+
+/**
+ * Assets whose artwork is one neutral ink, so the ink has to come from the theme.
+ *
+ * Derived from `MONOCHROME_CLIENT_MARKS` rather than restated, because two
+ * hand-maintained lists of the same fact drift. Nothing is added on top of it,
+ * and the two candidates that look like they belong here do not:
+ *
+ * - `openai.svg` is a single fill, but that fill is #10A37F -- OpenAI's brand
+ *   green. Masking it repaints a trademark in the theme's text color, which is
+ *   the same reason `dsh` stays an image despite being single-ink.
+ * - `grok.svg` is #000000, a genuine neutral and a real masking candidate. It
+ *   is xAI's published asset with a literal fill, and rewriting that file to
+ *   `currentColor` is a change to someone else's mark rather than a rendering
+ *   choice, so it stays an image here.
+ */
+export const MASKED_MARKS: ReadonlySet<string> = new Set(
+  [...MONOCHROME_CLIENT_MARKS].map(clientId => CLIENT_MARKS[clientId]).filter((src): src is string => src !== undefined),
+);
+
+/** The mark for a row, or null when it has none. */
+export function markFor(clientId: OverviewClientId): string | null {
+  return INTEGRATION_MARKS[clientId];
+}
+

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -1002,7 +1002,7 @@ export const de: Record<TKey, string> = {
   "integrations.tabsLabel": "Integrationsbereiche",
   "integrations.tab.overview": "Übersicht",
   "integrations.tab.keys": "API-Schlüssel",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -1497,7 +1497,7 @@ export const en = {
   "integrations.tabsLabel": "Integration surfaces",
   "integrations.tab.overview": "Overview",
   "integrations.tab.keys": "API Keys",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/fr.ts
+++ b/gui/src/i18n/fr.ts
@@ -1470,7 +1470,7 @@ export const fr: Record<TKey, string> = {
   "integrations.tabsLabel": "Surfaces d’intégration",
   "integrations.tab.overview": "Vue d’ensemble",
   "integrations.tab.keys": "Clés API",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -1430,7 +1430,7 @@ export const ja: Record<TKey, string> = {
   "integrations.tabsLabel": "連携画面",
   "integrations.tab.overview": "概要",
   "integrations.tab.keys": "API キー",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -1026,7 +1026,7 @@ export const ko: Record<TKey, string> = {
   "integrations.tabsLabel": "연동 화면",
   "integrations.tab.overview": "개요",
   "integrations.tab.keys": "API 키",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -1481,7 +1481,7 @@ export const ru: Record<TKey, string> = {
   "integrations.tabsLabel": "Разделы интеграций",
   "integrations.tab.overview": "Обзор",
   "integrations.tab.keys": "Ключи API",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/tr.ts
+++ b/gui/src/i18n/tr.ts
@@ -1488,7 +1488,7 @@ export const tr: Record<TKey, string> = {
   "integrations.tabsLabel": "Entegrasyon yüzeyleri",
   "integrations.tab.overview": "Genel Bakış",
   "integrations.tab.keys": "API Anahtarları",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/zh-TW.ts
+++ b/gui/src/i18n/zh-TW.ts
@@ -2035,7 +2035,7 @@ export const zhTW: Record<TKey, string> = {
   "integrations.tabsLabel": "整合表面",
   "integrations.tab.overview": "總覽",
   "integrations.tab.keys": "API 金鑰",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -1019,7 +1019,7 @@ export const zh: Record<TKey, string> = {
   "integrations.tabsLabel": "集成页面",
   "integrations.tab.overview": "概览",
   "integrations.tab.keys": "API 密钥",
-  "integrations.tab.codex": "Codex CLI",
+  "integrations.tab.codex": "Codex",
   "integrations.tab.claude": "Claude",
   "integrations.tab.grok": "Grok Build",
   "integrations.tab.opencode": "OpenCode",

--- a/gui/src/pages/Integrations.tsx
+++ b/gui/src/pages/Integrations.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { navigateHash, normalizeHashPath } from "../hash-routing";
 import { useT } from "../i18n/shared";
+import ClientMark from "../components/ClientMark";
+import { INTEGRATION_MARKS } from "../components/integration-marks";
 import ApiKeys from "./ApiKeys";
 import Claude from "./Claude";
 import Grok from "./Grok";
@@ -23,6 +25,18 @@ function tabDomId(tab: IntegrationTab): string {
 
 function panelDomId(tab: IntegrationTab): string {
   return `integrations-panel-${tab}`;
+}
+
+/*
+ * The strip carries 17 tabs on one row, which is precisely where a mark earns
+ * its place: the eye finds a logo faster than it reads the tenth label. Two
+ * tabs have no client behind them -- `overview` is the page itself and `keys`
+ * is a credential surface, not an integration -- so they stay text-only rather
+ * than borrowing a mark that would imply a client.
+ */
+function tabMark(tab: IntegrationTab): string | null {
+  if (tab === "overview" || tab === "keys") return null;
+  return INTEGRATION_MARKS[tab] ?? null;
 }
 
 export default function Integrations({ apiBase }: { apiBase: string }) {
@@ -109,6 +123,9 @@ export default function Integrations({ apiBase }: { apiBase: string }) {
             onClick={() => selectTab(definition.id, true)}
             onKeyDown={handleTabKeyDown}
           >
+            {tabMark(definition.id) && (
+              <ClientMark src={tabMark(definition.id)} label={t(definition.labelKey)} size={14} />
+            )}
             {t(definition.labelKey)}
           </button>
         ))}

--- a/gui/src/pages/integrations/FileIntegrationPage.tsx
+++ b/gui/src/pages/integrations/FileIntegrationPage.tsx
@@ -3,6 +3,8 @@ import { useDataSurface } from "../../data-surface";
 import { DataSurfaceSkeleton } from "../../components/data-surface";
 import { useT, type TKey } from "../../i18n/shared";
 import { Notice, Switch } from "../../ui";
+import ClientMark from "../../components/ClientMark";
+import { markFor } from "../../components/integration-marks";
 import IntegrationStateBadge from "./IntegrationStateBadge";
 import RestoreDialog from "./RestoreDialog";
 import { RollbackHistory } from "./RollbackHistory";
@@ -143,6 +145,7 @@ export default function FileIntegrationPage({
   return (
     <section className="integration-client-page">
       <div className="integration-client-head">
+        <ClientMark src={markFor(client)} label={t(TAB_LABEL_KEY[client])} size={24} />
         <h3>{t(TAB_LABEL_KEY[client])}</h3>
         <IntegrationStateBadge
           state={status.state}

--- a/gui/src/pages/integrations/IntegrationsOverview.tsx
+++ b/gui/src/pages/integrations/IntegrationsOverview.tsx
@@ -4,6 +4,8 @@ import { DataSurfaceSkeleton } from "../../components/data-surface";
 import { navigateHash } from "../../hash-routing";
 import { useT } from "../../i18n/shared";
 import { Notice, Switch } from "../../ui";
+import ClientMark from "../../components/ClientMark";
+import { markFor } from "../../components/integration-marks";
 import IntegrationStateBadge from "./IntegrationStateBadge";
 import ConsequenceDialog, { type ConsequenceCopy } from "./ConsequenceDialog";
 import RestoreDialog from "./RestoreDialog";
@@ -98,6 +100,12 @@ function OverviewCard({
   return (
     <li className="integration-card" data-client={row.id}>
       <div className="integration-card-head">
+        {/*
+          Before the title, not inside it: the title IS the card's one control
+          and its accessible name, so a mark inside the button would be read as
+          part of the client name. The mark is decorative and aria-hidden.
+        */}
+        <ClientMark src={markFor(row.id)} label={t(row.labelKey)} size={20} />
         <h4>
           <button type="button" className="integration-card-link" onClick={onOpen}>
             {t(row.labelKey)}

--- a/gui/src/styles-integrations.css
+++ b/gui/src/styles-integrations.css
@@ -47,6 +47,56 @@
 
 .integration-client-head { display: flex; align-items: center; gap: 10px; }
 .integration-client-head h3 { margin: 0; }
+
+/* One brand mark, four surfaces. Sized from a custom property so the same three
+   rules serve the 14px tab strip, the 20px overview card and the 24px client
+   page header without a variant class per size. */
+.client-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: var(--client-mark-size, 20px);
+  height: var(--client-mark-size, 20px);
+}
+
+.client-mark--img img {
+  width: 100%;
+  height: 100%;
+  border-radius: 2px;
+}
+
+/* A single-ink mark is painted with the surrounding text color instead of its
+   own, so it follows the theme. Without this a white-on-transparent logo is
+   invisible in light mode and a near-black one invisible in dark -- which is
+   not hypothetical, it shipped that way for prime, opencode and kimi. */
+.client-mark--mask {
+  background: var(--text);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}
+
+/* Placeholder for a client whose vendor publishes no usable asset. Honest about
+   being one: muted, and the slot a real mark drops into later. */
+.client-mark--monogram {
+  font-size: var(--text-label);
+  font-weight: var(--weight-semibold);
+  color: var(--muted);
+  line-height: 1;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--raised);
+}
+
+/* The card head is space-between, so without this the badge would land between
+   the mark and the title. The title takes the free space instead. */
+.integration-card-head h4 { flex: 1 1 auto; min-width: 0; }
+
+.page-tab > .client-mark { margin-right: 6px; vertical-align: -2px; }
 .integration-client-head .switch { margin-left: auto; }
 
 /* A config path is the thing a user copies when a refusal tells them to

--- a/gui/tests/client-config-panel.test.tsx
+++ b/gui/tests/client-config-panel.test.tsx
@@ -274,10 +274,12 @@ test("dialog closes on Escape and returns focus to its trigger", async () => {
 });
 
 test("each client row shows its own brand mark, never a borrowed one", async () => {
-  // Nine clients ship a real first-party asset; gajae and hermes have none that
-  // qualifies and fall back to a monogram tile. The rule this guards is that no
-  // client ever borrows another product's logo — not that every client has an
-  // asset. Uniqueness is the teeth: a borrowed logo would show up twice.
+  // Every client now ships a real first-party asset, two of them traced from the
+  // vendor's own raster. The rule this guards is that no client ever borrows
+  // another product's logo; uniqueness is the teeth, because a borrowed logo
+  // would show up twice. Completeness of the map is guarded separately in
+  // client-marks-assets.test.ts, and the monogram branch stays for the next
+  // client that arrives without an asset.
   //
   // A mark reaches the DOM one of two ways. A plated brand SVG is an <img>; a
   // single-ink silhouette is a masked span so the theme supplies its color. Both
@@ -287,7 +289,7 @@ test("each client row shows its own brand mark, never a borrowed one", async () 
   const { root, container } = await mountPanel();
 
   // OpenCode is monochrome, so its mark is masked rather than an <img>.
-  const opencodeMark = row(container, "OpenCode").querySelector<HTMLElement>(".awi-clientconfig-mark-mask");
+  const opencodeMark = row(container, "OpenCode").querySelector<HTMLElement>(".client-mark--mask");
   expect(opencodeMark).not.toBeNull();
   expect(opencodeMark!.style.maskImage || opencodeMark!.style.webkitMaskImage)
     .toContain("/provider-icons/opencode.svg");
@@ -297,7 +299,7 @@ test("each client row shows its own brand mark, never a borrowed one", async () 
   // rendering paths.
   const imgSources = [...container.querySelectorAll("img")]
     .map(img => img.getAttribute("src"));
-  const maskSources = [...container.querySelectorAll<HTMLElement>(".awi-clientconfig-mark-mask")]
+  const maskSources = [...container.querySelectorAll<HTMLElement>(".client-mark--mask")]
     .map(node => {
       const raw = node.style.maskImage || node.style.webkitMaskImage;
       return raw.replace(/^url\(["']?/, "").replace(/["']?\)$/, "");
@@ -312,7 +314,7 @@ test("each client row shows its own brand mark, never a borrowed one", async () 
   }
   // A masked mark is a bare span, so it must not announce itself either; the
   // slot around it already carries aria-hidden.
-  for (const node of container.querySelectorAll(".awi-clientconfig-mark-mask")) {
+  for (const node of container.querySelectorAll(".client-mark--mask")) {
     expect(node.textContent).toBe("");
   }
 

--- a/gui/tests/integration-marks.test.ts
+++ b/gui/tests/integration-marks.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { INTEGRATION_MARKS, MASKED_MARKS } from "../src/components/integration-marks";
+import { CLIENT_MARKS, MONOCHROME_CLIENT_MARKS } from "../src/components/apikeys-workspace/client-config-clients";
+import { TABS } from "../src/pages/integrations/integration-tabs";
+
+const PUBLIC_DIR = join(import.meta.dir, "..", "public");
+
+function bodyOf(src: string): string {
+  return readFileSync(join(PUBLIC_DIR, src.replace(/^\//, "")), "utf8");
+}
+
+function inksOf(body: string): Set<string> {
+  const matches = body.match(/(?:fill|stop-color)\s*[:=]\s*"?#[0-9a-fA-F]{3,8}/g) ?? [];
+  return new Set(matches.map(raw => raw.split(/[:=]/).pop()!.replace(/"/g, "").trim().toLowerCase()));
+}
+
+/*
+ * The page renders a mark for every row it draws, so a row whose id is missing
+ * from the map renders nothing where a logo should be. The map is a Record over
+ * OverviewClientId, so the compiler catches an omission -- but only for ids that
+ * type already knows. This asserts the values are real.
+ */
+test("every Integrations row has a mark that resolves to a committed file", () => {
+  const broken = Object.entries(INTEGRATION_MARKS)
+    .filter(([, src]) => src !== null && !existsSync(join(PUBLIC_DIR, src.replace(/^\//, ""))));
+  expect(broken).toEqual([]);
+});
+
+/*
+ * A null value is a legitimate answer -- it renders a monogram -- but none of the
+ * current rows should be taking it. If one does, either an asset was dropped or a
+ * client was added without a mark decision, and both look like a rendering bug
+ * from the outside.
+ */
+test("no Integrations row falls back to a monogram today", () => {
+  const monogram = Object.entries(INTEGRATION_MARKS)
+    .filter(([, src]) => src === null)
+    .map(([id]) => id);
+  expect(monogram).toEqual([]);
+});
+
+/*
+ * Masking paints the artwork with the theme's text color, discarding whatever
+ * the file carries. Doing that to a multi-color mark flattens a brand palette
+ * into one ink, and the result still renders and still looks deliberate, which is
+ * why this needs a test rather than review attention.
+ */
+test("no multi-color asset is masked", () => {
+  const flattened: string[] = [];
+  for (const src of MASKED_MARKS) {
+    const body = bodyOf(src);
+    const gradient = /<(linearGradient|radialGradient)[\s>]/.test(body);
+    const inks = inksOf(body);
+    if (gradient || inks.size > 1) flattened.push(`${src}: ${inks.size} ink(s)${gradient ? " + gradient" : ""}`);
+  }
+  expect(flattened).toEqual([]);
+});
+
+/*
+ * The inverse rule, and the one that cannot be derived from the file: a mark may
+ * be a single ink and still not be a masking candidate, because that ink is the
+ * brand. openai.svg is #10A37F and deepseek-harness.svg is #4d6bfe; masking
+ * either repaints a trademark in the theme's text color. Pinned with their inks
+ * so a vendor changing its asset shows up here rather than silently satisfying
+ * the assertion.
+ */
+test("a single-ink asset whose ink is a brand color is not masked", () => {
+  for (const [src, ink] of [
+    ["/provider-icons/openai.svg", "#10a37f"],
+    ["/provider-icons/deepseek-harness.svg", "#4d6bfe"],
+  ] as const) {
+    expect(MASKED_MARKS.has(src), `${src} must not be masked`).toBe(false);
+    expect([...inksOf(bodyOf(src))], `${src} ink changed upstream`).toEqual([ink]);
+  }
+});
+
+/*
+ * MASKED_MARKS is derived from MONOCHROME_CLIENT_MARKS rather than restated, and
+ * this is what makes that derivation observable: the two must describe the same
+ * assets. A second hand-maintained list would drift, and the drift would be a
+ * mark masked on one surface and not on another.
+ */
+test("the masked set is exactly the monochrome client marks", () => {
+  const expected = [...MONOCHROME_CLIENT_MARKS].map(id => CLIENT_MARKS[id]).filter(Boolean).sort();
+  expect([...MASKED_MARKS].sort()).toEqual(expected as string[]);
+});
+
+/*
+ * The tab strip draws a mark per tab, and two tabs have no client behind them:
+ * overview is the page and keys is a credential surface. Every OTHER tab must be
+ * in the map, or its tab renders bare while its neighbours carry logos.
+ */
+test("every client tab has a mark", () => {
+  const bare = TABS
+    .filter(tab => tab.id !== "overview" && tab.id !== "keys")
+    .filter(tab => !(tab.id in INTEGRATION_MARKS));
+  expect(bare.map(tab => tab.id)).toEqual([]);
+});
+

--- a/gui/tests/integrations-surfaces.test.tsx
+++ b/gui/tests/integrations-surfaces.test.tsx
@@ -776,3 +776,83 @@ test("every export client has both an Integrations tab and a file-surface entry"
   const orphaned = [...FILE_CLIENTS].filter(id => !clientIds.has(id));
   expect(orphaned).toEqual([]);
 });
+
+/*
+ * The mark has to reach every surface, not just the API tab it started on. Three
+ * of them are checked here; the fourth is client-config-panel.test.tsx.
+ *
+ * These assert on the rendered DOM rather than on the map, because the map being
+ * right and the component never being called is exactly the failure a map-only
+ * test cannot see -- and it is the failure that would ship, since the marks were
+ * correct in data long before any surface drew them.
+ */
+test("a client page header draws its client's mark", async () => {
+  stateResponse = () => json(status({
+    clientId: "dsh",
+    configPath: "/tmp/home/.dsh/settings.yaml",
+  }));
+  await mountClient(true, "dsh");
+
+  const head = container.querySelector(".integration-client-head")!;
+  const mark = head.querySelector<HTMLElement>(".client-mark");
+  expect(mark, "the client page header should carry a mark").not.toBeNull();
+  // dsh is single-ink but its ink is DeepSeek blue, so it renders as an image.
+  expect(mark!.querySelector("img")?.getAttribute("src")).toBe("/provider-icons/deepseek-harness.svg");
+  // Decoration beside a heading that already names the client.
+  expect(mark!.getAttribute("aria-hidden")).toBe("true");
+});
+
+test("every overview card draws a mark, and none of them names itself", async () => {
+  await mountOverview();
+
+  const cards = [...container.querySelectorAll(".integration-card")];
+  expect(cards.length).toBeGreaterThan(4);
+  const bare = cards
+    .filter(card => card.querySelector(".client-mark") === null)
+    .map(card => card.getAttribute("data-client"));
+  expect(bare).toEqual([]);
+
+  // A mark next to a visible label must not join the accessible name, or a
+  // screen reader says the client twice.
+  for (const mark of container.querySelectorAll(".client-mark")) {
+    expect(mark.getAttribute("aria-hidden")).toBe("true");
+  }
+  for (const img of container.querySelectorAll(".client-mark img")) {
+    expect(img.getAttribute("alt")).toBe("");
+  }
+
+  // The card head is space-between; the mark must sit with the title rather than
+  // after the badge, so it is the first child.
+  const head = cards[0]!.querySelector(".integration-card-head")!;
+  expect(head.firstElementChild?.classList.contains("client-mark")).toBe(true);
+});
+
+test("the tab strip marks every client tab and leaves the two non-client tabs bare", async () => {
+  const [{ createRoot }, { LanguageProvider }, { default: Integrations }] = await Promise.all([
+    import("react-dom/client"),
+    import("../src/i18n/provider"),
+    import("../src/pages/Integrations"),
+  ]);
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <Integrations apiBase={apiBase} />
+      </LanguageProvider>,
+    );
+  });
+  await act(async () => { await new Promise<void>(resolve => testWindow.setTimeout(resolve, 30)); });
+
+  const tabs = [...container.querySelectorAll<HTMLElement>(".page-tab")];
+  expect(tabs.length).toBeGreaterThan(10);
+  const marked = tabs.filter(tab => tab.querySelector(".client-mark") !== null);
+  // overview and keys carry no client, so they carry no mark.
+  expect(tabs.length - marked.length).toBe(2);
+
+  const codexTab = tabs.find(tab => tab.id === "integrations-tab-codex")!;
+  expect(codexTab.querySelector(".client-mark img")?.getAttribute("src")).toBe("/provider-icons/openai.svg");
+  // The label lost its "CLI": the mark carries that identity now, and the row
+  // covers the app and SDK too.
+  expect(codexTab.textContent).toBe("Codex");
+});
+


### PR DESCRIPTION
## Summary

The brand mark was only ever drawn in one place: the API tab's connect rows. The Integrations page — 17 tabs, 16 cards, a header per client — carried none, so the surface a user actually goes to in order to connect a client was the one that could not show them which client they were looking at.

![the tab strip with every client mark](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/integrations-marks-tabs.png)

Fifteen client tabs, each with its logo. `Overview` and `API Keys` stay bare on purpose — the first is the page itself and the second is a credential surface, not an integration, so a mark there would imply a client that does not exist.

![the integrations page at 1440 wide](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/integrations-marks-desktop.png)

## One component owns the decision

`ClientMark` is now the single place that decides how a mark is painted. The rule it owns is the one that was already got wrong once: a single-ink logo drawn as an `<img>` disappears against one of the two themes, so it is drawn as a CSS mask tinted with the surrounding text color instead. That ternary was inline in `ClientConfigRow`, which was fine at one call site and would have become four copies of a branch whose wrong side renders nothing at all.

Marks now appear on the overview cards, on every client tab, and in each file-client page header, and `ClientConfigRow` calls the same component rather than keeping its own copy.

Four rows have no export client behind them and take marks from provider icons already committed. Codex uses OpenAI's; Claude and Claude Desktop share one, because they are one brand on two surfaces and a distinct desktop mark would imply a distinction that does not exist; Grok uses its own.

## Two assets that look maskable and are not

`MASKED_MARKS` is keyed by asset path where `MONOCHROME_CLIENT_MARKS` is keyed by client id, and it is derived from it rather than restated. `kimi-color.svg` is reachable both as a provider icon and as a client mark; a path-keyed set cannot mask it on one surface and leave it unmasked on the other, and two hand-maintained lists of one fact drift.

- `openai.svg` is a single fill, but that fill is `#10A37F` — OpenAI's green, the brand itself. Masking it repaints a trademark in the theme's text color, which is exactly why `dsh` stays an image despite being single-ink.
- `grok.svg` is `#000000`, a genuine neutral and a real masking candidate. It is xAI's published asset with a literal fill, and rewriting that file to `currentColor` is a change to someone else's mark rather than a rendering decision. It stays an image, and its low contrast on the dark theme is visible in the screenshot above rather than papered over.

## The Codex label

`integrations.tab.codex` reads `"Codex"` in all nine locales instead of `"Codex CLI"`. The mark carries that identity now, and the row covers the app and the SDK too, so the suffix was both redundant and slightly wrong. `integrations.codex.title` and `.body` keep theirs — they describe routing behavior, where "CLI" is accurate.

## Accessibility

Every mark is `aria-hidden` and every mark image carries an empty `alt`. Each sits beside a label that already names the client, so a mark that joined the accessible name would make a screen reader say "Claude Claude". Asserted rather than assumed.

## Verification

Nine guards, each driven red before being made green. Three of them assert the rendered DOM rather than the map, because the map being right while the component is never called is precisely the failure a data-only test cannot see — and it is the failure that would have shipped here, since the marks were correct in data long before any surface drew them.

Falsification runs:

| falsified | result |
|---|---|
| removed the tab-strip `ClientMark` | `(fail) the tab strip marks every client tab and leaves the two non-client tabs bare` |
| removed the overview-card `ClientMark` | `(fail) every overview card draws a mark, and none of them names itself` |
| added `openai.svg` to `MASKED_MARKS` | 3 failures at once, including `a single-ink asset whose ink is a brand color is not masked` |

- `cd gui && bun test tests/integrations-surfaces.test.tsx tests/integration-marks.test.ts` — 33 pass, 0 fail
- `cd gui && bun test tests/client-config-panel.test.tsx` — 14 pass, 0 fail
- `cd gui && bun test tests/locale-parity.test.ts` — 4 pass, 0 fail
- `bun x tsc --noEmit` and `cd gui && bun x tsc --noEmit` — exit 0
- `bun run lint:gui` — clean
- `bun run build:gui` — succeeds; the screenshots are that build served and rendered

Rendered at 1440 and 390 wide. At mobile width the strip wraps to four rows with every mark intact:

![the integrations page at 390 wide](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/integrations-marks-mobile.png)

The card head is `space-between`, so the mark had to be pinned with the title or the state badge would land between them; the desktop screenshot is that check.

Backend suite is left to CI.

## Checklist

- [x] Targets the parent PR's head branch (stacked child; retarget to `dev` after the parent lands)
- [x] GUI change includes screenshots
- [x] No credential, auth or workflow surface touched
- [x] New behavior has regression tests, each driven red first


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client and provider brand marks to integration tabs, overview cards, and integration page headers.
  * Added consistent fallback, sizing, and monochrome styling for brand marks.
* **Improvements**
  * Updated the Codex integration label from “Codex CLI” to “Codex” across supported languages.
* **Bug Fixes**
  * Improved brand mark rendering consistency and accessibility across integration surfaces.
* **Tests**
  * Added coverage for mark selection, styling, placement, and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->