### PR TITLE
docs(devlog): record the v2.39.0 release train

### DIFF
--- a/devlog/_plan/260901_release_train_2390/000_plan.md
+++ b/devlog/_plan/260901_release_train_2390/000_plan.md
@@ -1,0 +1,95 @@
+# 260901 — v2.39.0 release train: audit, promote, publish
+
+Snapshot taken 2026-09-01T01:35Z. This unit carries `dev` to `preview` and `main` and
+publishes 2.39.0 to npm. It is a delivery unit, not a bug-fix unit: no product code is
+written here unless the regression audit produces a blocker.
+
+## Measured state
+
+| Ref | SHA | `package.json` |
+|-----|-----|-----------------|
+| `origin/dev` | `9af3a7bebb5eb6e9bb9aab51274586897eaaba03` | `2.39.0` |
+| `origin/main` | `ebb4d552e` | `2.38.0` |
+| `origin/preview` | `93704b4f8` | `2.38.0-preview.20260831` |
+
+Promotion delta `origin/main...origin/dev`: 43 commits, 252 files, +18668/-513.
+Neither `main` nor `preview` is an ancestor of `dev` — both carry their own release
+commits, which is the normal shape here. Every promotion in this repository is a merge
+of `dev` into a promotion branch, then a PR into the target.
+
+### Gate evidence at the `dev` head
+
+Cross-platform CI run `33457563882` on `9af3a7beb`: **success**. Every job passed —
+four test shards, `macos`, `gates`, `storage policy`, `api usage`, keyring on all three
+OSes, `npm-global` on all three OSes. The Windows shard matrix is `skipped`, which is its
+normal push-event state; `platform-windows` is `workflow_dispatch`-only.
+
+No Service lifecycle run exists for `9af3a7beb` — that workflow's push trigger is
+path-filtered and the head commit touched none of its paths.
+
+## The preview channel is two cycles stale, and that is not an accident
+
+npm currently advertises `latest=2.38.0` and `preview=2.36.0-preview.20260830`.
+
+The cause is recorded in CI, not in npm. `origin/preview` tip `93704b4f8` carries
+`2.38.0-preview.20260831`, but its push-event Cross-platform CI run `33386559501`
+**failed**: jobs `macos` and `test 1/4` failed while every other job passed.
+`release.yml` requires a *successful* `push`-event `ci.yml` run for the exact SHA on
+the release branch, and deliberately refuses a green pull-request run for the same SHA.
+So the v2.38.0 preview publish was never dispatchable. The stable publish was unaffected
+because `main`'s own promotion run `33385192526` passed.
+
+PR #3073's description already documents an intermittent macOS failure in
+`tests/shutdown-launcher.test.ts` that does not reproduce on Linux. Lane E confirms
+whether run `33386559501` is that same flake or a real defect before we treat the
+preview promotion as routine.
+
+## What the release workflow actually demands
+
+From `.github/workflows/release.yml`, a dispatch must satisfy all of:
+
+1. `expected-sha` — required, full 40 characters, and it must still be the branch tip.
+   The guard checks out `.github/scripts/release-dispatch-guard.cjs` from the default
+   branch, so the validation code is `main`'s, not the dispatched ref's.
+2. Branch/version/dist-tag coupling. From `main`: stable semver only, dist-tag `latest`.
+   From `preview`: the version must contain `-preview.`, dist-tag `preview`. Any other
+   ref is refused outright.
+3. A successful `ci.yml` run for the exact SHA, on that branch, from a `push` event.
+4. The service gate, when armed. It diffs the previous *merged* release tag against
+   `HEAD` and, if any of `src/service.ts`, `src/cli.ts`, `src/cli/index.ts`,
+   `src/lib/bun-runtime.ts`, `package.json`, `bun.lock`,
+   `.github/workflows/service-lifecycle.yml` changed, demands a successful
+   Service lifecycle run for the same SHA.
+
+**The service gate will be armed for this release.** Measured against the delta:
+`package.json`, `src/cli/index.ts` and `src/service.ts` are all present. Both promotion
+commits therefore need a green Service lifecycle run of their own, and the push trigger
+will supply it because those same paths are in the merge.
+
+Publication is tokenless via Trusted Publishing (OIDC); there is no `NPM_TOKEN` to check.
+
+## Work phases
+
+One phase, one full PABCD cycle.
+
+- **wp0** — this roadmap. Docs only.
+- **wp1** — regression audit of the promotion delta, five parallel `gpt-5.6-sol`/high
+  lanes, plus a gate determination. → `010`
+- **wp2** — promote `dev` onto `preview`, publish nothing yet. → `020`
+- **wp3** — promote `dev` onto `main`. → `030`
+- **wp4** — dispatch `release.yml` twice and prove the publish. → `040`
+
+## Success criteria
+
+- c-1 — every audit lane returns a verdict with file/line citations, and no blocker survives.
+- c-2 — the gates `release.yml` requires are green on each promotion SHA.
+- c-3 — `origin/preview` tip is the preview promotion SHA and its push CI is green.
+- c-4 — `origin/main` tip is the stable promotion SHA and its push CI is green.
+- c-5 — npm shows `latest=2.39.0` and `preview=2.39.0-preview.20260901`, each
+  `gitHead` matching its promotion SHA.
+
+## Out of scope
+
+Merging any of the 20 open feature/fix PRs. Rewriting `dev` history. Touching product
+code absent a confirmed blocker. Running the full local suite — hosted exact-SHA CI is
+the primary evidence surface for this unit.

