### PR TITLE
feat(gui): give the Add-Provider catalog its logos

### DIFF
--- a/gui/src/components/provider-catalog/ProviderCatalog.tsx
+++ b/gui/src/components/provider-catalog/ProviderCatalog.tsx
@@ -13,6 +13,7 @@ import {
 } from "./provider-presets";
 import { shouldShowLoginHint, type CatalogLoginHint } from "./login-hint-visibility";
 import { LoginHint } from "../login-url-block";
+import { ProviderIcon } from "../provider-workspace/ProviderRail";
 
 export type AccountLoginStatus = { loggedIn: boolean; email?: string; error?: string; needsReauth?: boolean };
 export type AccountLoginRow = {
@@ -149,6 +150,14 @@ export default function ProviderCatalog({
         )}
         {tier !== "accounts" && rows.map(p => (
           <button type="button" key={p.id} className="list-row" onClick={() => onSelectPreset(p)}>
+            {/*
+              The one list a user reads to CHOOSE a provider, and until now the only
+              provider surface with no marks at all. `CatalogPreset.id` is the
+              registry id, so this reuses `providerIconSrc` and, with it, the
+              mask/plate decision the rail already owns -- a mark cannot be legible
+              in the workspace and invisible here.
+            */}
+            <ProviderIcon name={p.id} adapter={p.adapter} cls="provider-icon provider-icon-sm" />
             <div>
               <div className="title">{p.label}</div>
               <div className="sub"><code className="chip">{p.adapter}</code>{p.note ? ` · ${p.note}` : ""}</div>
@@ -174,6 +183,9 @@ export default function ProviderCatalog({
           return (
             <div key={row.id} className={`list-row provider-catalog-account-row${showHint ? " provider-catalog-account-row--waiting" : ""}`}>
               <div className="provider-catalog-account-row-head">
+              {/* Account rows are providers too. A logo beside Cursor and a bare
+                  tile beside Kiro reads as a bug, not as a distinction. */}
+              <ProviderIcon name={row.id} cls="provider-icon provider-icon-sm" />
               <div>
                 <div className="title">{row.label}</div>
                 <div className="sub">{statusText}</div>

--- a/gui/src/styles/provider-catalog.css
+++ b/gui/src/styles/provider-catalog.css
@@ -60,6 +60,16 @@
   text-overflow: ellipsis;
 }
 
+/* Both row kinds are space-between, so a mark placed before the title would push
+   the badges into the middle of the row. The text block takes the free space
+   instead, and `min-width: 0` lets a long provider label ellipsize rather than
+   widen the row past the modal.
+
+   Scoped to the catalog on purpose: `.list-row` is shared, and the other lists
+   that use it have no mark to lay out. */
+.provider-catalog-rows .provider-icon { flex: 0 0 auto; }
+.provider-catalog-rows .provider-icon + div { flex: 1 1 auto; min-width: 0; }
+
 /* An account row is normally one horizontal line (`.list-row` is a row flex).
    While a login for that row is in flight it grows a second line for the
    authorization URL, device code, and paste field, so the head keeps the

--- a/gui/tests/provider-catalog-marks.test.tsx
+++ b/gui/tests/provider-catalog-marks.test.tsx
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { LanguageProvider } from "../src/i18n/provider";
+import AddProviderModal from "../src/components/AddProviderModal";
+
+/**
+ * The Add-Provider catalog is the list a user reads to CHOOSE a provider, and it
+ * was the only provider surface with no marks at all -- the rail, the details
+ * panel and the dashboard rows have drawn them for a while.
+ *
+ * These pin the two properties that make the marks correct rather than merely
+ * present: every row has one, and none of them is announced.
+ */
+
+const globals = ["document", "window", "navigator", "localStorage", "IS_REACT_ACT_ENVIRONMENT"] as const;
+let previous: Record<(typeof globals)[number], unknown>;
+let win: Window;
+let host: HTMLElement;
+let root: Root | null = null;
+let originalFetch: typeof globalThis.fetch;
+
+/** Two presets whose ids resolve a mark, and one that cannot. */
+const PRESETS = [
+  { id: "cerebras", label: "Cerebras", adapter: "openai-completions", baseUrl: "https://api.cerebras.ai/v1", auth: "key" },
+  { id: "together", label: "Together", adapter: "openai-completions", baseUrl: "https://api.together.xyz/v1", auth: "key" },
+  // No asset upstream: this row must still draw the fallback tile.
+  { id: "chutes", label: "Chutes", adapter: "openai-completions", baseUrl: "https://llm.chutes.ai/v1", auth: "key" },
+];
+
+beforeEach(() => {
+  previous = Object.fromEntries(globals.map(k => [k, Reflect.get(globalThis, k)])) as typeof previous;
+  originalFetch = globalThis.fetch;
+  win = new Window({ url: "http://localhost/" });
+  Object.defineProperty(win.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperties(globalThis, {
+    document: { configurable: true, value: win.document },
+    window: { configurable: true, value: win },
+    navigator: { configurable: true, value: win.navigator },
+    localStorage: { configurable: true, value: win.localStorage },
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/provider-presets") return Response.json({ providers: PRESETS });
+      if (url.pathname === "/api/oauth/providers") return Response.json({ providers: [] });
+      if (url.pathname === "/api/usage") return Response.json({ providers: [] });
+      return Response.json({});
+    },
+  });
+
+  host = win.document.createElement("div") as unknown as HTMLElement;
+  win.document.body.appendChild(host as never);
+});
+
+afterEach(async () => {
+  if (root) {
+    const current = root;
+    await act(async () => { current.unmount(); });
+    root = null;
+  }
+  for (const key of globals) {
+    Object.defineProperty(globalThis, key, { configurable: true, value: previous[key] });
+  }
+  Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+  await win.happyDOM?.close?.();
+});
+
+async function mountCatalog() {
+  const { createRoot } = await import("react-dom/client");
+  await act(async () => {
+    root = createRoot(host);
+    root.render(
+      <LanguageProvider>
+        {/* `paid` is where an API-key preset buckets; the default `free` tab would
+            render an empty list and make these assertions vacuous. */}
+        <AddProviderModal apiBase="" existingNames={[]} initialTier="paid" onClose={() => {}} onAdded={() => {}} />
+      </LanguageProvider>,
+    );
+  });
+  await act(async () => { await new Promise(r => setTimeout(r, 60)); });
+}
+
+function catalogRows(): HTMLElement[] {
+  return [...host.querySelectorAll<HTMLElement>(".provider-catalog-rows .list-row")];
+}
+
+/*
+ * Every row, including the one whose vendor publishes nothing. A provider with no
+ * asset must still render the fallback tile: the row that draws neither is
+ * indistinguishable from a broken lookup, and misaligned against its neighbours.
+ */
+test("every catalog row draws a mark, including a provider with no asset", async () => {
+  await mountCatalog();
+  const rows = catalogRows();
+  expect(rows.length).toBeGreaterThan(0);
+  const bare = rows.filter(row => row.querySelector(".provider-icon") === null);
+  expect(bare.map(row => row.textContent?.slice(0, 24))).toEqual([]);
+});
+
+/*
+ * The mark sits beside a label that already names the provider, so it must add
+ * nothing to the accessible name -- an `<img alt="Cerebras">` next to the word
+ * Cerebras makes a screen reader say it twice.
+ */
+test("a catalog mark is decoration, not a second announcement of the name", async () => {
+  await mountCatalog();
+  for (const img of host.querySelectorAll(".provider-catalog-rows .provider-icon img")) {
+    expect(img.getAttribute("alt")).toBe("");
+    expect(img.getAttribute("aria-hidden")).toBe("true");
+  }
+});
+
+/*
+ * The mark comes first, before the title block. `.list-row` is space-between, so
+ * a mark inserted anywhere else pushes the badge strip into the middle of the row.
+ */
+test("the mark leads the row so the badges stay right-aligned", async () => {
+  await mountCatalog();
+  for (const row of catalogRows()) {
+    expect(row.firstElementChild?.classList.contains("provider-icon")).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary

The Add-Provider catalog is the list a user reads to **choose** a provider, and it was the only provider surface with no marks at all -- the rail, the details panel and the dashboard rows have drawn them for a while. A page of names is a worse place to pick from than a page of logos.

![catalog](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/catalog-dark.png)

`CatalogPreset.id` is the registry id, so this reuses `ProviderIcon` rather than adding a lookup: the mask/plate decision from #3098 comes along, and a mark cannot be legible in the workspace and invisible here. Account rows get the same treatment -- a logo beside Cursor and a bare tile beside Kiro reads as a bug rather than a distinction. A provider with no asset still draws the fallback tile, so no row is left visually short.

**One layout rule.** `.list-row` is space-between, so a mark placed before the title would push the badge strip into the middle of the row. The text block takes the free space instead, and `min-width: 0` lets a long label ellipsize rather than widen the row past the modal. Scoped to the catalog, because `.list-row` is shared and no other list has a mark to lay out.

## Verification

- `cd gui && bun test tests/provider-catalog-marks.test.tsx` -> 3 pass. Driven red twice: removing the component from the preset rows (2 red), and giving the mark an `alt` that makes a screen reader announce the provider name twice (1 red).
- Measured at 620px and 400px in both themes: **10 of 10 rows marked**, the mark first in every row, and the badge strip a uniform 14px from the right edge -- no row pushed out of alignment.
- `bun x tsc --noEmit` exit 0 both roots; `bun run lint:gui` clean; `bun run privacy:scan` passed.

| light | dark, mobile |
|---|---|
| ![light](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/catalog-light.png) | ![mobile](https://raw.githubusercontent.com/lidge-jun/opencodex/assets/aside-and-rollback-260831/catalog-dark-mobile.png) |

Local suites beyond the focused file were not run; CI is the gate.

## Checklist

- [x] Focused regression tests, each falsified
- [x] `bun x tsc --noEmit` clean (root + gui)
- [x] `bun run lint:gui` and `bun run privacy:scan` clean
- [x] Screenshots at desktop and mobile widths in both themes
- [x] Targets `dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider icons to preset and account rows in the provider catalog.
  * Added fallback icons for providers without an upstream asset.
  * Improved row layout so badges remain aligned and long provider names truncate cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->