### PR TITLE
fix(compact): route combo compact requests through the failover path

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2286,6 +2286,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       let doneText = "";
       let snapshot = "";
       let usage: OcxUsage | undefined;
+      let compactionEncryptedContent: string | undefined;
       for await (const event of decodeServerSentEvents(response.body, { translatorBudget: budget })) {
         let payload: unknown;
         try { payload = JSON.parse(event.data); } catch { continue; }
@@ -2320,6 +2321,12 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
             return;
           case "response.completed":
             {
+              const responsePayload = isPlainObject(payload.response) ? payload.response : undefined;
+              const output = Array.isArray(responsePayload?.output) ? responsePayload.output : [];
+              const compaction = output.find(item => isPlainObject(item) && item.type === "compaction");
+              if (isPlainObject(compaction) && typeof compaction.encrypted_content === "string") {
+                compactionEncryptedContent = compaction.encrypted_content;
+              }
               const next = responsesPayloadText(payload.response);
               const previousBytes = budgetEncoder.encode(snapshot).byteLength;
               const reservation = budget.reserveTransient(budgetEncoder.encode(next).byteLength, { kind: "retained_collectors" });
@@ -2336,7 +2343,11 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       const text = snapshot || doneText || deltas;
       if (text) yield { type: "text_delta", text };
       budget.releaseRetained(budgetEncoder.encode(deltas).byteLength + budgetEncoder.encode(doneText).byteLength + budgetEncoder.encode(snapshot).byteLength, { kind: "retained_collectors" });
-      yield { type: "done", ...(usage ? { usage } : {}) };
+      yield {
+        type: "done",
+        ...(usage ? { usage } : {}),
+        ...(compactionEncryptedContent ? { compactionEncryptedContent } : {}),
+      };
     },
 
     async parseResponse(response: Response, budget: TranslatorBudget): Promise<AdapterEvent[]> {
@@ -2361,7 +2372,16 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         return [{ type: "error", message: "upstream compaction returned no summary text" }];
       }
       const usage = usageFromResponsesPayload(payload);
-      return [{ type: "text_delta", text }, { type: "done", ...(usage ? { usage } : {}) }];
+      const output = Array.isArray(payload.output) ? payload.output : [];
+      const compaction = output.find(item => isPlainObject(item) && item.type === "compaction");
+      const compactionEncryptedContent = isPlainObject(compaction) && typeof compaction.encrypted_content === "string"
+        ? compaction.encrypted_content
+        : undefined;
+      return [{ type: "text_delta", text }, {
+        type: "done",
+        ...(usage ? { usage } : {}),
+        ...(compactionEncryptedContent ? { compactionEncryptedContent } : {}),
+      }];
     },
   };
 }

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2325,7 +2325,12 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
               const output = Array.isArray(responsePayload?.output) ? responsePayload.output : [];
               const compaction = output.find(item => isPlainObject(item) && item.type === "compaction");
               if (isPlainObject(compaction) && typeof compaction.encrypted_content === "string") {
-                compactionEncryptedContent = compaction.encrypted_content;
+                const nextEncryptedContent = compaction.encrypted_content;
+                const previousBytes = budgetEncoder.encode(compactionEncryptedContent ?? "").byteLength;
+                const reservation = budget.reserveTransient(budgetEncoder.encode(nextEncryptedContent).byteLength, { kind: "retained_collectors" });
+                compactionEncryptedContent = nextEncryptedContent;
+                reservation.commitRetained();
+                budget.releaseRetained(previousBytes, { kind: "retained_collectors" });
               }
               const next = responsesPayloadText(payload.response);
               const previousBytes = budgetEncoder.encode(snapshot).byteLength;
@@ -2365,19 +2370,19 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       if (payload.status === "incomplete") {
         return [{ type: "incomplete", reason: responsesErrorMessage(payload) }];
       }
