### PR TITLE
fix(openai): allow canonical fake-IP addresses on provider PATCH

### DIFF
--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -752,7 +752,13 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       if (!canonicalBudgetOnly) {
         const serviceTierError = providerServiceTierConfigError(name, next);
         if (serviceTierError) return jsonResponse({ error: serviceTierError }, 400);
-        const resolvedError = await providerDestinationResolvedError(name, next);
+        // Same DNS gate as POST and re-enable: the canonical built-in OpenAI forward
+        // provider may resolve through Clash/Mihomo fake-IP DNS (198.18.0.0/15), so the
+        // ordinary PATCH must not reject the very same destination the provider was
+        // created with. Loopback, RFC1918, metadata, and mixed dangerous answers still
+        // fail closed; nothing else gains the exception.
+        const allowBenchmarkAddresses = name === "openai" && isCanonicalOpenAiForwardProvider(next);
+        const resolvedError = await providerDestinationResolvedError(name, next, { allowBenchmarkAddresses });
         if (resolvedError) return jsonResponse({ error: resolvedError }, 400);
       }
     } else if (applied.enablingOpenAi) {

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -2462,6 +2462,149 @@ describe("provider management validation", () => {
     }
   });
 
+  test("canonical OpenAI PATCH passes allowBenchmarkAddresses into destination resolution", async () => {
+    // The ordinary field-mask PATCH resolves the SAME canonical chatgpt.com destination
+    // POST and re-enable already admit. Without the benchmark opt-in here, a Clash/Mihomo
+    // fake-IP user (chatgpt.com → 198.18.0.0/15) could create the provider but could never
+    // patch a context overlay onto it. Loopback/RFC1918/metadata and mixed dangerous
+    // answers still fail closed (covered by destination-policy-resolved tests and below).
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const liveConfig: OcxConfig = {
+      port: 0,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect },
+      },
+    };
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError")
+      .mockResolvedValue(null);
+
+    try {
+      const patch = async (name: string, body: unknown) => {
+        const request = new Request(`http://127.0.0.1/api/providers?name=${encodeURIComponent(name)}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        return handleManagementAPI(request, new URL(request.url), liveConfig, {
+          createManagementConvergeCodex: catalogConvergenceFactory(),
+        });
+      };
+
+      const canonical = await patch("openai", { modelContextWindows: { "gpt-5.6-luna": 900000 } });
+      expect(canonical?.status).toBe(200);
+      expect(resolvedError).toHaveBeenCalledWith(
+        "openai",
+        expect.objectContaining({ baseUrl: canonicalDirect.baseUrl }),
+        { allowBenchmarkAddresses: true },
+      );
+    } finally {
+      resolvedError.mockRestore();
+    }
+  });
+
+  test("PATCH destination benchmark exception stays scoped to the canonical openai row", async () => {
+    // A non-canonical openai row and any OpenAI-LOOKING custom provider must not inherit
+    // the fake-IP exception: their PATCHes still fail closed on benchmark answers.
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const liveConfig: OcxConfig = {
+      port: 0,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect },
+        mirror: {
+          adapter: "openai-chat",
+          baseUrl: "https://mirror.example.test/v1",
+          apiKey: "sk-secret-value",
+        },
+        "openai-proxy": {
+          adapter: "openai-chat",
+          baseUrl: "https://mirror.example.test/v1",
+          apiKey: "sk-secret-value",
+        },
+      },
+    };
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError")
+      .mockResolvedValue(
+        "baseUrl hostname mirror.example.test resolves to a benchmark address (198.18.0.30); set allowPrivateNetwork:true only for intentionally local/self-hosted providers",
+      );
+
+    try {
+      const patch = async (name: string, body: unknown) => {
+        const request = new Request(`http://127.0.0.1/api/providers?name=${encodeURIComponent(name)}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        return handleManagementAPI(request, new URL(request.url), liveConfig, {
+          createManagementConvergeCodex: catalogConvergenceFactory(),
+        });
+      };
+
+      const custom = await patch("mirror", { defaultModel: "gpt-x" });
+      expect(custom?.status).toBe(400);
+      expect(resolvedError).toHaveBeenCalledWith(
+        "mirror",
+        expect.anything(),
+        { allowBenchmarkAddresses: false },
+      );
+
+      // Non-canonical row named "openai"-adjacent: no exception either.
+      const openaiProxy = await patch("openai-proxy", { defaultModel: "gpt-x" });
+      expect(openaiProxy?.status).toBe(400);
+      expect(resolvedError).toHaveBeenCalledWith(
+        "openai-proxy",
+        expect.anything(),
+        { allowBenchmarkAddresses: false },
+      );
+    } finally {
+      resolvedError.mockRestore();
+    }
+  });
+
+  test("canonical OpenAI PATCH still rejects non-benchmark private destination answers", async () => {
+    // The benchmark opt-in must not relax the rest of the SSRF guard: if the probe
+    // classifies the canonical destination as loopback/private/metadata, the PATCH fails.
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const liveConfig: OcxConfig = {
+      port: 0,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect },
+      },
+    };
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError")
+      .mockResolvedValue("baseUrl hostname chatgpt.com resolves to a loopback address (127.0.0.1); set allowPrivateNetwork:true only for intentionally local/self-hosted providers");
+
+    try {
+      const request = new Request("http://127.0.0.1/api/providers?name=openai", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ modelContextWindows: { "gpt-5.6-luna": 900000 } }),
+      });
+      const response = await handleManagementAPI(request, new URL(request.url), liveConfig, {
+        createManagementConvergeCodex: catalogConvergenceFactory(),
+      });
+      expect(response?.status).toBe(400);
+      expect(await response?.json()).toMatchObject({
+        error: expect.stringContaining("loopback address"),
+      });
+      expect(resolvedError).toHaveBeenCalledWith(
+        "openai",
+        expect.anything(),
+        { allowBenchmarkAddresses: true },
+      );
+    } finally {
+      resolvedError.mockRestore();
+    }
+  });
+
   test("disabled-only PATCH cannot re-enable a noncanonical openai row unchanged", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

Canonical OpenAI already allows Clash/Mihomo-style `198.18.0.0/15` fake-IP DNS results during provider creation and re-enable.

The ordinary field-mask provider PATCH path did not pass the same `allowBenchmarkAddresses` exception.

As a result, the exact same canonical OpenAI provider could be created successfully but later reject a context-window or other legal provider PATCH with a benchmark-address destination-policy error.

This PR applies the existing canonical OpenAI fake-IP exception consistently to the PATCH path.

## Security

The exception remains limited to:

- the exact canonical built-in OpenAI forward provider
- benchmark/fake-IP addresses already recognized by the existing policy

This does **not** enable `allowPrivateNetwork`.

The existing SSRF protections continue rejecting:

- loopback
- RFC1918
- metadata addresses
- dangerous mixed DNS answers
- custom or OpenAI-like non-canonical providers

## Regression coverage

- canonical OpenAI PATCH passes `allowBenchmarkAddresses: true`
- custom and OpenAI-like providers receive no benchmark exception
- loopback, RFC1918, metadata, and mixed DNS answers remain rejected
- literal benchmark URLs remain rejected
- the exception remains DNS-only and canonical-provider-only

## Verification

- `bun test tests/destination-policy-resolved.test.ts` — 45 passed, 0 failed
- `bun test tests/management-provider-validation.test.ts --test-name-pattern "canonical OpenAI PATCH passes allowBenchmarkAddresses|PATCH destination benchmark exception stays scoped|canonical OpenAI PATCH still rejects non-benchmark private destination answers"` — 3 passed, 0 failed
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- `git diff --check upstream/dev...HEAD` — passed

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated provider edits to correctly support Clash/Mihomo fake-IP DNS responses for the built-in OpenAI provider.
  - Continued blocking unsafe destinations, including loopback, private-network, metadata, and mixed-risk addresses.
  - Custom and OpenAI-lookalike providers remain subject to strict destination validation.

- **Tests**
  - Added coverage for valid fake-IP responses and rejected unsafe destinations during provider updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->