### PR TITLE
fix(openai): allow canonical fake-IP addresses on provider PATCH (carry of #3122)

### DIFF
--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -752,7 +752,13 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       if (!canonicalBudgetOnly) {
         const serviceTierError = providerServiceTierConfigError(name, next);
         if (serviceTierError) return jsonResponse({ error: serviceTierError }, 400);
-        const resolvedError = await providerDestinationResolvedError(name, next);
+        // Same DNS gate as POST and re-enable: the canonical built-in OpenAI forward
+        // provider may resolve through Clash/Mihomo fake-IP DNS (198.18.0.0/15), so the
+        // ordinary PATCH must not reject the very same destination the provider was
+        // created with. Loopback, RFC1918, metadata, and mixed dangerous answers still
+        // fail closed; nothing else gains the exception.
+        const allowBenchmarkAddresses = name === "openai" && isCanonicalOpenAiForwardProvider(next);
+        const resolvedError = await providerDestinationResolvedError(name, next, { allowBenchmarkAddresses });
         if (resolvedError) return jsonResponse({ error: resolvedError }, 400);
       }
     } else if (applied.enablingOpenAi) {

--- a/tests/management-provider-validation.test.ts
+++ b/tests/management-provider-validation.test.ts
@@ -2462,6 +2462,149 @@ describe("provider management validation", () => {
     }
   });
 