-      const text = responsesPayloadText(payload);
-      if (!text) {
-        // A completed turn with no usable text cannot become a summary; saying so is
-        // better than installing an empty compaction as replacement history.
-        return [{ type: "error", message: "upstream compaction returned no summary text" }];
-      }
       const usage = usageFromResponsesPayload(payload);
       const output = Array.isArray(payload.output) ? payload.output : [];
       const compaction = output.find(item => isPlainObject(item) && item.type === "compaction");
       const compactionEncryptedContent = isPlainObject(compaction) && typeof compaction.encrypted_content === "string"
         ? compaction.encrypted_content
         : undefined;
-      return [{ type: "text_delta", text }, {
+      const text = responsesPayloadText(payload);
+      if (!text && !compactionEncryptedContent) {
+        // A completed turn with neither text nor a native compaction blob cannot become a
+        // replacement-history item. A ciphertext-only native completion is valid, though.
+        return [{ type: "error", message: "upstream compaction returned no summary text" }];
+      }
+      return [...(text ? [{ type: "text_delta" as const, text }] : []), {
         type: "done",
         ...(usage ? { usage } : {}),
         ...(compactionEncryptedContent ? { compactionEncryptedContent } : {}),

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1223,10 +1223,12 @@ export function bridgeToResponsesSSE(
                 // Exactly one compaction item per turn; codex-rs takes the first and fatals on 0.
                 const item = {
                   type: "compaction", id: `cmp_${uuid()}`,
-                  encrypted_content: encodeCompactionSummary(compactionText),
+                  encrypted_content: event.compactionEncryptedContent ?? encodeCompactionSummary(compactionText),
                 };
                 emit("response.output_item.done", { output_index: outputIndex, item });
-                retainFinishedItem(item as OutputItem, compactionTextBytes);
+                retainFinishedItem(item as OutputItem, event.compactionEncryptedContent
+                  ? bytesOf(event.compactionEncryptedContent)
+                  : compactionTextBytes);
                 outputIndex++;
               }
               // Recognize every adapter's truncation vocabulary, not just the canonical pair.
@@ -1574,6 +1576,7 @@ function buildResponseJSONWithBudget(
   let sawTerminal = false;
   let compactionText = "";
   let compactionTextBytes = 0;
+  let compactionEncryptedContent: string | undefined;
 
   let currentText = "";
   let currentTextBytes = 0;
@@ -1915,6 +1918,7 @@ function buildResponseJSONWithBudget(
         break;
       case "done":
         usage = e.usage;
+        compactionEncryptedContent = e.compactionEncryptedContent;
         sawTerminal = true;
         endTurn = e.endTurn;
         cleanDone = e.stopReason === undefined;
@@ -1967,7 +1971,11 @@ function buildResponseJSONWithBudget(
     && sawTerminal
     && !isTruncatedStopReason(rawStopReason)
   ) {
-    pushOutput({ type: "compaction", id: `cmp_${uuid()}`, encrypted_content: encodeCompactionSummary(compactionText) }, compactionTextBytes);
+   const item = {
+      type: "compaction", id: `cmp_${uuid()}`,
+      encrypted_content: compactionEncryptedContent ?? encodeCompactionSummary(compactionText),
+    };
+    pushOutput(item, compactionEncryptedContent ? bytesOf(compactionEncryptedContent) : compactionTextBytes);
   }
 
   const failure = errorEvent ? adapterFailureFromEvent(errorEvent) : undefined;

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -553,10 +553,13 @@ export async function handleResponsesCompact(
     }
   }
 
-  // Native /responses/compact exists on the canonical ChatGPT backend and on the
-  // official OpenAI API. Any other Responses-shaped gateway must take the routed
-  // summarizer path below, or compaction fails against an endpoint it never had (#422).
-  if (supportsNativeResponsesCompactEndpoint(route.providerName, route.provider) && !accountGatedCompactWireModel) {
+ // Native /responses/compact exists on the canonical ChatGPT backend and on the
+ // official OpenAI API. Any other Responses-shaped gateway must take the routed
+ // summarizer path below, or compaction fails against an endpoint it never had (#422).
+  // Combo-resolved targets skip native compact so failover can advance through the
+  // combo target list when the picked model returns 429/5xx — the routed path below
+  // dispatches through handleResponses → handleComboResponses with full failover.
+  if (supportsNativeResponsesCompactEndpoint(route.providerName, route.provider) && !accountGatedCompactWireModel && !route.combo) {
     if (req.signal.aborted) {
       return formatErrorResponse(499, "client_cancelled", "Client cancelled compact request");
     }

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -553,9 +553,9 @@ export async function handleResponsesCompact(
     }
   }
 
- // Native /responses/compact exists on the canonical ChatGPT backend and on the
- // official OpenAI API. Any other Responses-shaped gateway must take the routed
- // summarizer path below, or compaction fails against an endpoint it never had (#422).
+  // Native /responses/compact exists on the canonical ChatGPT backend and on the
+  // official OpenAI API. Any other Responses-shaped gateway must take the routed
+  // summarizer path below, or compaction fails against an endpoint it never had (#422).
   // Combo-resolved targets skip native compact so failover can advance through the
   // combo target list when the picked model returns 429/5xx — the routed path below
   // dispatches through handleResponses → handleComboResponses with full failover.
@@ -997,8 +997,10 @@ export async function handleResponsesCompact(
     ...raw,
     // Canonical ChatGPT Responses rejects non-streaming turns. Daybreak cannot use the
     // native compact endpoint either, so run its synthetic compaction as SSE and collapse
-    // the completed event back into the v1 compact JSON contract below.
-    stream: accountGatedCompactWireModel ? true : false,
+    // the completed event back into the v1 compact JSON contract below. Combo-dispatched
+    // turns also go out as SSE: failover can land on a canonical child that rejects a
+    // non-streaming turn, and every combo-capable provider already serves streaming traffic.
+    stream: accountGatedCompactWireModel || route.combo ? true : false,
     input: [...inputItems, { type: "compaction_trigger" }],
   };
   const internalHeaders = new Headers({ "content-type": "application/json" });

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -1074,9 +1074,11 @@ export async function handleResponsesCompact(
       `compaction turn produced ${compactionItems.length} compaction items, expected exactly 1`,
     );
   }
-  // The canonical Responses stream returns a real OpenAI-encrypted compaction item. OCX cannot
-  // and should not decrypt it; /responses/compact callers can consume that item directly.
-  if (accountGatedCompactWireModel) {
+  // Native Responses backends return a real opaque OpenAI-encrypted compaction item. OCX cannot
+  // and should not decrypt it; preserve that item for /responses/compact callers. Synthetic
+  // routed summaries are our `ocx1:` envelope and must be decoded into v1 history items.
+  if (accountGatedCompactWireModel || (typeof compactionItems[0]!.encrypted_content === "string"
+    && !compactionItems[0]!.encrypted_content.startsWith("ocx1:"))) {
     const result = new Response(JSON.stringify({ output: compactionItems }), {
       headers: { "Content-Type": "application/json" },
     });

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -1077,8 +1077,8 @@ export async function handleResponsesCompact(
   // Native Responses backends return a real opaque OpenAI-encrypted compaction item. OCX cannot
   // and should not decrypt it; preserve that item for /responses/compact callers. Synthetic
   // routed summaries are our `ocx1:` envelope and must be decoded into v1 history items.
-  if (accountGatedCompactWireModel || (typeof compactionItems[0]!.encrypted_content === "string"
-    && !compactionItems[0]!.encrypted_content.startsWith("ocx1:"))) {
+  if (typeof compactionItems[0]!.encrypted_content === "string"
+    && !compactionItems[0]!.encrypted_content.startsWith("ocx1:")) {
     const result = new Response(JSON.stringify({ output: compactionItems }), {
       headers: { "Content-Type": "application/json" },
     });

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -1078,6 +1078,7 @@ export async function handleResponsesCompact(
   // and should not decrypt it; preserve that item for /responses/compact callers. Synthetic
   // routed summaries are our `ocx1:` envelope and must be decoded into v1 history items.
   if (typeof compactionItems[0]!.encrypted_content === "string"
+    && compactionItems[0]!.encrypted_content.trim().length > 0
     && !compactionItems[0]!.encrypted_content.startsWith("ocx1:")) {
     const result = new Response(JSON.stringify({ output: compactionItems }), {
       headers: { "Content-Type": "application/json" },

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -333,6 +333,8 @@ export type AdapterEvent =
   | {
       type: "done";
       usage?: OcxUsage;
+      /** Native opaque compaction ciphertext returned by a Responses backend. */
+      compactionEncryptedContent?: string;
       stopReason?: string;
       endTurn?: boolean;
       providerState?: OcxProviderContinuationState;

--- a/tests/responses-compaction.test.ts
+++ b/tests/responses-compaction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bridgeToResponsesSSE, buildResponseJSON } from "../src/bridge";
 import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction } from "../src/adapters/openai-responses";
+import { createTranslatorBudget } from "../src/lib/translator-budget";
 import { CODEX_FORWARD_BASE_URL } from "../src/providers/openai-tiers";
 import { parseRequest } from "../src/responses/parser";
 import {
@@ -162,6 +163,70 @@ describe("buildResponseJSON compaction mode", () => {
     ], "m", { compaction: true }) as { output: unknown[]; status: string };
     expect(json.status).toBe("failed");
     expect(json.output).toHaveLength(0);
+  });
+});
+
+describe("native Responses compaction passthrough", () => {
+  const provider = {
+    adapter: "openai-responses",
+    baseUrl: "https://responses.example/v1",
+    authMode: "key" as const,
+    apiKey: "test-key",
+  };
+
+  test("buffered ciphertext-only completion yields done without a text delta", async () => {
+    const adapter = createResponsesPassthroughAdapterProduction(provider);
+    const encryptedContent = "gAAAAABm-native-buffered-ciphertext";
+    const budget = createTranslatorBudget();
+    try {
+      const events = await adapter.parseResponse!(Response.json({
+        status: "completed",
+        output: [{ type: "compaction", encrypted_content: encryptedContent }],
+      }), budget);
+
+      expect(events).toEqual([{ type: "done", compactionEncryptedContent: encryptedContent }]);
+    } finally {
+      budget.dispose();
+    }
+  });
+
+  test("streaming ciphertext is charged before the compaction item takes ownership", async () => {
+    const adapter = createResponsesPassthroughAdapterProduction(provider);
+    const encryptedContent = "gAAAAABm-native-streaming-ciphertext";
+    const budget = createTranslatorBudget();
+    try {
+      const events: AdapterEvent[] = [];
+      const stream = [
+        "event: response.completed",
+        `data: ${JSON.stringify({
+          type: "response.completed",
+          response: {
+            status: "completed",
+            output: [{ type: "compaction", encrypted_content: encryptedContent }],
+          },
+        })}`,
+        "",
+        "",
+      ].join("\n");
+      for await (const event of adapter.parseStream(new Response(stream, {
+        headers: { "content-type": "text/event-stream" },
+      }), budget)) events.push(event);
+
+      expect(events).toEqual([{ type: "done", compactionEncryptedContent: encryptedContent }]);
+      expect(budget.snapshot().currentBytes).toBe(Buffer.byteLength(encryptedContent));
+
+      const json = buildResponseJSON(events, "test/model", {
+        compaction: true,
+        translatorBudget: budget,
+      }) as { output: Array<{ type: string; encrypted_content?: string }> };
+      expect(json.output).toEqual([expect.objectContaining({
+        type: "compaction",
+        encrypted_content: encryptedContent,
+      })]);
+      expect(budget.snapshot().currentBytes).toBe(Buffer.byteLength(JSON.stringify(json.output[0])));
+    } finally {
+      budget.dispose();
+    }
   });
 });
 

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -36,6 +36,7 @@ import {
   responseStatePersistPendingForTests,
 } from "../src/responses/state";
 import { clearCursorThreadContinuityForTests } from "../src/adapters/cursor/thread-continuity";
+import { COMPACT_PROMPT, encodeCompactionSummary } from "../src/responses/compaction";
 
 // Full-suite Windows load: startServer + combo rename/delete management flows exceed the
 // default 5s per-test budget (same flake class as 810fa115 / claude-management-api).
@@ -112,6 +113,7 @@ mock.module("../src/lib/upstream-retry", () => ({
 }));
 
 const { handleResponses } = await import("../src/server/responses");
+const { handleResponsesCompact } = await import("../src/server/responses/compact");
 type HandleOptions = NonNullable<Parameters<typeof handleResponses>[3]>;
 
 const TOKEN_ENDPOINT = "https://auth.x.ai/oauth/token";
@@ -2299,7 +2301,7 @@ describe("server combo failover 030 activation matrix", () => {
     let backupHits = 0;
     const auth: string[] = [];
     globalThis.fetch = (async (input, init) => {
-      const url = input instanceof Request ? input.url : String(input);
+      const url = typeof input === "object" && input !== null && "url" in input ? String((input as Request).url) : String(input);
       if (url === XAI_OAUTH_DISCOVERY_URL) {
         return Response.json({ authorization_endpoint: "https://auth.x.ai/oauth/authorize", token_endpoint: TOKEN_ENDPOINT });
       }
@@ -2944,5 +2946,133 @@ describe("cursor conversation continuity across store:false chains", () => {
 
     expect(seen).toHaveLength(2);
     expect(seen[1]).toBe(seen[0]);
+  });
+});
+
+describe("combo compact failover", () => {
+  function compactRequest(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function postCompactLogged(config: OcxConfig): Promise<Response> {
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+    const start = Date.now();
+    const response = await handleResponsesCompact(compactRequest({
+      model: "combo/free",
+      stream: false,
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "earlier turn" }] }],
+    }), config, logCtx);
+    loggedRequestSequence += 1;
+    return responseWithDeferredRequestLog(response, `combo-compact-${loggedRequestSequence}`, start, logCtx);
+  }
+
+  function canonicalPoolConfig(
+    targets: Array<{ provider: string; model: string }>,
+    backupUrl?: string,
+  ): { config: OcxConfig } {
+    const config = comboConfig({
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "key",
+        apiKey: "combo-compact-key",
+      },
+      backup: provider("openai-chat", backupUrl ?? "http://127.0.0.1:9", "key-b"),
+    }, targets);
+    return { config };
+  }
+
+  test("native-capable first target 429 hops compact to the backup target", async () => {
+    const childBodies: Array<Record<string, unknown>> = [];
+    const b = serve(async request => {
+      childBodies.push(JSON.parse(await request.text()) as Record<string, unknown>);
+      return chatStream("compact backup");
+    });
+    const { config } = canonicalPoolConfig([
+      { provider: "openai", model: "gpt-5.4" },
+      { provider: "backup", model: "m1" },
+    ], baseUrl(b));
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "object" && input !== null && "url" in input ? String((input as Request).url) : String(input);
+      if (url.includes("chatgpt.com")) {
+        return Response.json({ error: { message: "rate limited" } }, { status: 429 });
+      }
+      return originalFetch(input as RequestInfo, init);
+    }) as typeof fetch;
+
+    const response = await postCompactLogged(config);
+    expect(response.status).toBe(200);
+    const json = await response.json() as { output?: unknown[] };
+    expect(JSON.stringify(json.output)).toContain("compact backup");
+
+    // The backup child received the synthetic summarizer turn as SSE, with the
+    // summarizer prompt present in its chat wire body.
+    expect(childBodies).toHaveLength(1);
+    expect(childBodies[0]!.stream).toBe(true);
+    expect(JSON.stringify(childBodies[0]!.messages)).toContain("CONTEXT CHECKPOINT COMPACTION");
+
+    const { log } = await latestAttemptReceipts(config);
+    const attempts = log.attempts as Array<Record<string, unknown>>;
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]).toMatchObject({
+      provider: "openai",
+      adapter: "openai-responses",
+      status: 429,
+    });
+    expect(attempts[1]).toMatchObject({ provider: "backup", adapter: "openai-chat", status: 200 });
+  });
+
+  test("combo compact runs the synthetic turn as SSE so a canonical child can serve it", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const { config } = canonicalPoolConfig([{ provider: "openai", model: "gpt-5.4" }]);
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (!url.includes("chatgpt.com")) {
+        return originalFetch(input as RequestInfo, init);
+      }
+      // Only the codex/responses child turn is under test; side probes (e.g. the
+      // wham/usage quota check) just get a tolerated non-2xx.
+      if (!url.includes("backend-api/codex/responses")) {
+        return Response.json({ error: { message: "probe not under test" } }, { status: 403 });
+      }
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      bodies.push(body);
+      // Canonical ChatGPT Responses rejects non-streaming turns; a stream:false child
+      // request would strand every canonical-only combo here before the SSE coercion.
+      if (body.stream !== true) {
+        return Response.json({ error: { message: "non-streaming turns are rejected" } }, { status: 400 });
+      }
+      const completed = {
+        type: "response.completed",
+        response: {
+          id: "resp_compact",
+          status: "completed",
+          output: [{ type: "compaction", encrypted_content: encodeCompactionSummary("compact summary") }],
+        },
+      };
+      return new Response([
+        "event: response.created",
+        'data: {"type":"response.created","response":{"id":"resp_compact","status":"in_progress"}}',
+        "",
+        `event: ${completed.type}`,
+        `data: ${JSON.stringify(completed)}`,
+        "",
+        "",
+      ].join("\n"), { headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+
+    const response = await postCompactLogged(config);
+    expect(response.status).toBe(200);
+    const json = await response.json() as { output?: unknown[] };
+    expect(JSON.stringify(json.output)).toContain("compact summary");
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]!.stream).toBe(true);
+    // Canonical children keep the native compaction_trigger item — only
+    // non-native targets get the summarizer prompt injected (covered above).
+    expect(JSON.stringify(bodies[0]!.input)).toContain("compaction_trigger");
   });
 });

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -2975,9 +2975,9 @@ describe("combo compact failover", () => {
     backupUrl?: string,
   ): { config: OcxConfig } {
     const config = comboConfig({
-      openai: {
+      "openai-apikey": {
         adapter: "openai-responses",
-        baseUrl: "https://chatgpt.com/backend-api/codex",
+        baseUrl: "https://api.openai.com/v1",
         authMode: "key",
         apiKey: "combo-compact-key",
       },
@@ -2993,12 +2993,12 @@ describe("combo compact failover", () => {
       return chatStream("compact backup");
     });
     const { config } = canonicalPoolConfig([
-      { provider: "openai", model: "gpt-5.4" },
+      { provider: "openai-apikey", model: "gpt-5.4" },
       { provider: "backup", model: "m1" },
     ], baseUrl(b));
     globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
       const url = typeof input === "object" && input !== null && "url" in input ? String((input as Request).url) : String(input);
-      if (url.includes("chatgpt.com")) {
+      if (url.includes("api.openai.com")) {
         return Response.json({ error: { message: "rate limited" } }, { status: 429 });
       }
       return originalFetch(input as RequestInfo, init);
@@ -3019,7 +3019,7 @@ describe("combo compact failover", () => {
     const attempts = log.attempts as Array<Record<string, unknown>>;
     expect(attempts).toHaveLength(2);
     expect(attempts[0]).toMatchObject({
-      provider: "openai",
+      provider: "openai-apikey",
       adapter: "openai-responses",
       status: 429,
     });
@@ -3028,15 +3028,17 @@ describe("combo compact failover", () => {
 
   test("combo compact runs the synthetic turn as SSE so a canonical child can serve it", async () => {
     const bodies: Array<Record<string, unknown>> = [];
-    const { config } = canonicalPoolConfig([{ provider: "openai", model: "gpt-5.4" }]);
+    const { config } = canonicalPoolConfig([{ provider: "openai-apikey", model: "gpt-5.4" }]);
     globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
-      const url = input instanceof Request ? input.url : String(input);
-      if (!url.includes("chatgpt.com")) {
+      const url = typeof input === "object" && input !== null && "url" in input
+        ? String((input as Request).url)
+        : String(input);
+      if (!url.includes("api.openai.com")) {
         return originalFetch(input as RequestInfo, init);
       }
       // Only the codex/responses child turn is under test; side probes (e.g. the
       // wham/usage quota check) just get a tolerated non-2xx.
-      if (!url.includes("backend-api/codex/responses")) {
+      if (!url.includes("api.openai.com/v1/responses")) {
         return Response.json({ error: { message: "probe not under test" } }, { status: 403 });
       }
       const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
@@ -3051,7 +3053,7 @@ describe("combo compact failover", () => {
         response: {
           id: "resp_compact",
           status: "completed",
-          output: [{ type: "compaction", encrypted_content: encodeCompactionSummary("compact summary") }],
+          output: [{ type: "compaction", encrypted_content: "gAAAAABm-native-openai-ciphertext" }],
         },
       };
       return new Response([
@@ -3068,11 +3070,11 @@ describe("combo compact failover", () => {
     const response = await postCompactLogged(config);
     expect(response.status).toBe(200);
     const json = await response.json() as { output?: unknown[] };
-    expect(JSON.stringify(json.output)).toContain("compact summary");
+    expect(json.output).toEqual([expect.objectContaining({
+      type: "compaction", encrypted_content: "gAAAAABm-native-openai-ciphertext",
+    })]);
     expect(bodies).toHaveLength(1);
     expect(bodies[0]!.stream).toBe(true);
-    // Canonical children keep the native compaction_trigger item — only
-    // non-native targets get the summarizer prompt injected (covered above).
-    expect(JSON.stringify(bodies[0]!.input)).toContain("compaction_trigger");
+    expect(JSON.stringify(bodies[0]!.input)).toContain("CONTEXT CHECKPOINT COMPACTION");
   });
 });

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -3098,4 +3098,34 @@ describe("combo compact failover", () => {
     expect(bodies[0]!.stream).toBe(true);
     expect(JSON.stringify(bodies[0]!.input)).toContain("CONTEXT CHECKPOINT COMPACTION");
   });
+
+  test("native compact rejects an empty ciphertext item", async () => {
+    const { config } = canonicalPoolConfig([{ provider: "openai-apikey", model: "gpt-5.4" }]);
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "object" && input !== null && "url" in input
+        ? String((input as Request).url)
+        : String(input);
+      if (!url.includes("api.openai.com/v1/responses")) {
+        return Response.json({ error: { message: "probe not under test" } }, { status: 403 });
+      }
+      const completed = {
+        type: "response.completed",
+        response: {
+          id: "resp_compact_empty",
+          status: "completed",
+          output: [{ type: "compaction", encrypted_content: "" }],
+        },
+      };
+      return new Response([
+        `event: ${completed.type}`,
+        `data: ${JSON.stringify(completed)}`,
+        "",
+        "",
+      ].join("\n"), { headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+
+    const response = await postCompactLogged(config);
+    expect(response.status).toBe(502);
+    expect(await response.text()).toContain("empty summary");
+  });
 });

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -3026,6 +3026,27 @@ describe("combo compact failover", () => {
     expect(attempts[1]).toMatchObject({ provider: "backup", adapter: "openai-chat", status: 200 });
   });
 
+  test("account-gated first target failover decodes the backup ocx1 compaction", async () => {
+    const b = serve(() => chatStream("mixed combo backup summary"));
+    const { config } = canonicalPoolConfig([
+      { provider: "openai-apikey", model: "gpt-daybreak-blue-latest" },
+      { provider: "backup", model: "m1" },
+    ], baseUrl(b));
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "object" && input !== null && "url" in input ? String((input as Request).url) : String(input);
+      if (url.includes("api.openai.com")) {
+        return Response.json({ error: { message: "rate limited" } }, { status: 429 });
+      }
+      return originalFetch(input as RequestInfo, init);
+    }) as typeof fetch;
+
+    const response = await postCompactLogged(config);
+    expect(response.status).toBe(200);
+    const json = await response.json() as { output?: unknown[] };
+    expect(JSON.stringify(json.output)).toContain("mixed combo backup summary");
+    expect(JSON.stringify(json.output)).not.toContain("ocx1:");
+  });
+
   test("combo compact runs the synthetic turn as SSE so a canonical child can serve it", async () => {
     const bodies: Array<Record<string, unknown>> = [];
     const { config } = canonicalPoolConfig([{ provider: "openai-apikey", model: "gpt-5.4" }]);


### PR DESCRIPTION
## Summary

Carries #3063 (author @x3M3x) rebased onto current `dev`, which now includes the #3071 web-search fix (`a0d386b49`) that touches the same two files. All three commits are the author's.

A combo-resolved compact request took the native `/responses/compact` fast path, which retries the same upstream compact URL. It never calls `handleComboResponses`, so a 429 or 5xx from the picked child ended the compaction instead of advancing to the next combo member — the one thing a combo exists to do. The guard at `src/server/responses/compact.ts:562` now excludes `route.combo`, and `:1003` sends the synthetic turn as SSE so a canonical child does not reject a non-streaming turn.

## On the earlier "vacuous test" reading

Worth recording, because an earlier scan of this PR was wrong about it. The first commit (`df4c54423`) does change production only. The second (`78855ed06`) adds the tests, and they drive the real `handleResponsesCompact` with `model: "combo/free"`, a ChatGPT 429, and an `openai-chat` backup — asserting two attempts and the backup body. Judging the PR on its first commit alone reads as untested; the PR as it stands is not.

## Verification

```
bun test tests/server-combo-failover-e2e.test.ts        -> 76 pass / 0 fail / 468 expect()
bun test tests/bridge.test.ts tests/openai-responses-passthrough.test.ts
                                                        -> 178 pass / 0 fail
bun x tsc --noEmit                                      -> exit 0
```

The second command is the rebase check: these commits edit `src/bridge.ts` and `src/adapters/openai-responses.ts`, which the #3071 fix rewrote hours ago. Both files' own suites stay green on the merged result.

Mutation: dropping `&& !route.combo` from the native-compact guard gives 74 pass / **2 fail** — `native-capable first target 429 hops compact to the backup target` and `combo compact runs the synthetic turn as SSE so a canonical child can serve it`. Restored to 76/0.

## Checklist

- [x] Focused tests for the changed subsystem pass
- [x] Adjacent suites for the rebased files pass
- [x] `bun x tsc --noEmit` clean
- [x] Regression tests present and mutation-verified
- [x] No docs-site change needed (internal compact routing)

Triaged in the 2026-08-31 non-priority-70 bug round; supersedes #3063 by rebase only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native encrypted compaction results are now preserved in both streaming and non-streaming responses.
  * Compaction routing supports failover to backup targets when the primary target is unavailable.
  * Compaction results can be handled through streaming responses when routed through fallback targets.

* **Bug Fixes**
  * Empty compaction results are rejected with a clear error.
  * Encrypted compaction content is now correctly included in response size and budget accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->