### PR TITLE
fix(history): resolve a rollout's session_meta by thread id (#3026)

### DIFF
--- a/devlog/_plan/260831_prio70_train_round2/030_wp3_forked_rollout_restore.md
+++ b/devlog/_plan/260831_prio70_train_round2/030_wp3_forked_rollout_restore.md
@@ -394,3 +394,35 @@ scan on `ssh lidge`.
 `Closes #3026`. PR #3056 is 630 commits behind `dev`; carry its id-aware reader with
 credit to its author rather than rebasing that branch, the same way round 1's wp3
 carried Ingwannu's `aec717722`.
+
+## What implementation added beyond this plan
+
+Seven adversarial review rounds against the built branch (findings 3, 2, 1, 1, 2, 2, 0).
+The eleven planning rounds got the classifier right; every implementation finding was in
+the machinery around it, which is worth recording separately:
+
+- **A surviving manifest has to be re-snapshotted, not just re-marked.** The plan said to
+  reopen the relabel marker on a new routing attempt. That was half of it: the entry also
+  carries `hadFirstUserMessage` and `hasUserEvent`, and both described the previous
+  attempt. The stale message flag made the new routed row match the expected post-image;
+  the stale event value restored the thread to a state two events old.
+- **Refreshing the baseline needs the same proof the classifier needs.** Tuple equality
+  does not establish that the previous relabel was undone — route-then-legacy-recovery
+  lands on the original tuple. A restore that lands and passes its readback now records
+  `relabel: "none"`, which is the proof. Nothing wrote that value before.
+- **A sixth cell, and it refuses.** When the proof is absent and the row has drifted,
+  neither reading is safe. That is the plan's undecidable shape arriving one layer up, in
+  `rememberOriginal` rather than in the classifier, and it refuses the same way.
+- **The decision is direction and origin, not one flag.** Reverse drift is always foreign;
+  `0 → 1` is the user's for an exec-origin entry, under a `none` marker, or when the
+  previous route would have written 0; everything else refuses, and a legacy `undefined`
+  is not `false`.
+- **The refusal has to reach a person.** `failureReason: "integrity"` alone reads as
+  "retry or run doctor", and an ambiguous reroute is not retryable. The specific code now
+  travels through the worker and job layers to an operator message that says the manifest
+  needs manual resolution.
+
+And two about verification: a regression that let an ordinary restore consume the manifest
+never reached the reopen path at all, and the legacy-return end-to-end test passed because
+the fixture's rollout omitted `source`, so restore refused at rollout preflight before the
+classifier was consulted. Both were green for reasons unrelated to what they claimed.

--- a/src/codex/history-job.ts
+++ b/src/codex/history-job.ts
@@ -110,6 +110,8 @@ export type CodexHistoryJobOutcome =
   | { readonly kind: "blocked"; readonly reason: "busy" | "database" | "unsafe-path" | "desired_disabled" | "desired_enabled" }
   | { readonly kind: "failed"; readonly reason: "worker-error" | "worker-died" | "timeout";
       readonly message: string; readonly historyFailureReason?: CodexHistoryFailureReason;
+      /** Specific integrity condition when `historyFailureReason` is `"integrity"`. */
+      readonly historyIntegrityCode?: string;
       readonly rows?: number; readonly files?: number };
 
 /**
@@ -258,6 +260,13 @@ export function describeHistoryJobFailure(
     return "permission was denied while writing Codex history; this is not a Codex app lock. Run 'ocx doctor'.";
   }
   if (outcome.historyFailureReason === "integrity") {
+    // Not every integrity stop is a retry. An ambiguous reroute means two histories
+    // produced the same row and no durable fact separates them, so retrying reaches the
+    // same refusal - the manifest needs a person, and saying "run doctor" sends them the
+    // wrong way.
+    if (outcome.historyIntegrityCode === "history_apply_ambiguous_reroute") {
+      return "a Codex history entry could not be re-routed because its manifest cannot prove whether an earlier relabel was undone; nothing was changed and the manifest was kept. Resolve it manually rather than retrying.";
+    }
     return partiallyChanged
       ? "the history backup or its restore target changed after a partial restore; the manifest was retained for review and safe retry. Run 'ocx doctor'."
       : "the history backup or its restore target failed integrity checks; no unverified provider metadata was applied. Run 'ocx doctor'.";
@@ -298,6 +307,7 @@ function classifyWorkerResult(result: HistoryWorkerResult): CodexHistoryJobOutco
       reason: "worker-error",
       message: redactWorkerMessage(result.message),
       ...(result.reason ? { historyFailureReason: result.reason } : {}),
+      ...(result.integrityCode ? { historyIntegrityCode: result.integrityCode } : {}),
       ...(result.rows !== undefined && result.files !== undefined
         ? { rows: result.rows, files: result.files }
         : {}),

--- a/src/codex/history-manifest.ts
+++ b/src/codex/history-manifest.ts
@@ -103,7 +103,7 @@ export function validateCodexHistoryBackupManifest(
   expectedStateDbPath: string,
 ): CodexHistoryManifestValidation {
   if (!isRecord(raw)
-    || raw.version !== 1
+    || (raw.version !== 1 && raw.version !== 2)
     || typeof raw.stateDbPath !== "string"
     || !raw.stateDbPath.trim()
     || !isAbsolute(raw.stateDbPath)
@@ -130,6 +130,12 @@ export function validateCodexHistoryBackupManifest(
       || typeof value.hasUserEvent !== "number"
       || !Number.isSafeInteger(value.hasUserEvent)
       || (value.hasUserEvent !== 0 && value.hasUserEvent !== 1)
+      // Optional, but not unvalidated: a truthy `hadFirstUserMessage: "false"` would select
+      // the wrong restore verdict, and an unrecognized `relabel` would be read as a state
+      // the classifier does not have.
+      || (value.hadFirstUserMessage !== undefined && typeof value.hadFirstUserMessage !== "boolean")
+      || (value.relabel !== undefined
+        && value.relabel !== "pending" && value.relabel !== "committed" && value.relabel !== "none")
       || !hasAllowedProvenance(value)) {
       return { ok: false, reason: "schema", scope: "entry-provenance" };
     }

--- a/src/codex/history-manifest.ts
+++ b/src/codex/history-manifest.ts
@@ -10,10 +10,37 @@ export interface CodexHistoryBackupEntry {
   modelProvider: string;
   source: string;
   hasUserEvent: 0 | 1;
+  /**
+   * Whether the row had a non-empty `first_user_message` when the snapshot was taken.
+   *
+   * Routing derives the post-image `has_user_event` from the message AT SNAPSHOT TIME
+   * (`history-provider.ts` `routeOpenai`), so a restore that recomputes it from the
+   * message as it is NOW will mistake the user's first message for OpenCodex's own write
+   * and erase it. Only the emptiness is recorded, never the text: this manifest is a file
+   * on disk and the message is user content.
+   *
+   * Optional because manifests written before this field exists cannot be given one. An
+   * entry without it falls back to the current-row reading, which is exactly as imprecise
+   * as the behaviour it replaces and no worse.
+   */
+  hadFirstUserMessage?: boolean;
+  /**
+   * Whether OpenCodex's routing relabel is known to have landed for this entry.
+   *
+   * `pending` is written before the routing write and resolved after it, so a crash
+   * between the two leaves an honest "unknown" rather than a confident wrong answer. The
+   * observed row resolves it: the recorded original means the write did not land, the
+   * expected post-image means it did.
+   *
+   * Absent on entries written before the field existed. Those refuse only in the one
+   * genuinely undecidable case — original tuple with `has_user_event` moved 0 to 1 —
+   * which `dev` already refuses today.
+   */
+  relabel?: "pending" | "committed" | "none";
 }
 
 export interface CodexHistoryBackupManifest {
-  version: 1;
+  version: 1 | 2;
   stateDbPath: string;
   entries: Record<string, CodexHistoryBackupEntry>;
 }

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -227,6 +227,11 @@ function integrityFailureResult(error: CodexHistoryIntegrityError): CodexHistory
     files: error.progress.files,
     failed: true,
     failureReason: "integrity",
+    // The specific code, so an operator sees WHICH integrity condition stopped the
+    // transition rather than a generic "run doctor". `history_apply_ambiguous_reroute` in
+    // particular needs manual resolution: the manifest is intact and the safe move is to
+    // inspect it, not to retry.
+    integrityCode: error.message,
   };
 }
 
@@ -239,6 +244,15 @@ export interface CodexHistorySyncResult {
   failed?: true;
   /** Why the retry budget was exhausted when `failed` is set. */
   failureReason?: CodexHistoryFailureReason;
+  /**
+   * The specific integrity condition, when `failureReason` is `"integrity"`.
+   *
+   * `failureReason` alone tells an operator only that something was inconsistent, which
+   * reads as "retry or run doctor". Some of these are not retryable —
+   * `history_apply_ambiguous_reroute` means two histories produced the same row and the
+   * manifest needs a human — so the code travels with the result.
+   */
+  integrityCode?: string;
 }
 
 interface ThreadRow {
@@ -480,6 +494,7 @@ function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSna
     // arrived in between. Re-record it, and promote the manifest so the field is covered by
     // the schema that declares it.
     const previousRelabel = existing.relabel;
+    const previousHadFirstUserMessage = existing.hadFirstUserMessage;
     existing.relabel = "pending";
     existing.hadFirstUserMessage = hasFirstUserMessage(row.first_user_message);
     // `hasUserEvent` is the value restore returns to, and the previous attempt's can be two
@@ -498,13 +513,22 @@ function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSna
       manifest.version = 2;
       return;
     }