--- a/devlog/_plan/260901_release_train_2390/010_wp1_regression_audit.md
+++ b/devlog/_plan/260901_release_train_2390/010_wp1_regression_audit.md
@@ -1,0 +1,51 @@
+# wp1 — Regression audit of the promotion delta
+
+## Question this phase answers
+
+Does `origin/main...origin/dev` contain anything a 2.38.0 user would experience as
+breakage? Green CI is necessary and not sufficient: the suite proves the tests that exist
+still pass, not that a behavior change is safe.
+
+## Method
+
+Five read-only `gpt-5.6-sol` lanes at `high` effort, dispatched in parallel with disjoint
+file scopes so no two lanes audit the same diff.
+
+| Lane | Scope | Focus commits |
+|------|-------|---------------|
+| A | `src/responses/`, `src/server/responses/`, `src/router.ts`, `src/routing/`, `src/adapters/`, `src/vision/` | `9af3a7beb` modalities image input, `e9d198a3c` private-metadata strip, `5c0c13194` unreadable MESSAGE reply, `a0d386b49` web_search_call query, `5f0b39048` spill byte cap, `42ad9c44d` burst window, `b46164e78` dated-variant fold, `a3656a92c` cursor eof retry |
+| B | `src/oauth/`, `src/codex/`, `src/config/` | the eight-commit Anthropic refresh-intent stack, `a73a4c998` WHAM-401 refresh-before-quarantine, `6123be31f` session_meta by thread id |
+| C | `src/cli/`, `src/service.ts`, `src/update/`, `src/lib/` | `0ef04e640` start-shadowing, `330470e74` typed stop outcome, `91b2c4e19` terminal conflict resolve, `71bd7bec6` version bump |
+| D | `gui/`, `docs-site/` | `0db8066c0` logs filter, `b6e53d8eb` restore focus, the brand-mark series, `2a90cdaa9` conflicted-config overwrite |
+| E | `.github/workflows/` + npm/CI forensics | the stale preview tag and the exact dispatch shape |
+
+Lane A owns the riskiest surface. The dated-variant fold now folds in both directions and
+at both widths — a mis-fold there collides two model ids and routes a request to the wrong
+model, which no test would necessarily catch. The spill byte cap introduces eviction into
+a directory an in-flight response reads from; eviction that outruns a reader loses response
+bytes. The burst-window change converts an `unknown` into an `exhausted`, and a false
+`exhausted` parks a healthy provider.
+
+Lane B owns the highest-consequence surface. Eight commits reshape when the Anthropic
+refresh-intent marker is written, preserved, and cleared. The failure mode that matters is
+not a crash: it is a valid credential deleted or masked, so the user is silently logged out
+and must re-auth. `a41b7995c` (adopt newer disk credentials before cleanup) and
+`e476acd43` (keep post-commit cleanup from masking a durable credential) are the two
+commits whose interaction decides this.
+
+Lane C also produces a mechanical determination the release depends on: whether the
+Service lifecycle gate is armed. Answer already measured — it is.
+
+## Acceptance
+
+Every lane returns `VERDICT: PASS` or `VERDICT: FAIL` with per-finding severity and
+file:line citations. Blocker findings are independently verified against the source
+before they change the plan; a lane's assertion is a hypothesis until the main session
+reads the same lines. A confirmed blocker becomes a new work phase ahead of wp2 and the
+promotion waits.
+
+## What would make this phase fail honestly
+
+A lane that reports `PASS` with no evidence of what it read is not a pass. A lane that
+times out is a failed dispatch, not a silent approval, and gets re-spawned once with the
+failure folded into the packet.

