### PR TITLE
fix(catalog): fold dated model ids in both directions and at both widths

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -936,9 +936,30 @@ export function resolveComboCatalogMember(
   };
 }
 
+/**
+ * A date-stamped deployment suffix, in the two widths providers actually publish:
+ * `YYYYMMDD` (Anthropic: `claude-haiku-4-5-20251001`) and `MMDD` (Alibaba Token Plan / DeepSeek:
+ * `deepseek-v4-pro-0813`). The four-digit branch validates the month and day so an ordinary
+ * numeric suffix — a `-4096` context size, a `-2025` year — cannot be read as a deployment date.
+ * The eight-digit branch stays a bare digit run on purpose: tightening it to a real calendar date
+ * would change which ids fold today, which is not what this fixes.
+ */
+const DATED_VARIANT_SUFFIX = /^(\d{8}|(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01]))$/;
+
+function hasDatedSuffix(longer: string, shorter: string): boolean {
+  return longer.startsWith(`${shorter}-`)
+    && DATED_VARIANT_SUFFIX.test(longer.slice(shorter.length + 1));
+}
+
+/**
+ * True when the two ids name the same deployment family and differ only by a date suffix, in
+ * EITHER direction. The fold used to run one way only — configured base against a dated live id —
+ * so a provider that advertises just the base id while the account is entitled to a dated one
+ * (#3024) had that configured id silently dropped from the live catalog while `discovery` still
+ * reported `ok`.
+ */
 export function isDatedVariantId(liveId: string, configuredId: string): boolean {
-  if (!liveId.startsWith(`${configuredId}-`)) return false;
-  return /^\d{8}$/.test(liveId.slice(configuredId.length + 1));
+  return hasDatedSuffix(liveId, configuredId) || hasDatedSuffix(configuredId, liveId);
 }
 
 export const lastDropWarnSignature = new Map<string, string>();

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -3651,12 +3651,81 @@ describe("Codex catalog routed normalization", () => {
     }
   });
 
