### PR TITLE
fix(catalog): widen the dated-variant fold and guard its direction at the merge loop

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -936,9 +936,70 @@ export function resolveComboCatalogMember(
   };
 }
 
+const DATED_VARIANT_YYYYMMDD = /^(\d{4})(\d{2})(\d{2})$/;
+const DATED_VARIANT_YYMMDD = /^(2\d)(\d{2})(\d{2})$/;
+const DATED_VARIANT_MMDD_OR_YYMM = /^(\d{2})(\d{2})$/;
+
+/** Whether a Gregorian year contains February 29th. */
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+/**
+ * Whether a month/day pair exists in the given year. Without a year, February 29th is
+ * accepted because it occurs in at least one calendar year.
+ */
+function isValidCalendarDate(year: number | undefined, month: number, day: number): boolean {
+  if (year !== undefined && (year < 1 || year > 9999)) return false;
+  if (month < 1 || month > 12 || day < 1) return false;
+  const daysInMonth = [
+    31, year === undefined || isLeapYear(year) ? 29 : 28, 31, 30, 31, 30,
+    31, 31, 30, 31, 30, 31,
+  ];
+  return day <= daysInMonth[month - 1]!;
+}
+
+/**
+ * Release-date suffixes providers actually publish: `YYYYMMDD` (`-20251001`), `YYMMDD`
+ * (`-260806`), `MMDD` (`-0813`) and `YYMM` (`-2512`). A `\d{8}`-only rule matched none of
+ * the dated ids on a real multi-provider install, so DeepSeek, Kimi, Mistral, Qwen and
+ * Solar aliases all fell through to `droppedConfiguredIds` (#3024).
+ *
+ * Calendar validation rejects impossible month-end and leap-day values as well as ordinary
+ * numeric suffixes such as `-2048`, `-4096` and `-8192`. `-1024` is the one irreducible
+ * collision — it is a valid `MMDD` (October 24th) — so it reads as dated. That is a known,
+ * accepted cost; the test table pins it so it cannot become a surprise later.
+ *
+ * Hyphenated ISO suffixes (`-2024-08-06`, `-05-06`) are deliberately out of scope: a
+ * hyphenated suffix is ambiguous against ordinary name segments and needs its own call.
+ */
+function isDatedVariantSuffix(suffix: string): boolean {
+  const yyyyMmDd = DATED_VARIANT_YYYYMMDD.exec(suffix);
+  if (yyyyMmDd) {
+    return isValidCalendarDate(
+      Number(yyyyMmDd[1]), Number(yyyyMmDd[2]), Number(yyyyMmDd[3]),
+    );
+  }
+
+  const yyMmDd = DATED_VARIANT_YYMMDD.exec(suffix);
+  if (yyMmDd) {
+    return isValidCalendarDate(
+      2000 + Number(yyMmDd[1]), Number(yyMmDd[2]), Number(yyMmDd[3]),
+    );
+  }
+
+  const mmDdOrYyMm = DATED_VARIANT_MMDD_OR_YYMM.exec(suffix);
+  if (!mmDdOrYyMm) return false;
+  const first = Number(mmDdOrYyMm[1]);
+  const second = Number(mmDdOrYyMm[2]);
+  return isValidCalendarDate(undefined, first, second)
+    || (first >= 20 && first <= 29 && second >= 1 && second <= 12);
+}
+
+/** Whether `liveId` is a supported dated release of the configured base id. */
 export function isDatedVariantId(liveId: string, configuredId: string): boolean {
   if (!liveId.startsWith(`${configuredId}-`)) return false;
-  return /^\d{8}$/.test(liveId.slice(configuredId.length + 1));
+  return isDatedVariantSuffix(liveId.slice(configuredId.length + 1));
 }
 
 export const lastDropWarnSignature = new Map<string, string>();

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -3651,12 +3651,66 @@ describe("Codex catalog routed normalization", () => {
     }
   });
 
