### PR TITLE
fix(responses): always carry query on web_search_call for Console Go (#3071)

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -920,9 +920,19 @@ function backfillWebSearchQueries(body: unknown): unknown {
     if (!isPlainObject(item) || item.type !== "web_search_call") return item;
     const action = item.action;
     if (!isPlainObject(action) || action.type !== "search") return item;
-    if (typeof action.query !== "string" || Array.isArray(action.queries)) return item;
-    changed = true;
-    return { ...item, action: { ...action, queries: [action.query] } };
+    // Repair whichever side is missing so both strict parsers pass:
+    // DeepSeek native Responses requires `queries`; Console Go requires `query`.
+    const rep: Record<string, unknown> = { ...action };
+    let itemChanged = false;
+    if (typeof action.query !== "string" && Array.isArray(action.queries) && action.queries.length > 0) {
+      rep.query = action.queries[0];       // multi-query item recorded before the fix
+      itemChanged = true;
+    } else if (typeof action.query === "string" && !Array.isArray(action.queries)) {
+      rep.queries = [action.query];        // single-query item recorded before the fix
+      itemChanged = true;
+    }
+    if (itemChanged) changed = true;
+    return itemChanged ? { ...item, action: rep } : item;
   });
   return changed ? { ...body, input } : body;
 }

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -901,13 +901,21 @@ function annotateEmptyResponsesToolOutputs(body: unknown, enabled: boolean): unk
  * Runs on every forward request; with intact pairs it returns the original reference.
  */
 /**
- * Backfill `queries` on a replayed single-query `web_search_call`.
+ * Repair a replayed `web_search_call` action that is missing either key.
  *
  * `webSearchAction()` in the bridge now emits both keys, but that only helps items
  * created after the fix. A conversation that already recorded
- * `{type:"search", query:"..."}` replays that stored item on every subsequent turn, and
- * DeepSeek's native Responses parser requires `queries` — so upgrading alone leaves
- * those threads permanently 400ing with `missing field 'queries'` (#930).
+ * `{type:"search", query:"..."}` or `{type:"search", queries:[...]}` replays that stored
+ * item on every subsequent turn. DeepSeek's native Responses parser requires `queries`
+ * (#930) and Console Go's validator requires `query` (#3071), so upgrading alone leaves
+ * those threads permanently 400ing in one direction or the other. The repair runs both
+ * ways.
+ *
+ * Input items carry a loose schema, so a stored `queries` is not necessarily an array of
+ * strings. A non-string first member is left alone rather than copied into `query`:
+ * writing `query: 123` would satisfy the presence check and still fail the validator this
+ * repair exists to satisfy, while claiming a successful repair. An empty `queries: []`
+ * canonicalizes to the same shape the bridge emits for an empty search.
  *
  * Runs on every Responses request, on both `input` items and the `action` nested inside
  * them. Returns the original reference when nothing needs repair, so the common path
@@ -924,9 +932,19 @@ function backfillWebSearchQueries(body: unknown): unknown {
     // DeepSeek native Responses requires `queries`; Console Go requires `query`.
     const rep: Record<string, unknown> = { ...action };
     let itemChanged = false;
-    if (typeof action.query !== "string" && Array.isArray(action.queries) && action.queries.length > 0) {
-      rep.query = action.queries[0];       // multi-query item recorded before the fix
-      itemChanged = true;
+    if (typeof action.query !== "string" && Array.isArray(action.queries)) {
+      if (action.queries.length === 0) {
+        // An empty array satisfies neither validator. Canonicalize to the empty-search
+        // shape the bridge emits rather than inventing a query.
+        rep.query = "";
+        rep.queries = [""];
+        itemChanged = true;
+      } else if (typeof action.queries[0] === "string") {
+        rep.query = action.queries[0];     // multi-query item recorded before the fix
+        itemChanged = true;
+      }
+      // A non-string first member is left untouched: copying it would produce an invalid
+      // singular field while reporting a successful repair.
     } else if (typeof action.query === "string" && !Array.isArray(action.queries)) {
       rep.queries = [action.query];        // single-query item recorded before the fix
       itemChanged = true;

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -912,10 +912,12 @@ function annotateEmptyResponsesToolOutputs(body: unknown, enabled: boolean): unk
  * ways.
  *
  * Input items carry a loose schema, so a stored `queries` is not necessarily an array of
- * strings. A non-string first member is left alone rather than copied into `query`:
- * writing `query: 123` would satisfy the presence check and still fail the validator this
- * repair exists to satisfy, while claiming a successful repair. An empty `queries: []`
- * canonicalizes to the same shape the bridge emits for an empty search.
+ * strings. A partly- or wholly-malformed array is left alone rather than used as a source
+ * for the singular field: writing `query: 123` would satisfy the presence check and still
+ * fail the validator this repair exists to satisfy, and deriving `query` from
+ * `["a", 42]` would satisfy Console Go while leaving DeepSeek to reject the same replay.
+ * An empty `queries: []` canonicalizes to the shape the bridge emits for an empty search,
+ * keeping an existing `query` when the item has one.
  *
  * Runs on every Responses request, on both `input` items and the `action` nested inside
  * them. Returns the original reference when nothing needs repair, so the common path
@@ -932,20 +934,26 @@ function backfillWebSearchQueries(body: unknown): unknown {
     // DeepSeek native Responses requires `queries`; Console Go requires `query`.
     const rep: Record<string, unknown> = { ...action };
     let itemChanged = false;
-    if (typeof action.query !== "string" && Array.isArray(action.queries)) {
-      if (action.queries.length === 0) {
-        // An empty array satisfies neither validator. Canonicalize to the empty-search
-        // shape the bridge emits rather than inventing a query.
-        rep.query = "";
-        rep.queries = [""];
-        itemChanged = true;
-      } else if (typeof action.queries[0] === "string") {
-        rep.query = action.queries[0];     // multi-query item recorded before the fix
+    const hasQuery = typeof action.query === "string";
+    const queries = Array.isArray(action.queries) ? action.queries : undefined;
+    if (queries !== undefined && queries.length === 0) {
+      // An empty array satisfies neither validator. Canonicalize to the empty-search
+      // shape the bridge emits, keeping an existing query rather than discarding it.
+      const query = hasQuery ? action.query as string : "";
+      rep.query = query;
+      rep.queries = [query];
+      itemChanged = true;
+    } else if (!hasQuery && queries !== undefined) {
+      // A plural array is only a usable source for the singular field when EVERY member
+      // is a string: deriving `query` from a partly-malformed array would satisfy Console
+      // Go while leaving DeepSeek to reject the same replay. Wholly malformed arrays are
+      // left untouched — coercing or dropping members would invent semantics the stored
+      // item never had.
+      if (queries.every(entry => typeof entry === "string")) {
+        rep.query = queries[0];            // multi-query item recorded before the fix
         itemChanged = true;
       }
-      // A non-string first member is left untouched: copying it would produce an invalid
-      // singular field while reporting a successful repair.
-    } else if (typeof action.query === "string" && !Array.isArray(action.queries)) {
+    } else if (hasQuery && queries === undefined) {
       rep.queries = [action.query];        // single-query item recorded before the fix
       itemChanged = true;
     }
@@ -2125,9 +2133,10 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         outBody = repairOversizedReplayCallIds(outBody);
       }
       outBody = stripUnsupportedReasoningSummaryDelivery(outBody, parsed.modelId);
-      // Repair stored history from before the bridge emitted both keys: a conversation
-      // that already recorded a single-query web_search_call replays it every turn, and
-      // a strict parser rejects the whole request over it (#930).
+      // Repair stored history from before the bridge emitted both keys, in either
+      // direction: a conversation that already recorded a web_search_call replays it
+      // every turn, and a strict parser rejects the whole request over the missing key —
+      // `queries` for DeepSeek (#930), `query` for Console Go (#3071).
       outBody = backfillWebSearchQueries(outBody);
       if (!isCanonicalOpenAiForwardProvider(provider)) {
         outBody = promoteClientLoadedTools(outBody);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -146,16 +146,20 @@ export { adapterFailureFromMessage } from "./lib/errors";
 /**
  * Build the native `WebSearchAction::Search` payload from the queries that ran.
  *
- * Single query → `{ query, queries: [query] }`. Batch → `{ queries }` with NO singular
- * `query`. Empty → `{ query: "", queries: [""] }`.
+ * Every action carries BOTH keys: `{ query, queries }`, where `query` is the first
+ * member. Empty → `{ query: "", queries: [""] }`.
  *
- * The asymmetry is load-bearing in both directions. DeepSeek's native Responses parser
+ * Carrying both is load-bearing in both directions. DeepSeek's native Responses parser
  * makes `queries` a required field, and Console Go's upstream validator makes `query` a
  * required field — so a replayed `web_search_call` carried in the history of every
  * subsequent turn fails deserialization with `missing field 'queries'` (#930) or 400s
  * with `missing required field 'query'` unless both keys are present. Carrying both keys
  * in every case satisfies both strict parsers; the trade-off is that a multi-query batch
  * loses the "<first> ..." ellipsis in codex-rs and shows the first query as the label.
+ *
+ * That trade is deliberate: a cosmetic label against a conversation that 400s on every
+ * subsequent turn. Do not restore the old batch-omits-`query` shape to win the ellipsis
+ * back — it reopens #3071.
  *
  * This fixes items created from here on. History recorded before it is repaired at the
  * replay boundary by `backfillWebSearchQueries()` in the Responses adapter.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -149,24 +149,20 @@ export { adapterFailureFromMessage } from "./lib/errors";
  * Single query → `{ query, queries: [query] }`. Batch → `{ queries }` with NO singular
  * `query`. Empty → `{ query: "", queries: [""] }`.
  *
- * The asymmetry is load-bearing in both directions. codex-rs prefers a non-empty `query`
- * for the cell label and renders "<first> ..." only when `query` is ABSENT and
- * `queries.len() > 1`, so adding `query` to a batch would collapse the plural ellipsis.
- * Meanwhile DeepSeek's native Responses parser makes `queries` a required field, so a
- * replayed one-term `web_search_call` — carried in the history of every subsequent turn
- * — fails deserialization with `missing field 'queries'` and 400s the rest of the
- * conversation (#930). Carrying both keys in the single case satisfies the strict parser
- * without changing what codex-rs displays.
+ * The asymmetry is load-bearing in both directions. DeepSeek's native Responses parser
+ * makes `queries` a required field, and Console Go's upstream validator makes `query` a
+ * required field — so a replayed `web_search_call` carried in the history of every
+ * subsequent turn fails deserialization with `missing field 'queries'` (#930) or 400s
+ * with `missing required field 'query'` unless both keys are present. Carrying both keys
+ * in every case satisfies both strict parsers; the trade-off is that a multi-query batch
+ * loses the "<first> ..." ellipsis in codex-rs and shows the first query as the label.
  *
  * This fixes items created from here on. History recorded before it is repaired at the
  * replay boundary by `backfillWebSearchQueries()` in the Responses adapter.
  */
 function webSearchAction(queries: string[]): Record<string, unknown> {
-  if (queries.length <= 1) {
-    const query = queries[0] ?? "";
-    return { type: "search", query, queries: [query] };
-  }
-  return { type: "search", queries };
+  const first = queries[0] ?? "";
+  return { type: "search", query: first, queries: queries.length > 0 ? queries : [first] };
 }
 
 interface OutputItem {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -1075,7 +1075,7 @@ describe("Responses bridge web_search_call native item", () => {
     });
   });
 
