### PR TITLE
fix(gui): wire the provider marks that were already committed

### DIFF
--- a/gui/src/provider-icons.ts
+++ b/gui/src/provider-icons.ts
@@ -28,6 +28,8 @@ const PROVIDER_ICON_ALIASES: Record<string, string> = {
   kiro: "kiro-color.svg",
   "lm-studio": "lm-studio-color.svg",
   mistral: "mistral-color.svg",
+  minimax: "minimax.svg",
+  "minimax-cn": "minimax.svg",
   moonshot: "moonshot-color.svg",
   nvidia: "nvidia-color.svg",
   ollama: "ollama-color.svg",
@@ -47,7 +49,9 @@ const PROVIDER_ICON_ALIASES: Record<string, string> = {
   vllm: "vllm-color.svg",
   xai: "grok.svg",
   "mimo-free": "xiaomi-color.svg",
+  mimo: "xiaomi-color.svg",
   xiaomi: "xiaomi-color.svg",
+  "xiaomi-mimo": "xiaomi-color.svg",
 };
 
 /**

--- a/gui/tests/provider-icons.test.ts
+++ b/gui/tests/provider-icons.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { PROVIDER_REGISTRY } from "../../src/providers/registry";
+import { providerIconSrc } from "../src/provider-icons";
+
+const PUBLIC_DIR = join(import.meta.dir, "..", "public", "provider-icons");
+
+/**
+ * Asset filenames that could plausibly belong to a provider id.
+ *
+ * A plan variant is a billing arrangement, not a brand -- `alibaba-token-plan`
+ * wears the Alibaba mark -- so the first dash-segment is probed too.
+ */
+function candidateAssets(providerId: string): string[] {
+  const stem = providerId.split("-")[0]!;
+  return [
+    `${providerId}.svg`,
+    `${providerId}-color.svg`,
+    `${stem}.svg`,
+    `${stem}-color.svg`,
+  ];
+}
+
+/*
+ * The gap this exists for, stated plainly: `minimax.svg` was committed for the
+ * MiniMax Code CLIENT and the MiniMax PROVIDER kept rendering an initial tile for
+ * weeks. Nothing could have told anyone. `CLIENT_MARKS` is keyed by
+ * `ExportClientId` and `PROVIDER_ICON_ALIASES` by provider id, so adding artwork
+ * on one side leaves no signal on the other, and the fallback tile is a designed
+ * state that looks identical to a mistake.
+ *
+ * This is the only check that closes that loop, and it keeps closing it as new
+ * assets land: a mark added for any reason is immediately owed a provider row.
+ */
+test("a provider whose brand asset is already committed is actually wired to it", () => {
+  const files = new Set(readdirSync(PUBLIC_DIR).filter(name => name.endsWith(".svg")));
+  const unwired: string[] = [];
+  for (const entry of PROVIDER_REGISTRY) {
+    if (providerIconSrc(entry.id)) continue;
+    const found = candidateAssets(entry.id).find(name => files.has(name));
+    if (found) unwired.push(`${entry.id}: ${found} is committed but PROVIDER_ICON_ALIASES has no row`);
+  }
+  expect(unwired).toEqual([]);
+});
+
+/*
+ * A mistyped filename renders a broken image, which is strictly worse than the
+ * fallback tile it replaced: the tile is deliberate and legible, the broken image
+ * is a visual defect. The map is plain strings, so nothing else checks this.
+ */
+test("every wired provider icon names a file that exists", () => {
+  const broken = PROVIDER_REGISTRY
+    .map(entry => [entry.id, providerIconSrc(entry.id)] as const)
+    .filter((pair): pair is readonly [string, string] => pair[1] !== undefined)
+    .filter(([, src]) => !existsSync(join(PUBLIC_DIR, src.split("/").pop()!)))
+    .map(([id, src]) => `${id} -> ${src}`);
+  expect(broken).toEqual([]);
+});
+
+/*
+ * The four rows this phase added, pinned by intent rather than by count.
+ *
+ * MiniMax is one brand on two endpoints (`api.minimax.io` and `api.minimaxi.com`),
+ * the same shape as the three Alibaba ids that already share one asset. Xiaomi's
+ * MiMo ids are the same brand as `mimo-free`, which was already wired -- the
+ * inconsistency was the bug.
+ */
+test("the MiniMax and Xiaomi MiMo provider ids resolve to their brand's mark", () => {
+  expect(providerIconSrc("minimax")).toBe("/provider-icons/minimax.svg");
+  expect(providerIconSrc("minimax-cn")).toBe("/provider-icons/minimax.svg");
+  expect(providerIconSrc("xiaomi-mimo")).toBe("/provider-icons/xiaomi-color.svg");
+  expect(providerIconSrc("mimo")).toBe("/provider-icons/xiaomi-color.svg");
+  // The precedent that makes the two above consistent rather than novel.
+  expect(providerIconSrc("mimo-free")).toBe("/provider-icons/xiaomi-color.svg");
+});


### PR DESCRIPTION
## Summary

`minimax.svg` landed for the MiniMax Code **client** in #3082. The MiniMax **provider** kept rendering a coloured initial tile, because `CLIENT_MARKS` is keyed by `ExportClientId` and `PROVIDER_ICON_ALIASES` by provider id -- adding artwork on one side leaves no signal on the other. `xiaomi-color.svg` had the same problem and more visibly: `mimo-free` was already wired to it while `xiaomi-mimo` and `mimo`, the same brand, were not.

Four alias rows. `minimax` and `minimax-cn` are one brand on two endpoints (`api.minimax.io`, `api.minimaxi.com`), the same shape as the three Alibaba ids that already share one asset. Both assets are multi-colour -- `xiaomi-color.svg` carries #FF6900 and three more, `minimax.svg` a `linearGradient` -- so neither is a masking candidate and this PR makes no painting decision.

Providers with no resolved mark: **38 -> 34**.

**The guard is the part that matters.** The fallback tile is a designed state that looks exactly like a mistake, so nothing could tell a maintainer that committed artwork was unwired. The new test probes, for every registry provider without an alias, whether a plausibly-named asset is already sitting in the directory, and fails with the filename when one is. It keeps closing that loop as the sourcing lanes add assets.

Rendered at 19px in the `.provider-icon` tile, both themes, all four ids loading:

| dark | light |
|---|---|
| ![dark](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/wired-dark.png) | ![light](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/wired-light.png) |

## Verification

- `cd gui && bun test tests/provider-icons.test.ts` -> 3 pass. Driven red twice: removing the `minimax` row (2 red, including the gap-class guard) and pointing an alias at a filename that is not committed (2 red).
- Full GUI suite -> **1157 pass / 0 fail** across 187 files.
- `bun x tsc --noEmit` exit 0 both roots; `bun run lint:gui` clean; `bun run privacy:scan` passed.
- The 38 -> 34 count was read out of `PROVIDER_REGISTRY` through `providerIconSrc`, not recalled. Rendered geometry and tile colour measured with `getComputedStyle` under emulated `prefers-color-scheme`.

Full local backend suite not run per the repository scoped-change rule; CI is the gate.

## Checklist

- [x] Focused regression tests, each falsified
- [x] `bun x tsc --noEmit` clean (root + gui)
- [x] `bun run lint:gui` and `bun run privacy:scan` clean
- [x] Screenshot of the rendered marks in both themes
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branded icons for MiniMax providers.
  * Added branded icons for MiMo/Xiaomi providers.

* **Bug Fixes**
  * Improved provider icon mapping so supported provider IDs display the correct brand assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->