### PR TITLE
fix(responses): notice an unreadable MESSAGE reply, not just NEW_TASK

### DIFF
--- a/src/server/responses/encrypted-payload.ts
+++ b/src/server/responses/encrypted-payload.ts
@@ -175,7 +175,24 @@ function textWithoutFernetRuns(payload: string, runs: readonly FernetTokenRun[])
   return `${text}${payload.slice(last)}`;
 }
 
-export const AGENT_MESSAGE_ROUTING_ENVELOPE = /(?:^|\n)Message Type\s*:\s*NEW_TASK[^\n]*\nTask name\s*:[^\n]*\nSender\s*:[^\n]*\nPayload\s*:\s*(?:\n|$)/gi;
+/**
+ * The routing header codex-rs writes above a delegated agent payload.
+ *
+ * `MESSAGE` is matched as well as `NEW_TASK`, and only for the unreadability CHECK --
+ * recovery stays NEW_TASK-only. #3021 reported a subagent `MESSAGE` arriving in the
+ * parent conversation as raw `gAAAA...` ciphertext after an `adapter_eof`. The detector
+ * decides "unreadable" by stripping the envelope and asking whether any plaintext
+ * survives, so an envelope shape it does not recognise counts as surviving text: a
+ * `MESSAGE` whose entire body is one Fernet token measured as READABLE and was forwarded
+ * verbatim.
+ *
+ * Widening the strip is not the same as widening recovery. Recovery decrypts, and
+ * decrypting a `MESSAGE` on the parent's behalf would build a plaintext oracle out of a
+ * payload the parent's session may have no right to read. This only lets the proxy
+ * NOTICE that what it is about to forward is unreadable ciphertext, which is what the
+ * report asks for: fail closed with a structured error rather than paste the token.
+ */
+export const AGENT_MESSAGE_ROUTING_ENVELOPE = /(?:^|\n)Message Type\s*:\s*(?:NEW_TASK|MESSAGE)[^\n]*\nTask name\s*:[^\n]*\nSender\s*:[^\n]*\nPayload\s*:\s*(?:\n|$)/gi;
 
 // CXC is the compatibility-hook control namespace. Strip only the tagged paragraph:
 // later untagged paragraphs may be genuine task text. Repeated CXC paragraphs are

--- a/tests/v2-agent-message-failfast.test.ts
+++ b/tests/v2-agent-message-failfast.test.ts
@@ -32,6 +32,10 @@ const ROUTING_ENVELOPE = [
   "",
 ].join("\n");
 
+// The same envelope a delegated agent uses to REPLY, as opposed to being spawned.
+// #3021 saw one of these reach the parent conversation as raw `gAAAA...` text.
+const MESSAGE_ROUTING_ENVELOPE = ROUTING_ENVELOPE.replace("NEW_TASK", "MESSAGE");
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
@@ -133,6 +137,46 @@ describe("V2 routed agent-message ciphertext guard", () => {
       { type: "input_text", text: ROUTING_ENVELOPE },
       { type: "encrypted_content", encrypted_content: FERNET_TASK },
     ]))).toBe(true);