-    // No proof, and the row disagrees with the recorded baseline. Neither reading is safe:
-    // keeping the record erases activity the user generated, refreshing it preserves an
-    // event OpenCodex authored. That is the same undecidable shape the classifier refuses
-    // on, so refuse here too rather than committing to one interpretation. Restore keeps
-    // working from the manifest that already exists.
+    // No proof, and the row disagrees with the recorded baseline. Whether that is decidable
+    // depends on what the previous route could have written: it sets the event to 1 only
+    // when the message was non-empty at ITS snapshot. If it would have written 0, the
+    // observed 1 cannot be OpenCodex's and is the user's — the same expected-event-0 cell
+    // the classifier preserves rather than refuses.
+    //
+    // Only when the previous route could itself have authored the difference are the two
+    // histories indistinguishable, and that is where refusing beats guessing: keeping the
+    // record would erase real activity, refreshing it would preserve an event OpenCodex
+    // wrote.
     if (observedEvent !== existing.hasUserEvent) {
-      throw new CodexHistoryIntegrityError("history_apply_ambiguous_reroute");
+      const priorRouteCouldAuthorIt = previousHadFirstUserMessage === true;
+      if (priorRouteCouldAuthorIt) {
+        throw new CodexHistoryIntegrityError("history_apply_ambiguous_reroute");
+      }
+      if (atOriginalTuple) existing.hasUserEvent = observedEvent;
     }
     manifest.version = 2;
     return;

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -469,13 +469,31 @@ function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSna
   const existing = manifest.entries[row.id];
   if (existing) {
     // A surviving entry means a previous route/restore cycle did not consume its manifest.
-    // Its `relabel` describes THAT attempt, and this one has not written yet — leaving a
-    // stale `committed` here would let a later restore treat the marker as proof that
-    // OpenCodex authored an event flag the user had since set. The snapshot itself stays:
-    // it is the original provenance and must not be overwritten by a routed row.
+    // Its `relabel` describes THAT attempt, and this one has not written yet, so a stale
+    // `committed` would let a later restore treat the marker as proof that OpenCodex
+    // authored an event flag the user had since set.
+    //
+    // The provenance tuple stays — it is the ORIGINAL, and a routed row must never
+    // overwrite it. But `hadFirstUserMessage` is not provenance: it describes the input to
+    // one routing write, and this attempt has its own. Leaving the previous attempt's value
+    // makes the new routed row match the expected post-image and erases activity that
+    // arrived in between. Re-record it, and promote the manifest so the field is covered by
+    // the schema that declares it.
     existing.relabel = "pending";
+    existing.hadFirstUserMessage = hasFirstUserMessage(row.first_user_message);
+    // `hasUserEvent` is the value restore returns to, and for THIS attempt that is the
+    // row as it stands now. The previous attempt's value predates a restore that already
+    // happened plus whatever the user did afterwards, so keeping it would restore the
+    // thread to a state that is two events old. Provider and source are provenance and
+    // stay; only when the row is back at the recorded original tuple is its event flag
+    // the honest pre-route baseline.
+    if (row.model_provider === existing.modelProvider && row.source === existing.source) {
+      existing.hasUserEvent = Number(row.has_user_event) === 1 ? 1 : 0;
+    }
+    manifest.version = 2;
     return;
   }
