### PR TITLE
docs(devlog): plan brand marks for the 38 providers that render bare

### DIFF
--- a/devlog/_plan/260901_provider_marks/000_plan.md
+++ b/devlog/_plan/260901_provider_marks/000_plan.md
@@ -1,0 +1,81 @@
+# Provider marks
+
+Unit opened 2026-09-01. The Integrations page now draws a logo beside every
+client it names. The provider surface does not: 38 of 83 registry providers fall
+back to a coloured initial tile, and the Add-Provider catalog draws no mark at
+all for any provider.
+
+## The measurement
+
+```
+PROVIDER_REGISTRY          83 entries
+providerIconSrc() resolves 45
+returns undefined for      38
+```
+
+Three of the 38 are not a sourcing problem at all -- the asset is committed and
+the alias map simply never learned about it:
+
+| provider | asset already on disk |
+|---|---|
+| `minimax` | `minimax.svg` |
+| `minimax-cn` | `minimax.svg` |
+| `xiaomi-mimo` | `xiaomi-color.svg` |
+
+`minimax.svg` landed in #3082 for the MiniMax Code *client*. Nothing connected
+it to the MiniMax *provider*, because the two maps are unrelated:
+`CLIENT_MARKS` is keyed by `ExportClientId` and `PROVIDER_ICON_ALIASES` by
+provider id. That is the whole defect, and it is the cheapest one in this unit.
+
+The remaining 35 have no asset:
+
+```
+nous umans neuralwatt orcarouter bizrouter cerebras chutes deepinfra hyperbolic
+nscale vultr baseten sambanova nebius digitalocean scaleway featherless novita
+together venice zai zhipu-bigmodel zhipu-bigmodel-coding nanogpt synthetic
+siliconflow tencent-coding-plan volcengine volcengine-coding-plan
+volcengine-agent-plan parallel zenmux litellm kilo mimo
+```
+
+## Where a missing mark shows
+
+`providerIconSrc` has exactly one consumer, `ProviderIcon` in `ProviderRail.tsx`,
+which three surfaces render: the rail itself, `ProviderDetails`, and
+`ProviderOverviewDashboard`. When it returns `undefined` the component falls back
+to `ProviderFallbackMark` -- a deterministic hue-per-id initial tile. That
+fallback is good; a page of them where competitors show logos is not.
+
+`ProviderCatalog.tsx` is separate and worse: its preset rows draw a title, an
+adapter chip and badges, and no mark whatsoever. This is the surface the user
+picks a provider FROM, so it is the one place a logo does the most work.
+
+## Sourcing has real targets
+
+Every registry entry carries `baseUrl` and `dashboardUrl`, so no lane has to
+guess where a vendor lives. `cerebras` is `cloud.cerebras.ai`, `sambanova` is
+`cloud.sambanova.ai`, `nebius` is `tokenfactory.nebius.com`, and so on. Those
+URLs are the lane inputs.
+
+Three of the 35 are not independent brands and should be handled as aliases
+rather than sourced twice: `zhipu-bigmodel-coding` is `zhipu-bigmodel`,
+`volcengine-coding-plan` and `volcengine-agent-plan` are `volcengine`, and
+`mimo` is the same Xiaomi MiMo brand as `xiaomi-mimo`.
+
+## Work phases
+
+| Phase | Doc | Deliverable |
+|---|---|---|
+| wp1 | this unit | Research and roadmap (docs only) |
+| wp2 | 010 | Wire the three present-but-unmapped assets + the gap-class guard |
+| wp3 | 020 | Aside lane A: sourcing the first half |
+| wp4 | 030 | Aside lane B: sourcing the second half, vectorize raster-only |
+| wp5 | 040 | Painting contract on the provider surface, measured in both themes |
+| wp6 | 050 | Catalog marks + stack delivery |
+
+## Ordering constraint
+
+wp2 depends on nothing but the map and can land first. wp3 and wp4 are
+independent of each other and of wp2 -- they only add files and alias rows -- so
+they can run as parallel Aside lanes and land as sibling PRs. wp5 depends on both
+sourcing lanes, because the mask decision needs the actual assets to measure. wp6
+is last because the catalog change should draw the full set, not a partial one.