+  });
+
+  /**
+   * #3021: a delegated subagent's MESSAGE reply reached the parent conversation as
+   * raw `gAAAA...` ciphertext after an `adapter_eof`.
+   *
+   * The detector decides "unreadable" by stripping the routing envelope and asking
+   * whether any plaintext survives, so an envelope shape it does not recognise counts
+   * as surviving text. The envelope pattern matched only NEW_TASK, so a MESSAGE whose
+   * entire body was one Fernet token measured as READABLE and was forwarded verbatim.
+   *
+   * This is the detection half only. Recovery stays NEW_TASK-only on purpose:
+   * decrypting a MESSAGE on the parent's behalf would build a plaintext oracle out of
+   * a payload the parent's session may not be entitled to read.
+   */
+  test("blocks a MESSAGE reply envelope followed only by a Fernet payload", () => {
+    expect(hasUnreadableEncryptedAgentTask(agentMessage([
+      { type: "input_text", text: MESSAGE_ROUTING_ENVELOPE },
+      { type: "encrypted_content", encrypted_content: FERNET_TASK },
+    ]))).toBe(true);
+  });
+
+  test("blocks a MESSAGE envelope carried inside the encrypted slot itself", () => {
+    // The shape the report describes: header and ciphertext arrive as one
+    // encrypted_content string rather than as separate parts.
+    expect(hasUnreadableEncryptedAgentTask(agentMessage([
+      {
+        type: "encrypted_content",
+        encrypted_content: `${MESSAGE_ROUTING_ENVELOPE}${FERNET_TASK}`,
+      },
+    ]))).toBe(true);
+  });
+
+  test("a MESSAGE reply that carries real text stays readable", () => {
+    // The control. Widening the envelope must not turn every agent reply into a
+    // blocked one -- only the ones with nothing left after the header comes off.
+    expect(hasUnreadableEncryptedAgentTask(agentMessage([
+      { type: "input_text", text: `${MESSAGE_ROUTING_ENVELOPE}the worker finished the migration` },
+      { type: "encrypted_content", encrypted_content: FERNET_TASK },
+    ]))).toBe(false);
   });
 
   test("blocks a control preamble mixed into the Fernet slot before sanitization", async () => {


### PR DESCRIPTION
## Summary

Closes #3021. After an `adapter_eof`, a delegated subagent's `MESSAGE` reply reached the parent conversation as a raw `gAAAA...` payload instead of plaintext or a structured error.

`hasUnreadableEncryptedAgentTask` decides "unreadable" by stripping the routing envelope and asking whether any plaintext survives. `AGENT_MESSAGE_ROUTING_ENVELOPE` matched only `NEW_TASK`, so a `MESSAGE` header was never stripped and counted as *surviving text* — a reply whose entire body was one Fernet token measured as **readable** and was forwarded verbatim.

Measured on `dev` with a structurally valid Fernet token, before the change:

```
NEW_TASK -> true   (detected as unreadable)
MESSAGE  -> false  (#3021's case: forwarded)
```

and after:

```
NEW_TASK -> true
MESSAGE  -> true
```

## Detection, not recovery

This widens the envelope pattern used by the unreadability **check**. `recoverEncryptedAgentTask` stays `NEW_TASK`-only, and that boundary is the point.

Recovery decrypts. Decrypting a `MESSAGE` on the parent's behalf would build a plaintext oracle out of a payload the parent's session may have no entitlement to read — the reporter's own expected behavior says decryption should happen "only in the owning account/session context". Letting the proxy *notice* that what it is about to forward is unreadable ciphertext is a different and much smaller thing, and it is the half the report actually asks for: fail closed with a structured error rather than paste the token.

The reporter withheld the ciphertext, correctly. None was needed — `structurallyValidFernetTokens` already existed, so the defect was reproducible from the wire shape alone.

## Verification

```
bun test tests/v2-agent-message-failfast.test.ts tests/agent-task-recovery.test.ts
  -> 42 pass / 0 fail / 125 expect()
bun x tsc --noEmit -> exit 0
```

Mutation: reverting the pattern to `NEW_TASK`-only gives 21 pass / **2 fail** — `blocks a MESSAGE reply envelope followed only by a Fernet payload` and `blocks a MESSAGE envelope carried inside the encrypted slot itself`. Restored to 23/0.

The third new test is the control: a `MESSAGE` reply that carries real text alongside a token stays **readable** in both directions. Widening the envelope must not turn every agent reply into a blocked one, only the ones with nothing left after the header comes off.

`tests/agent-task-recovery.test.ts` is included to show the recovery path is unchanged.

## Checklist

- [x] Focused tests for the changed subsystem pass
- [x] Recovery-path tests included and unchanged
- [x] `bun x tsc --noEmit` clean
- [x] Regression tests present and mutation-verified, with a control
- [x] No docs-site change needed (internal payload classification)

Triaged in the 2026-08-31 non-priority-70 bug round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encrypted agent messages with `MESSAGE` routing headers.
  * Unreadable encrypted content is now detected consistently in delegated-agent replies, including when embedded within message content.
  * Valid text replies remain readable and are no longer incorrectly treated as unreadable payloads.

* **Tests**
  * Added coverage for encrypted message replies, embedded routing envelopes, and readable text responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->