### PR TITLE
fix(release): call the dev version bump instead of listening for an event that never fires

### DIFF
--- a/.github/workflows/dev-version-bump.yml
+++ b/.github/workflows/dev-version-bump.yml
@@ -14,18 +14,35 @@ name: Dev version bump
 # sign-off that a bot cannot supply. Until that merge the red persists. This converts a
 # forgotten chore into a queued, reviewable change - not into an automatic repair.
 #
-# A `release` event resolves this workflow file from the repository DEFAULT branch
-# (`main`), not from `dev` - the same trap documented in cleanup-closed-pr-branches.yml.
-# So merging this file to `dev` installs it but arms nothing; it first fires after an
-# ordinary dev -> main promotion carries it there.
+# WHY THIS IS CALLED, NOT TRIGGERED. It used to listen for `release: published`, and in
+# that form it ran ZERO times across v2.37.0, v2.38.0 and v2.39.0 - every one of those
+# bumps was still opened by hand (#3045, #3076, #3127). The workflow was not broken; the
+# event never existed. `release.yml` creates the GitHub release with
+# `GH_TOKEN: ${{ github.token }}`, and GitHub does not start workflow runs from events
+# raised by the default `GITHUB_TOKEN`. A `release: published` listener therefore cannot
+# observe a release this repository publishes itself, no matter which branch it sits on.
+#
+# The fix keeps the credential surface unchanged: no PAT, no app token, no
+# `contents: write` on the release job. `release.yml` CALLS this workflow directly after
+# a successful publish, so the run is a child of the release run instead of a reaction to
+# an event that is never delivered.
+#
+# A `workflow_call` body resolves from the CALLER's ref, and `release.yml` only ever runs
+# on `main` or `preview` (its own branch gate). So this file must be on `main` to take
+# effect - the same promotion requirement the old comment described, now for a different
+# reason.
 #
 # There is deliberately no `workflow_dispatch`: a branch-selected manual run executes
 # THAT branch body with `contents: write`. Re-drive a missed run by running
 # `bun scripts/bump-dev-version.ts <released> package.json` locally and opening the pull
 # request normally.
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      released-version:
+        description: "The tag that just published, e.g. v2.39.0"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -69,7 +86,7 @@ jobs:
       - name: Decide the version dev should carry
         id: decide
         env:
-          RELEASED_VERSION: ${{ github.event.release.tag_name }}
+          RELEASED_VERSION: ${{ inputs.released-version }}
         run: |
           set -euo pipefail
           bun scripts/bump-dev-version.ts "${RELEASED_VERSION}" package.json