+  test("canonical OpenAI PATCH passes allowBenchmarkAddresses into destination resolution", async () => {
+    // The ordinary field-mask PATCH resolves the SAME canonical chatgpt.com destination
+    // POST and re-enable already admit. Without the benchmark opt-in here, a Clash/Mihomo
+    // fake-IP user (chatgpt.com → 198.18.0.0/15) could create the provider but could never
+    // patch a context overlay onto it. Loopback/RFC1918/metadata and mixed dangerous
+    // answers still fail closed (covered by destination-policy-resolved tests and below).
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const liveConfig: OcxConfig = {
+      port: 0,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect },
+      },
+    };
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError")
+      .mockResolvedValue(null);
+
+    try {
+      const patch = async (name: string, body: unknown) => {
+        const request = new Request(`http://127.0.0.1/api/providers?name=${encodeURIComponent(name)}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        return handleManagementAPI(request, new URL(request.url), liveConfig, {
+          createManagementConvergeCodex: catalogConvergenceFactory(),
+        });
+      };
+
+      const canonical = await patch("openai", { modelContextWindows: { "gpt-5.6-luna": 900000 } });
+      expect(canonical?.status).toBe(200);
+      expect(resolvedError).toHaveBeenCalledWith(
+        "openai",
+        expect.objectContaining({ baseUrl: canonicalDirect.baseUrl }),
+        { allowBenchmarkAddresses: true },
+      );
+    } finally {
+      resolvedError.mockRestore();
+    }
+  });
+
+  test("PATCH destination benchmark exception stays scoped to the canonical openai row", async () => {
+    // A non-canonical openai row and any OpenAI-LOOKING custom provider must not inherit
+    // the fake-IP exception: their PATCHes still fail closed on benchmark answers.
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const liveConfig: OcxConfig = {
+      port: 0,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect },
+        mirror: {
+          adapter: "openai-chat",
+          baseUrl: "https://mirror.example.test/v1",
+          apiKey: "sk-secret-value",
+        },
+        "openai-proxy": {
+          adapter: "openai-chat",
+          baseUrl: "https://mirror.example.test/v1",
+          apiKey: "sk-secret-value",
+        },
+      },
+    };
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError")
+      .mockResolvedValue(
+        "baseUrl hostname mirror.example.test resolves to a benchmark address (198.18.0.30); set allowPrivateNetwork:true only for intentionally local/self-hosted providers",
+      );
+
+    try {
+      const patch = async (name: string, body: unknown) => {
+        const request = new Request(`http://127.0.0.1/api/providers?name=${encodeURIComponent(name)}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        return handleManagementAPI(request, new URL(request.url), liveConfig, {
+          createManagementConvergeCodex: catalogConvergenceFactory(),
+        });
+      };
+
+      const custom = await patch("mirror", { defaultModel: "gpt-x" });
+      expect(custom?.status).toBe(400);
+      expect(resolvedError).toHaveBeenCalledWith(
+        "mirror",
+        expect.anything(),
+        { allowBenchmarkAddresses: false },
+      );
+
+      // Non-canonical row named "openai"-adjacent: no exception either.
+      const openaiProxy = await patch("openai-proxy", { defaultModel: "gpt-x" });
+      expect(openaiProxy?.status).toBe(400);
+      expect(resolvedError).toHaveBeenCalledWith(
+        "openai-proxy",
+        expect.anything(),
+        { allowBenchmarkAddresses: false },
+      );
+    } finally {
+      resolvedError.mockRestore();
+    }
+  });
+
+  test("canonical OpenAI PATCH still rejects non-benchmark private destination answers", async () => {
+    // The benchmark opt-in must not relax the rest of the SSRF guard: if the probe
+    // classifies the canonical destination as loopback/private/metadata, the PATCH fails.
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    const liveConfig: OcxConfig = {
+      port: 0,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect },
+      },
+    };
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError")
+      .mockResolvedValue("baseUrl hostname chatgpt.com resolves to a loopback address (127.0.0.1); set allowPrivateNetwork:true only for intentionally local/self-hosted providers");
+
+    try {
+      const request = new Request("http://127.0.0.1/api/providers?name=openai", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ modelContextWindows: { "gpt-5.6-luna": 900000 } }),
+      });
+      const response = await handleManagementAPI(request, new URL(request.url), liveConfig, {
+        createManagementConvergeCodex: catalogConvergenceFactory(),
+      });
+      expect(response?.status).toBe(400);
+      expect(await response?.json()).toMatchObject({
+        error: expect.stringContaining("loopback address"),
+      });
+      expect(resolvedError).toHaveBeenCalledWith(
+        "openai",
+        expect.anything(),
+        { allowBenchmarkAddresses: true },
+      );
+    } finally {
+      resolvedError.mockRestore();
+    }
+  });
+
   test("disabled-only PATCH cannot re-enable a noncanonical openai row unchanged", async () => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

Carries #3122 (author @Flowershangfromthebranches) onto current `dev`. The commit is the author's, cherry-picked with `-x`; authorship is preserved in `git log`.

Closes #3122 once this lands.

Canonical OpenAI provider **creation** (`src/server/management/provider-routes.ts:588-589`) and **reload** (`:512-513`) already pass `allowBenchmarkAddresses`, which admits the `198.18.0.0/15` range that Clash/Mihomo-style fake-IP DNS returns. The ordinary field-mask **PATCH** path did not, so the exact same provider could be created successfully and then reject a later context-window PATCH against the identical destination.

## Why it is carried rather than rebased in place

@Flowershangfromthebranches has `read` permission, and `.github/workflows/enforce-pr-target.yml:740-746` applies the contributor readiness checklist to authors without push permission. A maintainer force-push to the fork branch would re-draft the PR and reset four boxes only the author can tick — the PR would be stranded in draft waiting on a contributor, having already done the work. Carrying preserves the author's commit while letting a maintainer-authored PR satisfy the gate.

## Security review

This is a caller of `src/lib/destination-policy.ts`, so it went through explicit security review rather than a maintainer read. Verdict: PASS, zero blockers.

The question worth asking was whether `next` is a partial field mask — if it were, a PATCH could set a subset of fields so `isCanonicalOpenAiForwardProvider(next)` returns true while the effective stored provider is not canonical. It is not: `applyProviderPatchFields` opens with `const next: OcxProviderConfig = { ...provider }` (`:114-121`), and the route's own comment at `:737-739` says it validates "the MERGED provider". The three predicate fields are PATCH-writable, but gaining the exception and being the provider the exception exists for are the same act — the merged object must clear canonical seed validation at `src/server/auth-cors.ts:560-593` before the DNS probe runs.

Blast radius is one `continue` in the resolver loop (`src/lib/destination-policy.ts:339-349`): only individual benchmark answers are skipped, so loopback (`:54`), RFC1918/CGNAT (`:55-56`), metadata `169.254.169.254` (`:12-16`), IPv6 loopback/private/link-local (`:183-199`), and any mixed answer set still fail closed with the flag on. Literal benchmark URLs stay refused because synchronous validation runs before DNS handling (`:321-330`).

## Verification

```
bun test tests/management-provider-validation.test.ts tests/destination-policy-resolved.test.ts
  129 pass / 0 fail / 635 expect() calls
```

Both mutations are caught, which is what makes the tests a guard rather than a description:

| mutation | fails |
| --- | --- |
| flag hardcoded `true` | `PATCH destination benchmark exception stays scoped to the canonical openai row` |
| flag hardcoded `false` | `canonical OpenAI PATCH passes allowBenchmarkAddresses into destination resolution`, `canonical OpenAI PATCH still rejects non-benchmark private destination answers` |

Full local suite was run on this tree. Three failures, all in `tests/shutdown-launcher.test.ts` (`SIGINT`/`SIGTERM`/`SIGHUP` graceful shutdown), none touching this change — that is the known intermittent macOS flake #3061 is open against.

## Checklist

- [x] Targets `dev`
- [x] Focused regression tests for the changed subsystem pass
- [x] Security review completed for a destination-policy caller
- [x] Original authorship preserved
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider updates for the built-in OpenAI forward provider when using Clash/Mihomo fake-IP DNS.
  * Continued blocking loopback, private-network, metadata, and mixed-risk destinations.
  * Kept the exception limited to the canonical built-in provider; custom or similarly named providers remain protected.

* **Tests**
  * Added coverage for valid fake-IP resolution, provider-specific scoping, and unsafe destination rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->