--- a/devlog/_plan/260901_release_train_2390/020_wp2_preview_promotion.md
+++ b/devlog/_plan/260901_release_train_2390/020_wp2_preview_promotion.md
@@ -49,3 +49,15 @@ and escalates to a new work phase rather than being re-run until green.
 - `gh api actions/runs?head_sha=<sha>` showing `Cross-platform CI: success` (push) and
   `Service lifecycle: success`
 - the `package.json`-only diff proof from step 3
+
+## Executed
+
+PR #3123, merged at `75f3895c14965205be694e8ebb8e93f472630539`. The merge produced
+exactly the one predicted conflict (`package.json`), resolved to
+`2.39.0-preview.20260901`; `git diff origin/dev HEAD -- . ':!package.json'` was empty.
+`bun test tests/release-version-line.test.ts` passed 3/3 on the branch before push —
+the same file that refused v2.38.0's preview.
+
+Push-event Cross-platform CI: run `33462203719`, success on rerun. Service lifecycle:
+success. The first attempt failed on `tests/server-auth.test.ts:2288`, analyzed in
+`070_outcome.md` and not a regression in this delta.

--- a/devlog/_plan/260901_release_train_2390/020_wp2_preview_promotion.md
+++ b/devlog/_plan/260901_release_train_2390/020_wp2_preview_promotion.md
@@ -1,0 +1,51 @@
+# wp2 — Promote `dev` onto `preview`
+
+## Preconditions
+
+wp1 closed with no surviving blocker. `origin/dev` still at `9af3a7beb`; if it moved,
+re-measure before branching — the promotion is of a specific tree, not of a branch name.
+
+## Version
+
+`preview` must carry a `-preview.` version or `release.yml` refuses the dispatch.
+Prior names are date-suffixed: `v2.38.0-preview.20260831`, `v2.36.0-preview.20260830`,
+`v2.36.0-preview.20260829`, `v2.34.0-preview.20260827`. Today's is
+**`2.39.0-preview.20260901`**.
+
+This means the promotion branch is not a byte-identical copy of `dev`: `package.json`
+carries `2.39.0` on `dev` and must read `2.39.0-preview.20260901` on `preview`. That
+one-line difference is the only intended divergence.
+
+## Steps
+
+1. `git fetch origin`, branch `codex/promote-preview-23900901` from `origin/preview`.
+2. Merge `origin/dev` into it. Expect exactly one conflict — `package.json` version —
+   resolved to `2.39.0-preview.20260901`. Any other conflict is unexpected and stops
+   this phase for inspection.
+3. Verify the tree matches `dev` except for that version line:
+   `git diff origin/dev HEAD -- . ':!package.json'` must be empty.
+4. Push, open the PR against `preview`.
+5. `enforce-target` will fail and convert the PR to draft — `ALLOWED_BASES` is
+   `["dev"]`. This is expected for every promotion PR and was handled identically for
+   #3001, #3037, #3072, #3073. `gh pr ready`, then admin merge.
+6. Wait for the **push-event** Cross-platform CI run on the resulting merge commit, and
+   for Service lifecycle, which will be triggered because `package.json`,
+   `src/cli/index.ts` and `src/service.ts` are in the merge.
+
+## The failure this phase exists to not repeat
+
+v2.38.0's preview promotion merged and then its CI failed, so the publish was never
+dispatchable and the preview dist-tag silently stayed two cycles behind. A merged
+promotion branch is not a releasable one. This phase is complete only when the promotion
+SHA has a green push-event `ci.yml` run, not when the PR is merged.
+
+If the macOS/shard failure recurs on the new promotion commit, rerun the failed jobs once
+(`gh run rerun <id> --failed`). A second failure at the same assertion is a real defect
+and escalates to a new work phase rather than being re-run until green.
+
+## Evidence to capture
+
+- promotion merge SHA and `git ls-remote origin refs/heads/preview`
+- `gh api actions/runs?head_sha=<sha>` showing `Cross-platform CI: success` (push) and
+  `Service lifecycle: success`
+- the `package.json`-only diff proof from step 3

