### PR TITLE
docs(devlog): record the two defects the audit found after the unit closed

### DIFF
--- a/devlog/_fin/260831_aside_client_and_integrations_ux/090_outcome.md
+++ b/devlog/_fin/260831_aside_client_and_integrations_ux/090_outcome.md
@@ -14,6 +14,14 @@ Unit closed 2026-08-31. Every phase in this unit is on `dev`.
 | wp8 | 070 | #3083 | `d86ec3e03` -- marks on every surface |
 | wp9 | 080 | #3084 | `2a90cdaa9` -- conflict overwrite |
 
+Two follow-ups landed after the table above, both from auditing the merged head
+rather than from the plan:
+
+| what | PR | on `dev` as |
+|---|---|---|
+| Grok mark masked so it survives the dark theme | #3086 | `0cc73411a` |
+| `--overwrite-conflict` for the CLI, plus mobile dialog guards | #3088 | `91b2c4e19` |
+
 #3065 (`7853e8e05`) and #3074 landed alongside wp5: Aside's own mark plus the
 first version of the single-ink rule, and the property guards the pair relies on.
 
@@ -51,6 +59,20 @@ management envelope and restated again in the GUI adapter, with no import betwee
 them. The doc comment in `journal.ts` claimed a test asserted the three agree.
 None did, so a kind added in one place rendered as a raw i18n key with no type
 error anywhere. `tests/integrations-journal.test.ts` now reads all three.
+
+**A documented tradeoff was a defect.** 070 recorded `grok.svg` as staying an image
+because masking would be "editing someone else's mark". Measured on the dark card
+surface it was about 1.9:1 -- the glyph was effectively invisible, and had been since
+the mark landed. The reasoning was simply wrong about what masking does: the file is
+not modified, it is read as a shape and tinted, which is how xAI renders it
+themselves. Writing a tradeoff down does not make it correct, and neither this unit
+nor the pass that followed it measured the thing it was excusing.
+
+**Half a surface is not a surface.** 080 specified the overwrite escape hatch for the
+GUI and stopped there, which left `ocx integration client enable` dead-ending on the
+exact state the feature exists to escape. The user with no browser -- an SSH session,
+or an agent driving the proxy -- was the one still stuck. Fixed in #3088; the docs had
+meanwhile been asserting that a conflict simply locks.
 
 ## Verification as merged
 


### PR DESCRIPTION
## Summary

The outcome table stopped at #3084 and the unit was already in `_fin`, but auditing the merged head turned up two things the plan had gotten **wrong** rather than merely left undone.

**A documented tradeoff was a defect.** 070 recorded `grok.svg` as staying an image because masking would be "editing someone else's mark". Measured on the dark card surface it was about 1.9:1 -- the glyph was effectively invisible, and had been since the mark landed. The reasoning was wrong about what masking does: the file is not modified, it is read as a shape and tinted, which is how xAI renders it themselves. Writing a tradeoff down does not make it correct, and neither this unit nor the pass that followed it measured the thing it was excusing.

**Half a surface is not a surface.** 080 specified the overwrite escape hatch for the GUI and stopped there, leaving `ocx integration client enable` dead-ending on the exact state the feature exists to escape -- and the user with no browser (an SSH session, or an agent driving the proxy) was the one still stuck. The docs had meanwhile been asserting that a conflict simply locks.

Adds both follow-ups to the table (#3086 `0cc73411a`, #3088 `91b2c4e19`) and both corrections to the record.

## Verification

- `bun run privacy:scan` -> passed. This is the gate that matters for a `devlog/` change, since the scan is what makes a public devlog safe rather than merely visible.
- `bun test tests/repo-hygiene.test.ts` -> 12 pass.
- Every PR number and SHA read back from `gh pr view`, not recalled.

Docs only; nothing in the build, typecheck or test path reads from `devlog/`.

## Checklist

- [x] Docs-only change, no source touched
- [x] `bun run privacy:scan` clean
- [x] `bun test tests/repo-hygiene.test.ts` green
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added follow-up notes documenting dark-theme branding adjustments.
  * Documented the addition of a CLI overwrite option and mobile conflict-dialog safeguards.
  * Recorded lessons learned from visibility issues and incomplete conflict-handling coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->