@@ -88,7 +105,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NEXT_VERSION: ${{ steps.decide.outputs.version }}
-          RELEASED_VERSION: ${{ github.event.release.tag_name }}
+          RELEASED_VERSION: ${{ inputs.released-version }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Move `dev` past the version that just published.
+  #
+  # This is a CALL, not a `release: published` listener. The release is created with
+  # `github.token`, and GitHub does not start workflow runs from events that token
+  # raises - so a listener cannot observe a release this repository publishes itself. In
+  # that form it ran ZERO times across v2.37.0, v2.38.0 and v2.39.0 while every one of
+  # those bumps was opened by hand (#3045, #3076, #3127).
+  #
+  # `needs: publish` means this is skipped unless the publish job succeeded, so a failed
+  # publish or a failed release creation never opens a bump pull request; the explicit
+  # condition only adds the dry-run case. The called workflow declares its own
+  # `contents: write` / `pull-requests: write` for its own job, so nothing here gains
+  # write access.
+  #
+  # Both channels call this, and the double-call is safe because `bump-dev-version.ts`
+  # compares against what `dev` already carries. In the usual train `dev` is already at
+  # the stable core when the preview publishes, so that call returns `changed=false`
+  # ("dev already carries 2.40.0, which is ahead of the published 2.40.0-preview.*") and
+  # every later step is gated on that output. The stable call returns `changed=true` and
+  # opens the one pull request. A preview publishing while `dev` is genuinely behind
+  # still bumps it, which is the point.
+  #
+  # It is declared FIRST in this file, ahead of the jobs it depends on, because
+  # tests/ci-workflows.test.ts splits the workflow on `- name:` and reads each `run:`
+  # block to the start of the next one when it checks that dispatch inputs never
+  # interpolate into shell source. A job declared between two steps lands inside that
+  # window and reads as shell. Job order in YAML carries no execution meaning - `needs`
+  # does - so declaring it before its own dependency costs nothing.
+  bump-dev-version:
+    needs: publish
+    if: ${{ inputs.dry-run != true }}
+    uses: ./.github/workflows/dev-version-bump.yml
+    with:
+      released-version: v${{ inputs.version }}
+
   validate-dispatch:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

`.github/workflows/dev-version-bump.yml` has **never run**. Not once since it landed in #3013 — `gh api .../workflows/346296606/runs` returns `total_count: 0`, across v2.37.0, v2.38.0 and v2.39.0. Every one of those bumps was still opened by hand (#3045, #3076, #3127), which is exactly the chore the workflow was written to end.

The workflow was not broken. The event never existed.

## Why the event never arrives

`release.yml` creates the GitHub release with `GH_TOKEN: ${{ github.token }}` ([release.yml:350](https://github.com/lidge-jun/opencodex/blob/dev/.github/workflows/release.yml#L350)), and GitHub does not start new workflow runs from events raised by the default `GITHUB_TOKEN`. So a `release: published` listener can never observe a release this repository publishes itself — on any branch. The old header blamed the default-branch resolution trap, which is real but was not what stopped it: moving the file to `main` (which #3013 did) armed nothing.

The tag push does not rescue it either. `release.yml` pushes `refs/tags/vX.Y.Z` with the same token, and no workflow run exists for those tag pushes.

## The fix

`release.yml` **calls** the bump workflow after a successful publish, so the run is a child of the release run rather than a reaction to an undelivered event:

```yaml
bump-dev-version:
  needs: publish
  if: ${{ inputs.dry-run != true }}
  uses: ./.github/workflows/dev-version-bump.yml
  with:
    released-version: v${{ inputs.version }}
```

`dev-version-bump.yml` becomes `on: workflow_call` with a `released-version` input, replacing the two `github.event.release.tag_name` reads.

**No new credential.** No PAT, no app token, no `contents: write` added to the release job. The called workflow keeps its own `contents: write` / `pull-requests: write` scoped to its own job, and ruleset `Protect dev` still means a human merges the resulting PR. This changes *how the job starts*, nothing about what it may do.

**Failure and dry-run behavior.** `needs: publish` already skips the job unless the publish succeeded; the explicit condition only adds the dry-run case. A failed publish or a failed release creation opens nothing.

**Both channels call it, and that is safe.** `bump-dev-version.ts` compares against what `dev` already carries, verified against the current tree:

```
preview publish while dev=2.40.0 -> {"changed":false,"reason":"dev already carries 2.40.0, which is ahead of the published 2.40.0-preview.20260910"}
stable  publish while dev=2.40.0 -> {"changed":true,"version":"2.41.0"}
```

Every later step is gated on `changed`, so the preview call is a no-op in the usual train and the stable call opens the one PR. A preview publishing while `dev` is genuinely behind still bumps it.

## One non-obvious detail

`bump-dev-version` is declared **first** in `release.yml`, ahead of the jobs it depends on. `tests/ci-workflows.test.ts:735` splits the workflow on `- name:` and reads each `run:` block to the start of the next one, checking that dispatch inputs never interpolate into shell source. A job declared after the last step lands inside that window and reads as shell — the test failed on the first two placements I tried, correctly. Job order in YAML carries no execution meaning (`needs` does), so declaring it before its own dependency costs nothing and keeps the injection check honest rather than weakening it.

## Verification

```
$ bun test tests/ci-workflows.test.ts tests/cleanup-orphaned-workflows.test.ts \
           tests/release-version-line.test.ts tests/bump-dev-version.test.ts
 155 pass
 0 fail
```

Both workflows re-parse as valid YAML with the expected job graph, and no `github.event.release` reference remains in the bump workflow.

## What this cannot verify here

A `workflow_call` body resolves from the **caller's** ref, and `release.yml` only runs on `main` or `preview`. So this takes effect after an ordinary `dev` → `main` promotion carries it there — the next release is the first real exercise. That is the same activation delay #3013 had, now for a different reason, and it is stated here rather than discovered later.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to automatically update the development version after a successful production release.
  * Prevented development-version updates during dry-run releases.
  * Improved compatibility between release workflows and self-published releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->