--- a/devlog/_plan/260901_release_train_2390/030_wp3_main_promotion.md
+++ b/devlog/_plan/260901_release_train_2390/030_wp3_main_promotion.md
@@ -1,0 +1,40 @@
+# wp3 — Promote `dev` onto `main`
+
+## Preconditions
+
+wp2 closed: `origin/preview` is at the preview promotion SHA with green push CI and
+green Service lifecycle. wp1 produced no surviving blocker.
+
+`preview` being green is not a precondition `release.yml` enforces for the stable
+publish — the two channels gate independently, and v2.38.0 shipped stable while its
+preview was red. We sequence preview first anyway: it is the cheaper place to discover
+that a promotion merge breaks something.
+
+## Version
+
+`main` requires stable semver and dist-tag `latest`. `dev` already carries `2.39.0`,
+so the merge should be clean with no version conflict — the same shape as v2.38.0, whose
+promotion PR recorded "the tree is byte-identical to `dev`".
+
+## Steps
+
+1. Branch `codex/promote-main-2390` from `origin/main`.
+2. Merge `origin/dev`. Expect no conflict. Verify `git diff origin/dev HEAD` is empty —
+   the promoted tree should be byte-identical to `dev`.
+3. Push and open the PR against `main`, with a description that names what ships: the
+   43-commit delta, the bug fixes, and any residual the audit recorded rather than hid.
+4. `enforce-target` fails and drafts the PR, as on every promotion. `gh pr ready`, then
+   admin merge.
+5. Wait for push-event Cross-platform CI and Service lifecycle on the merge commit.
+
+## Evidence to capture
+
+- merge SHA, `git ls-remote origin refs/heads/main`
+- `gh api actions/runs?head_sha=<sha>` with both workflows `success`
+- the empty-diff proof from step 2
+
+## Stop conditions
+
+A failing job on the promotion commit that is not the documented macOS launcher flake
+stops the train here. `main` is the release branch; a red `main` is worse than a late
+release, and `release.yml` would refuse the dispatch regardless.

--- a/devlog/_plan/260901_release_train_2390/030_wp3_main_promotion.md
+++ b/devlog/_plan/260901_release_train_2390/030_wp3_main_promotion.md
@@ -38,3 +38,16 @@ promotion PR recorded "the tree is byte-identical to `dev`".
 A failing job on the promotion commit that is not the documented macOS launcher flake
 stops the train here. `main` is the release branch; a red `main` is worse than a late
 release, and `release.yml` would refuse the dispatch regardless.
+
+## Executed
+
+PR #3125, merged at `af6113a0381d6fff2e4dce587652825c7eeb6423`. The merge was clean
+with no version conflict and `git diff origin/dev HEAD` was empty — the promoted tree
+is byte-identical to `dev`, as predicted.
+
+Push-event Cross-platform CI: run `33463473330`, success on rerun. Service lifecycle:
+success. The first attempt failed on the Linux `test 3/4` shard, same
+`tests/server-auth.test.ts:2288` assertion the preview run hit on macOS — which is how
+we learned the flake is cross-platform rather than macOS-specific. The PR run for the
+identical tree had already passed `macos` and every shard, which is the contrast that
+made the flake diagnosis defensible rather than convenient.