-  test("a batched (plural) search emits action.search.queries without a singular query", () => {
+  test("a batched (plural) search carries both query and queries for Console Go (#3071)", () => {
     const json = buildResponseJSON([
       { type: "web_search_call_begin", id: "ws_3" },
       { type: "web_search_call_end", id: "ws_3", queries: ["rust async", "tokio runtime"] },
@@ -1085,9 +1085,10 @@ describe("Responses bridge web_search_call native item", () => {
 
     const output = json.output as Record<string, unknown>[];
     const action = (output[0] as Record<string, unknown>).action as Record<string, unknown>;
-    // Native renders "<first> ..." only when `query` is absent and queries.len() > 1.
-    expect(action).toEqual({ type: "search", queries: ["rust async", "tokio runtime"] });
-    expect(action.query).toBeUndefined();
+    // Console Go's upstream validator requires singular `query` on the search action,
+    // and DeepSeek native Responses requires `queries` — so a batch carries both now.
+    expect(action).toEqual({ type: "search", query: "rust async", queries: ["rust async", "tokio runtime"] });
+    expect(action.query).toBe("rust async");
   });
 
   test("a single-query search also carries queries so strict parsers accept the replay (#930)", () => {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -1088,7 +1088,6 @@ describe("Responses bridge web_search_call native item", () => {
     // Console Go's upstream validator requires singular `query` on the search action,
     // and DeepSeek native Responses requires `queries` — so a batch carries both now.
     expect(action).toEqual({ type: "search", query: "rust async", queries: ["rust async", "tokio runtime"] });
-    expect(action.query).toBe("rust async");
   });
 
   test("a single-query search also carries queries so strict parsers accept the replay (#930)", () => {

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -1295,11 +1295,11 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(input[0]).not.toHaveProperty("id");
   });
 
-  test("backfills queries on a replayed single-query web_search_call (#930)", () => {
+  test("backfills web_search_call actions in either missing direction (#930, #3071)", () => {
     // The bridge fix only helps items created after it. A conversation that already
-    // recorded {type:"search", query:"..."} replays that stored item every turn, and
-    // DeepSeek's parser rejects the whole request over it — so upgrading alone would
-    // leave those threads permanently broken.
+    // recorded a legacy web_search_call replays that stored item every turn. DeepSeek's
+    // parser rejects an action without `queries` (#930) and Console Go rejects one
+    // without `query` (#3071) — so upgrading alone would leave those threads broken.
     const adapter = createResponsesPassthroughAdapter(provider);
     const request = adapter.buildRequest({
       modelId: "provider-model",
@@ -1319,9 +1319,8 @@ describe("OpenAI Responses passthrough sanitization", () => {
 
     // Repaired: singular query gains the array the strict parser requires.
     expect(input[0].action).toEqual({ type: "search", query: "legacy", queries: ["legacy"] });
-    // Untouched: a batch already satisfies the parser, and adding `query` would collapse
-    // the native plural rendering.
-    expect(input[1].action).toEqual({ type: "search", queries: ["a", "b"] });
+    // Repaired: multi-query batch gains the singular `query` Console Go requires.
+    expect(input[1].action).toEqual({ type: "search", query: "a", queries: ["a", "b"] });
     // Untouched: not a search action.
     expect(input[2].action).toEqual({ type: "open_page", url: "https://example.test" });
   });

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -1325,6 +1325,36 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(input[2].action).toEqual({ type: "open_page", url: "https://example.test" });
   });
 
+  test("does not forge a singular query from a malformed or empty queries array (#3071)", () => {
+    // Input items use a loose schema, so a stored `queries` need not be an array of
+    // strings. Copying a non-string first member would satisfy the presence check and
+    // still fail the Console Go validator this repair exists to satisfy — a repair that
+    // reports success and produces an invalid shape is worse than no repair.
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "provider-model",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "provider-model",
+        input: [
+          { type: "web_search_call", id: "ws_num", status: "completed", action: { type: "search", queries: [42] } },
+          { type: "web_search_call", id: "ws_obj", status: "completed", action: { type: "search", queries: [{ q: "x" }] } },
+          { type: "web_search_call", id: "ws_empty", status: "completed", action: { type: "search", queries: [] } },
+        ],
+      },
+    }, meta);
+    const input = (JSON.parse(request.body) as { input: Array<{ action: Record<string, unknown> }> }).input;
+
+    // Left alone: a non-string first member is not a query.
+    expect(input[0].action).toEqual({ type: "search", queries: [42] });
+    expect(input[1].action).toEqual({ type: "search", queries: [{ q: "x" }] });
+    // Canonicalized: an empty array satisfies neither validator, so it becomes the same
+    // empty-search shape the bridge emits rather than being passed through.
+    expect(input[2].action).toEqual({ type: "search", query: "", queries: [""] });
+  });
+
   test("strips invalid type-specific ids from serialized input items", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const encryptedContent = "opaque-openai-encrypted-content";

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -1355,6 +1355,30 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(input[2].action).toEqual({ type: "search", query: "", queries: [""] });
   });
 
+  test("repairs a partly-malformed or already-queried empty action (#3071)", () => {
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "provider-model",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "provider-model",
+        input: [
+          { type: "web_search_call", id: "ws_mixed", status: "completed", action: { type: "search", queries: ["a", 42] } },
+          { type: "web_search_call", id: "ws_qempty", status: "completed", action: { type: "search", query: "legacy", queries: [] } },
+        ],
+      },
+    }, meta);
+    const input = (JSON.parse(request.body) as { input: Array<{ action: Record<string, unknown> }> }).input;
+
+    // Left alone: deriving `query: "a"` would satisfy Console Go and leave DeepSeek to
+    // reject the same replay over the non-string second member.
+    expect(input[0].action).toEqual({ type: "search", queries: ["a", 42] });
+    // Canonicalized without discarding the query the item already carried.
+    expect(input[1].action).toEqual({ type: "search", query: "legacy", queries: ["legacy"] });
+  });
+
   test("strips invalid type-specific ids from serialized input items", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const encryptedContent = "opaque-openai-encrypted-content";


### PR DESCRIPTION
## Summary

Closes #3071. Carries @kunqi.lai's two commits from #3069 unmodified with authorship preserved, then closes the gaps two review rounds found.

Console Go's upstream validator requires a singular `query` on a `web_search_call` search action; DeepSeek's native Responses parser requires plural `queries` (#930). The bridge emitted `queries` only for multi-query batches, so any conversation containing one 400s on every subsequent turn - the item is replayed in the history of each request, so the thread is permanently poisoned.

`webSearchAction()` now emits both keys in every case. The trade is real and deliberate: codex-rs renders "<first> ..." only when `query` is absent and `queries.len() > 1`, so a batch now shows its first query as the label. A cosmetic label against a thread that cannot continue. The comment says so, since the previous comment argued for the old shape two lines above the code.

`backfillWebSearchQueries()` repairs stored history in both directions, and three guards keep it from claiming repairs it cannot make:

- an empty `queries: []` canonicalizes to the bridge's empty-search shape, keeping an existing `query` rather than discarding it;
- a singular field is derived from a plural array only when every member is a string - deriving from `["a", 42]` would satisfy Console Go and leave DeepSeek to reject the same replay;
- a wholly malformed array is left untouched, because coercing or dropping members would invent semantics the stored item never had.

Reviewed twice by an adversarial lane. The first round found the empty-with-query case bypassing every branch and the partly-malformed array producing a one-sided repair; the second returned PASS.

Plan and evidence: [devlog/_plan/260831_prio70_train_round2/010_wp1_web_search_query_field.md](devlog/_plan/260831_prio70_train_round2/010_wp1_web_search_query_field.md).

## Verification

Focused, on exact head `ed31953a8`:

```
bun test tests/bridge.test.ts tests/openai-responses-passthrough.test.ts
  -> 178 pass / 0 fail / 555 expect()
bun run typecheck -> exit 0
```

Every new assertion was driven red before the fix landed:

| assertion | red against |
|---|---|
| batch carries both keys | `dev` |
| replayed batch gains `query` | `dev` |
| `[42]` and `[{q:"x"}]` left untouched | contributor head `085d03425`, which produced `query: 42` |
| `queries: []` canonicalizes | both |
| `["a", 42]` left untouched | `8f426e8ac` |
| `{query:"legacy", queries:[]}` keeps its query | `8f426e8ac` |

Full suite, typecheck and privacy scan run on a Linux host at this exact head; results in a follow-up comment.

## Checklist

- [x] Targets `dev`
- [x] Behavior change carries focused regression tests, each driven red first
- [x] No user-facing surface changed, so no `docs-site/` update is required
- [x] No credentials, request bodies, or account identifiers added
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web search request compatibility by consistently providing both singular and plural query fields.
  * Repaired incomplete replayed web search data in either direction.
  * Added safe handling for empty, mixed-type, and invalid query arrays without inventing unsupported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->