--- a/devlog/_plan/260901_provider_marks/010_wp2_wire_present_assets.md
+++ b/devlog/_plan/260901_provider_marks/010_wp2_wire_present_assets.md
@@ -1,0 +1,49 @@
+# wp2 — wire the assets that are already committed
+
+Three providers render an initial tile while their artwork sits in the repo. No
+sourcing, no tracing, no vendor site: three map rows and a guard.
+
+## The change
+
+`gui/src/provider-icons.ts`, in `PROVIDER_ICON_ALIASES`:
+
+```ts
+  minimax: "minimax.svg",
+  "minimax-cn": "minimax.svg",
+  "xiaomi-mimo": "xiaomi-color.svg",
+```
+
+`minimax` and `minimax-cn` are one brand on two endpoints (`api.minimax.io` and
+`api.minimaxi.com`), the same way `alibaba` and `alibaba-token-plan-intl`
+already share `alibaba-color.svg`. `xiaomi-mimo` is Xiaomi's MiMo endpoint and
+`xiaomi-color.svg` is already wired for `xiaomi` and `mimo-free`.
+
+`mimo` (the token-plan id) belongs here too by the same argument, and takes
+`xiaomi-color.svg`.
+
+## The guard, and why this class needs one
+
+The defect is not that someone forgot a row. It is that nothing could tell them:
+`CLIENT_MARKS` and `PROVIDER_ICON_ALIASES` are different maps over different key
+spaces, so committing `minimax.svg` for the client left no signal that the
+provider of the same name was still bare.
+
+New test, `gui/tests/provider-icons.test.ts`:
+
+1. **Every registry id whose brand asset exists on disk is wired.** For each
+   provider without an alias, probe `<id>.svg`, `<id>-color.svg`, and the same
+   two for the id's first dash-segment. A hit is a failure with the filename
+   named, because it means the artwork is present and the map is stale.
+   Falsify by deleting the `minimax` row.
+2. **Every alias points at a file that exists.** A typo'd filename renders a
+   broken image, which is worse than the fallback tile it replaced. Falsify by
+   pointing one alias at a name that is not committed.
+
+Test 1 is the one that matters: it is the only thing that would have caught this
+gap, and it will catch the next one automatically as wp3/wp4 add assets.
+
+## Out of scope here
+
+No new artwork, no README changes (nothing new is sourced), no painting-mode
+decisions -- `minimax.svg` is a gradient wave and `xiaomi-color.svg` is
+multi-colour, so both stay images under the existing rule.

--- a/devlog/_plan/260901_provider_marks/020_wp3_lane_a.md
+++ b/devlog/_plan/260901_provider_marks/020_wp3_lane_a.md
@@ -1,0 +1,67 @@
+# wp3 — Aside sourcing lane A
+
+Half the unsourced providers. Lane A and lane B (030) are independent: each only
+adds files under `gui/public/provider-icons/`, alias rows, and README entries, so
+they can run as parallel Aside dispatches and land as sibling PRs.
+
+## Lane A targets
+
+The registry gives each one a canonical domain, so no lane guesses where a vendor
+lives.
+
+| provider | domain to search |
+|---|---|
+| `cerebras` | cloud.cerebras.ai |
+| `together` | together.xyz |
+| `deepinfra` | deepinfra.com |
+| `sambanova` | sambanova.ai |
+| `baseten` | baseten.co |
+| `nebius` | tokenfactory.nebius.com |
+| `hyperbolic` | hyperbolic.ai |
+| `novita` | novita.ai |
+| `featherless` | featherless.ai |
+| `venice` | venice.ai |
+| `chutes` | chutes.ai |
+| `nscale` | nscale.com |
+| `vultr` | vultr.com |
+| `digitalocean` | digitalocean.com |
+| `scaleway` | scaleway.com |
+| `siliconflow` | siliconflow.cn |
+| `litellm` | litellm.ai (BerriAI/litellm) |
+
+## Acceptance per asset
+
+An accepted mark is a square-ish brand mark with real path geometry. Rejected on
+sight, with the rejection recorded:
+
+- a `<text>` element standing in for a glyph (the Hermes favicon case: 113 bytes,
+  renders per-machine, blank where the font lacks the character);
+- a `<image>` or base64 raster inside an SVG wrapper -- that is a PNG wearing a
+  costume, and it will not scale or mask;
+- a horizontal wordmark where a square slot needs a mark. The rail draws a 19px
+  box; a 129x32 lockup renders as an illegible smear. This is what disqualified
+  the MiniMax docs asset in the previous unit.
+
+When the vendor publishes only raster -- a favicon PNG, an app icon, an OG image
+-- vectorize it. That path is already proven in this repository:
+`hermes-agent.svg` is `potrace -s --flat --turdsize 8 --alphamax 1.0` over an
+alpha+luma mask, and `gajae-code.svg` is seven k-means colour layers at a 128px
+box. Single-ink silhouette takes potrace; multi-colour art takes the layered
+trace. Downsample before tracing or upscaled pixel art produces a megabyte of
+staircase geometry.
+
+## Naming
+
+`<provider-id>.svg` for a mark that carries its own colour, `<provider-id>-color.svg`
+only where the directory's existing convention already uses that suffix for the
+same brand. The directory is one flat namespace shared with client marks, so a
+name that collides with a client gets the vendor-qualified form (`hermes-agent.svg`
+is the precedent).
+
+## Provenance
+
+Every accepted asset gets a README entry: source URL, fetch date, whether it is
+the product's mark or the publisher's, every modification made, and every
+candidate rejected with the reason. A provider with nothing usable upstream gets
+an entry too -- what was searched, what was found, why it was refused -- and keeps
+its fallback tile. That is a recorded partial and a legitimate outcome.