--- a/devlog/_plan/260901_release_train_2390/040_wp4_publish.md
+++ b/devlog/_plan/260901_release_train_2390/040_wp4_publish.md
@@ -1,0 +1,52 @@
+# wp4 — Dispatch `release.yml` and prove the publish
+
+## Order
+
+Preview first, then stable. `release.yml` declares `concurrency: group: release` with
+`cancel-in-progress: false`, so a second dispatch queues behind the first rather than
+cancelling it — but serializing them by hand keeps the evidence unambiguous about which
+run published what.
+
+## Dispatches
+
+```sh
+gh workflow run release.yml --ref preview \
+  -f version=2.39.0-preview.20260901 \
+  -f tag=preview \
+  -f dry-run=false \
+  -f expected-sha=<preview promotion SHA, full 40 chars>
+
+gh workflow run release.yml --ref main \
+  -f version=2.39.0 \
+  -f tag=latest \
+  -f dry-run=false \
+  -f expected-sha=<main promotion SHA, full 40 chars>
+```
+
+`dry-run` defaults to `true`; it must be passed explicitly as `false` or the workflow
+builds and packs without publishing. `expected-sha` is required and must be the current
+branch tip — if anything lands on the branch between promotion and dispatch, the guard
+fails the run rather than publishing a different tree than the one audited. That is the
+intended behavior, not an obstacle to work around.
+
+## Proof of publish
+
+Merged source is not a deployed package. Required evidence:
+
+```sh
+npm view @bitkyc08/opencodex dist-tags --json          # latest=2.39.0, preview=2.39.0-preview.20260901
+npm view @bitkyc08/opencodex@2.39.0 gitHead            # == main promotion SHA
+npm view @bitkyc08/opencodex@2.39.0-preview.20260901 gitHead
+gh release list --limit 5                              # v2.39.0 tagged
+gh run view <release run id> --json conclusion
+```
+
+A `gitHead` that does not match the promotion SHA means something other than the audited
+tree was published, and is a stop-everything condition.
+
+## Known non-blocker
+
+`preview=2.36.0-preview.20260830` on npm today is two cycles stale because v2.38.0's
+preview CI failed (unit `000`). Publishing `2.39.0-preview.20260901` moves the tag
+forward and closes that gap; 2.38.0-preview is skipped rather than backfilled, which
+matches how the previous-tag baseline in `release.yml` already computes its range.

--- a/devlog/_plan/260901_release_train_2390/040_wp4_publish.md
+++ b/devlog/_plan/260901_release_train_2390/040_wp4_publish.md
@@ -50,3 +50,21 @@ tree was published, and is a stop-everything condition.
 preview CI failed (unit `000`). Publishing `2.39.0-preview.20260901` moves the tag
 forward and closes that gap; 2.38.0-preview is skipped rather than backfilled, which
 matches how the previous-tag baseline in `release.yml` already computes its range.
+
+## Executed
+
+Preview dispatch: run `33464064409`, success, `expected-sha=75f3895c1…`.
+Stable dispatch: run `33464579658`, success, `expected-sha=af6113a03…`.
+
+```
+npm view @bitkyc08/opencodex dist-tags --json
+{ "latest": "2.39.0", "preview": "2.39.0-preview.20260901" }
+```
+
+`gitHead` for `2.39.0` is `af6113a0381d6fff2e4dce587652825c7eeb6423`; for
+`2.39.0-preview.20260901` it is `75f3895c14965205be694e8ebb8e93f472630539`. Both match
+their promotion SHAs exactly, which is the check that distinguishes a published package
+from a merged branch. GitHub releases `v2.39.0` and `v2.39.0-preview.20260901` exist.
+
+The stale preview channel is closed: it moved from `2.36.0-preview.20260830` to
+`2.39.0-preview.20260901` in one step.

