### PR TITLE
fix(cursor): retry a discovery stream that ends before HTTP/2 headers

### DIFF
--- a/src/adapters/cursor/live-models.ts
+++ b/src/adapters/cursor/live-models.ts
@@ -262,6 +262,7 @@ async function fetchCursorUsableModelsHttp2Once(opts: CursorUsableModelsOptions)
     req.on("error", () => close({ ok: false, error: "transport", detail: "HTTP/2 request failed" }));
     req.on("end", () => {
       if (bodyRejected) return;
+      if (status === 0) return close({ ok: false, error: "transport", detail: "HTTP/2 response ended before headers" });
       if (status === 401 || status === 403) {
         return close({ ok: false, error: "auth", detail: `HTTP ${status}` });
       }

--- a/tests/cursor-hardening.test.ts
+++ b/tests/cursor-hardening.test.ts
@@ -424,6 +424,25 @@ describe("Cursor discovery bounded retry", () => {
     expect(result).toEqual({ ok: true, models: ["gpt-5.5-high"] });
   });
 
+  test("retries an HTTP/2 stream that ends before response headers", async () => {
+    const body = toBinary(GetUsableModelsResponseSchema, create(GetUsableModelsResponseSchema, {
+      models: [create(ModelDetailsSchema, { modelId: "gpt-5.5-high" })],
+    }));
+    let requests = 0;
+    const result = await withDiscoveryServer(stream => {
+      requests += 1;
+      if (requests === 1) {
+        stream.close(http2.constants.NGHTTP2_NO_ERROR);
+        return;
+      }
+      stream.respond({ ":status": 200, "content-type": "application/proto" });
+      stream.end(body);
+    }, baseUrl => fetchCursorUsableModels({ apiKey: "test-token", baseUrl }));
+
+    expect(requests).toBe(2);
+    expect(result).toEqual({ ok: true, models: ["gpt-5.5-high"] });
+  });
+
   test("does not retry deterministic auth failures", async () => {
     let requests = 0;
     const result = await withDiscoveryServer(stream => {


### PR DESCRIPTION
## Summary

Carries #3052 (author @terrytan95) rebased onto current `dev`. The patch is one production line and needs no changes.

Cursor discovery over HTTP/2 starts with `status = 0` and only assigns it on `response`. When a stream ends before headers arrive — which real Cursor endpoints do intermittently — `req.on("end")` fell through every status branch to `{ error: "http", detail: "HTTP unknown" }`. The retry set is `timeout|transport` (`src/adapters/cursor/live-models.ts:54`), so `http` was never retried and the catalog recorded a discovery failure for a connection whose very next request succeeds. The HTTP/1.1 path already maps a fetch failure to `transport` at `:194-196`; this makes the HTTP/2 path agree.

Closes #3051.

## Verification

```
bun test tests/cursor-hardening.test.ts   -> 42 pass / 0 fail / 89 expect()
bun x tsc --noEmit                        -> exit 0
```

The test is not a stub: it stands up a real HTTP/2 server, closes the first stream with `NGHTTP2_NO_ERROR` before responding, and asserts both that a second request happened and that the model list came back. Mutation-checked — deleting the single production line gives 41 pass / **1 fail**, exactly `retries an HTTP/2 stream that ends before response headers`, then restored to 42/0.

The deterministic-auth test directly above it is the control: 401/403 and non-2xx statuses stay non-retryable, so this widens retry only to the pre-header case.

## Checklist

- [x] Focused tests for the changed subsystem pass
- [x] `bun x tsc --noEmit` clean
- [x] Regression test present and mutation-verified
- [x] No docs-site change needed (internal transport classification)

Triaged in the 2026-08-31 non-priority-70 bug round; supersedes #3052 only by rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of interrupted HTTP/2 connections while retrieving available models.
  - These interruptions are now correctly classified as transport errors, enabling the request to retry instead of reporting an misleading HTTP or authentication error.
  - Confirmed successful recovery when a subsequent attempt returns a valid response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->