### PR TITLE
fix(cli): stop start from shadowing a live configured-port proxy, and retry health

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -12,7 +12,7 @@ import { CLI_COMMANDS } from "./registry";
 import { isValidProviderName } from "../config/provider-name";
 import type { CliHead } from "./root";
 import type { ReadyArgs } from "./ready";
-import type { LiveProxy } from "../server/proxy-liveness";
+import type { LivenessIo, LiveProxy } from "../server/proxy-liveness";
 import type { OcxConfig } from "../types";
 import { hasHelpFlag, printSubcommandUsage, printUsage } from "./help";
 import { setIntegrationEnabled, shouldSyncCodexOnStart } from "../codex/desired-state";
@@ -29,7 +29,7 @@ export interface CliDispatchDeps {
   command: string | undefined;
   head: CliHead;
   loadConfig: () => OcxConfig;
-  findLiveProxy: () => Promise<LiveProxy | null>;
+  findLiveProxy: (io?: LivenessIo) => Promise<LiveProxy | null>;
   probeHostname: (hostname: string | undefined) => string;
   waitForProxy: (timeoutMs?: number) => Promise<LiveProxy | null>;
   startArgv: (port?: number) => string[];
@@ -542,7 +542,12 @@ const commandRunners: Record<string, CommandRunner> = {
   health: async deps => {
     const healthArgs = deps.args.slice(1);
     const wantsHealthJson = healthArgs.includes("--json");
-    const live = await deps.findLiveProxy();
+    // A proxy that has only just bound can miss a single probe while its event loop
+    // is still settling startup work — the same just-started race the stop paths
+    // already retry for (#764, SERVICE_STOP_LIVENESS). Without this, `ocx health`
+    // run seconds after a service restart reports a false negative on a proxy that
+    // is in fact serving.
+    const live = await deps.findLiveProxy({ attempts: 3 });
     if (wantsHealthJson) {
       console.log(JSON.stringify({ ok: !!live, pid: live?.pid ?? null, port: live?.port ?? null }));
     } else {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -230,7 +230,14 @@ async function handleStart(options: { block?: boolean } = {}) {
   const present = process.env.OPENCODEX_API_AUTH_TOKEN?.trim();
   if (present) assertNotAdminToken(present);
   const requestedPort = parsePortOption();
-  const owner = await findProxyOwnerBeforeJournalRecovery();
+  // Always probe the configured port, even when both state files are absent. A
+  // fallback-port sibling overwrites the pid/runtime records when it starts and
+  // removes them on its own shutdown, so their absence proves nothing about the
+  // configured port. Without the probe, `start` shadowed a healthy proxy with an
+  // ephemeral-port copy and re-pointed client config at the copy; the next sibling
+  // shutdown then left no runtime record for discovery at all. `handleEnsure`
+  // already passes this; `handleStart` is the path that did not.
+  const owner = await findProxyOwnerBeforeJournalRecovery({ probeConfiguredPort: true });
   if (owner.live) {
     // Service-wrapper context (opencodex-service.cmd `:loop`): a healthy proxy from
     // ANY source means the requested port is already served. Exit 0 so the wrapper's

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -123,6 +123,75 @@ describe("dispatchCommand exit codes", () => {
   });
 });
 
+/**
+ * `ocx health` probed once. A proxy that has only just bound can miss a single
+ * probe while its event loop is still settling startup work, so health run
+ * seconds after a service restart reported "Proxy not healthy" and exited 1 for
+ * a proxy that was in fact serving. The stop paths already retry this exact race
+ * under SERVICE_STOP_LIVENESS (#764); health did not.
+ */
+describe("health retries a just-started proxy", () => {
+  test("passes a retry budget to findLiveProxy", async () => {
+    const seen: (number | undefined)[] = [];
+    const deps = {
+      ...fakeDeps,
+      args: ["health"],
+      findLiveProxy: async (io?: { attempts?: number }) => {
+        seen.push(io?.attempts);
+        return { pid: 4242, port: 10100 } as never;
+      },
+    } as unknown as CliDispatchDeps;
+
+    expect(await dispatchCommand({ kind: "command", command: "health", args: deps.args }, deps)).toBe(0);
+    // More than one: a single attempt is the defect. The exact number is the
+    // stop path's, and is asserted rather than inferred so a silent drop back to
+    // one probe fails here.
+    expect(seen).toEqual([3]);
+  });
+
+  test("still reports an absent proxy as unhealthy", async () => {
+    const deps = {
+      ...fakeDeps,
+      args: ["health"],
+      findLiveProxy: async () => null,
+    } as unknown as CliDispatchDeps;
+
+    expect(await dispatchCommand({ kind: "command", command: "health", args: deps.args }, deps)).toBe(1);
+  });
+});
+
+/**
+ * `handleStart` skipped the configured-port probe whenever the pid file and the
+ * runtime-port record were both absent. That absence proves nothing: a
+ * fallback-port sibling overwrites both records when it starts and removes them
+ * when it stops, so `start` shadowed a healthy configured-port proxy with an
+ * ephemeral-port copy and re-pointed client config at the copy.
+ *
+ * Source-level because the executable path binds real ports and spawns a real
+ * child; this pins the one option that decides the behavior, next to the
+ * `handleEnsure` call site that already had it right.
+ */
+describe("start probes the configured port before shadowing it (source-level)", () => {
+  const cliSource = readFileSync(join(import.meta.dir, "../src/cli/index.ts"), "utf8");
+
+  test("every findProxyOwnerBeforeJournalRecovery call site asks for the probe", () => {
+    const calls = cliSource.match(/findProxyOwnerBeforeJournalRecovery\s*\(([^)]*)\)/g) ?? [];
+    // The declaration plus both call sites (handleStart, handleEnsure).
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    const invocations = calls.filter(call => !call.includes("options:"));
+    expect(invocations.length).toBe(2);
+    for (const call of invocations) {
+      expect(call).toContain("probeConfiguredPort: true");
+    }
+  });
+
+  test("the probe option still gates on an explicit true", () => {
+    // A truthy-but-not-true default would silently probe for callers that pass
+    // nothing, which is a different behavior than the one asserted above.
+    expect(cliSource).toContain("options.probeConfiguredPort === true");
+  });
+});
+
 describe("logout parses argv before touching the credential store", () => {
   /**
    * `ocx logout --json` used to lowercase `--json`, pass it to removeCredential as a provider


### PR DESCRIPTION
## Summary

Reimplements #3078 (author @Veritas-7) on `dev`. Both production hunks there are correct; the PR targets `main`, and its test file does not typecheck — `tests/cli-health-retry.test.ts` declares `const servers: Server[]` while importing only `IncomingMessage` and `ServerResponse`.

**`start` shadowed a live proxy.** `handleStart` skipped the configured-port probe whenever the pid file and the runtime-port record were both absent (`src/cli/index.ts:205-211`). That absence proves nothing: a fallback-port sibling overwrites both records when it starts and removes them when it stops. So `start` bound an ephemeral port over a healthy configured-port proxy, re-pointed client config at the ephemeral copy, and the next sibling shutdown left no runtime record for discovery at all. `handleEnsure` already passed `probeConfiguredPort: true`; `handleStart` is the one path that did not.

**`health` probed once.** A proxy that has only just bound can miss a single probe while its event loop is still settling startup work, so `ocx health` run seconds after a service restart reported `Proxy not healthy` and exited 1 for a proxy that was serving. The stop paths already retry this exact race under `SERVICE_STOP_LIVENESS` (#764).

## What changed from #3078

The tests. #3078 stands up real loopback servers and spawns a real child to exercise the shadow path. That is a lot of machinery for two one-line decisions, and one of its files does not compile. Here the retry budget is asserted through `dispatchCommand`'s injected `findLiveProxy`, and the start guard through a source oracle placed next to the `handleEnsure` call site that was already correct — the same source-oracle pattern `tests/cli-ready.test.ts` already uses for `handleStart` wiring.

## Verification

```
bun test tests/cli-dispatch.test.ts   -> 29 pass / 0 fail / 116 expect()
bun x tsc --noEmit                    -> exit 0
```

Mutation-checked, both restored:

| mutation | result |
| --- | --- |
| drop `probeConfiguredPort` from `handleStart` | 28 pass / **1 fail** — `every findProxyOwnerBeforeJournalRecovery call site asks for the probe` |
| drop the health retry budget | 28 pass / **1 fail** — `passes a retry budget to findLiveProxy` |

`still reports an absent proxy as unhealthy` is the control: retrying does not turn a dead proxy into a live one.

The retry is scoped to the `health` runner only — the other four `findLiveProxy` call sites in `dispatch.ts` keep their single probe.

## Checklist

- [x] Focused tests for the changed subsystem pass
- [x] `bun x tsc --noEmit` clean
- [x] Regression tests present and mutation-verified
- [x] Targets `dev`
- [x] No docs-site change needed (CLI probe behavior, no interface change)

Triaged in the 2026-08-31 non-priority-70 bug round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy health checks by retrying liveness probes during startup.
  - Ensured startup detects existing proxies on the configured port, including instances using fallback ports.
  - Preserved clear failure behavior when no active proxy is available.

- **Tests**
  - Added coverage for health-check retries and configured-port detection during start and ensure operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->