+  // #3024, end to end: the Alibaba Token Plan shape. The account is entitled to a dated id that
+  // upstream advertises only under its base id, so the configured id used to vanish from the live
+  // catalog while `discovery` still reported ok.
+  test("configured dated id is retained when live advertises only the base (issue #3024)", async () => {
+    clearModelCache("token-plan");
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      data: [
+        { id: "deepseek-v4-pro" },
+        { id: "deepseek-v4-flash-0731" },
+        { id: "qwen3.8-max" },
+      ],
+    }), { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
+    try {
+      const models = await gatherRoutedModels({
+        providers: {
+          "token-plan": {
+            baseUrl: "https://example.invalid",
+            adapter: "openai-chat",
+            authMode: "key",
+            apiKey: "k",
+            models: [
+              "qwen3.8-max",
+              "deepseek-v4-pro",
+              "deepseek-v4-pro-0813",
+              "deepseek-v4-flash-0731",
+              "deepseek-retired-9",
+            ],
+          },
+        },
+      });
+      const ids = models.map(m => m.id);
+      expect(ids).toContain("deepseek-v4-pro-0813"); // the id the report loses
+      expect(ids).toContain("deepseek-v4-pro"); // base still advertised upstream
+      expect(ids).toContain("deepseek-v4-flash-0731"); // four-digit id advertised verbatim
+      expect(ids).not.toContain("deepseek-retired-9"); // no live relative: still drops
+    } finally {
+      globalThis.fetch = originalFetch;
+      clearModelCache("token-plan");
+    }
+  });
+
   test("isDatedVariantId matches only <alias>-YYYYMMDD", () => {
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4-5")).toBe(true);
     expect(isDatedVariantId("claude-haiku-4-5-2025", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-latest", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5", "claude-haiku-4-5")).toBe(false);
     expect(isDatedVariantId("claude-haiku-4-5-20251001", "claude-haiku-4")).toBe(false);
+  });
+
+  // #3024: the fold ran one direction only and accepted one suffix width, so an account entitled
+  // to a dated id that upstream advertises only under its base id lost that configured id.
+  test("isDatedVariantId folds a four-digit MMDD suffix", () => {
+    expect(isDatedVariantId("deepseek-v4-pro-0813", "deepseek-v4-pro")).toBe(true);
+    expect(isDatedVariantId("deepseek-v4-flash-0731", "deepseek-v4-flash")).toBe(true);
+    expect(isDatedVariantId("model-1231", "model")).toBe(true);
+    expect(isDatedVariantId("model-0101", "model")).toBe(true);
+  });
+
+  test("isDatedVariantId folds in both directions", () => {
+    // configured dated, live base — the shape in the report.
+    expect(isDatedVariantId("deepseek-v4-pro", "deepseek-v4-pro-0813")).toBe(true);
+    expect(isDatedVariantId("claude-haiku-4-5", "claude-haiku-4-5-20251001")).toBe(true);
+  });
+
+  // A numeric suffix is not automatically a date. Month and day are range-checked so an ordinary
+  // one cannot be swallowed and aliased onto an unrelated live row's metadata.
+  test("isDatedVariantId refuses numeric suffixes that are not dates", () => {
+    expect(isDatedVariantId("model-4096", "model")).toBe(false);  // context size, month 40
+    expect(isDatedVariantId("model-1332", "model")).toBe(false);  // month 13
+    expect(isDatedVariantId("model-0000", "model")).toBe(false);  // month 00
+    expect(isDatedVariantId("model-0230", "model")).toBe(true);   // 02-30: calendar-invalid, width-valid
+    expect(isDatedVariantId("model-1240", "model")).toBe(false);  // day 40
+    expect(isDatedVariantId("model-081", "model")).toBe(false);   // three digits
+    expect(isDatedVariantId("model-08133", "model")).toBe(false); // five digits
   });
 
   test("disabled providers are excluded from routed model gathering", async () => {


### PR DESCRIPTION
Fixes #3024.

## Summary

`mergeConfiguredModelsIntoLiveCatalog` keeps a configured id when live discovery returns the same deployment under a date-suffixed id. `isDatedVariantId` decided that, and it was wrong in two independent ways:

1. it accepted only an eight-digit `YYYYMMDD` suffix, and
2. it folded only `configured = base` against `live = dated`.

Both halves have to hold for the reported case. Alibaba Token Plan entitles the account to `deepseek-v4-pro-0813` while upstream `GET /models` advertises just `deepseek-v4-pro`, so neither the four-digit suffix nor the reverse direction matched and the configured id was removed from the authoritative live catalog — **silently**, since `GET /api/providers` still reported `discovery: { "status": "ok" }`. The reporter verified the model is callable both directly upstream and through the proxy.

```ts
const DATED_VARIANT_SUFFIX = /^(\d{8}|(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01]))$/;

export function isDatedVariantId(liveId: string, configuredId: string): boolean {
  return hasDatedSuffix(liveId, configuredId) || hasDatedSuffix(configuredId, liveId);
}
```

## Two deliberate limits

**The four-digit branch range-checks month and day.** A numeric suffix is not automatically a date — a `-4096` context size or a `-2025` year must not be read as a deployment date and aliased onto an unrelated live row's metadata. Covered by a test.

**The eight-digit branch stays a bare digit run.** Tightening it to a real calendar date would change which ids fold today, which is not what this fixes.

The fold still requires a live relative, so an id with no live counterpart drops exactly as before.

## Verification

Reverting `isDatedVariantId` to its previous body turns all four new cases red, including the end-to-end one:

```
(fail) isDatedVariantId folds a four-digit MMDD suffix
(fail) isDatedVariantId folds in both directions
(fail) isDatedVariantId refuses numeric suffixes that are not dates
(fail) configured dated id is retained when live advertises only the base (issue #3024)
```

The end-to-end test reproduces the report's shape — upstream advertises `deepseek-v4-pro` and `deepseek-v4-flash-0731`, config lists both plus `deepseek-v4-pro-0813` and a `deepseek-retired-9` with no live relative — and asserts the first three survive while the last still drops.

- `bun run test` — **16628 pass, 14 skip, 0 fail, exit 0**; all six serial lanes green.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `tests/codex-catalog.test.ts` — 226 pass / 0 fail.

## One tradeoff worth stating

A provider that genuinely **retires** a dated id while keeping its base will now keep that id advertised, where dropping it was the right answer. The fold cannot distinguish "unadvertised but callable" from "retired".

The forward direction already carried the mirror image of this risk and was accepted. The cost of today's behaviour is concrete and reported: an entitled, verified-callable model disappears from the dashboard, `ocx models live`, and the Codex model picker, with no signal on any API surface.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of dated model variants during model discovery.
  * Supports both full-date (`YYYYMMDD`) and short-date (`MMDD`) variant formats.
  * Prevents unrelated numeric suffixes from being incorrectly interpreted as dates.
* **Tests**
  * Added coverage for matching dated and base model IDs in either direction.
  * Added validation for accepted and rejected date suffix formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->