### PR TITLE
fix(openai): exclude user-owned alias overlays from canonical seed validation

### DIFF
--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -587,6 +587,17 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
     // validation and then rejected by the seed comparison, so canonical OpenAI could never
     // set OR clear it — the value was admitted and then refused in the same request.
     delete canonicalCandidate.annotateEmptyToolOutputs;
+    // Alias fields are user-owned display/routing overlays written by the alias management
+    // API (PUT /api/providers/{name}/alias, /model-aliases, /api/default-aliases) and read at
+    // runtime (provider.defaultAliases ?? config.defaultModelAliases; provider.alias in
+    // router.ts; modelAliases via effectiveModelAliases). None of them alter the canonical
+    // transport identity (adapter/baseUrl/authMode/apiKeyTransport), and without these
+    // exclusions the same admitted-then-refused failure hit any canonical OpenAI provider
+    // that had ever set an alias: the seed comparison rejected the very next full-object
+    // write with "must equal the canonical built-in provider seed".
+    delete canonicalCandidate.alias;
+    delete canonicalCandidate.modelAliases;
+    delete canonicalCandidate.defaultAliases;
     const canonical = seed && sameCanonicalProviderSeed(canonicalCandidate, seed);
     if (!canonical) {
       return `provider ${name} must equal the canonical built-in provider seed`;

--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -587,17 +587,6 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
     // validation and then rejected by the seed comparison, so canonical OpenAI could never
     // set OR clear it — the value was admitted and then refused in the same request.
     delete canonicalCandidate.annotateEmptyToolOutputs;
-    // Alias fields are user-owned display/routing overlays written by the alias management
-    // API (PUT /api/providers/{name}/alias, /model-aliases, /api/default-aliases) and read at
-    // runtime (provider.defaultAliases ?? config.defaultModelAliases; provider.alias in
-    // router.ts; modelAliases via effectiveModelAliases). None of them alter the canonical
-    // transport identity (adapter/baseUrl/authMode/apiKeyTransport), and without these
-    // exclusions the same admitted-then-refused failure hit any canonical OpenAI provider
-    // that had ever set an alias: the seed comparison rejected the very next full-object
-    // write with "must equal the canonical built-in provider seed".
-    delete canonicalCandidate.alias;
-    delete canonicalCandidate.modelAliases;
-    delete canonicalCandidate.defaultAliases;
     const canonical = seed && sameCanonicalProviderSeed(canonicalCandidate, seed);
     if (!canonical) {
       return `provider ${name} must equal the canonical built-in provider seed`;

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -105,6 +105,63 @@ type ProviderPatchApplication =
       headersTouched: boolean;
     };
 
+const PROVIDER_ALIAS_OVERLAY_FIELDS = ["alias", "modelAliases", "defaultAliases"] as const;
+type ProviderAliasOverlayField = typeof PROVIDER_ALIAS_OVERLAY_FIELDS[number];
+
+/**
+ * Alias overlays are owned by the dedicated alias management routes. A full provider POST
+ * may round-trip an already-persisted value, but it must not create, clear, or change one.
+ * PATCH is field-masked and rejects these keys outright below.
+ */
+function providerAliasOverlayOwnershipError(
+  submitted: Record<string, unknown>,
+  existing: OcxProviderConfig | undefined,
+): string | null {
+  for (const field of PROVIDER_ALIAS_OVERLAY_FIELDS) {
+    if (!Object.hasOwn(submitted, field)) continue;
+    if (!existing || !Object.hasOwn(existing, field)) {
+      return `${field} is managed by the dedicated alias API`;
+    }
+    const incoming = submitted[field];
+    const persisted = existing[field];
+    if (field === "modelAliases") {
+      if (!isPlainRecord(incoming) || !isPlainRecord(persisted)) {
+        return "modelAliases is managed by the dedicated alias API";
+      }
+      const incomingEntries = Object.entries(incoming);
+      const persistedEntries = Object.entries(persisted);
+      if (
+        incomingEntries.length !== persistedEntries.length
+        || incomingEntries.some(([model, alias]) => typeof alias !== "string" || persisted[model] !== alias)
+      ) {
+        return "modelAliases is managed by the dedicated alias API";
+      }
+      continue;
+    }
+    if (incoming !== persisted) return `${field} is managed by the dedicated alias API`;
+  }
+  return null;
+}
+
+/** Remove only alias overlays whose ownership has already been established by the caller. */
+function providerTransportValidationCandidate(provider: Record<string, unknown>): Record<string, unknown> {
+  const candidate = { ...provider };
+  for (const field of PROVIDER_ALIAS_OVERLAY_FIELDS) delete candidate[field];
+  return candidate;
+}
+
+/** Preserve the authoritative alias values from the stored provider during a full edit. */
+function restorePersistedAliasOverlays(target: OcxProviderConfig, existing: OcxProviderConfig | undefined): void {
+  for (const field of PROVIDER_ALIAS_OVERLAY_FIELDS) {
+    delete (target as Record<ProviderAliasOverlayField, unknown>)[field];
+    if (!existing || !Object.hasOwn(existing, field)) continue;
+    const value = existing[field];
+    (target as Record<ProviderAliasOverlayField, unknown>)[field] = field === "modelAliases"
+      ? structuredClone(value)
+      : value;
+  }
+}
+
 /**
  * Apply the recognized PATCH field mask onto a provider copy. The caller runs this once
  * for validation and again inside the config mutation lock against the newest provider,
@@ -501,7 +558,10 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       return jsonResponse({ error: "provider reload target unavailable" }, 404);
     }
     const provider = diskConfig.providers[name]!;
-    const providerError = providerManagementConfigError(name, provider)
+    const providerError = providerManagementConfigError(
+      name,
+      providerTransportValidationCandidate(provider as unknown as Record<string, unknown>),
+    )
       ?? providerEmptyToolOutputConfigError(name, provider);
     if (providerError) return jsonResponse({ error: "provider reload target invalid" }, 409);
     const namespaceCollision = codexAccountNamespaceProviderCollisionError(
@@ -561,12 +621,17 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     let body: { name?: unknown; provider?: unknown; setDefault?: boolean };
     try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
     const name = typeof body.name === "string" ? body.name.trim() : "";
-    const providerError = providerManagementConfigError(name, body.provider)
-      ?? providerEmptyToolOutputConfigError(name, body.provider);
+    if (!isPlainRecord(body.provider)) return jsonResponse({ error: "provider must be a plain object" }, 400);
+    const existing = config.providers[name];
+    const aliasOwnershipError = providerAliasOverlayOwnershipError(body.provider, existing);
+    if (aliasOwnershipError) return jsonResponse({ error: aliasOwnershipError }, 400);
+    const transportCandidate = providerTransportValidationCandidate(body.provider);
+    const providerError = providerManagementConfigError(name, transportCandidate)
+      ?? providerEmptyToolOutputConfigError(name, transportCandidate);
     if (providerError) return jsonResponse({ error: providerError }, 400);
-    const serviceTierError = providerServiceTierConfigError(name, body.provider);
+    const serviceTierError = providerServiceTierConfigError(name, transportCandidate);
     if (serviceTierError) return jsonResponse({ error: serviceTierError }, 400);
-    const prov = body.provider ? stripCodexRuntimeProviderFields(body.provider as OcxProviderConfig) : undefined;
+    const prov = stripCodexRuntimeProviderFields(transportCandidate as unknown as OcxProviderConfig);
     // PATCH already clears on null; POST persisted the body as submitted, so a `null` here
     // reached disk and the next loadConfig() refused it. Canonicalize to absent, which is what
     // "clear" means everywhere else.
@@ -630,7 +695,6 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     // has no member for either field, so the add/edit form structurally cannot send them:
     // absence in the request means "not carried", never "the user deleted it". Deletion goes
     // through PATCH with an explicit null (#1409).
-    const existing = config.providers[name];
     if (!submittedRequestPacing && existing?.requestPacing) {
       prov.requestPacing = structuredClone(existing.requestPacing);
     }
@@ -656,6 +720,10 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
         ? { ...existing.modelAutoCompactTokenLimits, ...(prov.modelAutoCompactTokenLimits ?? {}) }
         : { ...existing.modelAutoCompactTokenLimits };
     }
+    // DNS validation above awaits. Re-read the live row so a dedicated alias write that
+    // completed during that wait remains authoritative instead of being overwritten by the
+    // older ownership snapshot used to admit this POST.
+    restorePersistedAliasOverlays(prov, config.providers[name]);
     config.providers[name] = stripRegistryOnlyStaticHeaders(name, prov);
     if (body.setDefault === true) config.defaultProvider = name;
     save(config);
@@ -677,6 +745,8 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     try { rawBody = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
     if (!isPlainRecord(rawBody)) return jsonResponse({ error: "provider patch body must be a plain object" }, 400);
     const keys = Object.keys(rawBody);
+    const aliasField = PROVIDER_ALIAS_OVERLAY_FIELDS.find(field => Object.hasOwn(rawBody, field));
+    if (aliasField) return jsonResponse({ error: `${aliasField} is managed by the dedicated alias API` }, 400);
     const hasMode = Object.hasOwn(rawBody, "codexAccountMode");
     const hasSetDefault = Object.hasOwn(rawBody, "setDefault");
     const canonicalBudgetOnly = name === "openai"
@@ -746,7 +816,10 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     if (applied.editorTouched && !pacingOnly) {
       const providerError = canonicalBudgetOnly
         ? canonicalOpenAiBudgetPatchError(next, rawBody, keys, config)
-        : providerManagementConfigError(name, next)
+        : providerManagementConfigError(
+            name,
+            providerTransportValidationCandidate(next as unknown as Record<string, unknown>),
+          )
           ?? providerEmptyToolOutputConfigError(name, next);
       if (providerError) return jsonResponse({ error: providerError }, 400);
       if (!canonicalBudgetOnly) {
@@ -786,7 +859,10 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       if (replay.editorTouched && !pacingOnly) {
         const syncError = canonicalBudgetOnly
           ? canonicalOpenAiBudgetPatchError(replay.next, rawBody, keys, config)
-          : providerManagementConfigError(name, replay.next)
+          : providerManagementConfigError(
+              name,
+              providerTransportValidationCandidate(replay.next as unknown as Record<string, unknown>),
+            )
             ?? providerEmptyToolOutputConfigError(name, replay.next);
         if (syncError) {
           replayError = syncError;

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -914,56 +914,233 @@ describe("provider management validation", () => {
     }
   });
 
-  // Regression: the alias overlays (defaultAliases, alias, modelAliases) are user-owned
-  // display/routing preferences written by the alias management API (PUT /api/default-aliases,
-  // /api/providers/{name}/alias, /api/providers/{name}/model-aliases) and read at runtime
-  // (defaultAliasesEnabled, router.ts alias lookup, effectiveModelAliases). They never alter
-  // the canonical transport identity, so the seed comparison must ignore them exactly like
-  // requestPacing and modelCosts already do. Before the fix, a canonical OpenAI provider that
-  // had ever set any alias was permanently locked out of full-object writes (POST/PATCH/PUT)
-  // with "must equal the canonical built-in provider seed".
-  test("canonical seed comparison ignores user-owned alias overlays", () => {
-    expect(providerManagementConfigError("openai", { ...canonicalDirect, defaultAliases: true })).toBeNull();
-    expect(providerManagementConfigError("openai", { ...canonicalDirect, defaultAliases: false })).toBeNull();
-    expect(providerManagementConfigError("openai", {
-      ...canonicalDirect,
-      alias: "my-openai",
+  test("full provider edit preserves aliases owned by the dedicated APIs", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const overlays = {
+      alias: "codex-native",
       modelAliases: { "gpt-5.6-luna": "luna" },
-    })).toBeNull();
-    expect(providerManagementConfigError("openai", {
-      ...canonicalDirect,
-      defaultAliases: true,
-      alias: "my-openai",
-      modelAliases: { "gpt-5.6-luna": "luna" },
-    })).toBeNull();
+      defaultAliases: false,
+    } as const;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: { openai: { ...canonicalDirect, ...overlays } },
+    } as OcxConfig);
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError").mockResolvedValue(null);
+    const server = startServer(0);
+    try {
+      // The dashboard's full editor omits alias-owned fields. The stored values must survive.
+      const omitted = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "openai", provider: canonicalDirect }),
+      });
+      expect(omitted.status).toBe(200);
+      expect(loadConfig().providers.openai).toMatchObject(overlays);
+
+      // A full-object client may round-trip the exact stored values, but still does not own them.
+      const roundTrip = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "openai", provider: { ...canonicalDirect, ...overlays } }),
+      });
+      expect(roundTrip.status).toBe(200);
+      expect(loadConfig().providers.openai).toMatchObject(overlays);
+    } finally {
+      resolvedError.mockRestore();
+      await server.stop(true);
+    }
   });
 
-  test("canonical seed guard still rejects transport tampering alongside alias overlays", () => {
-    // The alias exclusions must not weaken the canonical guard: mutating the transport
-    // identity (baseUrl / adapter / authMode) is still rejected even when alias overlays
-    // are present on the same payload.
-    expect(providerManagementConfigError("openai", {
-      ...canonicalDirect,
+  test("general provider writes cannot introduce a provider alias collision", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect },
+        deepseek: { adapter: "openai-chat", baseUrl: "https://api.deepseek.com/v1" },
+      },
+    } as OcxConfig);
+    const server = startServer(0);
+    try {
+      const before = readFileSync(join(TEST_DIR, "config.json"));
+      const post = await fetch(new URL("/api/providers", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "openai", provider: { ...canonicalDirect, alias: "deepseek" } }),
+      });
+      expect(post.status).toBe(400);
+
+      const patch = await fetch(new URL("/api/providers?name=openai", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ alias: "deepseek" }),
+      });
+      expect(patch.status).toBe(400);
+      expect(readFileSync(join(TEST_DIR, "config.json"))).toEqual(before);
+      expect(loadConfig().providers.openai?.alias).toBeUndefined();
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("general provider writes reject reserved duplicate and invalid model aliases", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: { openai: { ...canonicalDirect } },
+    } as OcxConfig);
+    const server = startServer(0);
+    try {
+      const before = readFileSync(join(TEST_DIR, "config.json"));
+      for (const modelAliases of [
+        { "gpt-5.6-luna": "gpt-5.6-sol" },
+        { "gpt-5.6-sol": "same", "gpt-5.6-luna": "SAME" },
+        { "gpt-5.6-luna": "not an alias" },
+      ]) {
+        const response = await fetch(new URL("/api/providers", server.url), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "openai", provider: { ...canonicalDirect, modelAliases } }),
+        });
+        expect(response.status).toBe(400);
+      }
+      const patch = await fetch(new URL("/api/providers?name=openai", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ modelAliases: { "gpt-5.6-luna": "luna" } }),
+      });
+      expect(patch.status).toBe(400);
+      expect(readFileSync(join(TEST_DIR, "config.json"))).toEqual(before);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("malformed alias overlays return bounded 4xx without config persistence", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: { openai: { ...canonicalDirect } },
+    } as OcxConfig);
+    const server = startServer(0);
+    try {
+      const before = readFileSync(join(TEST_DIR, "config.json"));
+      for (const overlay of [
+        { defaultAliases: "yes" },
+        { modelAliases: null },
+        { modelAliases: [] },
+        { modelAliases: { "gpt-5.6-luna": 42 } },
+      ]) {
+        const post = await fetch(new URL("/api/providers", server.url), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "openai", provider: { ...canonicalDirect, ...overlay } }),
+        });
+        expect(post.status).toBeGreaterThanOrEqual(400);
+        expect(post.status).toBeLessThan(500);
+
+        const patch = await fetch(new URL("/api/providers?name=openai", server.url), {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(overlay),
+        });
+        expect(patch.status).toBeGreaterThanOrEqual(400);
+        expect(patch.status).toBeLessThan(500);
+      }
+      expect(readFileSync(join(TEST_DIR, "config.json"))).toEqual(before);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("canonical transport tampering stays rejected with persisted alias overlays", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const overlays = {
+      alias: "codex-native",
+      modelAliases: { "gpt-5.6-luna": "luna" },
       defaultAliases: true,
-      baseUrl: "https://attacker.example/backend-api/codex",
-    })).toContain("canonical built-in provider seed");
-    expect(providerManagementConfigError("openai", {
-      ...canonicalDirect,
-      defaultAliases: true,
-      adapter: "openai-chat",
-    })).toContain("canonical built-in provider seed");
-    expect(providerManagementConfigError("openai", {
-      ...canonicalDirect,
-      defaultAliases: true,
-      authMode: "key",
-    })).toContain("canonical built-in provider seed");
-    // Non-openai providers keep their existing behavior: no canonical seed comparison.
-    expect(providerManagementConfigError("deepseek", {
-      adapter: "openai-chat",
-      baseUrl: "https://api.deepseek.com/v1",
-      apiKey: "sk-test",
-      defaultAliases: true,
-    })).toBeNull();
+    } as const;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: { openai: { ...canonicalDirect, ...overlays } },
+    } as OcxConfig);
+    const server = startServer(0);
+    try {
+      for (const tampering of [
+        { baseUrl: "https://attacker.example/backend-api/codex" },
+        { adapter: "openai-chat" },
+        { authMode: "key" },
+      ]) {
+        const response = await fetch(new URL("/api/providers?name=openai", server.url), {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(tampering),
+        });
+        expect(response.status).toBe(400);
+      }
+      expect(loadConfig().providers.openai).toMatchObject({ ...canonicalDirect, ...overlays });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("unrelated non-openai provider edits preserve persisted alias overlays", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "deepseek",
+      providers: {
+        deepseek: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.deepseek.com/v1",
+          alias: "ds",
+          modelAliases: { "deepseek-v4": "ds4-custom" },
+          defaultAliases: false,
+        },
+      },
+    } as OcxConfig);
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError").mockResolvedValue(null);
+    const server = startServer(0);
+    try {
+      const response = await fetch(new URL("/api/providers?name=deepseek", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contextWindow: 128000 }),
+      });
+      expect(response.status).toBe(200);
+      expect(loadConfig().providers.deepseek).toMatchObject({
+        alias: "ds",
+        modelAliases: { "deepseek-v4": "ds4-custom" },
+        defaultAliases: false,
+        contextWindow: 128000,
+      });
+    } finally {
+      resolvedError.mockRestore();
+      await server.stop(true);
+    }
   });
 
   test("canonical OpenAI with defaultAliases can still PATCH modelContextWindows", async () => {

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -1160,7 +1160,7 @@ describe("provider management validation", () => {
     } as OcxConfig);
     // This test targets the seed comparison, not the DNS policy; stub the destination
     // probe so the assertion stays independent of how chatgpt.com resolves locally.
-    spyOn(destinationPolicy, "providerDestinationResolvedError").mockResolvedValue(null);
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError").mockResolvedValue(null);
 
     const server = startServer(0);
     try {
@@ -1174,6 +1174,7 @@ describe("provider management validation", () => {
       // The alias overlay itself must survive the patch untouched.
       expect(loadConfig().providers.openai?.defaultAliases).toBe(true);
     } finally {
+      resolvedError.mockRestore();
       await server.stop(true);
     }
   });

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -914,6 +914,93 @@ describe("provider management validation", () => {
     }
   });
 
+  // Regression: the alias overlays (defaultAliases, alias, modelAliases) are user-owned
+  // display/routing preferences written by the alias management API (PUT /api/default-aliases,
+  // /api/providers/{name}/alias, /api/providers/{name}/model-aliases) and read at runtime
+  // (defaultAliasesEnabled, router.ts alias lookup, effectiveModelAliases). They never alter
+  // the canonical transport identity, so the seed comparison must ignore them exactly like
+  // requestPacing and modelCosts already do. Before the fix, a canonical OpenAI provider that
+  // had ever set any alias was permanently locked out of full-object writes (POST/PATCH/PUT)
+  // with "must equal the canonical built-in provider seed".
+  test("canonical seed comparison ignores user-owned alias overlays", () => {
+    expect(providerManagementConfigError("openai", { ...canonicalDirect, defaultAliases: true })).toBeNull();
+    expect(providerManagementConfigError("openai", { ...canonicalDirect, defaultAliases: false })).toBeNull();
+    expect(providerManagementConfigError("openai", {
+      ...canonicalDirect,
+      alias: "my-openai",
+      modelAliases: { "gpt-5.6-luna": "luna" },
+    })).toBeNull();
+    expect(providerManagementConfigError("openai", {
+      ...canonicalDirect,
+      defaultAliases: true,
+      alias: "my-openai",
+      modelAliases: { "gpt-5.6-luna": "luna" },
+    })).toBeNull();
+  });
+
+  test("canonical seed guard still rejects transport tampering alongside alias overlays", () => {
+    // The alias exclusions must not weaken the canonical guard: mutating the transport
+    // identity (baseUrl / adapter / authMode) is still rejected even when alias overlays
+    // are present on the same payload.
+    expect(providerManagementConfigError("openai", {
+      ...canonicalDirect,
+      defaultAliases: true,
+      baseUrl: "https://attacker.example/backend-api/codex",
+    })).toContain("canonical built-in provider seed");
+    expect(providerManagementConfigError("openai", {
+      ...canonicalDirect,
+      defaultAliases: true,
+      adapter: "openai-chat",
+    })).toContain("canonical built-in provider seed");
+    expect(providerManagementConfigError("openai", {
+      ...canonicalDirect,
+      defaultAliases: true,
+      authMode: "key",
+    })).toContain("canonical built-in provider seed");
+    // Non-openai providers keep their existing behavior: no canonical seed comparison.
+    expect(providerManagementConfigError("deepseek", {
+      adapter: "openai-chat",
+      baseUrl: "https://api.deepseek.com/v1",
+      apiKey: "sk-test",
+      defaultAliases: true,
+    })).toBeNull();
+  });
+
+  test("canonical OpenAI with defaultAliases can still PATCH modelContextWindows", async () => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      // Match a post-migration config (openaiProviderTierVersion set) so the startup
+      // openai tier migration does not rewrite the row: this test targets the seed
+      // comparison, not the one-time legacy migration.
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect, defaultAliases: true },
+      },
+    } as OcxConfig);
+    // This test targets the seed comparison, not the DNS policy; stub the destination
+    // probe so the assertion stays independent of how chatgpt.com resolves locally.
+    spyOn(destinationPolicy, "providerDestinationResolvedError").mockResolvedValue(null);
+
+    const server = startServer(0);
+    try {
+      const patch = await fetch(new URL("/api/providers?name=openai", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ modelContextWindows: { "gpt-5.6-luna": 900000 } }),
+      });
+      expect(patch.status).toBe(200);
+      expect(loadConfig().providers.openai?.modelContextWindows).toEqual({ "gpt-5.6-luna": 900000 });
+      // The alias overlay itself must survive the patch untouched.
+      expect(loadConfig().providers.openai?.defaultAliases).toBe(true);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   // #1409: the add/edit form's payload type has no member for contextWindow or
   test("provider POST overwrite preserves an explicit annotateEmptyToolOutputs: false", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

Canonical OpenAI provider validation compares the persisted provider row against the built-in transport seed.

OpenCodex's dedicated alias APIs can legally persist:

- `defaultAliases`
- `alias`
- `modelAliases`

After one of those overlays exists, an unrelated general provider edit such as a context-window PATCH could fail with:

`provider openai must equal the canonical built-in provider seed`

This validation deadlock is real, but the general provider write path must not become an unvalidated alias writer in order to resolve it.

The revised fix keeps alias ownership at the dedicated APIs:

- A full provider POST may omit alias fields or round-trip values exactly equal to the stored provider. The latest stored alias overlays are restored before persistence.
- A full provider POST cannot create, clear, or change alias overlays.
- General provider PATCH rejects `alias`, `modelAliases`, and `defaultAliases`; callers must use the dedicated alias endpoints.
- Canonical OpenAI transport validation runs against a candidate from which only already-owned stored overlays were removed.

## Safety

The canonical transport guard remains unchanged and continues rejecting changes to:

- `baseUrl`
- `adapter`
- `authMode`
- other canonical transport identity

The dedicated alias APIs remain the only writers that apply provider/combo/account collision checks, model-alias syntax and uniqueness rules, native-family reservations, and boolean shape validation.

Unrelated non-OpenAI provider edits retain their previous behavior and preserve stored aliases.

## Regression coverage

Tests cover:

- full provider edits preserving existing provider, model, and default aliases;
- provider POST/PATCH being unable to introduce a provider alias collision;
- reserved, duplicate, and invalid model aliases remaining rejected;
- non-boolean `defaultAliases` and malformed alias maps returning bounded 4xx without persistence;
- canonical OpenAI with stored aliases successfully PATCHing `modelContextWindows`;
- `baseUrl`, `adapter`, and `authMode` tampering remaining rejected;
- unrelated non-OpenAI edits remaining unchanged;
- the dedicated alias API's case-insensitive collision rules;
- destination-policy test spies being restored so later tests cannot receive a false green result.

## Verification

Exact publication head: `dd60f05d73599991b12e11298f741d34ed84ccbf`  
Exact upstream baseline: `15b0f701eb69d37382880124be9010e412c20411`  
Environment: Bun `1.4.0`, Node `v23.11.0`, identical local DNS/proxy/env.

- `bun test tests/management-provider-validation.test.ts --test-name-pattern "full provider edit preserves aliases|general provider writes cannot introduce|general provider writes reject reserved|malformed alias overlays|canonical transport tampering|unrelated non-openai provider edits|canonical OpenAI with defaultAliases can still PATCH modelContextWindows"` — 7 passed, 0 failed
- `bun test tests/alias-management-api.test.ts tests/provider-model-aliases.test.ts` — 9 passed, 0 failed
- `bun test tests/routing-profile.test.ts --test-name-pattern "alias collision validation"` — 1 passed, 0 failed
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- `git diff --check upstream/dev...HEAD` — passed

Full focused diagnostic under the same environment:

| Tree | Result |
|---|---:|
| PR head `dd60f05d7` | 73 pass / 18 fail |
| exact upstream/dev `15b0f701e` | 66 pass / 18 fail |

The PR adds seven passing regression tests. The 18 failures have the same test names and semantically identical destination-policy errors on both trees; there are no branch-only failures.

<details>
<summary>Identical baseline/environment failure set</summary>

- `provider PATCH sets, clears, and rejects annotateEmptyToolOutputs`
- `provider POST overwrite preserves modelCosts when the payload omits it`
- `provider POST overwrite preserves the account-failover opt-out when the payload omits it (#2568d)`
- `provider POST overwrite preserves an explicit annotateEmptyToolOutputs: false`
- `provider POST overwrite preserves hand-edited context windows (#1409) > an omitted modelContextWindows keeps the user's map, without registry seed keys`
- `provider POST overwrite preserves hand-edited context windows (#1409) > a submitted modelContextWindows updates that key and keeps the others`
- `provider POST overwrite preserves hand-edited context windows (#1409) > an omitted contextWindow keeps the user's scalar`
- `provider POST overwrite preserves hand-edited context windows (#1409) > a submitted contextWindow still wins`
- `provider POST overwrite preserves hand-edited context windows (#1409) > a brand-new provider still receives the registry seed`
- `provider POST overwrite preserves hand-edited context windows (#1409) > PATCH can still delete a key with an explicit null`
- `provider management rejects runtime metadata and accepts only canonical OpenAI option seeds`
- `provider management does not persist registry-only static auth headers for opencode-free`
- `provider PATCH can enable allowPrivateNetwork and then change baseUrl to localhost`
- `provider PATCH persists liveModels and provider metadata exposes the normalized state`
- `provider PATCH persists and clears structured-output model opt-outs`
- `provider management rejects POST setDefault for a disabled provider`
- `provider PATCH field-mask edits non-reserved providers and rejects unsafe fields (WP040)`
- `provider PATCH manages custom headers with merge and clear semantics`

</details>

All failures originate from this host's Clash/Mihomo fake-IP DNS mapping `.example` / `.example.test` fixtures into `198.18.0.0/15`, after which the existing destination policy correctly returns 400 instead of the tests' expected 200. Evidence from the same shell:

```text
relay.example       198.18.0.235
api.example.test    198.18.0.236
extra2.example.test 198.18.0.240
agw.example.test    198.18.0.241
```

This is an exact upstream baseline condition, not a PR regression.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved configured provider aliases during provider updates and reloads.
  - Prevented unauthorized or malformed alias changes from being saved.
  - Improved validation for provider submissions, including invalid request bodies and alias conflicts.
  - Protected canonical provider connection settings while allowing supported model configuration updates.
  - Ensured failed provider changes return an error without partially saving data.

- **Tests**
  - Added coverage for alias preservation, validation failures, collision handling, and model context-window updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->