-  test("isDatedVariantId matches only <alias>-YYYYMMDD", () => {
+  test("isDatedVariantId matches only <alias>-<date>", () => {
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4-5")).toBe(true);
     expect(isDatedVariantId("claude-haiku-4-5-2025", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-latest", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4")).toBe(false);
+  });
+
+  // Real ids from a multi-provider install. A `\d{8}`-only rule matched none of them, so
+  // every one of these aliases dropped out of the authoritative live catalog (#3024).
+  test.each([
+    ["YYYYMMDD", "claude-haiku-4-5-20251001", "claude-haiku-4-5"],
+    ["YYYYMMDD leap day", "acme-model-20240229", "acme-model"],
+    ["YYMMDD", "solar-pro4-260806", "solar-pro4"],
+    ["YYMMDD", "syn-pro-251021", "syn-pro"],
+    ["YYMMDD leap day", "acme-model-240229", "acme-model"],
+    ["MMDD", "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4-pro"],
+    ["MMDD", "moonshotai/kimi-k2-0905", "moonshotai/kimi-k2"],
+    ["MMDD", "openai/gpt-3.5-turbo-0613", "openai/gpt-3.5-turbo"],
+    ["MMDD leap day", "acme-model-0229", "acme-model"],
+    ["YYMM", "mistralai/mistral-large-2407", "mistralai/mistral-large"],
+    ["YYMM", "qwen/qwen3-235b-a22b-2507", "qwen/qwen3-235b-a22b"],
+  ])("folds a %s dated variant: %s", (_format, liveId, configuredId) => {
+    expect(isDatedVariantId(liveId, configuredId)).toBe(true);
+  });
+
+  test.each([
+    ["a version number", "mistralai/mistral-medium-3-5", "mistralai/mistral-medium-3"],
+    ["a context size", "openai/gpt-3.5-turbo-16k", "openai/gpt-3.5-turbo"],
+    ["a variant name", "qwen/qwen3-coder-30b-a3b-instruct", "qwen/qwen3-coder"],
+    ["a batch lane of a dated id", "deepseek/deepseek-v4-pro-0813:batch", "deepseek/deepseek-v4-pro"],
+    ["a bare year", "acme-model-2025", "acme-model"],
+    ["an impossible YYMM", "acme-model-1301", "acme-model"],
+    ["a non-leap YYYYMMDD", "acme-model-20250229", "acme-model"],
+    ["a non-leap YYMMDD", "acme-model-250229", "acme-model"],
+    ["an impossible YYYYMMDD month-end", "acme-model-20240431", "acme-model"],
+    ["an impossible YYMMDD month-end", "acme-model-240431", "acme-model"],
+    ["an impossible MMDD month-end", "acme-model-0431", "acme-model"],
+    // Hyphenated ISO is ambiguous against ordinary name segments; out of scope for now.
+    ["a hyphenated ISO date", "openai/gpt-4o-2024-08-06", "openai/gpt-4o"],
+    ["a hyphenated MM-DD", "google/gemini-2.5-pro-preview-05-06", "google/gemini-2.5-pro-preview"],
+  ])("does not fold %s: %s", (_label, liveId, configuredId) => {
+    expect(isDatedVariantId(liveId, configuredId)).toBe(false);
+  });
+
+  test.each(["2048", "4096", "8192"])("a %s context suffix is not a date", suffix => {
+    expect(isDatedVariantId(`acme-model-${suffix}`, "acme-model")).toBe(false);
+  });
+
+  // Known, accepted cost of allowing MMDD: October 24th is a real date, so a `-1024`
+  // context suffix is indistinguishable from one. No month/day tightening can exclude it.
+  test("a -1024 suffix reads as MMDD and is accepted", () => {
+    expect(isDatedVariantId("acme-model-1024", "acme-model")).toBe(true);
+  });
+
+  // The fold stays one-directional: a configured id the provider no longer lists must not
+  // be retained on the strength of a format match alone (#1690 is the explicit opt-in for
+  // that). `deepseek-v4-pro-0813` configured against a live `deepseek-v4-pro` stays dropped.
+  test("does not fold configured=dated against live=base", () => {
+    expect(isDatedVariantId("deepseek-v4-pro", "deepseek-v4-pro-0813")).toBe(false);
   });
 
   test("disabled providers are excluded from routed model gathering", async () => {

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applyNativeVisibility, augmentRoutedModelsWithMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, buildComboCatalogOmission, catalogModelSlug, clampCatalogModelsToCodexSupport, clampEntryToCodexSupportedEfforts, clampedDefaultEffort, CODEX_ACCOUNT_BOUND_CATALOG_KIND, CODEX_NATIVE_ALIAS_CATALOG_KIND, comboCatalogOmissionReason, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels as gatherRoutedModelsDirect, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_DAYBREAK_BLUE_MODEL, NATIVE_OPENAI_MODELS, nativeDefaultReasoningEffort, nativeInputModalities, nativeOpenAiCapabilitySourceSlug, nativeOpenAiContextWindow, nativeReasoningEfforts, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests, resolveComboCatalogMember, shouldExposeRoutedModel, upstreamNativeEntry } from "../src/codex/catalog";
-import { applyProviderConfigHints } from "../src/codex/catalog/provider-fetch";
+import { applyProviderConfigHints, mergeConfiguredModelsIntoLiveCatalog } from "../src/codex/catalog/provider-fetch";
 import {
   CODEX_CUSTOM_MODEL_CATALOG_KIND,
   CODEX_PROVIDER_MODEL_CATALOG_KIND,
@@ -3711,6 +3711,49 @@ describe("Codex catalog routed normalization", () => {
   // that). `deepseek-v4-pro-0813` configured against a live `deepseek-v4-pro` stays dropped.
   test("does not fold configured=dated against live=base", () => {
     expect(isDatedVariantId("deepseek-v4-pro", "deepseek-v4-pro-0813")).toBe(false);
+  });
+
+  // The predicate test above is necessary and not sufficient: it passes on any
+  // implementation, including one whose MERGE LOOP calls the predicate a second time with
+  // the arguments swapped. These three drive `mergeConfiguredModelsIntoLiveCatalog` itself,
+  // so they fail if the loop ever becomes bidirectional. Carried from #3041, where the
+  // reverse fold was proposed and then withdrawn — the guard outlives the proposal.
+  test("the merge loop does not infer a configured dated id from a live base id", () => {
+    const { models, droppedConfiguredIds } = mergeConfiguredModelsIntoLiveCatalog({
+      name: "deepseek",
+      provider: {},
+      models: [{ id: "deepseek-v4-pro" } as never],
+      configured: [{ id: "deepseek-v4-pro-0813" } as never],
+    });
+    expect(droppedConfiguredIds).toEqual(["deepseek-v4-pro-0813"]);
+    expect(models.map(m => m.id)).not.toContain("deepseek-v4-pro-0813");
+  });
+
+  test("the merge loop folds a live MMDD dated row onto its configured base", () => {
+    const { models, droppedConfiguredIds } = mergeConfiguredModelsIntoLiveCatalog({
+      name: "deepseek",
+      provider: {},
+      models: [{ id: "deepseek-v4-pro-0813" } as never],
+      configured: [{ id: "deepseek-v4-pro" } as never],
+    });
+    expect(droppedConfiguredIds).toEqual([]);
+    expect(models.map(m => m.id)).toContain("deepseek-v4-pro");
+  });
+
+  // Retention of a dated id is a decision someone made, not an inference from a name.
+  // Note what this set actually is: production fills `retainConfiguredModelIds` from combo
+  // targets, not from `providers.*.models`, so this pins the combo-target path (OCX-111).
+  // The operator-facing opt-in is #1690's `retainModels`, which does not exist yet.
+  test("a dated id named in retainConfiguredModelIds survives the drop", () => {
+    const { models, droppedConfiguredIds } = mergeConfiguredModelsIntoLiveCatalog({
+      name: "deepseek",
+      provider: {},
+      models: [{ id: "deepseek-v4-pro" } as never],
+      configured: [{ id: "deepseek-v4-pro-0813" } as never],
+      retainConfiguredModelIds: new Set(["deepseek-v4-pro-0813"]),
+    });
+    expect(droppedConfiguredIds).toEqual([]);
+    expect(models.map(m => m.id)).toContain("deepseek-v4-pro-0813");
   });
 
   test("disabled providers are excluded from routed model gathering", async () => {


### PR DESCRIPTION
## Summary

Supersedes #3034 and #3041, which found the same defect from two directions. This carries the better half of each.

`isDatedVariantId` only matched `-YYYYMMDD`, so every dated alias a provider actually publishes in another shape fell through to `droppedConfiguredIds` while discovery still reported `ok` (#3024). The matcher now accepts `YYYYMMDD`, `YYMMDD`, `MMDD` and `YYMM` with calendar validation, so `-2048`, `-4096`, `-8192`, `-20250229` and `-0431` stay rejected. `-1024` is October 24th and is the one irreducible collision; the test table pins it rather than pretending otherwise.

The first commit is #3034's work, cherry-picked with authorship intact.

The second commit moves the direction guard to where a resurrection would actually happen. #3034 pins one-wayness with a predicate assertion — `isDatedVariantId("deepseek-v4-pro", "deepseek-v4-pro-0813") === false` — which is true of *every* implementation, including one whose merge loop calls the predicate a second time with the arguments swapped. That is exactly what #3041 first proposed and then withdrew, so the guard needs to outlive the proposal. Three tests carried from #3041 drive `mergeConfiguredModelsIntoLiveCatalog` itself.

**This does not close #3024.** The reported case is a configured *dated* id against a live *base* id, and that still drops — deliberately, because a live base row is not callability evidence for a dated snapshot. Retaining it needs #1690's `retainModels` opt-in. Executed on this branch:

```
configured deepseek-v4-pro-0813 + live deepseek-v4-pro
  -> dropped: ["deepseek-v4-pro-0813"]
configured deepseek-v4-pro + live deepseek-v4-pro-0813
  -> dropped: [], ids: ["deepseek-v4-pro-0813","deepseek-v4-pro"]
```

## Verification

```
bun test tests/codex-catalog.test.ts   -> 254 pass / 0 fail / 980 expect()
bun x tsc --noEmit                     -> exit 0
```

Both directions mutation-checked, then restored:

| mutation | result |
| --- | --- |
| add `\|\| isDatedVariantId(candidate.id, live.id)` to the merge loop | 253 pass / **1 fail** — only `the merge loop does not infer a configured dated id from a live base id` |
| narrow the suffix back to `/^\d{8}$/` | 241 pass / **13 fail** — every MMDD/YYMM/YYMMDD fold plus the calendar rejections |

Neither mutation is caught by the predicate test alone, which is the argument for the second commit.

Suffix behavior probed directly over 22 shapes: accepted `2510 2412 2409 1024 2401 2101 0813 2407 1231 2612`; rejected `2048 4096 8192 2413 2400 3012 1912 0000 0100 1300 1601`.

## Checklist

- [x] Focused tests for the changed subsystem pass
- [x] `bun x tsc --noEmit` clean
- [x] No user-facing behavior needs a docs-site change (internal catalog fold)
- [x] Supersedes #3034 and #3041; both credited above

Triaged in the 2026-08-31 non-priority-70 bug round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of dated model variants across multiple date formats.
  - Prevented ordinary numeric suffixes, version numbers, variant names, and invalid dates from being misidentified as dated variants.
  - Correctly handles leap days and other calendar-specific date validation.
  - Preserved configured model entries according to catalog merge rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->