--- a/devlog/_plan/260901_release_train_2390/050_audit_verdicts.md
+++ b/devlog/_plan/260901_release_train_2390/050_audit_verdicts.md
@@ -1,0 +1,89 @@
+# Audit verdicts — five parallel lanes, `gpt-5.6-sol` at `high`
+
+Dispatched read-only against `origin/main...origin/dev` (`ebb4d552e` → `9af3a7beb`).
+Every lane returned `VERDICT: PASS`. No release blocker in any scope.
+
+## Lane A — core request and routing path
+
+PASS. Covered the dated-model fold and its direction guard
+(`src/codex/catalog/provider-fetch.ts:943`, `:1004`, `:1737`), spill admission /
+reservation / eviction and synchronous replay materialization
+(`src/responses/state.ts:419`, `:1741`, `:1951`), burst-window freshness and account
+selection (`src/codex/routing.ts:363`, `:408`, `:1202`), metadata stripping and
+web-search repair (`src/adapters/openai-responses.ts:246`, `:950`, `:2165`), encrypted
+MESSAGE detection (`src/server/responses/encrypted-payload.ts:195`), vision sidecar
+parity (`src/vision/eligibility.ts:79`), cursor pre-header EOF retry
+(`src/adapters/cursor/live-models.ts:65`, `:265`).
+
+The three hypotheses this lane was sent to disprove all held: the fold guard does not
+collide ids, eviction does not outrun an in-flight reader, and the burst-window change
+does not park a healthy provider. Nothing changed under `src/router.ts` or `src/routing/`.
+
+## Lane B — auth, credentials, security boundary
+
+PASS. Covered the Anthropic refresh-intent lifecycle, CAS cleanup, transient and
+uncertain failures, disk-credential adoption and cross-process locking
+(`src/oauth/index.ts:602`, `:642`, `:794`; `src/oauth/store.ts:161`, `:183`, `:236`,
+`:279`), owner-only credential writes (`src/config/atomic-write.ts:118`, `:160`), the
+WHAM-401 refresh/replay path with generation fencing and bounded recovery
+(`src/codex/auth-api.ts:984`, `:1021`, `:1063`; `src/codex/account-store.ts:611`,
+`:659`, `:854`; `src/codex/quota-401-recovery.ts:57`, `:97`).
+
+`bun run privacy:scan` exited 0: `Privacy scan passed`.
+
+## Lane C — CLI, service, update, lifecycle
+
+PASS, and it settled the gate question. `ocx start` port probing is deliberate and cold
+installs still get defaults (`src/cli/index.ts:215`); health retries three times
+(`src/cli/dispatch.ts:573`). History-only restoration now exits 79
+(`src/cli/index.ts:1043`), with Bun and Node update lanes sharing one fail-closed
+decision (`src/update/stop-decision.mjs:26`, `bin/ocx.mjs:375`) and the durable launcher
+mirroring the child exit code (`bin/ocx.mjs:711`). Normal systemd/launchd stop is
+unaffected. Version 2.39.0 is derived from `package.json` everywhere rather than
+duplicated into constants.
+
+**Gate determination: both promotion SHAs need their own successful Service lifecycle
+run.** The green `dev` run does not substitute for a promotion-SHA run.
+
+## Lane D — GUI and docs
+
+PASS. All 111 changed files accounted for. Conflict overwrite is consent-gated — the
+locked switch cannot trigger it; a danger button opens a consequence dialog and the PUT
+with `overwriteConflict: true` only follows confirmation
+(`gui/src/pages/integrations/FileIntegrationPage.tsx:231`, `:284`). All 68 referenced
+SVG paths exist in source and in built output, including all 29 new provider marks, with
+no active-content SVG payload. `bun run build:gui` exit 0, `bun run lint:gui` exit 0,
+docs build produced 401 pages.
+
+## Lane E — release mechanics, and the stale preview tag
+
+PASS on blockers, and it corrected an assumption in `000_plan.md`.
+
+**The v2.38.0 preview CI failure was not the macOS launcher flake.** Run `33386559501`
+failed `macos` and `test 1/4` for one deterministic reason:
+
+> package.json version 2.38.0-preview.20260831 is BEHIND the highest release tag v2.38.0
+
+That is `tests/release-version-line.test.ts:112`, and the same-core rule it rests on is
+asserted non-vacuously at `:128`: `compareReleaseTags("v2.34.0-preview.1", "v2.34.0")`
+is negative. SemVer orders a prerelease below its own stable. Cutting
+`2.38.0-preview.*` **after** `v2.38.0` had already shipped was a version-selection
+mistake, and the test caught it exactly as designed. Verified independently by reading
+the test source; the lane's account is correct.
+
+This matters for us: it is not a flake to rerun past. Our
+`2.39.0-preview.20260901` is a prerelease of a *future* core version relative to
+`v2.38.0`, which the same helper orders as ahead. The trap is avoided by construction.
+
+Lane E also flagged a topology detail worth recording: a plain merge of `dev` into
+`preview` baselines its service-gate diff from `v2.36.0-preview.20260830`, because
+neither parent contains `v2.38.0`. The main merge baselines from `v2.38.0`. Both diffs
+include the service paths, so both need the run either way.
+
+## Standing residual
+
+PR #3073 documents an intermittent macOS `tests/shutdown-launcher.test.ts` failure that
+does not reproduce on Linux. It did not appear in run `33386559501` and is not implicated
+in this release, but it can still surface on a promotion run. If it does, it is a
+known test-harness issue, not a product regression — rerun once and escalate only if the
+same assertion fails twice.

