### PR TITLE
test(auth): pin the websocket refresh account to stop a cross-platform flake

### DIFF
--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2230,6 +2230,7 @@ describe("server local API auth", () => {
         { id: "main", email: "main@example.test", isMain: true },
         { id: "pool-a", email: "pool@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
       ],
+      codexAccountNamespaces: { "ws-refresh": "pool-a" },
       activeCodexAccountId: "pool-a",
     } as OcxConfig);
     saveCodexAccountCredential("pool-a", {
@@ -2278,10 +2279,10 @@ describe("server local API auth", () => {
       });
 
       await waitForOpen;
-      ws.send(JSON.stringify({ type: "response.create", model: "gpt-test", input: "hello" }));
+      ws.send(JSON.stringify({ type: "response.create", model: "ws-refresh/gpt-test", input: "hello" }));
       await waitForTerminal();
       Date.now = () => now + 180_000;
-      ws.send(JSON.stringify({ type: "response.create", model: "gpt-test", input: "again" }));
+      ws.send(JSON.stringify({ type: "response.create", model: "ws-refresh/gpt-test", input: "again" }));
       await waitForTerminal();
       ws.close();
 


### PR DESCRIPTION
## Summary

Cherry-picks `926a8d8c4` out of #3109 onto its own branch. Two lines of test change; no product code.

`tests/server-auth.test.ts` — `websocket passthrough refreshes pool auth for each response.create turn` — is a real cross-platform flake. It failed **three times** during the v2.39.0 release train: twice on macOS (preview PR run, preview push run) and once on **Linux** `test 3/4` (main push run). Always the same assertion at `:2288`, always the first array element, always green on rerun.

```
expect(seenAuth).toEqual(["Bearer old-access-token", "Bearer new-access-token"])
- Expected  - 1
+ Received  + 1
```

## Why it races

The credential is stored with `expiresAt: now + 120_000` while `REFRESH_SKEW_MS` is `60_000` ([account-store.ts:22](https://github.com/lidge-jun/opencodex/blob/dev/src/codex/account-store.ts#L22)), and the refresh predicate is `cred.expiresAt > Date.now() + REFRESH_SKEW_MS` (`:717`) — only 60 s of clearance. `startServer(0)` runs at `:2245`, **before** `Date.now` is pinned at `:2249`, so work in that window reads the real clock. When the first turn lands on the wrong side of the skew boundary the refresh fires early and `seenAuth[0]` is already the new token. The second element is always correct, which is the signature of an early first refresh rather than a missing second one.

Not runner slowness: nothing times out, so the 30 s CI watchdog floor in `tests/helpers/ci-watchdog.ts` is not involved.

## The fix

Pin the account namespace (`codexAccountNamespaces: { "ws-refresh": "pool-a" }`) and route both turns through `ws-refresh/gpt-test`, so the turn resolves to a fixed account instead of racing account selection against the skew window.

## Why it is being carried here

The commit was authored on `codex/3063-combo-compact-failover` and rides on #3109, which is about routing combo compact requests through the failover path. The two are unrelated, and this flake taxes every release train in the meantime — three reruns and roughly 45 minutes on v2.39.0 alone. #3109 keeps its own commit; this branch carries the same change independently so it can land on its own schedule.

Authorship is preserved by cherry-pick.

## Verification

`git diff origin/dev --stat` is `tests/server-auth.test.ts | 5 +++--` — one file, three insertions, two deletions. Test-only; no `src/` change, so no product behavior moves.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated WebSocket authentication refresh coverage to verify account resolution within the correct namespace.
  * Confirmed refreshed access tokens are used for subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->