### PR TITLE
fix(gui): stop the Grok mark disappearing on the dark theme

### DIFF
--- a/gui/public/provider-icons/README.md
+++ b/gui/public/provider-icons/README.md
@@ -93,3 +93,50 @@ at 20px.
   is 292 px and a fixed area floor would have dropped it — it is the visor
   green, which is the feature that makes the character recognizable, so the
   floor is a fraction of the opaque area instead.
+
+## How a mark is painted
+
+Provenance is not the only fact that has to survive a handoff. Every mark is
+drawn one of two ways, and picking wrong makes a logo vanish rather than look
+slightly off:
+
+- **image** — the `<svg>` is rendered as-is, keeping its own colors. Correct for
+  anything multi-color, and for a single ink that *is* the brand.
+- **mask** — the file is used as a shape and filled with the surrounding text
+  color, so it follows the theme. Correct for a neutral silhouette, which would
+  otherwise be invisible against one of the two surfaces.
+
+The set lives in `gui/src/components/integration-marks.ts`. It is derived from
+`MONOCHROME_CLIENT_MARKS` for export clients, plus `MASKED_NATIVE_MARKS` for rows
+that have no export client to be keyed by.
+
+Decisions that are not obvious from looking at the file:
+
+- `grok.svg` **is masked.** One `#000000` fill on transparency measured about
+  1.9:1 on the dark card surface (`rgb(48,48,48)`) — effectively gone. Masking
+  does not modify xAI's file; it reads it as a shape, which is how xAI renders it
+  on their own dark surfaces. 11.17:1 dark and 17.67:1 light afterwards.
+- `openai.svg` **is not masked**, despite also being a single fill. That fill is
+  #10A37F, OpenAI's brand green, and repainting it discards information a reader
+  uses to identify the mark. Neutrality is the test, not ink count.
+- `deepseek-harness.svg` **is not masked** for the same reason: #4d6bfe is
+  DeepSeek blue. Its dark-theme contrast is adequate; if it ever is not, the fix
+  is a surface change, not a repaint.
+- `hermes-agent.svg` **is masked.** The trace is one near-black path, so it is
+  invisible on `#0d1117` untinted. Nothing about the Hermes brand is carried by
+  that particular black.
+- `minimax.svg` and `gajae-code.svg` **are not masked.** A gradient wave and a
+  seven-layer mascot respectively; masking would flatten both to one ink.
+- `prime-agent.svg` **is masked.** White on transparency, so as an image it was
+  invisible in light mode. This one shipped broken.
+- `opencode.svg` (#211E1E) and `kimi-color.svg` (#1A1A1A) **are masked.** Both
+  near-black single inks, invisible in dark mode as images. Both shipped broken
+  too, which is what established the rule.
+- `aside.svg` **is masked.** It already paints with `currentColor`, so it would
+  follow the theme either way; masking keeps it consistent with the other
+  silhouettes rather than depending on inherited color.
+
+Both directions are enforced in `gui/tests/integration-marks.test.ts`, including a
+luminance check that fails any single-ink near-neutral mark left as an image. That
+direction was missing until it caught `grok`; the same class of defect had already
+shipped once for `prime`, `opencode` and `kimi`.

--- a/gui/src/components/integration-marks.ts
+++ b/gui/src/components/integration-marks.ts
@@ -58,26 +58,44 @@ export const INTEGRATION_MARKS: Record<OverviewClientId, string | null> = {
 };
 
 /**
- * Assets whose artwork is one neutral ink, so the ink has to come from the theme.
- *
- * Derived from `MONOCHROME_CLIENT_MARKS` rather than restated, because two
- * hand-maintained lists of the same fact drift. Nothing is added on top of it,
- * and the two candidates that look like they belong here do not:
- *
- * - `openai.svg` is a single fill, but that fill is #10A37F -- OpenAI's brand
- *   green. Masking it repaints a trademark in the theme's text color, which is
- *   the same reason `dsh` stays an image despite being single-ink.
- * - `grok.svg` is #000000, a genuine neutral and a real masking candidate. It
- *   is xAI's published asset with a literal fill, and rewriting that file to
- *   `currentColor` is a change to someone else's mark rather than a rendering
- *   choice, so it stays an image here.
+* Assets whose artwork is one neutral ink, so the ink has to come from the theme.
+*
+ * The export-client half is derived from `MONOCHROME_CLIENT_MARKS` rather than
+ * restated, because two hand-maintained lists of the same fact drift.
+*
+ * `openai.svg` looks like it belongs here and does not: it is a single fill, but
+ * that fill is #10A37F -- OpenAI's brand green. Masking repaints a trademark in
+ * the theme's text color, the same reason `dsh` stays an image despite being
+ * single-ink.
  */
-export const MASKED_MARKS: ReadonlySet<string> = new Set(
-  [...MONOCHROME_CLIENT_MARKS].map(clientId => CLIENT_MARKS[clientId]).filter((src): src is string => src !== undefined),
-);
+/**
+ * The neutral-ink marks that belong to no export client.
+ *
+ * `MONOCHROME_CLIENT_MARKS` is keyed by `ExportClientId`, so it structurally
+ * cannot carry a native row's asset. Grok is a native row, which is the only
+ * reason its mark needs a second home rather than an entry there.
+ *
+ * `grok.svg` is one `#000000` fill on transparency. Measured on the dark card
+ * surface (`rgb(48,48,48)`) that is about 1.9:1 -- the glyph is very nearly gone,
+ * which a zoomed capture confirms. An earlier pass left it as an image on the
+ * grounds that masking would be editing someone else's mark; that reasoning does
+ * not survive contact with what masking is. The file is not modified. It is read
+ * as a shape and painted in the surrounding text color, which is how xAI renders
+ * it on their own dark surfaces. Flattening does not apply either: there is one
+ * ink to flatten.
+ *
+ * `openai.svg` still does not belong here, and the distinction is not neutrality
+ * in the abstract -- it is that #10A37F IS the brand. Repainting it loses
+ * information a reader uses to identify the mark. #000000 carries none.
+ */
+const MASKED_NATIVE_MARKS: readonly string[] = [NATIVE_MARKS.grok];
+
+export const MASKED_MARKS: ReadonlySet<string> = new Set([
+  ...[...MONOCHROME_CLIENT_MARKS].map(clientId => CLIENT_MARKS[clientId]).filter((src): src is string => src !== undefined),
+  ...MASKED_NATIVE_MARKS,
+]);
 
 /** The mark for a row, or null when it has none. */
 export function markFor(clientId: OverviewClientId): string | null {
   return INTEGRATION_MARKS[clientId];
 }
-

--- a/gui/tests/client-marks-assets.test.ts
+++ b/gui/tests/client-marks-assets.test.ts
@@ -121,6 +121,37 @@ test("every export client has a mark", () => {
 });
 
 /*
+ * Provenance is documented; how a mark is PAINTED was not, and that is the fact
+ * that actually broke. `grok.svg` sat unmasked at roughly 1.9:1 on the dark card
+ * because the reasoning for leaving it an image lived only in a code comment that
+ * was wrong about what masking does.
+ *
+ * This pins the README section rather than the decision itself -- the decision is
+ * enforced in integration-marks.test.ts. What it prevents is the next person
+ * re-litigating a case that was already measured, which is how grok stayed broken
+ * through two passes over the same file.
+ */
+test("the README explains how marks are painted, not only where they came from", () => {
+  const readme = readFileSync(join(PUBLIC_DIR, "provider-icons", "README.md"), "utf8");
+  expect(readme).toContain("## How a mark is painted");
+
+  /*
+   * Every masked mark has to be argued for by name. A mark added to the mask set
+   * without a line here is a decision nobody can review, and "it looked
+   * monochrome" is precisely the reasoning that needs to be written down.
+   */
+  const section = readme.slice(readme.indexOf("## How a mark is painted"));
+  const unexplained = [...MONOCHROME_CLIENT_MARKS]
+    .map(clientId => CLIENT_MARKS[clientId]!.split("/").pop()!)
+    .filter(file => !section.includes(file));
+  expect(unexplained).toEqual([]);
+
+  // The two cases a reader is most likely to get backwards.
+  expect(section).toContain("grok.svg");
+  expect(section).toContain("openai.svg");
+});
+
+/*
  * Two of the newest marks are traced from raster sources, which is a different
  * provenance claim from "fetched" and the one a reader is most likely to doubt.
  * The README has to carry the reproduction detail: the source file, and the

--- a/gui/tests/integration-marks.test.ts
+++ b/gui/tests/integration-marks.test.ts
@@ -80,11 +80,23 @@ test("a single-ink asset whose ink is a brand color is not masked", () => {
  * MASKED_MARKS is derived from MONOCHROME_CLIENT_MARKS rather than restated, and
  * this is what makes that derivation observable: the two must describe the same
  * assets. A second hand-maintained list would drift, and the drift would be a
- * mark masked on one surface and not on another.
- */
-test("the masked set is exactly the monochrome client marks", () => {
-  const expected = [...MONOCHROME_CLIENT_MARKS].map(id => CLIENT_MARKS[id]).filter(Boolean).sort();
-  expect([...MASKED_MARKS].sort()).toEqual(expected as string[]);
+* mark masked on one surface and not on another.
+*/
+test("the masked set is the monochrome client marks plus the native exceptions", () => {
+  const fromClients = [...MONOCHROME_CLIENT_MARKS].map(id => CLIENT_MARKS[id]).filter(Boolean) as string[];
+  /*
+   * The only additions allowed are marks belonging to rows with no export client,
+   * since MONOCHROME_CLIENT_MARKS is keyed by ExportClientId and structurally
+   * cannot hold them. Named here so a mask added for any OTHER reason -- which is
+   * how the two lists would start drifting -- fails.
+   */
+  const nativeExceptions = ["/provider-icons/grok.svg"];
+  expect([...MASKED_MARKS].sort()).toEqual([...fromClients, ...nativeExceptions].sort());
+
+  // Every export client's masking decision still comes from the derived set only.
+  const clientMarks = new Set(Object.values(CLIENT_MARKS).filter(Boolean) as string[]);
+  const maskedClientMarks = [...MASKED_MARKS].filter(src => clientMarks.has(src)).sort();
+  expect(maskedClientMarks).toEqual([...fromClients].sort());
 });
 
 /*
@@ -99,3 +111,69 @@ test("every client tab has a mark", () => {
   expect(bare.map(tab => tab.id)).toEqual([]);
 });
 
+/**
+ * Relative luminance, so "would this vanish?" is a measurement rather than a
+ * judgement about a hex string.
+ */
+function luminance(hex: string): number {
+  const raw = hex.replace("#", "");
+  const full = raw.length === 3 ? [...raw].map(c => c + c).join("") : raw.slice(0, 6);
+  const channel = (pair: string): number => {
+    const v = parseInt(pair, 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(full.slice(0, 2))
+    + 0.7152 * channel(full.slice(2, 4))
+    + 0.0722 * channel(full.slice(4, 6));
+}
+
+/*
+ * The rule the other direction, and the one that actually shipped broken.
+ *
+ * `no multi-color asset is masked` stops a brand palette being flattened. Nothing
+ * stopped the opposite: a mark that is one near-black ink drawn as an <img>, which
+ * is invisible against a dark surface. That is not hypothetical -- prime, opencode
+ * and kimi each shipped that way, and the fix was to mask them. Removing one from
+ * MONOCHROME_CLIENT_MARKS today reintroduces it silently, because an invisible
+ * <img> still renders, still has layout, and every existing assertion still holds.
+ *
+ * A near-neutral ink is one whose channels are close together: #0d1117 qualifies,
+ * OpenAI's #10a37f does not, which is what keeps this from arguing with the
+ * brand-color test above.
+ */
+test("a single-ink mark that would vanish against one theme is masked", () => {
+  const vanishing: string[] = [];
+  for (const src of new Set(Object.values(INTEGRATION_MARKS))) {
+    if (src === null) continue;
+    const body = bodyOf(src);
+    if (/<(linearGradient|radialGradient)[\s>]/.test(body)) continue;
+    const inks = [...inksOf(body)];
+    if (inks.length !== 1) continue;
+    const hex = inks[0]!.replace("#", "");
+    const full = hex.length === 3 ? [...hex].map(c => c + c).join("") : hex.slice(0, 6);
+    const channels = [full.slice(0, 2), full.slice(2, 4), full.slice(4, 6)].map(p => parseInt(p, 16));
+    const neutral = Math.max(...channels) - Math.min(...channels) <= 24;
+    if (!neutral) continue;
+    // Only the extremes vanish. A mid grey is legible on both surfaces.
+    const l = luminance(inks[0]!);
+    if (l > 0.12 && l < 0.75) continue;
+    if (!MASKED_MARKS.has(src)) vanishing.push(`${src}: ${inks[0]} would be invisible in one theme`);
+  }
+  expect(vanishing).toEqual([]);
+});
+
+/*
+ * The three marks added last, pinned by how they are PAINTED rather than by
+ * existing. Rendered measurement at 1440px: hermes flips ink with the theme
+ * (17.67:1 on the light card, 11.17:1 on the dark one), while gajae and minimax
+ * keep their own colors in both. This is the cheap version of that check.
+ */
+test("the three newest marks are painted the way their artwork requires", () => {
+  // A traced single-ink silhouette: invisible as an image on a dark surface.
+  expect(MASKED_MARKS.has("/provider-icons/hermes-agent.svg")).toBe(true);
+  // Multi-color artwork: masking would flatten a mascot and a gradient wave.
+  expect(MASKED_MARKS.has("/provider-icons/gajae-code.svg")).toBe(false);
+  expect(MASKED_MARKS.has("/provider-icons/minimax.svg")).toBe(false);
+  expect(inksOf(bodyOf("/provider-icons/gajae-code.svg")).size).toBeGreaterThan(1);
+  expect(/<linearGradient[\s>]/.test(bodyOf("/provider-icons/minimax.svg"))).toBe(true);
+});


### PR DESCRIPTION
## Summary

The Grok mark is one `#000000` fill on transparency, drawn as an `<img>`. On the dark card surface (`rgb(48,48,48)`) that measures about **1.9:1** -- the glyph is very nearly gone. It has been that way since the mark landed.

Before and after, dark theme, 8x zoom on the tab-strip mark:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/grok-dark-zoom.png) | ![after](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/grok-fixed-dark.png) |

A previous pass saw this and declined to fix it, on the grounds that masking would be "editing someone else's mark". That reasoning does not survive contact with what masking is. The file is not modified: it is read as a shape and painted in the surrounding text color, which is how xAI renders it on their own dark surfaces. Flattening a palette is not a risk here either -- there is exactly one ink to flatten. Measured after: **11.17:1** dark, **17.67:1** light.

Grok is a native row rather than an export client, so `MONOCHROME_CLIENT_MARKS` is keyed by a type that structurally cannot hold its asset. Hence `MASKED_NATIVE_MARKS` rather than an entry there.

**Why this was reachable at all.** The existing rule guards one direction only: it stops a multi-color asset being flattened by a mask. Nothing forced a near-black silhouette *into* the mask set, which is exactly the bug that already shipped once for `prime`, `opencode` and `kimi`. The new guard measures relative luminance of every single-ink, near-neutral mark and fails if an extreme one is drawn as an image. It found `grok` on its first run.

`openai.svg` still stays an image. The distinction is not neutrality in the abstract: #10A37F **is** OpenAI's brand, so repainting it loses information a reader uses to identify the mark. #000000 carries none.

## Verification

- `cd gui && bun test tests/integration-marks.test.ts tests/integrations-surfaces.test.tsx tests/client-config-panel.test.tsx tests/client-marks-assets.test.ts` -> 61 pass / 0 fail.
- Falsified three ways: reverting grok to unmasked (2 red, including the new guard), masking `openai.svg` (2 red), masking the multi-color Claude mark (1 red).
- Contrast measured from rendered `getComputedStyle` at 1440px under emulated `prefers-color-scheme` in both schemes, not reasoned about from hex strings.
- `bun x tsc --noEmit` clean in both roots; `bun run lint:gui` clean; `bun run build:gui` succeeds.

Full local suite not run per the repository scoped-change rule; CI is the gate.

## Checklist

- [x] Focused GUI tests green, each new guard falsified
- [x] `bun x tsc --noEmit` clean (root + gui)
- [x] `bun run lint:gui` clean
- [x] Screenshot of the UI change included (before/after)
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration mark rendering in themed interfaces.
  * Grok now adapts to the selected theme instead of displaying as an image.
  * Improved masking for monochrome and near-neutral marks.
  * Preserved accurate visual rendering for supported integration marks.

* **Documentation**
  * Added guidance explaining how provider and export-client marks are displayed, including theme-colored and full-color rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->