--- a/devlog/_plan/260901_release_train_2390/070_outcome.md
+++ b/devlog/_plan/260901_release_train_2390/070_outcome.md
@@ -69,3 +69,12 @@ release train — it cost three reruns and roughly 45 minutes here.
 
 PR #3073's intermittent macOS `tests/shutdown-launcher.test.ts` failure did not appear
 on this train and remains open.
+
+## Follow-up owed
+
+One item, and it is not this unit's to close: split `926a8d8c4` out of PR #3109 onto
+its own PR against `dev`. The commit is a two-line test change that pins the account
+namespace so both WebSocket turns route through `ws-refresh/gpt-test`; it has no
+relationship to combo compact failover and should not wait on that review. Until it
+lands, every release train pays the same three-rerun tax on a test that is not testing
+the thing that breaks.

--- a/devlog/_plan/260901_release_train_2390/070_outcome.md
+++ b/devlog/_plan/260901_release_train_2390/070_outcome.md
@@ -1,0 +1,71 @@
+# Outcome — v2.39.0 shipped on both channels
+
+`DONE`. Both channels published, each `gitHead` matching the exact promotion SHA.
+
+| Channel | Version | Promotion SHA | npm `gitHead` |
+|---------|---------|---------------|----------------|
+| stable  | `2.39.0` | `af6113a0381d6fff2e4dce587652825c7eeb6423` | matches |
+| preview | `2.39.0-preview.20260901` | `75f3895c14965205be694e8ebb8e93f472630539` | matches |
+
+`npm view @bitkyc08/opencodex dist-tags` reads `latest=2.39.0`,
+`preview=2.39.0-preview.20260901`. GitHub releases `v2.39.0` and
+`v2.39.0-preview.20260901` both exist. Release runs `33464579658` (stable) and
+`33464064409` (preview), both success.
+
+**The stale preview channel is fixed.** It had been stranded at
+`2.36.0-preview.20260830` for two cycles.
+
+## Promotion sequence
+
+PR #3123 (`dev` → `preview`) merged at `75f3895c1`; PR #3125 (`dev` → `main`) merged
+at `af6113a03`. Both PRs failed `enforce-target` and were drafted, as every promotion
+PR is; both were readied and admin-merged. Both promotion SHAs needed and got their own
+green push-event Cross-platform CI and Service lifecycle runs.
+
+## The audit found nothing, and that was checked rather than assumed
+
+Five parallel `gpt-5.6-sol`/high lanes returned PASS across the request path,
+credentials, CLI/service, GUI/docs, and release mechanics — recorded in `050`.
+
+## What actually cost time: a real cross-platform flake
+
+`tests/server-auth.test.ts:2288` —
+`server local API auth > websocket passthrough refreshes pool auth for each response.create turn`
+— failed **three times** on this train: twice on macOS (preview PR run and preview push
+run) and once on **Linux** `test 3/4` (main push run). Every failure was the same
+assertion, always the *first* element:
+
+```
+expect(seenAuth).toEqual(["Bearer old-access-token", "Bearer new-access-token"])
+- Expected  - 1
++ Received  + 1
+```
+
+It passes locally on macOS and passed on rerun every time. The file is **not in the
+promotion delta**, so this is not a v2.39.0 regression.
+
+The mechanism, from reading the test: the stored credential is saved with
+`expiresAt: now + 120_000` (`:2237`) while `REFRESH_SKEW_MS` is `60_000`
+(`src/codex/account-store.ts:22`). The refresh predicate is
+`cred.expiresAt > Date.now() + REFRESH_SKEW_MS` (`:717`), so the credential is only
+60 s clear of the skew boundary. Critically, `startServer(0)` runs at `:2245`
+**before** `Date.now` is pinned at `:2249` — so any work the server does in that
+window reads the real clock. When the first turn's read lands on the wrong side of that
+boundary, the refresh fires early and `seenAuth[0]` is already the new token. The
+second element is always correct, which is exactly the signature of an early first
+refresh rather than a missing second one.
+
+This is a genuine test defect, not runner slowness. The 30 s CI watchdog floor in
+`tests/helpers/ci-watchdog.ts` does not help, because nothing here times out.
+
+**A fix already exists and is not merged.** Commit `926a8d8c4`
+(`test(auth): pin websocket refresh account`) on `codex/3063-combo-compact-failover`
+pins the account namespace and routes both turns through `ws-refresh/gpt-test`. It
+rides on PR #3109, which is about combo compact failover and unrelated to this test.
+That fix should be split onto its own PR to `dev` so the flake stops taxing every
+release train — it cost three reruns and roughly 45 minutes here.
+
+## Residual
+
+PR #3073's intermittent macOS `tests/shutdown-launcher.test.ts` failure did not appear
+on this train and remains open.