+  manifest.version = 2;
   manifest.entries[row.id] = {
     id: row.id,
     rolloutPath: row.rollout_path,

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -479,15 +479,22 @@ function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSna
     // makes the new routed row match the expected post-image and erases activity that
     // arrived in between. Re-record it, and promote the manifest so the field is covered by
     // the schema that declares it.
+    const previousRelabel = existing.relabel;
     existing.relabel = "pending";
     existing.hadFirstUserMessage = hasFirstUserMessage(row.first_user_message);
-    // `hasUserEvent` is the value restore returns to, and for THIS attempt that is the
-    // row as it stands now. The previous attempt's value predates a restore that already
-    // happened plus whatever the user did afterwards, so keeping it would restore the
-    // thread to a state that is two events old. Provider and source are provenance and
-    // stay; only when the row is back at the recorded original tuple is its event flag
-    // the honest pre-route baseline.
-    if (row.model_provider === existing.modelProvider && row.source === existing.source) {
+    // `hasUserEvent` is the value restore returns to, and the previous attempt's value can
+    // be two events stale — a restore that already landed, plus whatever the user did
+    // afterwards. But refreshing it needs proof that the previous relabel was UNDONE, and
+    // the original tuple is not that proof: route-then-legacy-recovery lands on the same
+    // tuple, so refreshing there would adopt OpenCodex's own write as the user's baseline.
+    // This is the same ambiguity the classifier refuses on, arriving one layer up.
+    //
+    // `relabel: "none"` is the proof, written by a restore that actually completed. Absent
+    // it, keep the recorded baseline: an entry that is one event stale still restores to a
+    // state the user was in, while a wrong refresh silently rewrites what OpenCodex owns.
+    if (previousRelabel === "none"
+      && row.model_provider === existing.modelProvider
+      && row.source === existing.source) {
       existing.hasUserEvent = Number(row.has_user_event) === 1 ? 1 : 0;
     }
     manifest.version = 2;
@@ -1466,6 +1473,18 @@ function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): C
       if (error instanceof CodexHistoryIntegrityError) {
         throw new CodexHistoryIntegrityError(error.message, { rows: entries.length, files });
       }
+      // The restore landed and its readback passed; only finalization failed, so the
+      // manifest survives on disk. Record that its relabel is undone, or a later routing
+      // attempt cannot tell this entry from one still mid-route and has to keep a baseline
+      // that is now stale. Best-effort: a failure here leaves exactly the prior state.
+      try {
+        for (const entry of entries) {
+          const stored = manifest.entries[entry.id];
+          if (stored) stored.relabel = "none";
+        }
+        manifest.version = 2;
+        writeBackup(backupPath, manifest, stateDbPath);
+      } catch { /* the surviving manifest keeps its previous marker */ }
       const failureReason = classifyRecoverableHistoryError(error);
       if (failureReason) {
         return {

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -549,7 +549,7 @@ function snapshotRolloutForRestore(entry: CodexHistoryBackupEntry): RestoreRollo
   if (identityBefore === null) {
     throw new CodexHistoryIntegrityError("history_backup_rollout_unrestorable");
   }
-  const latest = readLatestSessionMeta(entry.rolloutPath);
+  const latest = readLatestSessionMetaForId(entry.rolloutPath, entry.id);
   if (!latest
     || (!rolloutMatchesRestoreTuple(latest, entry, entry.modelProvider, entry.source)
       && !rolloutMatchesExpectedPostImage(latest, entry))) {
@@ -628,7 +628,7 @@ function assertRestoreReadback(
       || !rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)) {
       throw new CodexHistoryIntegrityError("history_backup_database_readback_mismatch");
     }
-    const latest = readLatestSessionMeta(entry.rolloutPath);
+    const latest = readLatestSessionMetaForId(entry.rolloutPath, entry.id);
     if (inspectFirstLineProvider(entry.rolloutPath, entry.id, entry.modelProvider) !== "current"
       || !latest
       || !rolloutMatchesRestoreTuple(latest, entry, entry.modelProvider, entry.source)) {
@@ -663,6 +663,19 @@ function parseSessionMetaLine(line: string): ParsedSessionMeta | null {
 export function readLatestSessionMeta(path: string): ParsedSessionMeta | null {
   const raw = readFileSync(path, "utf8");
   return readLatestSessionMetaFromText(raw);
+}
+
+/**
+ * Same fold as {@link readLatestSessionMeta}, restricted to this thread's own metadata.
+ *
+ * A forked/branched rollout appends the SOURCE thread's `session_meta` after its own, and the
+ * app discards any record whose payload id is not the canonical thread id (codex-rs
+ * `apply_session_meta_from_item`). Reading the last line regardless of id therefore answers
+ * with a foreign thread's provider, which is neither what the app honors nor what we may patch.
+ */
+function readLatestSessionMetaForId(path: string, expectedId: string): ParsedSessionMeta | null {
+  const raw = readFileSync(path, "utf8");
+  return readLatestSessionMetaForIdFromText(raw, expectedId);
 }
 
 function readLatestSessionMetaFromText(raw: string): ParsedSessionMeta | null {
@@ -875,18 +888,15 @@ function updateSessionMeta(
     return { changed: false, durableProvider: false, conflict: true };
   }
 
-  const latest = readLatestSessionMeta(path);
+  // Resolve by id. The app ignores `session_meta` lines whose payload id != the canonical
+  // thread id (codex-rs `apply_session_meta_from_item`), and a forked rollout trails the source
+  // session's metadata, so the last line is not necessarily this thread's. Patching that record
+  // would clone the wrong thread's meta into a line the app discards; skipping the file entirely
+  // left forked threads unroutable and, once routed, unrestorable.
+  const latest = readLatestSessionMetaForId(path, expectedId);
   if (!latest) return { changed: false, durableProvider: false };
   const record = latest.record;
 
-  // The app ignores `session_meta` lines whose payload id != the canonical thread id
-  // (codex-rs `apply_session_meta_from_item`). Forked rollouts can embed a source session's
-  // metadata, so an id-mismatched latest line means we'd be cloning the wrong thread's meta and
-  // appending a line the app would discard. Skip rather than write a no-op/misleading line.
-  const payloadId = record.payload.id;
-  if (typeof payloadId !== "string" || payloadId !== expectedId) {
-    return { changed: false, durableProvider: false };
-  }
   const latestProvider = typeof record.payload.model_provider === "string" && record.payload.model_provider
     ? record.payload.model_provider
     : "openai";

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -503,32 +503,36 @@ function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSna
     // tuple alone is not proof: route-then-legacy-recovery lands on that same tuple, so
     // refreshing there would adopt OpenCodex's own write as the user's baseline.
     //
-    // `relabel: "none"` is that proof, written by a restore that landed and passed its
-    // readback. With it, the observed row is the honest pre-route baseline.
     const atOriginalTuple = row.model_provider === existing.modelProvider
       && row.source === existing.source;
     const observedEvent: 0 | 1 = Number(row.has_user_event) === 1 ? 1 : 0;
-    if (previousRelabel === "none" && atOriginalTuple) {
-      existing.hasUserEvent = observedEvent;
-      manifest.version = 2;
-      return;
-    }
-    // No proof, and the row disagrees with the recorded baseline. Whether that is decidable
-    // depends on what the previous route could have written: it sets the event to 1 only
-    // when the message was non-empty at ITS snapshot. If it would have written 0, the
-    // observed 1 cannot be OpenCodex's and is the user's — the same expected-event-0 cell
-    // the classifier preserves rather than refuses.
-    //
-    // Only when the previous route could itself have authored the difference are the two
-    // histories indistinguishable, and that is where refusing beats guessing: keeping the
-    // record would erase real activity, refreshing it would preserve an event OpenCodex
-    // wrote.
     if (observedEvent !== existing.hasUserEvent) {
-      const priorRouteCouldAuthorIt = previousHadFirstUserMessage === true;
-      if (priorRouteCouldAuthorIt) {
+      // The row's event disagrees with the recorded baseline. Whether that is decidable is
+      // a function of DIRECTION and ORIGIN, not of one flag:
+      //
+      // - `1 -> 0` is always foreign. Nothing in this system clears the flag: routing only
+      //   ever sets it, the user only ever sets it, and legacy recovery sets it to 1. A
+      //   baseline that moved down is a decision this manifest does not own.
+      // - `0 -> 1` on an exec-origin entry is the user's. `routeExec` moves `source` to
+      //   `cli` and legacy recovery does not move it back, so an exec-origin row wearing
+      //   its original tuple was never routed away and back.
+      // - `0 -> 1` with `relabel: "none"` is the user's: a restore landed and undid the
+      //   previous relabel, so the observed row is the honest pre-route state.
+      // - `0 -> 1` where the previous route would have written 0 is the user's, because
+      //   OpenCodex could not have authored a 1 it never writes.
+      // - `0 -> 1` where the previous route WOULD have written 1, or where a legacy entry
+      //   records nothing about it, is undecidable: routing-never-landed-plus-activity and
+      //   routing-landed-then-legacy-recovery produce the same row. Refuse rather than pick.
+      const reverseDrift = observedEvent === 0;
+      const execOrigin = existing.modelProvider !== "openai";
+      const priorRouteWroteZero = previousHadFirstUserMessage === false;
+      const decidable = !reverseDrift
+        && atOriginalTuple
+        && (execOrigin || previousRelabel === "none" || priorRouteWroteZero);
+      if (!decidable) {
         throw new CodexHistoryIntegrityError("history_apply_ambiguous_reroute");
       }
-      if (atOriginalTuple) existing.hasUserEvent = observedEvent;
+      existing.hasUserEvent = observedEvent;
     }
     manifest.version = 2;
     return;

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -462,7 +462,7 @@ function writeBackup(path: string, manifest: CodexHistoryBackupManifest, stateDb
   atomicWriteFile(path, JSON.stringify({ ...manifest, stateDbPath: manifest.stateDbPath ?? stateDbPath }, null, 2) + "\n");
 }
 
-function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ThreadRow): void {
+function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSnapshot): void {
   if (manifest.entries[row.id]) return;
   manifest.entries[row.id] = {
     id: row.id,
@@ -470,6 +470,15 @@ function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ThreadRow):
     modelProvider: row.model_provider,
     source: row.source,
     hasUserEvent: Number(row.has_user_event) === 1 ? 1 : 0,
+    // Emptiness only, never the text: the manifest is a file on disk and the message is
+    // user content. Routing derives the post-image event flag from the message as it was
+    // HERE, so a restore that re-reads the current message would mistake later user
+    // activity for OpenCodex's own write.
+    hadFirstUserMessage: hasFirstUserMessage(row.first_user_message),
+    // The routing write has not happened yet. Resolved to "committed" after it lands, or
+    // left pending if the process dies between the two - in which case the observed row
+    // is what decides.
+    relabel: "pending",
   };
 }
 
@@ -486,7 +495,13 @@ function rowMatchesRestoreTuple(
 
 function rowMatchesExpectedPostImage(row: RestoreRowSnapshot, entry: CodexHistoryBackupEntry): boolean {
   if (entry.modelProvider === "openai") {
-    const postHasUserEvent = hasFirstUserMessage(row.first_user_message) ? 1 : entry.hasUserEvent;
+    // Routing derived this from the message AT SNAPSHOT TIME (`routeOpenai`), so read the
+    // recorded flag when the manifest has one. Recomputing from the row's CURRENT message
+    // mistakes a first message the user sent after routing for OpenCodex's own write, and
+    // restore then erases it. Manifests written before the flag existed fall back to the
+    // current reading, which is exactly the behaviour this replaces and no worse.
+    const hadMessage = entry.hadFirstUserMessage ?? hasFirstUserMessage(row.first_user_message);
+    const postHasUserEvent = hadMessage ? 1 : entry.hasUserEvent;
     return rowMatchesRestoreTuple(row, "opencodex", entry.source, postHasUserEvent);
   }
   return hasFirstUserMessage(row.first_user_message)
@@ -497,6 +512,60 @@ function rowMatchesExpectedPostImage(row: RestoreRowSnapshot, entry: CodexHistor
       // can use its preserved first-line padding to recover exact provenance.
       || rowMatchesRestoreTuple(row, "openai", "cli", 1)
   );
+}
+
+/**
+ * What `has_user_event` should read after restore, or `null` when the row is not one this
+ * manifest owns.
+ *
+ * The field has two writers, so a final state cannot establish authorship on its own. Four
+ * shapes cover every row reachable in practice, and the tuple the row wears says which:
+ *
+ * - **A** exactly the recorded original: untouched, or already restored.
+ * - **B** the expected post-image: OpenCodex wrote it, so the recorded value is authoritative.
+ * - **C** the original tuple with the flag moved 0 to 1: either Codex-side user activity, or
+ *   OpenCodex routing that legacy recovery has since pulled back to the original provider.
+ * - **D** the post-image tuple with the flag moved 0 to 1: a routed row the user then touched.
+ *   No provenance needed - a row wearing the routed tuple was written by OpenCodex, so drift
+ *   on top of it can only be what followed.
+ *
+ * Only C is ambiguous, and only when the route's own expected event was 1: then "routing
+ * never landed and the user typed" and "routing landed and legacy recovery pulled it back"
+ * produce an identical row, and nothing durable separates them. That one cell refuses. A
+ * guess there either erases real activity or fabricates it.
+ */
+function restoredUserEventFor(row: RestoreRowSnapshot, entry: CodexHistoryBackupEntry): 0 | 1 | null {
+  if (rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)) {
+    return entry.hasUserEvent;                                   // A
+  }
+  if (rowMatchesExpectedPostImage(row, entry)) return entry.hasUserEvent;  // B
+
+  const drifted = Number(row.has_user_event) === 1 && entry.hasUserEvent === 0;
+  if (!drifted) return null;
+
+  const routeExpectedEvent = entry.hadFirstUserMessage ?? hasFirstUserMessage(row.first_user_message) ? 1 : 0;
+
+  // D: wearing the routed tuple, so the 1 arrived after OpenCodex wrote the row.
+  if (rowMatchesRestoreTuple(row, "opencodex", entry.source, 1)
+    || (entry.modelProvider !== "openai" && rowMatchesRestoreTuple(row, "opencodex", "cli", 1))) {
+    return 1;
+  }
+
+  // C: wearing the original tuple.
+  if (rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, 1)) {
+    // An exec-origin entry cannot reach here by legacy recovery: routeExec moves source to
+    // cli and recovery does not move it back, so the original tuple is unreachable that way.
+    if (entry.modelProvider !== "openai") return 1;
+    if (entry.relabel === "none") return 1;
+    if (entry.relabel === "committed") {
+      // OpenCodex authored the 1 only if its own routing write would have produced one.
+      return routeExpectedEvent === 1 ? 0 : 1;
+    }
+    if (entry.relabel === undefined) return null;  // legacy manifest: the pre-existing refusal
+    // pending: two histories reach this exact row and nothing durable tells them apart.
+    return routeExpectedEvent === 1 ? null : 1;
+  }
+  return null;
 }
 
 interface RestoreRolloutSnapshot {
@@ -608,8 +677,7 @@ function preflightRestoreRows(
     if (!row || typeof row.rollout_path !== "string" || !sameCodexHistoryPath(row.rollout_path, entry.rolloutPath)) {
       throw new CodexHistoryIntegrityError("history_backup_target_mismatch");
     }
-    if (!rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)
-      && !rowMatchesExpectedPostImage(row, entry)) {
+    if (restoredUserEventFor(row, entry) === null) {
       throw new CodexHistoryIntegrityError("history_backup_postimage_mismatch");
     }
     snapshots.set(entry.id, row);
@@ -625,7 +693,8 @@ function assertRestoreReadback(
     const row = getCurrent(entry.id);
     if (!row
       || !sameCodexHistoryPath(row.rollout_path, entry.rolloutPath)
-      || !rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)) {
+      || !rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, Number(row.has_user_event) === 1 ? 1 : 0)
+      || restoredUserEventFor(row, entry) === null) {
       throw new CodexHistoryIntegrityError("history_backup_database_readback_mismatch");
     }
     const latest = readLatestSessionMetaForId(entry.rolloutPath, entry.id);
@@ -1246,6 +1315,15 @@ function syncCodexHistoryProviderUnsafe(provider: CodexHistoryProvider, stateDbP
       throw error;
     }
 
+    // The routing writes landed. Resolve every pending marker and rewrite the manifest, so a
+    // later restore knows the relabel is OpenCodex's rather than having to infer it. A crash
+    // before this point leaves `pending`, which the observed row resolves at restore time.
+    for (const row of [...openaiRows, ...execRows]) {
+      const entry = manifest.entries[row.id];
+      if (entry?.relabel === "pending") entry.relabel = "committed";
+    }
+    writeBackup(backupPath, manifest, stateDbPath);
+
     return { rows: openaiRows.length + execRows.length, files };
   } finally {
     db.close();
@@ -1287,10 +1365,13 @@ function restoreCodexHistoryProvider(stateDbPath: string, backupPath: string): C
       for (const entry of entries) {
         const before = snapshots.get(entry.id);
         if (!before) throw new CodexHistoryIntegrityError("history_backup_snapshot_missing");
+        // Codex-side activity that arrived after OpenCodex wrote the row is the user's, and
+        // restoring the manifest's snapshot over it would erase it.
+        const restoredEvent = restoredUserEventFor(before, entry) ?? entry.hasUserEvent;
         const result = update.run(
           entry.modelProvider,
           entry.source,
-          entry.hasUserEvent,
+          restoredEvent,
           entry.id,
           before.rollout_path,
           before.model_provider,

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -482,20 +482,29 @@ function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSna
     const previousRelabel = existing.relabel;
     existing.relabel = "pending";
     existing.hadFirstUserMessage = hasFirstUserMessage(row.first_user_message);
-    // `hasUserEvent` is the value restore returns to, and the previous attempt's value can
-    // be two events stale — a restore that already landed, plus whatever the user did
-    // afterwards. But refreshing it needs proof that the previous relabel was UNDONE, and
-    // the original tuple is not that proof: route-then-legacy-recovery lands on the same
-    // tuple, so refreshing there would adopt OpenCodex's own write as the user's baseline.
-    // This is the same ambiguity the classifier refuses on, arriving one layer up.
+    // `hasUserEvent` is the value restore returns to, and the previous attempt's can be two
+    // events stale — a restore that already landed, plus whatever the user did afterwards.
+    // Refreshing it needs proof that the previous relabel was UNDONE, because the original
+    // tuple alone is not proof: route-then-legacy-recovery lands on that same tuple, so
+    // refreshing there would adopt OpenCodex's own write as the user's baseline.
     //
-    // `relabel: "none"` is the proof, written by a restore that actually completed. Absent
-    // it, keep the recorded baseline: an entry that is one event stale still restores to a
-    // state the user was in, while a wrong refresh silently rewrites what OpenCodex owns.
-    if (previousRelabel === "none"
-      && row.model_provider === existing.modelProvider
-      && row.source === existing.source) {
-      existing.hasUserEvent = Number(row.has_user_event) === 1 ? 1 : 0;
+    // `relabel: "none"` is that proof, written by a restore that landed and passed its
+    // readback. With it, the observed row is the honest pre-route baseline.
+    const atOriginalTuple = row.model_provider === existing.modelProvider
+      && row.source === existing.source;
+    const observedEvent: 0 | 1 = Number(row.has_user_event) === 1 ? 1 : 0;
+    if (previousRelabel === "none" && atOriginalTuple) {
+      existing.hasUserEvent = observedEvent;
+      manifest.version = 2;
+      return;
+    }
+    // No proof, and the row disagrees with the recorded baseline. Neither reading is safe:
+    // keeping the record erases activity the user generated, refreshing it preserves an
+    // event OpenCodex authored. That is the same undecidable shape the classifier refuses
+    // on, so refuse here too rather than committing to one interpretation. Restore keeps
+    // working from the manifest that already exists.
+    if (observedEvent !== existing.hasUserEvent) {
+      throw new CodexHistoryIntegrityError("history_apply_ambiguous_reroute");
     }
     manifest.version = 2;
     return;

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -361,7 +361,10 @@ function readBackupStrict(path: string, stateDbPath: string): StrictBackupRead {
     return {
       kind: "known",
       present: false,
-      manifest: { version: 1, stateDbPath, entries: {} },
+      // New manifests carry the snapshot and relabel fields, so they are v2. v1 stays
+      // readable: an entry written before those fields existed falls back to the
+      // current-row reading, which is the behaviour it was written under.
+      manifest: { version: 2, stateDbPath, entries: {} },
       fingerprint: "absent",
     };
   }
@@ -463,7 +466,16 @@ function writeBackup(path: string, manifest: CodexHistoryBackupManifest, stateDb
 }
 
 function rememberOriginal(manifest: CodexHistoryBackupManifest, row: ApplyRowSnapshot): void {
-  if (manifest.entries[row.id]) return;
+  const existing = manifest.entries[row.id];
+  if (existing) {
+    // A surviving entry means a previous route/restore cycle did not consume its manifest.
+    // Its `relabel` describes THAT attempt, and this one has not written yet — leaving a
+    // stale `committed` here would let a later restore treat the marker as proof that
+    // OpenCodex authored an event flag the user had since set. The snapshot itself stays:
+    // it is the original provenance and must not be overwritten by a routed row.
+    existing.relabel = "pending";
+    return;
+  }
   manifest.entries[row.id] = {
     id: row.id,
     rolloutPath: row.rollout_path,
@@ -534,7 +546,7 @@ function rowMatchesExpectedPostImage(row: RestoreRowSnapshot, entry: CodexHistor
  * produce an identical row, and nothing durable separates them. That one cell refuses. A
  * guess there either erases real activity or fabricates it.
  */
-function restoredUserEventFor(row: RestoreRowSnapshot, entry: CodexHistoryBackupEntry): 0 | 1 | null {
+export function restoredUserEventFor(row: RestoreRowSnapshot, entry: CodexHistoryBackupEntry): 0 | 1 | null {
   if (rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, entry.hasUserEvent)) {
     return entry.hasUserEvent;                                   // A
   }
@@ -545,11 +557,11 @@ function restoredUserEventFor(row: RestoreRowSnapshot, entry: CodexHistoryBackup
 
   const routeExpectedEvent = entry.hadFirstUserMessage ?? hasFirstUserMessage(row.first_user_message) ? 1 : 0;
 
-  // D: wearing the routed tuple, so the 1 arrived after OpenCodex wrote the row.
-  if (rowMatchesRestoreTuple(row, "opencodex", entry.source, 1)
-    || (entry.modelProvider !== "openai" && rowMatchesRestoreTuple(row, "opencodex", "cli", 1))) {
-    return 1;
-  }
+  // D: wearing the routed tuple, so the 1 arrived after OpenCodex wrote the row. The tuple
+  // is the one routing actually produces — `routeOpenai` keeps the source, `routeExec`
+  // moves exec to cli — so D and C cannot both match rather than merely being ordered.
+  const routedSource = entry.modelProvider === "openai" ? entry.source : "cli";
+  if (rowMatchesRestoreTuple(row, "opencodex", routedSource, 1)) return 1;
 
   // C: wearing the original tuple.
   if (rowMatchesRestoreTuple(row, entry.modelProvider, entry.source, 1)) {

--- a/src/codex/history-worker.ts
+++ b/src/codex/history-worker.ts
@@ -181,6 +181,7 @@ export function runHistoryUnitUnderLock(
       jobId,
       message: "history_transition_failed",
       ...(result.failureReason ? { reason: result.failureReason } : {}),
+      ...(result.integrityCode ? { integrityCode: result.integrityCode } : {}),
       ...(result.rows > 0 || result.files > 0 ? { rows: result.rows, files: result.files } : {}),
     };
   }

--- a/src/codex/history-worker.ts
+++ b/src/codex/history-worker.ts
@@ -75,6 +75,8 @@ export type HistoryWorkerResult =
       readonly reason: "busy" | "database" | "unsafe-path" | "desired_disabled" | "desired_enabled" }
   | { readonly type: "error"; readonly requestId: string; readonly jobId: string;
       readonly message: string; readonly reason?: CodexHistoryFailureReason;
+      /** Specific integrity condition, so a non-retryable one can be named as such. */
+      readonly integrityCode?: string;
       readonly rows?: number; readonly files?: number };
 
 const OPERATIONS: ReadonlySet<string> = new Set<CodexHistoryWorkerOperation>([

--- a/tests/codex-history-job.test.ts
+++ b/tests/codex-history-job.test.ts
@@ -132,6 +132,13 @@ test("the failure wording names the real reason instead of always blaming the Co
   expect(describeHistoryJobFailure(partialIntegrity, "restore")).toContain("partial restore");
   expect(describeHistoryJobFailure(partialIntegrity, "restore")).toContain("manifest was retained");
 
+  // An ambiguous reroute is not a retry: two histories produced the same row and no durable
+  // fact separates them, so "run doctor" points the operator the wrong way.
+  const ambiguous = { ...integrity, historyIntegrityCode: "history_apply_ambiguous_reroute" } as const;
+  expect(describeHistoryJobFailure(ambiguous, "apply")).toContain("cannot prove whether an earlier relabel was undone");
+  expect(describeHistoryJobFailure(ambiguous, "apply")).toContain("Resolve it manually");
+  expect(describeHistoryJobFailure(ambiguous, "apply")).not.toContain("'ocx doctor'");
+
   const partialPermission = { ...permission, rows: 1, files: 1 } as const;
   expect(describeHistoryJobFailure(partialPermission, "apply")).toContain("changed but did not converge");
   expect(describeHistoryJobFailure(partialPermission, "apply")).toContain("manifest was retained");

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -312,6 +312,9 @@ describe("Codex history provider sync", () => {
       ["C: pending with an expected-0 route is decidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],
       ["C: pending with an expected-1 route is undecidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: true }), null],
       ["C: legacy entry with drift refuses, as dev does", row("openai", "vscode", 1), entry({ hadFirstUserMessage: true }), null],
+      // Reverse drift is foreign under every provenance: nothing in this system clears the
+      // flag, so a baseline that moved down is a decision this manifest does not own.
+      ["reverse drift refuses even with a none marker", row("openai", "vscode", 0), entry({ hasUserEvent: 1, relabel: "none" }), null],
       ["C: exec-origin cannot be reached by legacy return", row("opencodex", "exec", 1), entry({ modelProvider: "opencodex", source: "exec", relabel: "pending", hadFirstUserMessage: true }), 1],
       // D - routed tuple with drift; no provenance needed.
       ["D: drift on the routed tuple is the user's", row("opencodex", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -161,6 +161,9 @@ describe("Codex history provider sync", () => {
       setBeforeHistoryBackupConsumeForTests(undefined);
     }
     expect(existsSync(fixture.backupPath)).toBe(true);
+    // The restore landed and only finalization failed, so the surviving manifest records
+    // that its relabel is undone - the proof a later attempt needs to refresh its baseline.
+    expect(JSON.parse(readFileSync(fixture.backupPath, "utf8")).entries["thread-1"].relabel).toBe("none");
 
     // The user types while the manifest is still on disk, then a second route runs.
     const active = new Database(fixture.dbPath);
@@ -213,6 +216,9 @@ describe("Codex history provider sync", () => {
       ["C: pending with an expected-0 route is decidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],
       ["C: pending with an expected-1 route is undecidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: true }), null],
       ["C: legacy entry with drift refuses, as dev does", row("openai", "vscode", 1), entry({ hadFirstUserMessage: true }), null],
+      // The route-then-legacy-recovery history the audits kept returning to: the row wears
+      // the original tuple, but OpenCodex authored the 1 because its route expected one.
+      ["C: legacy return of a committed expected-1 route restores 0", row("openai", "vscode", 1), entry({ relabel: "committed", hadFirstUserMessage: true }), 0],
       ["C: exec-origin cannot be reached by legacy return", row("opencodex", "exec", 1), entry({ modelProvider: "opencodex", source: "exec", relabel: "pending", hadFirstUserMessage: true }), 1],
       // D - routed tuple with drift; no provenance needed.
       ["D: drift on the routed tuple is the user's", row("opencodex", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -136,10 +136,12 @@ describe("Codex history provider sync", () => {
     expect(existsSync(fixture.backupPath)).toBe(false);
   });
 
-  test("a second routing attempt reopens the relabel marker (#3026)", () => {
-    // A surviving manifest means a previous cycle did not consume it. Its relabel describes
-    // THAT attempt; carrying a stale "committed" into a new route lets a later restore treat
-    // the marker as proof that OpenCodex authored an event flag the user had since set.
+  test("a surviving manifest is re-snapshotted by the next routing attempt (#3026)", () => {
+    // A manifest that outlives its restore is the real hazard: its recorded snapshot
+    // describes the PREVIOUS attempt. Carrying it into a new route makes the new routed row
+    // match the expected post-image, and restore then erases activity that arrived in
+    // between. Forcing the consume to fail is what actually reaches that path - an ordinary
+    // restore deletes the manifest and the reopen code never runs.
     const fixture = makeFixture();
     const db = new Database(fixture.dbPath);
     db.run("UPDATE threads SET first_user_message = NULL, has_user_event = 0 WHERE id = 'thread-1'");
@@ -147,24 +149,40 @@ describe("Codex history provider sync", () => {
 
     expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
       .toEqual({ rows: 1, files: 1 });
-    expect((JSON.parse(readFileSync(fixture.backupPath, "utf8")) as {
-      entries: Record<string, { relabel?: string }>;
-    }).entries["thread-1"]?.relabel).toBe("committed");
 
-    // Restore back to openai, then route again while the manifest still exists.
-    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
-      .toEqual({ rows: 1, files: 1 });
-    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
-      .toEqual({ rows: 1, files: 1 });
+    setBeforeHistoryBackupConsumeForTests(() => {
+      throw new Error("manifest consume interrupted");
+    });
+    try {
+      // Reported rather than thrown: the restore itself succeeded, only the consume failed.
+      expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+        .toMatchObject({ failed: true });
+    } finally {
+      setBeforeHistoryBackupConsumeForTests(undefined);
+    }
+    expect(existsSync(fixture.backupPath)).toBe(true);
 
-    // The new attempt's marker describes the new attempt.
+    // The user types while the manifest is still on disk, then a second route runs.
+    const active = new Database(fixture.dbPath);
+    active.run("UPDATE threads SET first_user_message = 'hello', has_user_event = 1 WHERE id = 'thread-1'");
+    active.close();
+    syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath);
+
     const after = JSON.parse(readFileSync(fixture.backupPath, "utf8")) as {
       version: number;
       entries: Record<string, { relabel?: string; hadFirstUserMessage?: boolean }>;
     };
     expect(after.version).toBe(2);
-    expect(after.entries["thread-1"]?.relabel).toBe("committed");
-    expect(after.entries["thread-1"]?.hadFirstUserMessage).toBe(false);
+    // Re-snapshotted for THIS attempt: the message is non-empty now, so the expected
+    // post-image is a 1 that OpenCodex itself wrote.
+    expect(after.entries["thread-1"]?.hadFirstUserMessage).toBe(true);
+
+    // And the user's activity survives the restore rather than being read as OpenCodex's.
+    syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath);
+    const restored = new Database(fixture.dbPath, { readonly: true });
+    expect(restored.query("SELECT model_provider, has_user_event FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "openai", has_user_event: 1 });
+    restored.close();
   });
 
   describe("restore classifier state matrix", () => {

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -189,21 +189,27 @@ describe("Codex history provider sync", () => {
     expect(JSON.parse(before.split("\n")[0])).toEqual(JSON.parse(after.split("\n")[0]));
   });
 
-  test("does not append when the latest session_meta belongs to a different thread id", () => {
+  test("appends this thread's own session_meta when the latest one belongs to a different thread id", () => {
     const { dbPath, backupPath, rollout } = makeFixture();
     // Simulate a forked rollout whose trailing session_meta embeds a *different* thread's id.
-    appendFileSync(rollout, JSON.stringify({
+    const foreignLine = JSON.stringify({
       type: "session_meta",
       timestamp: "2026-01-02T00:00:00.000Z",
       payload: { id: "some-other-forked-thread", model_provider: "openai", cwd: "/tmp" },
-    }) + "\n");
+    });
+    appendFileSync(rollout, foreignLine + "\n");
     const before = readFileSync(rollout, "utf8");
 
     const result = syncCodexHistoryProvider("opencodex", dbPath, backupPath);
 
-    // DB row still flips, but the rollout is left untouched (no misleading append for a foreign id).
-    expect(result.files).toBe(0);
-    expect(readFileSync(rollout, "utf8")).toBe(before);
+    // The append describes THIS thread — never a clone of the foreign record, which the app
+    // would discard. Routing the row without the file left the pair unrestorable (#3026).
+    expect(result.files).toBe(1);
+    const after = readFileSync(rollout, "utf8");
+    expect(after.startsWith(before)).toBe(true);
+    expect(latestSessionMetaPayload(rollout)).toMatchObject({ id: "thread-1", model_provider: "opencodex" });
+    // The foreign thread's record is still there, exactly once, exactly as written.
+    expect(after.split("\n").filter(Boolean).filter(line => line === foreignLine)).toHaveLength(1);
     const db = new Database(dbPath);
     expect(db.query("SELECT model_provider FROM threads WHERE id = 'thread-1'").get()).toEqual({ model_provider: "opencodex" });
     db.close();
@@ -628,6 +634,69 @@ describe("Codex history provider sync", () => {
       .toMatchObject({ rows: 1, files: 1, failed: true, failureReason: "integrity" });
     expect(existsSync(fixture.backupPath)).toBe(true);
     expect(latestSessionMetaPayload(fixture.rollout).model_provider).toBe("custom");
+  });
+
+  test("consumes the manifest when a foreign-id session_meta lands after restore readback", () => {
+    const fixture = makeFixture();
+    syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath);
+    // The same last-moment race as the same-id case above, except the arriving record belongs
+    // to another thread. The app discards it, so it is not a newer decision to protect.
+    setBeforeHistoryBackupConsumeForTests(() => {
+      appendFileSync(fixture.rollout, JSON.stringify({
+        type: "session_meta",
+        timestamp: "2026-03-04T00:00:00.000Z",
+        payload: { id: "parent-thread", model_provider: "custom", source: "exec" },
+      }) + "\n");
+    });
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    expect(existsSync(fixture.backupPath)).toBe(false);
+  });
+
+  test("restores a forked rollout that trails its parent thread's session_meta", () => {
+    const fixture = makeFixture();
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+
+    // A forked/branched session appends the SOURCE thread's session_meta after its own.
+    // codex-rs `apply_session_meta_from_item` ignores a record whose payload id is not the
+    // canonical thread id, so this line is ordinary rollout content, not an integrity fault.
+    appendFileSync(fixture.rollout, JSON.stringify({
+      type: "session_meta",
+      timestamp: "2026-03-03T00:00:00.000Z",
+      payload: { id: "parent-thread", model_provider: "openai", source: "cli" },
+    }) + "\n");
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    const db = new Database(fixture.dbPath, { readonly: true });
+    expect(db.query("SELECT model_provider, source FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "openai", source: "vscode" });
+    db.close();
+    expect(latestSessionMetaPayload(fixture.rollout)).toMatchObject({
+      id: "thread-1",
+      model_provider: "openai",
+      source: "vscode",
+    });
+    expect(existsSync(fixture.backupPath)).toBe(false);
+  });
+
+  test("leaves a foreign trailing session_meta untouched while restoring its own", () => {
+    const fixture = makeFixture();
+    syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath);
+    const parentLine = JSON.stringify({
+      type: "session_meta",
+      timestamp: "2026-03-03T00:00:00.000Z",
+      payload: { id: "parent-thread", model_provider: "opencodex", source: "exec" },
+    });
+    appendFileSync(fixture.rollout, parentLine + "\n");
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    // The parent's record still says what it said: restore repairs this thread only.
+    const lines = readFileSync(fixture.rollout, "utf8").split("\n").filter(Boolean);
+    expect(lines.filter(line => line === parentLine)).toHaveLength(1);
   });
 
   test("reports applied permission progress when manifest finalization is denied", () => {

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -181,11 +181,105 @@ describe("Codex history provider sync", () => {
     expect(after.entries["thread-1"]?.hadFirstUserMessage).toBe(true);
 
     // And the user's activity survives the restore rather than being read as OpenCodex's.
-    syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath);
+    // eslint-disable-next-line no-console
+    console.log("DIAG2 result=", JSON.stringify(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath)));
+    // eslint-disable-next-line no-console
+    console.log("DIAG afterRestore manifestGone=", !existsSync(fixture.backupPath));
     const restored = new Database(fixture.dbPath, { readonly: true });
     expect(restored.query("SELECT model_provider, has_user_event FROM threads WHERE id = 'thread-1'").get())
       .toEqual({ model_provider: "openai", has_user_event: 1 });
     restored.close();
+  });
+
+  test("refuses to reroute when the surviving manifest cannot prove its relabel was undone", () => {
+    // If the "none" proof could not be written - a read-only directory during the rewrite,
+    // say - the entry still reads "committed" while the row has drifted. Keeping the
+    // recorded baseline would erase the user's event; refreshing it would preserve one
+    // OpenCodex authored. Undecidable, so refuse rather than pick.
+    const fixture = makeFixture();
+    const db = new Database(fixture.dbPath);
+    db.run("UPDATE threads SET first_user_message = NULL, has_user_event = 0 WHERE id = 'thread-1'");
+    db.close();
+
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+
+    // Restore lands, finalization fails, and the proof write fails too: hand-write the
+    // manifest back to "committed" to model that outcome exactly.
+    setBeforeHistoryBackupConsumeForTests(() => { throw new Error("manifest consume interrupted"); });
+    try {
+      expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+        .toMatchObject({ failed: true });
+    } finally {
+      setBeforeHistoryBackupConsumeForTests(undefined);
+    }
+    const stranded = JSON.parse(readFileSync(fixture.backupPath, "utf8")) as {
+      entries: Record<string, { relabel?: string }>;
+    };
+    stranded.entries["thread-1"]!.relabel = "committed";
+    writeFileSync(fixture.backupPath, JSON.stringify(stranded));
+
+    // The user types, then a reroute is attempted against the unproven manifest.
+    const active = new Database(fixture.dbPath);
+    active.run("UPDATE threads SET first_user_message = 'hello', has_user_event = 1 WHERE id = 'thread-1'");
+    active.close();
+
+    // Reported as an integrity refusal with nothing applied, which is how this layer
+    // surfaces a state it will not guess at.
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toMatchObject({ rows: 0, files: 0, failed: true, failureReason: "integrity" });
+    // Nothing was rewritten: the row and its manifest are exactly as they were.
+    const untouched = new Database(fixture.dbPath, { readonly: true });
+    expect(untouched.query("SELECT model_provider, has_user_event FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "openai", has_user_event: 1 });
+    untouched.close();
+  });
+
+  test("restores an event OpenCodex authored even after legacy recovery returns the tuple", () => {
+    // The history the audit rounds kept circling: route writes opencodex/vscode/1, legacy
+    // recovery pulls it back to openai/vscode/1, and the row now wears its ORIGINAL tuple
+    // carrying an event OpenCodex wrote. The classifier has to read the committed marker
+    // plus the route's expected event rather than the tuple, or restore keeps a 1 the user
+    // never generated. A pure classifier input cannot express this - it needs the real
+    // route and the real recovery.
+    const fixture = makeFixture({ includeLegacy: true });
+
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    const routed = new Database(fixture.dbPath, { readonly: true });
+    expect(routed.query("SELECT model_provider, has_user_event FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "opencodex", has_user_event: 1 });
+    routed.close();
+
+    // Legacy recovery returns provider to openai and leaves the event flag at 1.
+    restoreLegacyOpenaiHistory(fixture.dbPath);
+    const recovered = new Database(fixture.dbPath, { readonly: true });
+    expect(recovered.query("SELECT model_provider, has_user_event FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "openai", has_user_event: 1 });
+    recovered.close();
+
+    // Restore must put the event back to the recorded original: the route expected a 1, so
+    // that 1 is OpenCodex's, not the user's.
+    const result = syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath);
+    const restored = new Database(fixture.dbPath, { readonly: true });
+    const row = restored.query<{ model_provider: string; source: string; has_user_event: number }, []>(
+      "SELECT model_provider, source, has_user_event FROM threads WHERE id = 'thread-1'",
+    ).get()!;
+    restored.close();
+
+    // Provenance is back either way. The event flag is the contract under test: it must not
+    // keep a 1 that OpenCodex authored, so either the restore returns it to 0 or the layer
+    // refuses and leaves the manifest for a human. What it must never do is silently accept
+    // the 1 as the user's and consume the manifest.
+    expect(row.model_provider).toBe("openai");
+    expect(row.source).toBe("vscode");
+    if (row.has_user_event === 1) {
+      expect(result).toMatchObject({ failed: true });
+      expect(existsSync(fixture.backupPath)).toBe(true);
+    } else {
+      expect(row.has_user_event).toBe(0);
+      expect(existsSync(fixture.backupPath)).toBe(false);
+    }
   });
 
   describe("restore classifier state matrix", () => {
@@ -216,9 +310,6 @@ describe("Codex history provider sync", () => {
       ["C: pending with an expected-0 route is decidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],
       ["C: pending with an expected-1 route is undecidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: true }), null],
       ["C: legacy entry with drift refuses, as dev does", row("openai", "vscode", 1), entry({ hadFirstUserMessage: true }), null],
-      // The route-then-legacy-recovery history the audits kept returning to: the row wears
-      // the original tuple, but OpenCodex authored the 1 because its route expected one.
-      ["C: legacy return of a committed expected-1 route restores 0", row("openai", "vscode", 1), entry({ relabel: "committed", hadFirstUserMessage: true }), 0],
       ["C: exec-origin cannot be reached by legacy return", row("opencodex", "exec", 1), entry({ modelProvider: "opencodex", source: "exec", relabel: "pending", hadFirstUserMessage: true }), 1],
       // D - routed tuple with drift; no provenance needed.
       ["D: drift on the routed tuple is the user's", row("opencodex", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -136,6 +136,63 @@ describe("Codex history provider sync", () => {
     expect(existsSync(fixture.backupPath)).toBe(false);
   });
 
+  test("preserves a first user message that arrived after routing (#3026)", () => {
+    // Routing derives the post-image has_user_event from the message AT SNAPSHOT TIME. A
+    // restore that recomputes it from the message as it is NOW reads the user's first
+    // message as OpenCodex's own write and erases the activity.
+    const fixture = makeFixture();
+    const db = new Database(fixture.dbPath);
+    db.run("UPDATE threads SET first_user_message = NULL, has_user_event = 0 WHERE id = 'thread-1'");
+    db.close();
+
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+
+    // The user types for the first time while the row is routed.
+    const active = new Database(fixture.dbPath);
+    active.run("UPDATE threads SET first_user_message = 'hello', has_user_event = 1 WHERE id = 'thread-1'");
+    active.close();
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    const restored = new Database(fixture.dbPath, { readonly: true });
+    // Provenance restored, activity kept: OpenCodex owns provider and source, the user owns
+    // this flag, and the routing write for this entry produced a 0.
+    expect(restored.query("SELECT model_provider, source, has_user_event FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "openai", source: "vscode", has_user_event: 1 });
+    restored.close();
+    expect(existsSync(fixture.backupPath)).toBe(false);
+  });
+
+  test("restores a legacy manifest that predates the snapshot fields", () => {
+    // Every manifest already on disk lacks hadFirstUserMessage and relabel. Refusing them
+    // would brick exactly the population this fix exists to repair, so an entry without the
+    // fields must restore on the pre-existing behaviour.
+    const fixture = makeFixture();
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+
+    // Rewrite the manifest in the v1 shape, dropping both new fields.
+    const manifest = JSON.parse(readFileSync(fixture.backupPath, "utf8")) as {
+      version: number;
+      entries: Record<string, Record<string, unknown>>;
+    };
+    manifest.version = 1;
+    for (const entry of Object.values(manifest.entries)) {
+      delete entry.hadFirstUserMessage;
+      delete entry.relabel;
+    }
+    writeFileSync(fixture.backupPath, JSON.stringify(manifest));
+
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    const restored = new Database(fixture.dbPath, { readonly: true });
+    expect(restored.query("SELECT model_provider, source, has_user_event FROM threads WHERE id = 'thread-1'").get())
+      .toEqual({ model_provider: "openai", source: "vscode", has_user_event: 0 });
+    restored.close();
+    expect(existsSync(fixture.backupPath)).toBe(false);
+  });
+
   test("does not route a new database row that was not captured in the manifest snapshot", () => {
     const fixture = makeFixture();
     const lateRollout = join(fixture.rollout, "..", "late-rollout.jsonl");

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { classifyRecoverableHistoryError, countPendingOpencodexHistory, historyBackupPathFor, isRecoverableHistoryError, migrateHistoryToOpenai, restoreLegacyOpenaiHistory, setAfterNoopPendingCountForTests, setAfterStrictHistoryRolloutAppendForTests, setBeforeHistoryApplyTransactionForTests, setBeforeHistoryBackupConsumeForTests, setBeforeStrictHistoryRolloutAppendForTests, setHistoryDbBusyTimeoutForTests, snapshotCodexHistoryNoop, syncCodexHistoryProvider, withHistoryRetry } from "../src/codex/history-provider";
+import { classifyRecoverableHistoryError, countPendingOpencodexHistory, historyBackupPathFor, isRecoverableHistoryError, migrateHistoryToOpenai, restoreLegacyOpenaiHistory, restoredUserEventFor, setAfterNoopPendingCountForTests, setAfterStrictHistoryRolloutAppendForTests, setBeforeHistoryApplyTransactionForTests, setBeforeHistoryBackupConsumeForTests, setBeforeStrictHistoryRolloutAppendForTests, setHistoryDbBusyTimeoutForTests, snapshotCodexHistoryNoop, syncCodexHistoryProvider, withHistoryRetry } from "../src/codex/history-provider";
 import { INVALID_HISTORY_BACKUP_FIXTURES, validHistoryBackupFixture } from "./helpers/codex-history-manifest-fixtures";
 
 // Windows CI: a transient file lock can consume the full production 5s busy timeout, tripping
@@ -134,6 +134,84 @@ describe("Codex history provider sync", () => {
       .toEqual({ model_provider: "openai", source: "vscode", first_user_message: null, has_user_event: 0 });
     restored.close();
     expect(existsSync(fixture.backupPath)).toBe(false);
+  });
+
+  test("a second routing attempt reopens the relabel marker (#3026)", () => {
+    // A surviving manifest means a previous cycle did not consume it. Its relabel describes
+    // THAT attempt; carrying a stale "committed" into a new route lets a later restore treat
+    // the marker as proof that OpenCodex authored an event flag the user had since set.
+    const fixture = makeFixture();
+    const db = new Database(fixture.dbPath);
+    db.run("UPDATE threads SET first_user_message = NULL, has_user_event = 0 WHERE id = 'thread-1'");
+    db.close();
+
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    expect((JSON.parse(readFileSync(fixture.backupPath, "utf8")) as {
+      entries: Record<string, { relabel?: string }>;
+    }).entries["thread-1"]?.relabel).toBe("committed");
+
+    // Restore back to openai, then route again while the manifest still exists.
+    expect(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+    expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
+      .toEqual({ rows: 1, files: 1 });
+
+    // The new attempt's marker describes the new attempt.
+    const after = JSON.parse(readFileSync(fixture.backupPath, "utf8")) as {
+      version: number;
+      entries: Record<string, { relabel?: string; hadFirstUserMessage?: boolean }>;
+    };
+    expect(after.version).toBe(2);
+    expect(after.entries["thread-1"]?.relabel).toBe("committed");
+    expect(after.entries["thread-1"]?.hadFirstUserMessage).toBe(false);
+  });
+
+  describe("restore classifier state matrix", () => {
+    // has_user_event has two writers, so the verdict is decided by which tuple the row
+    // wears plus the entry's recorded provenance. This table is the whole contract; the
+    // end-to-end tests above prove two of its rows against real databases.
+    const entry = (over: Partial<Parameters<typeof restoredUserEventFor>[1]> = {}) => ({
+      id: "t", rolloutPath: "/tmp/r.jsonl",
+      modelProvider: "openai", source: "vscode", hasUserEvent: 0 as 0 | 1,
+      ...over,
+    });
+    const row = (provider: string, source: string, event: 0 | 1, message: string | null = "hi") => ({
+      id: "t", rollout_path: "/tmp/r.jsonl",
+      model_provider: provider, source, has_user_event: event, first_user_message: message,
+    });
+
+    const cases: Array<[string, ReturnType<typeof row>, ReturnType<typeof entry>, 0 | 1 | null]> = [
+      // A - exactly the recorded original.
+      ["A: untouched original restores its own value", row("openai", "vscode", 0), entry(), 0],
+      // B - the expected post-image; OpenCodex wrote it, so the manifest is authoritative.
+      ["B: routed post-image restores the recorded 0", row("opencodex", "vscode", 1), entry({ hadFirstUserMessage: true }), 0],
+      ["B: routed post-image of a null-message row", row("opencodex", "vscode", 0, null), entry({ hadFirstUserMessage: false }), 0],
+      ["B: exec legacy bridge is still recognized", row("openai", "cli", 1), entry({ modelProvider: "opencodex", source: "exec", hasUserEvent: 1 }), 1],
+      // C - original tuple with 0 to 1 drift, decided by provenance.
+      ["C: relabel none is user activity", row("openai", "vscode", 1), entry({ relabel: "none", hadFirstUserMessage: false }), 1],
+      ["C: committed whose route expected 1 is OpenCodex's own", row("openai", "vscode", 1), entry({ relabel: "committed", hadFirstUserMessage: true }), 0],
+      ["C: committed whose route expected 0 cannot be OpenCodex's", row("openai", "vscode", 1), entry({ relabel: "committed", hadFirstUserMessage: false }), 1],
+      ["C: pending with an expected-0 route is decidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],
+      ["C: pending with an expected-1 route is undecidable", row("openai", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: true }), null],
+      ["C: legacy entry with drift refuses, as dev does", row("openai", "vscode", 1), entry({ hadFirstUserMessage: true }), null],
+      ["C: exec-origin cannot be reached by legacy return", row("opencodex", "exec", 1), entry({ modelProvider: "opencodex", source: "exec", relabel: "pending", hadFirstUserMessage: true }), 1],
+      // D - routed tuple with drift; no provenance needed.
+      ["D: drift on the routed tuple is the user's", row("opencodex", "vscode", 1), entry({ relabel: "pending", hadFirstUserMessage: false }), 1],
+      // An exec-origin row at opencodex/cli/1 is B, not D: routeExec always writes 1, so
+      // that IS the expected post-image and the recorded value is authoritative.
+      ["B: exec-origin post-image is opencodex/cli/1", row("opencodex", "cli", 1), entry({ modelProvider: "opencodex", source: "exec", hadFirstUserMessage: false }), 0],
+      // Neither shape - a foreign decision this manifest does not own.
+      ["reverse drift never restores", row("openai", "vscode", 0), entry({ hasUserEvent: 1, relabel: "committed" }), null],
+      ["a different provider is foreign", row("anthropic", "vscode", 0), entry(), null],
+      ["a different source is foreign", row("openai", "cli", 0), entry(), null],
+    ];
+
+    for (const [name, observed, recorded, expected] of cases) {
+      test(name, () => {
+        expect(restoredUserEventFor(observed, recorded)).toBe(expected);
+      });
+    }
   });
 
   test("preserves a first user message that arrived after routing (#3026)", () => {

--- a/tests/codex-history-provider.test.ts
+++ b/tests/codex-history-provider.test.ts
@@ -181,10 +181,7 @@ describe("Codex history provider sync", () => {
     expect(after.entries["thread-1"]?.hadFirstUserMessage).toBe(true);
 
     // And the user's activity survives the restore rather than being read as OpenCodex's.
-    // eslint-disable-next-line no-console
-    console.log("DIAG2 result=", JSON.stringify(syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath)));
-    // eslint-disable-next-line no-console
-    console.log("DIAG afterRestore manifestGone=", !existsSync(fixture.backupPath));
+    syncCodexHistoryProvider("openai", fixture.dbPath, fixture.backupPath);
     const restored = new Database(fixture.dbPath, { readonly: true });
     expect(restored.query("SELECT model_provider, has_user_event FROM threads WHERE id = 'thread-1'").get())
       .toEqual({ model_provider: "openai", has_user_event: 1 });
@@ -196,10 +193,12 @@ describe("Codex history provider sync", () => {
     // say - the entry still reads "committed" while the row has drifted. Keeping the
     // recorded baseline would erase the user's event; refreshing it would preserve one
     // OpenCodex authored. Undecidable, so refuse rather than pick.
+    //
+    // Undecidable requires that the previous route COULD have written the differing event:
+    // it sets 1 only when the message was non-empty at its own snapshot. So this fixture
+    // keeps the message, unlike the expected-0 case where an observed 1 is provably the
+    // user's.
     const fixture = makeFixture();
-    const db = new Database(fixture.dbPath);
-    db.run("UPDATE threads SET first_user_message = NULL, has_user_event = 0 WHERE id = 'thread-1'");
-    db.close();
 
     expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
       .toEqual({ rows: 1, files: 1 });
@@ -244,6 +243,15 @@ describe("Codex history provider sync", () => {
     // route and the real recovery.
     const fixture = makeFixture({ includeLegacy: true });
 
+    // The fixture's rollout omits `source`, which makes restore refuse during rollout
+    // preflight before the classifier is ever consulted - a test that passes on that
+    // refusal would stay green with a broken classifier. Write the matching source so the
+    // real path runs.
+    appendFileSync(fixture.rollout, JSON.stringify({
+      type: "session_meta",
+      payload: { id: "thread-1", model_provider: "openai", source: "vscode" },
+    }) + "\n");
+
     expect(syncCodexHistoryProvider("opencodex", fixture.dbPath, fixture.backupPath))
       .toEqual({ rows: 1, files: 1 });
     const routed = new Database(fixture.dbPath, { readonly: true });
@@ -267,19 +275,13 @@ describe("Codex history provider sync", () => {
     ).get()!;
     restored.close();
 
-    // Provenance is back either way. The event flag is the contract under test: it must not
-    // keep a 1 that OpenCodex authored, so either the restore returns it to 0 or the layer
-    // refuses and leaves the manifest for a human. What it must never do is silently accept
-    // the 1 as the user's and consume the manifest.
-    expect(row.model_provider).toBe("openai");
-    expect(row.source).toBe("vscode");
-    if (row.has_user_event === 1) {
-      expect(result).toMatchObject({ failed: true });
-      expect(existsSync(fixture.backupPath)).toBe(true);
-    } else {
-      expect(row.has_user_event).toBe(0);
-      expect(existsSync(fixture.backupPath)).toBe(false);
-    }
+    // The classifier reads the committed marker plus the route's expected event rather than
+    // the tuple, so the 1 is returned to 0 and the manifest is consumed.
+    // `files: 0` because the appended metadata already names openai/vscode; the database
+    // row is what this history put wrong.
+    expect(result).toEqual({ rows: 1, files: 0 });
+    expect(row).toEqual({ model_provider: "openai", source: "vscode", has_user_event: 0 });
+    expect(existsSync(fixture.backupPath)).toBe(false);
   });
 
   describe("restore classifier state matrix", () => {
@@ -1350,7 +1352,15 @@ describe("Design B migration helpers", () => {
 
     // Work cannot converge without its bound database; the manifest remains retry evidence.
     const result = migrateHistoryToOpenai(missingDb, backupPath);
-    expect(result).toEqual({ rows: 0, files: 0, failed: true, failureReason: "integrity" });
+    expect(result).toEqual({
+      rows: 0,
+      files: 0,
+      failed: true,
+      failureReason: "integrity",
+      // The specific condition travels with the result: an operator can tell a missing
+      // database from a manifest that needs manual resolution.
+      integrityCode: "history_state_database_missing",
+    });
     expect(existsSync(backupPath)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Closes #3026. Carries @ntdat812's `0af9c0fd5` from #3056 for the id-aware half, then adds the second half the issue reports.

**The id-aware half.** `readLatestSessionMeta` returned the last `session_meta` line regardless of whose thread id it carried. A forked rollout has more than one, so restore read a sibling thread's metadata, rejected the entry, and one bad entry fails the whole manifest — wedging every `ocx stop` and `ocx update`. The reporter measured 6 of 389 entries affected.

**The `has_user_event` half.** That field has two writers. Routing derives the post-image value from `first_user_message` *at snapshot time*; restore recomputed it from the message as it stands now. A row routed while its message was null, then given a first message by the user, looked exactly like OpenCodex's own write — and restore put it back to 0.

The manifest entry now records whether the message was non-empty at snapshot time. A boolean only, never the text: the manifest is a file on disk and the message is user content. Ownership is then decided by which tuple the row wears and a per-entry relabel marker written before the routing write and resolved after it, so a crash between the two leaves an honest unknown that the observed row resolves.

Some states genuinely cannot be decided — an OpenAI-origin entry wearing its original tuple with `0 → 1` drift, whose route would itself have written a 1, is reachable both by "routing never landed and the user typed" and by "routing landed and legacy recovery pulled it back". Those refuse, which is what `dev` already does there. A guess would either erase real activity or fabricate it, and the refusal now says so rather than reporting a generic integrity failure.

Manifests written before these fields exist keep the current-row reading and restore exactly as they do today. Refusing them would brick the population this fix exists to repair.

Seven adversarial review rounds, findings 3 → 2 → 1 → 1 → 2 → 2 → 0. They caught, among others: a stale `committed` marker surviving into a new attempt, a regression that never reached the code it claimed to test, and an over-broad refusal that rejected a decidable case.

Plan: [devlog/_plan/260831_prio70_train_round2/030_wp3_forked_rollout_restore.md](devlog/_plan/260831_prio70_train_round2/030_wp3_forked_rollout_restore.md).

## Verification

```
bun test tests/codex-history-provider.test.ts tests/codex-history-job.test.ts
  -> 78 pass / 0 fail / 319 expect()
bun run typecheck -> exit 0
```

A sixteen-row classifier matrix covers every cell, plus end-to-end regressions for the null-then-typed history, the route-then-legacy-recovery history, a surviving manifest re-snapshotted by the next attempt, the ambiguous reroute refusing, and a legacy v1 manifest restoring unchanged. Each behavioral regression was driven red first.

## Checklist

- [x] Targets `dev`
- [x] Behavior change carries focused regression tests, each driven red first
- [x] No user-facing surface changed, so no `docs-site/` update is required
- [x] No credentials, request bodies, or account identifiers added
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history restore and rerouting reliability, including safer handling of ambiguous or incomplete routing states.
  * Preserved user-event status more accurately during restores, including legacy history scenarios.
  * Ensured session metadata is read from the correct thread.
  * Added clearer operator messages when history integrity checks prevent a transition.

* **Improvements**
  * Enhanced backup manifest validation and compatibility with newer restore metadata.
  * Added integrity details to history failure results for more actionable troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->