--- a/devlog/_plan/260901_provider_marks/030_wp4_lane_b.md
+++ b/devlog/_plan/260901_provider_marks/030_wp4_lane_b.md
@@ -1,0 +1,55 @@
+# wp4 — Aside sourcing lane B
+
+The other half. Same acceptance rules, same vectorization path, same provenance
+obligations as 020; this doc records only what differs.
+
+## Lane B targets
+
+| provider | domain to search |
+|---|---|
+| `zai` | z.ai |
+| `zhipu-bigmodel` | bigmodel.cn |
+| `volcengine` | volcengine.com (Ark) |
+| `tencent-coding-plan` | cloud.tencent.com |
+| `nous` | nousresearch.com |
+| `nanogpt` | nano-gpt.com |
+| `synthetic` | synthetic.new |
+| `parallel` | platform.parallel.ai |
+| `zenmux` | zenmux.ai |
+| `kilo` | kilo.ai |
+| `umans` | umans.ai |
+| `neuralwatt` | neuralwatt.com |
+| `orcarouter` | orcarouter.ai |
+| `bizrouter` | bizrouter.ai |
+
+## Aliases, not separate sourcing
+
+Four ids are plan variants of a brand already in this lane and must NOT be
+sourced independently -- a second search would either duplicate the file or
+produce a different asset for the same company:
+
+| variant | takes the mark of |
+|---|---|
+| `zhipu-bigmodel-coding` | `zhipu-bigmodel` |
+| `volcengine-coding-plan` | `volcengine` |
+| `volcengine-agent-plan` | `volcengine` |
+| `mimo` | Xiaomi MiMo, wired in wp2 |
+
+This mirrors how `alibaba`, `alibaba-token-plan` and `alibaba-token-plan-intl`
+already share one asset: the plan is a billing arrangement, not a brand.
+
+## The two that may legitimately come back empty
+
+`nous` is Nous Research, whose desktop icon was already traced for the Hermes
+client mark in the previous unit. If the portal publishes nothing better, reusing
+`hermes-agent.svg` is WRONG -- that is the Hermes product mark, not the Nous
+company mark, and the registry entry is the company's inference portal. Record
+the distinction and prefer an empty result over a misattribution.
+
+`litellm` (lane A) and `parallel` are the other likely empties: one is a
+self-hosted proxy whose brand is a docs site, the other's `baseUrl` and
+`dashboardUrl` are the same host, which usually means there is no separate
+product identity to find.
+
+A recorded empty is a result. Inventing a mark, or borrowing a neighbouring
+brand's, is a misattribution that outlives the commit.

