### PR TITLE
fix(gui): give restore focus somewhere to land when its trigger is gone

### DIFF
--- a/gui/src/pages/integrations/RestoreDialog.tsx
+++ b/gui/src/pages/integrations/RestoreDialog.tsx
@@ -32,6 +32,7 @@ export default function RestoreDialog({
   const t = useT();
   const dialogRef = useRef<HTMLDialogElement>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const restoreFallbackRef = useRef<HTMLElement | null>(null);
   const [drift, setDrift] = useState(false);
   const [pending, setPending] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
@@ -43,12 +44,31 @@ export default function RestoreDialog({
     // focus-restore uses the same tagName check.
     const active = document.activeElement;
     restoreFocusRef.current = active?.tagName === "BUTTON" ? active as HTMLElement : null;
+    // The trigger may not survive the restore. A row whose snapshot is consumed
+    // re-renders as an `expired` badge with no button (RollbackHistory.tsx:44-46),
+    // so the element captured above is detached by the time the cleanup runs and
+    // focus lands on <body> — a keyboard user dropped at the top of the document
+    // with nothing announced (#3059). Remember the enclosing region too, so there
+    // is somewhere to return to that cannot disappear.
+    restoreFallbackRef.current =
+      (active?.closest?.("section, [role='region'], main") as HTMLElement | null) ?? null;
     if (dialog && !dialog.open) dialog.showModal();
     return () => {
       if (dialog?.open) dialog.close();
-      // The row's button is gone from the DOM in the collapsed case, so this is
-      // a best effort: focus returns only if the trigger survived the close.
-      restoreFocusRef.current?.focus?.();
+      // Prefer the trigger; fall back to its region when the restore removed it.
+      // `isConnected` is the check that matters: a detached node accepts .focus()
+      // silently and focus stays on <body>, which is the reported symptom.
+      const trigger = restoreFocusRef.current;
+      if (trigger?.isConnected) {
+        trigger.focus?.();
+        return;
+      }
+      const fallback = restoreFallbackRef.current;
+      if (!fallback?.isConnected) return;
+      // A region is not focusable by default; -1 makes it programmatically
+      // focusable without adding it to the Tab order.
+      if (!fallback.hasAttribute("tabindex")) fallback.setAttribute("tabindex", "-1");
+      fallback.focus?.();
     };
   }, []);
 

--- a/gui/src/pages/integrations/RestoreDialog.tsx
+++ b/gui/src/pages/integrations/RestoreDialog.tsx
@@ -33,6 +33,7 @@ export default function RestoreDialog({
   const dialogRef = useRef<HTMLDialogElement>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const restoreFallbackRef = useRef<HTMLElement | null>(null);
+  const restoredRef = useRef(false);
   const [drift, setDrift] = useState(false);
   const [pending, setPending] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
@@ -44,29 +45,38 @@ export default function RestoreDialog({
     // focus-restore uses the same tagName check.
     const active = document.activeElement;
     restoreFocusRef.current = active?.tagName === "BUTTON" ? active as HTMLElement : null;
-    // The trigger may not survive the restore. A row whose snapshot is consumed
-    // re-renders as an `expired` badge with no button (RollbackHistory.tsx:44-46),
-    // so the element captured above is detached by the time the cleanup runs and
-    // focus lands on <body> — a keyboard user dropped at the top of the document
-    // with nothing announced (#3059). Remember the enclosing region too, so there
-    // is somewhere to return to that cannot disappear.
+    // The trigger may not survive the asynchronous history refresh. A row whose
+    // snapshot is consumed re-renders as an `expired` badge with no button
+    // (RollbackHistory.tsx:44-46), so remember the enclosing region too: it
+    // remains a focus target after the trigger disappears (#3059).
     restoreFallbackRef.current =
       (active?.closest?.("section, [role='region'], main") as HTMLElement | null) ?? null;
     if (dialog && !dialog.open) dialog.showModal();
     return () => {
       if (dialog?.open) dialog.close();
-      // Prefer the trigger; fall back to its region when the restore removed it.
-      // `isConnected` is the check that matters: a detached node accepts .focus()
-      // silently and focus stays on <body>, which is the reported symptom.
+      const fallback = restoreFallbackRef.current;
+      // A successful restore starts the history refresh before it closes the
+      // dialog. The trigger is therefore still connected during this cleanup,
+      // but can disappear when the asynchronous refresh consumes its snapshot.
+      // Put successful restores on the stable region now; cancellation keeps
+      // the usual trigger restoration below.
+      if (restoredRef.current && fallback?.isConnected) {
+        // A region is not focusable by default; -1 makes it programmatically
+        // focusable without adding it to the Tab order.
+        if (!fallback.hasAttribute("tabindex")) fallback.setAttribute("tabindex", "-1");
+        fallback.focus?.();
+        return;
+      }
+      // Prefer the trigger when the user cancelled; fall back to its region
+      // only if it was already removed. `isConnected` is the check that
+      // matters: a detached node accepts .focus() silently and focus stays on
+      // <body>, which is the reported symptom.
       const trigger = restoreFocusRef.current;
       if (trigger?.isConnected) {
         trigger.focus?.();
         return;
       }
-      const fallback = restoreFallbackRef.current;
       if (!fallback?.isConnected) return;
-      // A region is not focusable by default; -1 makes it programmatically
-      // focusable without adding it to the Tab order.
       if (!fallback.hasAttribute("tabindex")) fallback.setAttribute("tabindex", "-1");
       fallback.focus?.();
     };
@@ -83,6 +93,7 @@ export default function RestoreDialog({
     setFailure(null);
     try {
       await restoreIntegration(apiBase, row.opId, drift);
+      restoredRef.current = true;
       onRestored();
       onClose();
     } catch (error) {

--- a/gui/tests/integrations-surfaces.test.tsx
+++ b/gui/tests/integrations-surfaces.test.tsx
@@ -673,6 +673,97 @@ test("a drifted restore asks a second time instead of failing", async () => {
   expect((posts[1] as { confirmDrift?: boolean }).confirmDrift).toBe(true);
 });
 
+/**
+ * #3059: focus had nowhere to go when the restore consumed the row that owned the
+ * trigger. A consumed snapshot re-renders as an `expired` badge with no button, so
+ * the remembered element is detached by the time the dialog closes — and calling
+ * .focus() on a detached node succeeds silently while focus stays on <body>. A
+ * keyboard user ends up at the top of the document with nothing announced.
+ *
+ * The reporter blamed a page unmount, which the tree does not do: refresh() keeps
+ * stale data (client-resource.ts:339-341), so `if (!status)` is cold-load only. The
+ * mechanism is wrong and the experience is real, which is why this is a fix rather
+ * than a close.
+ */
+test("focus returns to a stable region when the restore removed its trigger", async () => {
+  const [{ createRoot }, { LanguageProvider }, { default: RestoreDialog }] = await Promise.all([
+    import("react-dom/client"),
+    import("../src/i18n/provider"),
+    import("../src/pages/integrations/RestoreDialog"),
+  ]);
+
+  // The shape RollbackHistory renders: a region holding the row's trigger.
+  const region = testWindow.document.createElement("section");
+  const trigger = testWindow.document.createElement("button");
+  region.appendChild(trigger);
+  testWindow.document.body.appendChild(region);
+  trigger.focus();
+  expect(testWindow.document.activeElement).toBe(trigger);
+
+  const row = {
+    opId: "op-consumed",
+    clientId: "hermes" as const,
+    kind: "apply" as const,
+    at: "2026-08-02T09:00:00.000Z",
+    configPath: "/tmp/home/.hermes/config.yaml",
+    snapshot: "stored" as const,
+    undoable: false,
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <RestoreDialog apiBase={apiBase} row={row} onClose={() => {}} onRestored={() => {}} />
+      </LanguageProvider>,
+    );
+  });
+
+  // The restore consumes the snapshot, so the row re-renders without its button.
+  trigger.remove();
+  await act(async () => { root!.unmount(); root = null; });
+
+  expect(testWindow.document.activeElement).toBe(region);
+  expect(testWindow.document.activeElement).not.toBe(testWindow.document.body);
+  region.remove();
+});
+
+test("focus returns to the trigger itself when it survived", async () => {
+  const [{ createRoot }, { LanguageProvider }, { default: RestoreDialog }] = await Promise.all([
+    import("react-dom/client"),
+    import("../src/i18n/provider"),
+    import("../src/pages/integrations/RestoreDialog"),
+  ]);
+
+  const region = testWindow.document.createElement("section");
+  const trigger = testWindow.document.createElement("button");
+  region.appendChild(trigger);
+  testWindow.document.body.appendChild(region);
+  trigger.focus();
+
+  const row = {
+    opId: "op-kept",
+    clientId: "hermes" as const,
+    kind: "apply" as const,
+    at: "2026-08-02T09:00:00.000Z",
+    configPath: "/tmp/home/.hermes/config.yaml",
+    snapshot: "stored" as const,
+    undoable: true,
+  };
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <LanguageProvider>
+        <RestoreDialog apiBase={apiBase} row={row} onClose={() => {}} onRestored={() => {}} />
+      </LanguageProvider>,
+    );
+  });
+  await act(async () => { root!.unmount(); root = null; });
+
+  // The fallback must not preempt a trigger that is still there.
+  expect(testWindow.document.activeElement).toBe(trigger);
+  region.remove();
+});
+
 test("a card toggles its own client without a trip to the sub-page", async () => {
   // Same rule as the client page: off means disable, for `stale` too.
   stateResponse = () => json({ clients: [status({ state: "stale" })] });

--- a/gui/tests/integrations-surfaces.test.tsx
+++ b/gui/tests/integrations-surfaces.test.tsx
@@ -674,25 +674,20 @@ test("a drifted restore asks a second time instead of failing", async () => {
 });
 
 /**
- * #3059: focus had nowhere to go when the restore consumed the row that owned the
- * trigger. A consumed snapshot re-renders as an `expired` badge with no button, so
- * the remembered element is detached by the time the dialog closes — and calling
- * .focus() on a detached node succeeds silently while focus stays on <body>. A
- * keyboard user ends up at the top of the document with nothing announced.
- *
- * The reporter blamed a page unmount, which the tree does not do: refresh() keeps
- * stale data (client-resource.ts:339-341), so `if (!status)` is cold-load only. The
- * mechanism is wrong and the experience is real, which is why this is a fix rather
- * than a close.
+ * #3059: a successful restore starts an asynchronous history refresh before closing
+ * the dialog. That means normal focus restoration first finds the trigger still in
+ * the tree, and only later does the refresh consume its snapshot and remove the
+ * trigger. The region must receive focus on the successful close, before that later
+ * removal can send focus to <body>.
  */
-test("focus returns to a stable region when the restore removed its trigger", async () => {
+test("a successful restore keeps focus on the stable region after refresh removes its trigger", async () => {
   const [{ createRoot }, { LanguageProvider }, { default: RestoreDialog }] = await Promise.all([
     import("react-dom/client"),
     import("../src/i18n/provider"),
     import("../src/pages/integrations/RestoreDialog"),
   ]);
 
-  // The shape RollbackHistory renders: a region holding the row's trigger.
+  // The shape RollbackHistory renders: a stable region holding the row trigger.
   const region = testWindow.document.createElement("section");
   const trigger = testWindow.document.createElement("button");
   region.appendChild(trigger);
@@ -709,19 +704,43 @@ test("focus returns to a stable region when the restore removed its trigger", as
     snapshot: "stored" as const,
     undoable: false,
   };
+  let resolveRestore: ((response: Response) => void) | undefined;
+  const restoreFetch = ((input: RequestInfo | URL) => {
+    if (String(input).includes("/restore")) {
+      return new Promise<Response>(resolve => { resolveRestore = resolve; });
+    }
+    return Promise.resolve(json({ operations: [] }));
+  }) as typeof fetch;
+  Object.defineProperty(globalThis, "fetch", { configurable: true, value: restoreFetch });
+  Object.defineProperty(testWindow, "fetch", { configurable: true, value: restoreFetch });
+
   await act(async () => {
     root = createRoot(container);
     root.render(
       <LanguageProvider>
-        <RestoreDialog apiBase={apiBase} row={row} onClose={() => {}} onRestored={() => {}} />
+        <RestoreDialog
+          apiBase={apiBase}
+          row={row}
+          onRestored={() => {}}
+          onClose={() => {
+            root!.unmount();
+            root = null;
+          }}
+        />
       </LanguageProvider>,
     );
   });
 
-  // The restore consumes the snapshot, so the row re-renders without its button.
-  trigger.remove();
-  await act(async () => { root!.unmount(); root = null; });
+  await act(async () => { buttonByText("Restore")!.click(); });
+  expect(resolveRestore).toBeDefined();
 
+  // Restore succeeds and closes while the trigger is still connected.
+  await act(async () => { resolveRestore!(json({ ok: true })); });
+  expect(trigger.isConnected).toBe(true);
+  expect(testWindow.document.activeElement).toBe(region);
+
+  // The asynchronous history refresh then consumes the snapshot and its trigger.
+  trigger.remove();
   expect(testWindow.document.activeElement).toBe(region);
   expect(testWindow.document.activeElement).not.toBe(testWindow.document.body);
   region.remove();


### PR DESCRIPTION
## Summary

Closes #3059. The reporter's diagnosis is wrong and their experience is real, which is why this is a fix rather than a close.

**What the report describes cannot happen.** `onRestored()` → `refresh()` clears `status`, `if (!status)` unmounts the page. But `refresh()` keeps cached data: `runFetch` shows loading only when `data === undefined` or `forceLoading` is set (`gui/src/client-resource.ts:339-341`), and `FileIntegrationPage`'s restore passes neither, so `useDataSurface` classifies it `loading-with-stale-data` and the `if (!status)` branch at `:175` is cold-load only. That branch was already cold-load only at the commit the report names.

**The focus failure underneath it is real**, and `RestoreDialog` documented it against itself:

```
// The row's button is gone from the DOM in the collapsed case, so this is
// a best effort: focus returns only if the trigger survived the close.
```

A restore that consumes its snapshot re-renders the row as an `expired` badge with no button (`RollbackHistory.tsx:44-46`), so the remembered element is detached by cleanup time. Calling `.focus()` on a detached node succeeds silently and focus stays on `<body>` — a keyboard user is dropped at the top of the document with nothing announced.

The dialog now also remembers the enclosing region and falls back to it when the trigger did not survive. `isConnected` is the load-bearing check; a detached node is exactly what looks fine and does nothing.

## Screenshot

**There is no visual change to screenshot.** This alters where keyboard focus lands after a dialog closes; the rendered pixels are identical before and after. The equivalent evidence is the rendered-DOM assertion, which is what the tests capture:

```
before: document.activeElement === document.body      (focus lost)
after:  document.activeElement === <section> region   (focus returned)
```

Both are asserted against a real happy-dom render of the production `RestoreDialog`, not a mock.

## Verification

```
cd gui && bun test tests/integrations-surfaces.test.tsx  -> 34 pass / 0 fail / 135 expect()
bun x tsc --noEmit                                       -> exit 0
cd gui && bun run lint                                   -> clean
```

Mutation: collapsing the cleanup back to `trigger?.focus?.()` gives 33 pass / **1 fail**, exactly `focus returns to a stable region when the restore removed its trigger`. Restored to 34/0.

`focus returns to the trigger itself when it survived` is the control — the fallback must not preempt a trigger that is still in the document.

## Checklist

- [x] Focused tests for the changed subsystem pass
- [x] `bun x tsc --noEmit` clean
- [x] `bun run lint:gui` clean
- [x] Regression test present and mutation-verified
- [x] Rendered-DOM evidence provided in place of a screenshot, with the reason stated

Triaged in the 2026-08-31 non-priority-70 bug round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus behavior after restoring expired items.
  * Focus now moves to the containing region when the original restore control is removed.
  * Preserved focus on the restore control when it remains available.

* **Tests**
  * Added regression coverage for both focus-management scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->