### PR TITLE
chore(release): move dev to 2.40.0 after the v2.39.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Moves `dev` to **2.40.0** after the v2.39.0 release. One line in `package.json`, nothing else.

Without this, `dev` carries `2.39.0` — a version that is now published — and `tests/release-version-line.test.ts` fails on `dev` and on **every pull request opened against it**. That is inherited red a contributor cannot fix from their own diff.

## Why 2.40.0

Decided by `scripts/bump-dev-version.ts`, not by hand:

```
$ bun scripts/bump-dev-version.ts v2.39.0 package.json
{"changed":true,"version":"2.40.0","reason":"v2.39.0 is a stable release, so dev moves to the next minor 2.40.0"}
```

The rule is about the published version's shape: a stable `X.Y.Z` means that core is consumed, so `dev` moves to `X.(Y+1).0`. (A published prerelease would instead mean `dev` takes the stable core it belongs to.)

## Why this is a hand-opened PR

`.github/workflows/dev-version-bump.yml` exists to open exactly this PR on `release: published`, and it did not fire — the workflow has **0 runs** since it landed in #3013.

The cause is not a broken workflow. `release.yml` creates the GitHub release with `GH_TOKEN: ${{ github.token }}` ([release.yml:380](https://github.com/lidge-jun/opencodex/blob/main/.github/workflows/release.yml#L380)), and GitHub does not start new workflow runs from events raised by the default `GITHUB_TOKEN`. So a `release: published` trigger can never observe a release this repository publishes itself. The workflow's own header anticipates a missed run and names this exact recovery path:

> Re-drive a missed run by running `bun scripts/bump-dev-version.ts <released> package.json` locally and opening the pull request normally.

That is what this PR is. Worth noting for a follow-up: the same reasoning applies to v2.37.0 and v2.38.0, whose bumps (#3045, #3076) were also opened by hand — so the automation has never actually fired, and the four historical hand-repairs it was written to end are still ongoing. Making it work needs either a PAT/app token on the release step or a different trigger; that is a separate change and out of scope here.

## Verification

The freeness gate the workflow would have run, executed locally on this branch:

```
$ bun test tests/release-version-line.test.ts
 3 pass
 0 fail
```

`2.40.0` is unused: `npm view @bitkyc08/opencodex@2.40.0` is a 404, and `git ls-remote --tags origin 'refs/tags/v2.40.0*'` is empty.

`git diff origin/dev --name-only` is `package.json` alone.

## Checklist

- [x] Version chosen by the script, not by hand
- [x] Release-version-line gate green on this branch
- [x] Target version unused on npm and in the tag set
- [x] Single-file diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application to version 2.40.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->