--- a/devlog/_plan/260901_provider_marks/040_wp5_painting.md
+++ b/devlog/_plan/260901_provider_marks/040_wp5_painting.md
@@ -1,0 +1,76 @@
+# wp5 — the painting contract on the provider surface
+
+Depends on both sourcing lanes: the mask decision is a property of the artwork,
+so it cannot be made before the artwork exists.
+
+## The rule, and its record of shipping broken
+
+A mark is drawn one of two ways. As an image it keeps its own colour, which is
+correct for multi-colour art and for a single ink that IS the brand. As a themed
+mask the file is used as a shape and filled with the surrounding text colour,
+which is correct for a neutral silhouette that would otherwise vanish against one
+of the two surfaces.
+
+Getting this wrong is not hypothetical. It has shipped four times: `prime`
+(white on transparent, invisible in light mode), `opencode` (#211E1E) and `kimi`
+(#1A1A1A) invisible in dark, and then `grok` (#000000, ~1.9:1 on the dark card),
+which survived two passes over the same file because a code comment argued it
+away instead of measuring it.
+
+## What the provider surface does today
+
+`ProviderIcon` renders `<img src={src}>` unconditionally. There is no mask path
+at all, so a neutral silhouette added by wp3/wp4 is invisible in one theme with
+no mechanism to fix it short of editing the vendor's file.
+
+The client side already solved this in `ClientMark` + `MASKED_MARKS`. The
+provider side needs the same two-branch decision, and the sets must stay
+DERIVED rather than restated -- two hand-maintained lists of the same fact drift,
+and the drift is a mark masked on one surface and not another.
+
+## The change
+
+1. `provider-icons.ts` grows a masked-set export, keyed by asset path exactly as
+   `MASKED_MARKS` is, so an asset reachable from both surfaces cannot be masked on
+   one and not the other.
+2. `ProviderIcon` branches on it: masked assets render a `<span>` with
+   `mask-image` and `background: var(--text)`; everything else stays an `<img>`.
+   The fallback tile is untouched.
+3. The luminance guard from `gui/tests/integration-marks.test.ts` is generalized
+   to cover provider assets: any single-ink, near-neutral mark (channel spread
+   <= 24, luminance outside 0.12-0.75) that is NOT masked fails, and any
+   multi-colour or gradient mark that IS masked fails.
+
+## Verification is measurement, not reading
+
+A hex string does not tell you what the user sees; the surface colour is half the
+equation. Drive a headless browser over the built GUI, emulate
+`prefers-color-scheme` light and dark, read `getComputedStyle` for each mark and
+for the surface behind it, and compute the contrast ratio. Capture desktop (1440)
+and mobile (390) in both themes.
+
+That procedure is what found grok at 1.9:1 after two passes had declared it
+acceptable. Any provider mark landing under 3:1 against its own surface is a
+defect regardless of what the file's colours suggest.
+
+## Three things the audit corrected in this doc
+
+**The surface is the tile, not the page.** `.provider-icon` is a 31px tile with
+`background: var(--raised)` and a border, so a provider mark is measured against
+`light-dark(#f4f4f4, #303030)` -- not against the card or page background the
+client marks sit on. Same numbers by coincidence today, different variables
+tomorrow; the measurement must read the tile's computed background rather than
+assume the client surface.
+
+**The tile already sets `color: var(--text)`.** That is what a `mask` branch needs
+for `background: var(--text)` to resolve correctly, so the mask path costs one
+rule and no new custom property.
+
+**A third painting mechanism already exists and must not become a fourth.**
+`.usage-source-mark--mono` on the Usage page uses `filter: invert(1)` under a dark
+theme -- a different technique from `ClientMark`'s CSS mask, applied to the same
+`grok.svg` this repository just masked on the Integrations page. Inverting is not
+equivalent: it maps #000 to #fff rather than to `--text`, and it inverts any
+colour present rather than recolouring a silhouette. wp5 either brings that
+call site onto the shared decision or documents why Usage differs. What it must
+not do is add a third spelling of the same idea.

--- a/devlog/_plan/260901_provider_marks/050_wp6_catalog_and_delivery.md
+++ b/devlog/_plan/260901_provider_marks/050_wp6_catalog_and_delivery.md
@@ -1,0 +1,55 @@
+# wp6 — marks in the Add-Provider catalog, and stack delivery
+
+Last because the catalog should draw the full set. Landing it before the sourcing
+lanes would show a page of fallback tiles and invite a second pass over the same
+file.
+
+## The catalog draws no marks at all
+
+`ProviderCatalog.tsx` renders each preset row as a title, an adapter chip and
+badges. This is the surface a user picks a provider FROM -- a list of names where
+a logo would do the most work of anywhere in the app, and the one place that has
+none.
+
+`providerIconSrc` is keyed by provider id and `CatalogPreset.id` is that same id,
+so the existing map serves this surface with no new lookup. The row grows a
+`ProviderIcon` before its title block, matching the rail's markup so both
+surfaces share the mask decision and the fallback tile.
+
+The `accounts` tier rows get the same treatment: they are providers too, and a
+row that shows a logo next to `Cursor` and a bare tile next to `Kiro` reads as a
+bug rather than a distinction.
+
+## Guards
+
+1. Every catalog row renders a mark element -- either the asset or the fallback
+   tile, never nothing. Falsify by removing the component from the row.
+2. The mark is `aria-hidden` beside a visible label, or a screen reader announces
+   the provider twice. This is the rule the client marks already follow.
+3. Row geometry is stable: adding a 19px mark must not push the badges out of the
+   row at mobile width. Measured, not assumed.
+
+## Delivery
+
+Stacked parent-to-child, each PR reviewable alone:
+
+```
+wp1 roadmap ──► wp2 wire+guard ──► wp5 painting ──► wp6 catalog
+                wp3 lane A ──┤
+                wp4 lane B ──┘
+```
+
+wp3 and wp4 are siblings off wp2 rather than a chain: they touch disjoint asset
+files and adjacent alias rows, so serializing them would only add rebases. wp5
+merges after both because it measures the assets they add.
+
+Every push uses `--no-verify`; the local full backend suite is forbidden, so
+backend proof comes from CI. Each PR merges with `--squash --admin` only after
+its own CI is green including the unsharded macOS job, and each child is rebased
+onto the new `dev` tip after its parent lands.
+
+## Closing
+
+The unit moves to `_fin` with an outcome doc recording, per phase, the merge
+commit and what the plan got wrong. The previous unit's outcome doc is the
+template: it is worth more for the corrections than for the table.


### PR DESCRIPTION
## Summary

`PROVIDER_REGISTRY` has 83 entries. `providerIconSrc()` resolves 45 and returns `undefined` for **38**, so those fall back to a coloured initial tile in the provider rail, the details panel and the dashboard rows. The Add-Provider catalog is worse: it draws no mark for any provider at all, and that is the surface a user picks a provider *from*.

Three of the 38 need no sourcing. `minimax.svg` landed for the MiniMax Code **client** in #3082 and nothing connected it to the MiniMax **provider**, because `CLIENT_MARKS` is keyed by `ExportClientId` and `PROVIDER_ICON_ALIASES` by provider id. Same story for `xiaomi-color.svg` and `xiaomi-mimo`. That is three map rows plus a guard, and the guard is what makes the class of gap visible next time.

The other 35 get two parallel Aside sourcing lanes. Every registry entry carries `baseUrl` and `dashboardUrl`, so no lane has to guess where a vendor lives. Raster-only vendors get vectorized the same way `hermes-agent.svg` (potrace) and `gajae-code.svg` (k-means colour layers) were.

Docs only: `000` roadmap plus decade docs `010`, `020`, `030`, `040`, `050`, one per implementation phase.

**The audit corrected three things** in the painting doc rather than letting them reach implementation:

- Provider marks sit on a `.provider-icon` tile with `background: var(--raised)` and a border, not on the page surface the client marks use. Contrast has to be measured against the tile.
- That tile already sets `color: var(--text)`, so a mask branch costs one CSS rule and no new custom property.
- A **third** painting mechanism already exists: `.usage-source-mark--mono` uses `filter: invert(1)` under a dark theme, applied to the same `grok.svg` the Integrations page just masked. Inverting is not equivalent to masking -- it maps #000 to #fff rather than to `--text`. wp5 either brings that call site onto the shared decision or documents why Usage differs; what it must not do is add a fourth spelling of the same idea.

## Verification

- `bun run privacy:scan` -> passed. This is the gate that matters for a `devlog/` change.
- `bun test tests/repo-hygiene.test.ts` -> 12 pass.
- The 38/83 split, the three already-committed assets, and the per-provider domains were all read out of `PROVIDER_REGISTRY` and `providerIconSrc` programmatically, not recalled.

Docs only; nothing in the build, typecheck or test path reads from `devlog/`.

## Checklist

- [x] Docs-only change, no source touched
- [x] `bun run privacy:scan` clean
- [x] `bun test tests/repo-hygiene.test.ts` green
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive plans for improving provider icon coverage across the application.
  * Documented sourcing standards, alias handling, fallback behavior, accessibility, theming, and mobile layout considerations.
  * Defined the delivery phases, testing expectations, and quality criteria for provider marks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->