### PR TITLE
fix(responses): strip Codex-private item metadata at the noncanonical boundary

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -237,6 +237,30 @@ function stripCanonicalOnlyToolFields(body: unknown, includeCapabilityGated: boo
 }
 
 /**
+ * Codex keeps this ChatGPT-internal item metadata when its configured provider name is `openai`.
+ * Loopback OpenCodex injection intentionally retains that provider identity for history continuity,
+ * even when the proxy ultimately routes the request to a public Responses destination. Those
+ * destinations reject the private field as an unknown `input[*]` parameter, so remove it at the
+ * noncanonical boundary without mutating the caller-owned raw body.
+ */
+function stripInternalChatMessageMetadataPassthrough(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!isPlainObject(item) || !Object.hasOwn(item, "internal_chat_message_metadata_passthrough")) {
+      return item;
+    }
+    changed = true;
+    const next = { ...item };
+    delete next.internal_chat_message_metadata_passthrough;
+    return next;
+  });
+
+  return changed ? { ...body, input } : body;
+}
+
+/**
  * When `store` is false, the upstream API does not persist response items. Any item ID
  * forwarded in `input` is then interpreted as a reference to a stored item that does not
  * exist, producing a 404. Strip all item IDs in this case — `call_id` pairing is unaffected.
@@ -2139,6 +2163,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       // `queries` for DeepSeek (#930), `query` for Console Go (#3071).
       outBody = backfillWebSearchQueries(outBody);
       if (!isCanonicalOpenAiForwardProvider(provider)) {
+        outBody = stripInternalChatMessageMetadataPassthrough(outBody);
         outBody = promoteClientLoadedTools(outBody);
       }
       if (!isCanonicalOpenAiForwardProvider(provider)) {

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -122,6 +122,80 @@ test("noncanonical pool-required providers use only their configured static cred
   expect(request.headers.session_id).toBeUndefined();
 });
 
+test("noncanonical Responses destinations strip Codex-private item metadata", () => {
+  const rawBody = {
+    model: "openai/gpt-5.6-sol",
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "ping" }],
+        internal_chat_message_metadata_passthrough: { turn_id: "turn-1" },
+      },
+      {
+        type: "function_call",
+        name: "lookup",
+        arguments: "{}",
+        call_id: "call-1",
+        internal_chat_message_metadata_passthrough: { turn_id: "turn-1" },
+      },
+    ],
+  };
+
+  for (const configuredProvider of [
+    {
+      adapter: "openai-responses",
+      baseUrl: "https://gateway.example/v1",
+      authMode: "key" as const,
+      apiKey: "test-key",
+    },
+    {
+      adapter: "openai-responses",
+      baseUrl: "https://gateway.example/v1",
+      authMode: "forward" as const,
+    },
+  ]) {
+    const request = createResponsesPassthroughAdapter(configuredProvider).buildRequest({
+      modelId: rawBody.model,
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: rawBody,
+    }, { headers: new Headers() });
+    const body = JSON.parse(request.body) as { input: Record<string, unknown>[] };
+
+    expect(body.input.every(item => !("internal_chat_message_metadata_passthrough" in item)))
+      .toBe(true);
+  }
+
+  expect(rawBody.input.every(item => "internal_chat_message_metadata_passthrough" in item))
+    .toBe(true);
+});
+
+test("canonical ChatGPT forward preserves Codex-private item metadata", () => {
+  const request = createResponsesPassthroughAdapter(provider).buildRequest({
+    modelId: "gpt-5.6-sol",
+    context: { messages: [] },
+    stream: true,
+    options: {},
+    _rawBody: {
+      model: "gpt-5.6-sol",
+      input: [{
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "ping" }],
+        internal_chat_message_metadata_passthrough: { turn_id: "turn-1" },
+      }],
+    },
+  }, { headers: new Headers({ authorization: "Bearer token" }) });
+  const body = JSON.parse(request.body) as {
+    input: { internal_chat_message_metadata_passthrough?: unknown }[];
+  };
+
+  expect(body.input[0].internal_chat_message_metadata_passthrough)
+    .toEqual({ turn_id: "turn-1" });
+});
+
 test("passthrough serialized-body observation releases after the request settles", () => {
   const budget = createTranslatorBudget();
   const request = createResponsesPassthroughAdapter(provider).buildRequest({


### PR DESCRIPTION
## Summary

Carries #3066 (author @yanzhibo-bytedance) rebased onto current `dev`. Both commits are the author's and needed no changes.

Codex ≥0.151 attaches `internal_chat_message_metadata_passthrough` to Responses `input[]` items. OpenCodex occupies the built-in `openai` slot, so that private field reaches whatever destination the request is routed to, and a strict upstream rejects it as an unknown `input[*]` parameter. The adapter now removes it at the noncanonical boundary, copy-on-write so `_rawBody` stays caller-owned.

**Supersedes #3038**, which found the same defect. See below.

## Why this one and not #3038

They differ in layer, and the layer is the whole decision.

#3038 strips inside `core.ts` and `compact.ts` after `readJsonRequestBody`, unconditionally — including on the canonical ChatGPT forward path, where the field is not foreign at all. `isCanonicalOpenAiForwardProvider` exists precisely to mark that destination (`src/providers/openai-tiers.ts:34-37`).

Its tests are also vacuous: `tests/openai-internal-request-metadata.test.ts` imports `stripOpenAiInternalRequestMetadata` and calls it directly. It never drives `handleResponses`, compact, or an adapter `buildRequest`, so deleting both production call sites leaves that file green.

#3066 strips inside `createResponsesPassthroughAdapter().buildRequest`, inside the existing `if (!isCanonicalOpenAiForwardProvider(provider))` block, and its tests call that production `buildRequest`.

## Verification

```
bun test tests/openai-responses-passthrough.test.ts  -> 117 pass / 0 fail / 372 expect()
bun x tsc --noEmit                                   -> exit 0
```

Two mutations, each restored:

| mutation | result |
| --- | --- |
| remove the strip call site | 116 pass / **1 fail** — `noncanonical Responses destinations strip Codex-private item metadata` |
| move the call outside the noncanonical guard | 116 pass / **1 fail** — `canonical ChatGPT forward preserves Codex-private item metadata` |

Two mutations, two different failures: stripping and ChatGPT preservation are guarded independently, which is exactly the property #3038's test layer cannot assert.

## Known residual

Official `openai-apikey` native compact bypasses this adapter, so a strict-validator failure on that specific destination is not covered here. That destination is OpenAI-operated and outside the reported joy-openai / `gpt-5.6-sol` failure; it belongs in its own change if it ever reproduces.

## Checklist

- [x] Focused tests for the changed subsystem pass
- [x] `bun x tsc --noEmit` clean
- [x] Regression tests present and mutation-verified
- [x] No docs-site change needed (wire-level request hygiene)

Triaged in the 2026-08-31 non-priority-70 bug round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented private internal metadata from being sent to routed Responses API destinations.
  * Preserved required metadata when communicating with the canonical ChatGPT backend.
  * Ensured request data remains unchanged for callers while being safely filtered for forwarding.

* **Tests**
  * Added coverage confirming metadata filtering and preservation across supported destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->