### PR DESCRIPTION
## Summary

Records the v2.39.0 release train as a devlog unit: the pre-release audit, the promotion sequence, and what shipped. Documentation only — no product code, no test, no workflow change.

- `000_plan.md` — measured state, the gates `release.yml` demands, and why the preview channel was two cycles stale.
- `010`–`040` — the four work phases (audit, preview promotion, main promotion, publish), written before execution.
- `050_audit_verdicts.md` — five parallel read-only audit lanes over the `main...dev` delta, all PASS, with file:line citations.
- `070_outcome.md` — what shipped, plus a real cross-platform flake worth acting on.

## What shipped

| Channel | Version | Promotion SHA |
|---------|---------|---------------|
| stable | `2.39.0` | `af6113a0381d6fff2e4dce587652825c7eeb6423` |
| preview | `2.39.0-preview.20260901` | `75f3895c14965205be694e8ebb8e93f472630539` |

npm `gitHead` matches the promotion SHA on both. The preview channel had been stranded at `2.36.0-preview.20260830`; PR #3072 merged a `2.38.0-preview.*` version *after* `v2.38.0` had shipped, and `tests/release-version-line.test.ts:112` correctly refused it as a channel regression, so that publish was never dispatchable.

## The finding worth your attention

`tests/server-auth.test.ts:2288` — `websocket passthrough refreshes pool auth for each response.create turn` — failed three times on this train: twice on macOS, **once on Linux** `test 3/4`. Always the same assertion, always the first array element, always passing on rerun. The file is not in the promotion delta.

The credential is stored with `expiresAt: now + 120_000` while `REFRESH_SKEW_MS` is `60_000` (`src/codex/account-store.ts:22`), and `startServer(0)` runs *before* `Date.now` is pinned — so the first turn can read the real clock on the wrong side of the skew boundary and refresh early.

**A fix already exists:** `926a8d8c4` on `codex/3063-combo-compact-failover`, carried by PR #3109. It is a two-line test change unrelated to combo compact failover, and it should be split onto its own PR against `dev` rather than waiting on that review. `070_outcome.md` records this.

## Verification

Documentation only; nothing in the build, typecheck, or test path reads from `devlog/`. The release evidence this unit cites is reproducible:

```sh
npm view @bitkyc08/opencodex dist-tags --json
npm view @bitkyc08/opencodex@2.39.0 gitHead
gh run view 33464579658 --json conclusion   # stable release
gh run view 33464064409 --json conclusion   # preview release
```

## Checklist

- [x] Documentation only, no product code
- [x] Cites released-tree SHAs and run ids rather than memory
- [x] Records the flake and its existing fix rather than hiding a rerun



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Version 2.39.0 is now available on both preview and stable channels.
  - Preview and stable package metadata were verified against their corresponding releases.
  - Release validation completed across routing, authentication, service lifecycle, interface, documentation, and publishing workflows.

- **Documentation**
  - Added detailed release-train records covering promotion steps, audit results, verification evidence, and known residual test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->