### PR TITLE
fix(service): Windows cold-start budget and code-page-mangled scheduler paths (rebase of #3104)

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -661,6 +661,23 @@ export function installedServiceListenPort(): number {
 export const SERVICE_INSTALL_HEALTH_MS = 20_000;
 
 /**
+ * Windows gets a longer budget because its cold start does more before the
+ * listener exists: NTFS ACL hardening and previous-session journal recovery
+ * both run first, and #3009 recorded a service that bound a few seconds past
+ * the 20s deadline and then stayed healthy. Reporting that as a terminal
+ * repair failure is worse than waiting — the caller's fallback is to start a
+ * second proxy against a port that is about to be taken.
+ */
+export const SERVICE_INSTALL_HEALTH_WINDOWS_MS = 45_000;
+
+/** The health budget for the platform this is running on. */
+export function serviceInstallHealthMs(
+  platform: NodeJS.Platform = process.platform,
+): number {
+  return platform === "win32" ? SERVICE_INSTALL_HEALTH_WINDOWS_MS : SERVICE_INSTALL_HEALTH_MS;
+}
+
+/**
  * Whether a proxy actually answers on the port this install/start just produced.
  *
  * Registration is not service: `launchctl list` reports a job that never bound, and
@@ -690,12 +707,23 @@ export async function confirmServiceServing(
   const now = deps.now ?? Date.now;
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)));
   const probe = deps.probe ?? (async (p, h) => !!(await proxyIdentityAt(p, { hostname: h })));
-  const deadline = now() + (deps.timeoutMs ?? SERVICE_INSTALL_HEALTH_MS);
+  const deadline = now() + (deps.timeoutMs ?? serviceInstallHealthMs());
+  let waited = false;
   for (;;) {
     if (await probe(port, hostname)) return { ok: true, port };
-    if (now() >= deadline) return { ok: false, port };
+    if (now() >= deadline) break;
     await sleep(500);
+    waited = true;
   }
+  // The probe that ran last started before the deadline, so a service that binds
+  // during it is reported as dead (#3009). Knock once more after a short grace
+  // before calling it a failure. A zero budget means the caller asked not to
+  // wait, so it gets exactly the single probe it asked for and nothing more.
+  if (waited) {
+    await sleep(500);
+    if (await probe(port, hostname)) return { ok: true, port };
+  }
+  return { ok: false, port };
 }
 
 /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -1963,6 +1963,67 @@ function taskXmlDecodedValueEquals(xml: string, tag: string, expected: string): 
   return taskXmlDecodeEntities(value).trim().toLowerCase() === expected.trim().toLowerCase();
 }
 
+/**
+ * Characters a console code page substitutes when it cannot carry the original.
+ * Windows writes `?` per unrepresentable character, some layers write U+FFFD, and a
+ * few drop them entirely.
+ */
+const CODE_PAGE_SUBSTITUTIONS = /^[?\uFFFD]*$/;
+
+/**
+ * Compare a value that OpenCodex itself wrote against what `schtasks /query /xml` read
+ * back, tolerating ONLY the characters the console code page could not carry.
+ *
+ * `runFile` already reads the query as bytes, so this is not a spawn-decoding bug: the
+ * conversion happens inside `schtasks` before the bytes exist. A profile named outside
+ * the active code page — `C:\\Users\\김병준\\...` — comes back as `C:\\Users\\???\\...`, so an
+ * exact comparison rejected a registration this process had just created correctly and
+ * `ocx service install` rolled it back (#3064).
+ *
+ * The tolerance is deliberately narrow. Each unrepresentable RUN in the expected value
+ * may match only a run of substitution characters — never arbitrary text, and never a
+ * path separator. A wildcard as wide as `[^\\\\/]*` would leave a fully non-ASCII segment with
+ * no anchors at all, so `C:\\Users\\김병준\\x.vbs` would match `C:\\Users\\Admin\\x.vbs` and this
+ * process would adopt, repair, or delete another account's task. Accepting a foreign
+ * live task is a worse failure than the rollback this fixes.
+ */
+function taskXmlLossyValueEquals(reported: string, expected: string): boolean {
+  const a = reported.trim().toLowerCase();
+  const b = expected.trim().toLowerCase();
+  if (a === b) return true;
+  // Nothing unrepresentable in the expectation means there was nothing to mangle,
+  // so any difference is a real one.
+  if (!/[^\x00-\x7F]/.test(b)) return false;
+  const parts = b.split(/([^\x00-\x7F]+)/);
+  let rest = a;
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i]!;
+    if (i % 2 === 0) {
+      // Literal ASCII run: it must be present verbatim, which is what keeps every
+      // directory boundary and file name in the path verified.
+      if (!rest.startsWith(part)) return false;
+      rest = rest.slice(part.length);
+      continue;
+    }
+    // Unrepresentable run: consume only substitution characters, and stop at the
+    // next literal so a trailing run cannot swallow the remainder of the string.
+    const next = parts[i + 1] ?? "";
+    const end = next === "" ? rest.length : rest.indexOf(next);
+    if (end < 0) return false;
+    if (!CODE_PAGE_SUBSTITUTIONS.test(rest.slice(0, end))) return false;
+    rest = rest.slice(end);
+  }
+  return rest === "";
+}
+
+function taskXmlDecodedLossyValueEquals(xml: string, tag: string, expected: string): boolean {
+  if (taskXmlHasPrefixedTag(xml, tag)) return false;
+  if (taskXmlElementCount(xml, tag) !== 1) return false;
+  const value = new RegExp(`<${tag}(?:\\s[^>]*?)?>([^<]*)<\\/${tag}>`, "i").exec(xml)?.[1];
+  if (value === undefined) return false;
+  return taskXmlLossyValueEquals(taskXmlDecodeEntities(value), expected);
+}
+
 function taskXmlOptionalValueEquals(xml: string, tag: string, expected: string): boolean {
   // Check the prefixed form first: treating `<t:Enabled>false</t:Enabled>` as an
   // omission would turn an explicitly disabled task into a healthy one.
@@ -2025,7 +2086,14 @@ function windowsTaskTriggerScopeAcceptable(element: string, expectedUserId: stri
   if (userIdCount === 0) return true;
   if (userIdCount !== 1) return false;
   if (expectedUserId === undefined) return false;
-  return taskXmlDecodedValueEquals(element, "UserId", expectedUserId);
+  // Same tolerance as Command and Arguments, and for the same reason:
+  // buildWindowsTaskXml writes the live account name here, so an account named
+  // outside the console code page comes back mangled and an exact comparison
+  // rejects a task that is in fact correctly scoped (#3064). The literal-ASCII
+  // requirement is what keeps this safe -- a DOMAIN\\User scope keeps its backslash
+  // verified, so a substitution run can never swallow the domain and let another
+  // domain's account match.
+  return taskXmlDecodedLossyValueEquals(element, "UserId", expectedUserId);
 }
 
 /** Validate the stable OpenCodex action, principal, settings, and logon trigger. */
@@ -2058,8 +2126,12 @@ function windowsTaskRegistrationBaseHealthy(
     // quotes we wrote as `&quot;` back to literal `"` on export, so an escaped
     // needle never matched and a healthy task read as permanently stale (#608).
     // Case-insensitive: elevated `schtasks /create` may rewrite System32 casing.
-    && taskXmlDecodedValueEquals(action, "Command", wscript)
-    && taskXmlDecodedValueEquals(action, "Arguments", `/b /nologo "${launcher}"`);
+    // Lossy on purpose: both name paths under the user profile, which the query
+    // cannot carry when the profile is named outside the code page (#3064). Only
+    // unrepresentable characters are forgiven; every ASCII segment and every
+    // separator is still matched literally.
+    && taskXmlDecodedLossyValueEquals(action, "Command", wscript)
+    && taskXmlDecodedLossyValueEquals(action, "Arguments", `/b /nologo "${launcher}"`);
 }
 
 /** Validate the security/lifecycle-critical fields of the registered scheduler task. */

--- a/src/service.ts
+++ b/src/service.ts
@@ -739,14 +739,15 @@ async function reportServiceServing(
   verb: "installed" | "started" | "repaired",
   deps: Parameters<typeof confirmServiceServing>[0] = {},
 ): Promise<void> {
-  const serving = await confirmServiceServing(deps);
+  const healthBudgetMs = deps.timeoutMs ?? serviceInstallHealthMs();
+  const serving = await confirmServiceServing({ ...deps, timeoutMs: healthBudgetMs });
   if (serving.ok) {
     console.log(`✅ opencodex service ${verb} and serving on port ${serving.port}.`);
     return;
   }
   console.error(
     `⚠️  Service ${verb}, but no proxy answered on port ${serving.port} within `
-    + `${Math.trunc(SERVICE_INSTALL_HEALTH_MS / 1000)}s.\n`
+    + `${Math.trunc(healthBudgetMs / 1000)}s.\n`
     + `   The manager registered the job; that is not the same as serving.\n`
     + `   Log:       ${serviceLogPath()}\n`
     + `   Meanwhile: ocx start   (serves in the foreground)`,
@@ -1832,7 +1833,7 @@ export function buildWindowsTaskXml(
   script = windowsServiceScriptPath(),
   launcher = windowsLauncherVbsPath(),
   attemptNonce?: string,
-  sessionTriggerUserId = cachedCurrentWindowsIdentity()?.name,
+  sessionTriggerUserId = cachedCurrentWindowsIdentity()?.sid,
 ): string {
   const escapedWscript = taskXmlString(windowsWscript());
   // Escape the launcher path independently for the <Arguments> element; quoting it
@@ -2086,14 +2087,12 @@ function windowsTaskTriggerScopeAcceptable(element: string, expectedUserId: stri
   if (userIdCount === 0) return true;
   if (userIdCount !== 1) return false;
   if (expectedUserId === undefined) return false;
-  // Same tolerance as Command and Arguments, and for the same reason:
-  // buildWindowsTaskXml writes the live account name here, so an account named
-  // outside the console code page comes back mangled and an exact comparison
-  // rejects a task that is in fact correctly scoped (#3064). The literal-ASCII
-  // requirement is what keeps this safe -- a DOMAIN\\User scope keeps its backslash
-  // verified, so a substitution run can never swallow the domain and let another
-  // domain's account match.
-  return taskXmlDecodedLossyValueEquals(element, "UserId", expectedUserId);
+  // Scope is an identity boundary, unlike the launcher path. Newly generated tasks
+  // use the locale-independent SID from cachedCurrentWindowsIdentity(), so there is
+  // no reason to forgive code-page substitutions here. A lossy account-name compare
+  // lets two non-ASCII users collapse to the same `???` value and can make repair
+  // start another account's fixed-name task.
+  return taskXmlDecodedValueEquals(element, "UserId", expectedUserId);
 }
 
 /** Validate the stable OpenCodex action, principal, settings, and logon trigger. */
@@ -2139,7 +2138,7 @@ export function windowsTaskRegistrationHealthy(
   xml: string,
   wscript = windowsWscript(),
   launcher = windowsLauncherVbsPath(),
-  expectedUserId: string | null = cachedCurrentWindowsIdentity()?.name ?? null,
+  expectedUserId: string | null = cachedCurrentWindowsIdentity()?.sid ?? null,
 ): boolean {
   const scrubbed = taskXmlWithoutCommentsAndCdata(xml);
   const triggers = taskXmlSection(scrubbed, "Triggers");
@@ -2178,7 +2177,7 @@ export function readWindowsSchedulerXmlState(
   xml: string,
   wscript?: string,
   launcher?: string,
-  expectedUserId: string | null = cachedCurrentWindowsIdentity()?.name ?? null,
+  expectedUserId: string | null = cachedCurrentWindowsIdentity()?.sid ?? null,
 ): WindowsSchedulerXmlState {
   const installed = xml.length > 0;
   if (!installed) return { installed: false, enabled: false, registrationHealthy: false };
@@ -3955,7 +3954,7 @@ export function serviceStartableFromTray(service: ServiceDiagnostic): boolean {
 }
 
 export interface WindowsTaskDiagnosticIdentityDeps {
-  currentIdentity?: () => Readonly<{ name: string }> | null;
+  currentIdentity?: () => Readonly<{ sid: string; name: string }> | null;
   resolvePrincipal?: (timeoutMs: number) => string;
 }
 
@@ -3970,7 +3969,7 @@ export function resolveWindowsTaskDiagnosticUserId(
 ): string | null {
   const currentIdentity = deps.currentIdentity ?? cachedCurrentWindowsIdentity;
   const cached = currentIdentity();
-  if (cached) return cached.name;
+  if (cached) return cached.sid;
 
   const scrubbed = taskXmlWithoutCommentsAndCdata(schedulerXml);
   const triggers = taskXmlSection(scrubbed, "Triggers");
@@ -3981,7 +3980,7 @@ export function resolveWindowsTaskDiagnosticUserId(
   } catch {
     return null;
   }
-  return currentIdentity()?.name ?? null;
+  return currentIdentity()?.sid ?? null;
 }
 
 export interface WindowsServiceDiagnosticInputs {
@@ -4005,7 +4004,7 @@ export interface WindowsServiceDiagnosticInputs {
 
 export function deriveWindowsServiceDiagnostic(inputs: WindowsServiceDiagnosticInputs): ServiceDiagnostic {
   const expectedUserId = inputs.schedulerExpectedUserId === undefined
-    ? cachedCurrentWindowsIdentity()?.name ?? null
+    ? cachedCurrentWindowsIdentity()?.sid ?? null
     : inputs.schedulerExpectedUserId;
   const schedulerState = readWindowsSchedulerXmlState(
     inputs.schedulerXml,

--- a/src/service.ts
+++ b/src/service.ts
@@ -1116,9 +1116,10 @@ export function evaluateWindowsSchedulerInstallVerification(inputs: {
   nativeStatus: "started" | "stopped" | "nonexistent" | "unknown";
   wscript?: string;
   launcher?: string;
+  expectedUserId?: ExpectedWindowsTaskUserId | null;
 }): WindowsSchedulerInstallVerification {
   const registrationHealthy = inputs.xml.length > 0
-    && windowsTaskRegistrationHealthy(inputs.xml, inputs.wscript, inputs.launcher);
+    && windowsTaskRegistrationHealthy(inputs.xml, inputs.wscript, inputs.launcher, inputs.expectedUserId);
   // Permanent invalidity: the XML IS published but violates the registration
   // contract — no amount of settling changes it. Empty/unreadable XML stays
   // transient (publication lag).

--- a/src/service.ts
+++ b/src/service.ts
@@ -735,7 +735,7 @@ export async function confirmServiceServing(
  * fall back to a direct proxy start rather than reporting a successful update over a
  * dead port.
  */
-async function reportServiceServing(
+export async function reportServiceServing(
   verb: "installed" | "started" | "repaired",
   deps: Parameters<typeof confirmServiceServing>[0] = {},
 ): Promise<void> {
@@ -1840,11 +1840,9 @@ export function buildWindowsTaskXml(
   // keeps spaces intact, and /b (batch mode) suppresses script error popups.
   const escapedLauncherArgs = taskXmlString(`/b /nologo "${launcher}"`);
   // `UserId` is optional in the schema, and omitting it makes a SessionStateChangeTrigger
-  // fire for ANY account's session change. Scope it to the installing account when that
-  // account is already known. The lookup is never forced here: this builder is synchronous
-  // and its output is validated before registration, so a failed or unavailable lookup must
-  // degrade to the unscoped trigger rather than leave the task with no recovery at all.
-  // `LogonTrigger` above is unscoped for the same reason and predates this change.
+  // fire for ANY account's session change. Production registration resolves and passes the
+  // installing account SID explicitly; the optional parameter remains only for deterministic
+  // builders/tests, and the live validator rejects an unscoped recovery trigger.
   const sessionUserIdElement = sessionTriggerUserId
     ? `\n      <UserId>${taskXmlString(sessionTriggerUserId)}</UserId>`
     : "";
@@ -1893,6 +1891,24 @@ export function buildWindowsTaskXml(
   </Actions>
 </Task>
 `;
+}
+
+type ExpectedWindowsTaskUserId = string | readonly string[];
+
+function cachedWindowsTaskUserIds(): readonly string[] | null {
+  const identity = cachedCurrentWindowsIdentity();
+  return identity ? [identity.sid, identity.name] : null;
+}
+
+function resolvedWindowsTaskSid(): string {
+  let identity = cachedCurrentWindowsIdentity();
+  if (!identity) {
+    const principal = resolveCurrentWindowsPrincipal(WINDOWS_PRINCIPAL_LOOKUP_TIMEOUT_MS);
+    identity = cachedCurrentWindowsIdentity();
+    if (!identity && /^\*S-1-(?:\d+-)+\d+$/i.test(principal)) return principal.slice(1).toUpperCase();
+  }
+  if (!identity) throw new Error("Windows Task Scheduler identity could not be resolved.");
+  return identity.sid;
 }
 
 function taskXmlSection(xml: string, tag: string): string {
@@ -2058,7 +2074,10 @@ export function windowsTaskRegistrationOwnedByAttempt(xml: string, attemptNonce:
  * carrying one disabled trigger plus a different enabled one must not pass because the two
  * halves were found in unrelated elements.
  */
-function windowsTaskHasSessionRecoveryTriggers(triggers: string, expectedUserId: string | undefined): boolean {
+function windowsTaskHasSessionRecoveryTriggers(
+  triggers: string,
+  expectedUserId: ExpectedWindowsTaskUserId | undefined,
+): boolean {
   const scoped = triggers.match(/<SessionStateChangeTrigger(?:\s[^>]*)?>[\s\S]*?<\/SessionStateChangeTrigger>/gi) ?? [];
   return WINDOWS_SESSION_RECOVERY_STATE_CHANGES.every(stateChange =>
     scoped.some(element =>
@@ -2068,23 +2087,25 @@ function windowsTaskHasSessionRecoveryTriggers(triggers: string, expectedUserId:
 }
 
 /**
- * A trigger's scope is acceptable when it is unscoped, or names the expected account.
+ * A trigger's scope is acceptable only when it names the expected account exactly.
  *
- * An unscoped trigger is accepted rather than rejected: the schema makes `UserId` optional,
- * the pre-existing `LogonTrigger` is unscoped for the same reason, and rejecting it would
- * mean an installation whose account lookup is unavailable loses session recovery entirely.
- * An explicitly scoped trigger is accepted only when the current account is known and matches.
+ * An unscoped recovery trigger is not identity proof. Production registration resolves a SID
+ * before writing XML; a missing scope therefore means the fixed-name task is legacy or foreign
+ * and must be refreshed from an exact legacy snapshot or preserved for manual review.
  * Treating an unknown expected identity as a wildcard would let a fresh status process accept a
  * task bound to another user's session and suppress the repair that should replace it.
  */
-function windowsTaskTriggerScopeAcceptable(element: string, expectedUserId: string | undefined): boolean {
+function windowsTaskTriggerScopeAcceptable(
+  element: string,
+  expectedUserId: ExpectedWindowsTaskUserId | undefined,
+): boolean {
   // A prefixed `<t:UserId>` is a real scope this validator cannot read: taskXmlElementCount()
   // counts only unprefixed tags, so without this the element below would look ABSENT and the
   // trigger would be accepted as unscoped even though it is bound to some other account.
   // Reject it outright rather than guess, and do so before the optional-field check.
   if (taskXmlHasPrefixedTag(element, "UserId")) return false;
   const userIdCount = taskXmlElementCount(element, "UserId");
-  if (userIdCount === 0) return true;
+  if (userIdCount === 0) return false;
   if (userIdCount !== 1) return false;
   if (expectedUserId === undefined) return false;
   // Scope is an identity boundary, unlike the launcher path. Newly generated tasks
@@ -2092,7 +2113,8 @@ function windowsTaskTriggerScopeAcceptable(element: string, expectedUserId: stri
   // no reason to forgive code-page substitutions here. A lossy account-name compare
   // lets two non-ASCII users collapse to the same `???` value and can make repair
   // start another account's fixed-name task.
-  return taskXmlDecodedValueEquals(element, "UserId", expectedUserId);
+  const expectedValues = typeof expectedUserId === "string" ? [expectedUserId] : expectedUserId;
+  return expectedValues.some(value => taskXmlDecodedValueEquals(element, "UserId", value));
 }
 
 /** Validate the stable OpenCodex action, principal, settings, and logon trigger. */
@@ -2100,6 +2122,7 @@ function windowsTaskRegistrationBaseHealthy(
   xml: string,
   wscript = windowsWscript(),
   launcher = windowsLauncherVbsPath(),
+  allowLossyPaths = true,
 ): boolean {
   const scrubbed = taskXmlWithoutCommentsAndCdata(xml);
   // taskXmlSection() takes the FIRST match and the schema allows arbitrary XML under
@@ -2129,8 +2152,11 @@ function windowsTaskRegistrationBaseHealthy(
     // cannot carry when the profile is named outside the code page (#3064). Only
     // unrepresentable characters are forgiven; every ASCII segment and every
     // separator is still matched literally.
-    && taskXmlDecodedLossyValueEquals(action, "Command", wscript)
-    && taskXmlDecodedLossyValueEquals(action, "Arguments", `/b /nologo "${launcher}"`);
+    && (allowLossyPaths
+      ? taskXmlDecodedLossyValueEquals(action, "Command", wscript)
+        && taskXmlDecodedLossyValueEquals(action, "Arguments", `/b /nologo "${launcher}"`)
+      : taskXmlDecodedValueEquals(action, "Command", wscript)
+        && taskXmlDecodedValueEquals(action, "Arguments", `/b /nologo "${launcher}"`));
 }
 
 /** Validate the security/lifecycle-critical fields of the registered scheduler task. */
@@ -2138,7 +2164,7 @@ export function windowsTaskRegistrationHealthy(
   xml: string,
   wscript = windowsWscript(),
   launcher = windowsLauncherVbsPath(),
-  expectedUserId: string | null = cachedCurrentWindowsIdentity()?.sid ?? null,
+  expectedUserId: ExpectedWindowsTaskUserId | null = cachedWindowsTaskUserIds(),
 ): boolean {
   const scrubbed = taskXmlWithoutCommentsAndCdata(xml);
   const triggers = taskXmlSection(scrubbed, "Triggers");
@@ -2151,13 +2177,13 @@ export function windowsTaskRegistrationHealthy(
 
 /**
  * The only stale definition repair may replace automatically: the previous OpenCodex task
- * shape whose action/principal/settings are still exact and which has no session triggers yet.
+ * shape whose action/principal/settings are byte-exact and which has no session triggers yet.
  * Arbitrary unhealthy or partially modified fixed-name tasks are preserved for manual review.
  */
 function windowsTaskRegistrationRefreshableLegacy(xml: string): boolean {
   const scrubbed = taskXmlWithoutCommentsAndCdata(xml);
   const triggers = taskXmlSection(scrubbed, "Triggers");
-  return windowsTaskRegistrationBaseHealthy(xml)
+  return windowsTaskRegistrationBaseHealthy(xml, undefined, undefined, false)
     && taskXmlElementCount(triggers, "SessionStateChangeTrigger") === 0
     && !taskXmlHasPrefixedTag(triggers, "SessionStateChangeTrigger");
 }
@@ -2177,7 +2203,7 @@ export function readWindowsSchedulerXmlState(
   xml: string,
   wscript?: string,
   launcher?: string,
-  expectedUserId: string | null = cachedCurrentWindowsIdentity()?.sid ?? null,
+  expectedUserId: ExpectedWindowsTaskUserId | null = cachedWindowsTaskUserIds(),
 ): WindowsSchedulerXmlState {
   const installed = xml.length > 0;
   if (!installed) return { installed: false, enabled: false, registrationHealthy: false };
@@ -2341,7 +2367,11 @@ function writeWindowsSchedulerAssets(): void {
   // UTF-16LE + BOM: a BOM-less UTF-8 VBS mis-decodes non-ASCII (e.g. Korean) profile
   // paths on some WSH/codepage combinations — same contract as the task XML below.
   writeServiceAssetWithRetry(windowsLauncherVbsPath(), `\uFEFF${buildWindowsLauncherVbs(script)}`, "utf16le");
-  writeServiceAssetWithRetry(windowsTaskXmlPath(), `\uFEFF${buildWindowsTaskXml(script)}`, "utf16le");
+  writeServiceAssetWithRetry(
+    windowsTaskXmlPath(),
+    `\uFEFF${buildWindowsTaskXml(script, windowsLauncherVbsPath(), undefined, resolvedWindowsTaskSid())}`,
+    "utf16le",
+  );
 }
 
 const WINDOWS_SCHEDULER_STAGE_PREFIX = "opencodex-service-stage-";
@@ -2414,7 +2444,12 @@ export function stageWindowsSchedulerRegistrationXml(
     // document while UAC is pending; the file harden independently proves its identity.
     writeXml(
       xmlPath,
-      `\uFEFF${buildWindowsTaskXml(windowsServiceScriptPath(), windowsLauncherVbsPath(), attemptNonce)}`,
+      `\uFEFF${buildWindowsTaskXml(
+        windowsServiceScriptPath(),
+        windowsLauncherVbsPath(),
+        attemptNonce,
+        resolvedWindowsTaskSid(),
+      )}`,
     );
     hardenPath(xmlPath);
     ownedWindowsSchedulerStages.add(xmlPath);
@@ -2754,7 +2789,7 @@ export interface RepairServiceDeps {
   /** Publishes the captured registration only when the fixed task name remains absent. */
   restoreSchedulerIfAbsent?: (registeredXml: string) => Promise<void>;
   /** Resolves the account the registered triggers must match; null when it cannot be resolved. */
-  resolveExpectedUserId?: (registeredXml: string) => string | null;
+  resolveExpectedUserId?: (registeredXml: string) => ExpectedWindowsTaskUserId | null;
   /** Test seam — defaults to process.platform so Linux CI cannot hit real installSystemd. */
   platform?: NodeJS.Platform;
 }
@@ -2859,7 +2894,18 @@ export async function repairService(deps: RepairServiceDeps = {}): Promise<void>
       undefined,
       expectedUserId,
     );
-    if (!registrationHealthy && !windowsTaskRegistrationRefreshableLegacy(registeredXml)) {
+    const expectedValues = expectedUserId === null
+      ? []
+      : typeof expectedUserId === "string" ? [expectedUserId] : expectedUserId;
+    const preferredSid = expectedValues[0];
+    const triggers = taskXmlSection(taskXmlWithoutCommentsAndCdata(registeredXml), "Triggers");
+    // An exact legacy account name is safe to recognize, but rewrite it to the
+    // locale-independent SID while repair already owns the mutation boundary.
+    const identityUpgradeNeeded = registrationHealthy
+      && preferredSid !== undefined
+      && !windowsTaskHasSessionRecoveryTriggers(triggers, preferredSid);
+    const refreshableLegacy = windowsTaskRegistrationRefreshableLegacy(registeredXml);
+    if (!registrationHealthy && !refreshableLegacy) {
       const scopedButUnresolved = expectedUserId === null
         && taskXmlElementCount(
           taskXmlSection(taskXmlWithoutCommentsAndCdata(registeredXml), "Triggers"),
@@ -2880,7 +2926,7 @@ export async function repairService(deps: RepairServiceDeps = {}): Promise<void>
     // Re-register only when the registered XML is actually stale, so the ordinary repair
     // stays free of `schtasks /create` and its UAC prompt.
     let startExpectedXml = registeredXml;
-    if (!registrationHealthy) {
+    if (!registrationHealthy || identityUpgradeNeeded) {
       // The task was stopped above, so a failed replacement must not exit here: `/create /f`
       // can be rejected, elevation can be cancelled, and staging or verification can fail.
       // Any of those would leave a previously runnable proxy stopped and the user worse off
@@ -3966,10 +4012,10 @@ export interface WindowsTaskDiagnosticIdentityDeps {
 export function resolveWindowsTaskDiagnosticUserId(
   schedulerXml: string,
   deps: WindowsTaskDiagnosticIdentityDeps = {},
-): string | null {
+): readonly string[] | null {
   const currentIdentity = deps.currentIdentity ?? cachedCurrentWindowsIdentity;
   const cached = currentIdentity();
-  if (cached) return cached.sid;
+  if (cached) return [cached.sid, cached.name];
 
   const scrubbed = taskXmlWithoutCommentsAndCdata(schedulerXml);
   const triggers = taskXmlSection(scrubbed, "Triggers");
@@ -3980,7 +4026,8 @@ export function resolveWindowsTaskDiagnosticUserId(
   } catch {
     return null;
   }
-  return currentIdentity()?.sid ?? null;
+  const resolved = currentIdentity();
+  return resolved ? [resolved.sid, resolved.name] : null;
 }
 
 export interface WindowsServiceDiagnosticInputs {
@@ -3992,7 +4039,7 @@ export interface WindowsServiceDiagnosticInputs {
    */
   schedulerXml: string;
   /** Resolved effective account for explicit scheduler trigger scopes; null means unknown. */
-  schedulerExpectedUserId?: string | null;
+  schedulerExpectedUserId?: ExpectedWindowsTaskUserId | null;
   /** Whether the on-disk service assets exist. A filesystem concern, not an XML one. */
   schedulerAssetsPresent: boolean;
   nativeStatus: "started" | "stopped" | "nonexistent" | "unknown";
@@ -4004,7 +4051,7 @@ export interface WindowsServiceDiagnosticInputs {
 
 export function deriveWindowsServiceDiagnostic(inputs: WindowsServiceDiagnosticInputs): ServiceDiagnostic {
   const expectedUserId = inputs.schedulerExpectedUserId === undefined
-    ? cachedCurrentWindowsIdentity()?.sid ?? null
+    ? cachedWindowsTaskUserIds()
     : inputs.schedulerExpectedUserId;
   const schedulerState = readWindowsSchedulerXmlState(
     inputs.schedulerXml,

--- a/src/service.ts
+++ b/src/service.ts
@@ -1911,6 +1911,16 @@ function resolvedWindowsTaskSid(): string {
   return identity.sid;
 }
 
+/** Render the exact UTF-16 task document published by production registration paths. */
+export function buildWindowsTaskXmlDocument(
+  script = windowsServiceScriptPath(),
+  launcher = windowsLauncherVbsPath(),
+  attemptNonce?: string,
+  sessionTriggerUserId = resolvedWindowsTaskSid(),
+): string {
+  return `\uFEFF${buildWindowsTaskXml(script, launcher, attemptNonce, sessionTriggerUserId)}`;
+}
+
 function taskXmlSection(xml: string, tag: string): string {
   return new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, "i").exec(xml)?.[1] ?? "";
 }
@@ -2180,10 +2190,14 @@ export function windowsTaskRegistrationHealthy(
  * shape whose action/principal/settings are byte-exact and which has no session triggers yet.
  * Arbitrary unhealthy or partially modified fixed-name tasks are preserved for manual review.
  */
-function windowsTaskRegistrationRefreshableLegacy(xml: string): boolean {
+function windowsTaskRegistrationRefreshableLegacy(
+  xml: string,
+  wscript = windowsWscript(),
+  launcher = windowsLauncherVbsPath(),
+): boolean {
   const scrubbed = taskXmlWithoutCommentsAndCdata(xml);
   const triggers = taskXmlSection(scrubbed, "Triggers");
-  return windowsTaskRegistrationBaseHealthy(xml, undefined, undefined, false)
+  return windowsTaskRegistrationBaseHealthy(xml, wscript, launcher, false)
     && taskXmlElementCount(triggers, "SessionStateChangeTrigger") === 0
     && !taskXmlHasPrefixedTag(triggers, "SessionStateChangeTrigger");
 }
@@ -2369,7 +2383,7 @@ function writeWindowsSchedulerAssets(): void {
   writeServiceAssetWithRetry(windowsLauncherVbsPath(), `\uFEFF${buildWindowsLauncherVbs(script)}`, "utf16le");
   writeServiceAssetWithRetry(
     windowsTaskXmlPath(),
-    `\uFEFF${buildWindowsTaskXml(script, windowsLauncherVbsPath(), undefined, resolvedWindowsTaskSid())}`,
+    buildWindowsTaskXmlDocument(script, windowsLauncherVbsPath()),
     "utf16le",
   );
 }
@@ -2444,12 +2458,12 @@ export function stageWindowsSchedulerRegistrationXml(
     // document while UAC is pending; the file harden independently proves its identity.
     writeXml(
       xmlPath,
-      `\uFEFF${buildWindowsTaskXml(
+      buildWindowsTaskXmlDocument(
         windowsServiceScriptPath(),
         windowsLauncherVbsPath(),
         attemptNonce,
         resolvedWindowsTaskSid(),
-      )}`,
+      ),
     );
     hardenPath(xmlPath);
     ownedWindowsSchedulerStages.add(xmlPath);
@@ -2790,6 +2804,9 @@ export interface RepairServiceDeps {
   restoreSchedulerIfAbsent?: (registeredXml: string) => Promise<void>;
   /** Resolves the account the registered triggers must match; null when it cannot be resolved. */
   resolveExpectedUserId?: (registeredXml: string) => ExpectedWindowsTaskUserId | null;
+  /** Exact scheduler action values used by validation; defaults to the installed paths. */
+  schedulerWscript?: string;
+  schedulerLauncher?: string;
   /** Test seam — defaults to process.platform so Linux CI cannot hit real installSystemd. */
   platform?: NodeJS.Platform;
 }
@@ -2890,8 +2907,8 @@ export async function repairService(deps: RepairServiceDeps = {}): Promise<void>
     const expectedUserId = (deps.resolveExpectedUserId ?? resolveWindowsTaskDiagnosticUserId)(registeredXml);
     const registrationHealthy = windowsTaskRegistrationHealthy(
       registeredXml,
-      undefined,
-      undefined,
+      deps.schedulerWscript,
+      deps.schedulerLauncher,
       expectedUserId,
     );
     const expectedValues = expectedUserId === null
@@ -2904,7 +2921,11 @@ export async function repairService(deps: RepairServiceDeps = {}): Promise<void>
     const identityUpgradeNeeded = registrationHealthy
       && preferredSid !== undefined
       && !windowsTaskHasSessionRecoveryTriggers(triggers, preferredSid);
-    const refreshableLegacy = windowsTaskRegistrationRefreshableLegacy(registeredXml);
+    const refreshableLegacy = windowsTaskRegistrationRefreshableLegacy(
+      registeredXml,
+      deps.schedulerWscript,
+      deps.schedulerLauncher,
+    );
     if (!registrationHealthy && !refreshableLegacy) {
       const scopedButUnresolved = expectedUserId === null
         && taskXmlElementCount(

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -1177,6 +1177,16 @@ async function restartAfterUpdate(
         const result = run(job, cmd.bin, cmd.args, repairTimeoutMs);
         serviceOk = result.status === 0;
         if (!serviceOk) {
+          if (result.timedOut) {
+            // UAC and scheduler mutation can outlive a fixed child deadline. Once the
+            // worker kills that child, ownership is ambiguous: launching a foreground
+            // proxy here can race a registration that completes moments later.
+            updateJob(job, {}, "Service repair timed out with Task Scheduler state unknown; refusing a competing direct start.");
+            throw new Error(
+              "Service repair timed out with Task Scheduler state unknown; refusing a competing direct start. "
+              + "Run 'ocx service status', then 'ocx service repair' by hand.",
+            );
+          }
           // The refresh that just failed was `ocx service repair` (serviceReinstallArgs).
           // It normally reuses a healthy registration, but a stale definition may have tried
           // guarded re-registration/elevation. Advising `install` here would unconditionally
@@ -1190,15 +1200,6 @@ async function restartAfterUpdate(
             `Service refresh failed (exit ${result.status ?? "?"}); falling back to a direct proxy start.`
             + " Run 'ocx service repair' by hand to see the reason, then 'ocx service status'.",
           );
-          if (result.timedOut) {
-            // UAC and scheduler mutation can outlive a fixed child deadline. Once the
-            // worker kills that child, ownership is ambiguous: launching a foreground
-            // proxy here can race a registration that completes moments later.
-            throw new Error(
-              "Service repair timed out with Task Scheduler state unknown; refusing a competing direct start. "
-              + "Run 'ocx service status', then 'ocx service repair' by hand.",
-            );
-          }
         }
       } finally {
         if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -692,7 +692,12 @@ export function startUpdateJob(
  * and a bounded, structured summary — enough to tell a user which step failed and how, with no
  * free-form vendor text passing through the boundary. Detailed output stays ephemeral.
  */
-function runLoggedCommand(job: UpdateJobState, bin: string, args: string[], timeout: number): { status: number | null; signal: NodeJS.Signals | null } {
+function runLoggedCommand(
+  job: UpdateJobState,
+  bin: string,
+  args: string[],
+  timeout: number,
+): { status: number | null; signal: NodeJS.Signals | null; timedOut: boolean } {
   job = updateJob(job, {}, `$ ${formatCommand(bin, args)}`);
   const result = spawnSync(bin, args, {
     encoding: "utf8",
@@ -703,7 +708,11 @@ function runLoggedCommand(job: UpdateJobState, bin: string, args: string[], time
   const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
   const summary = summarizeCommandOutput(stdout, stderr, result.status, result.signal);
   if (summary) updateJob(job, {}, summary);
-  return { status: result.status, signal: result.signal };
+  return {
+    status: result.status,
+    signal: result.signal,
+    timedOut: (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT",
+  };
 }
 
 /**
@@ -993,7 +1002,7 @@ export interface RestartIo {
     bin: string,
     args: string[],
     timeoutMs: number,
-  ) => { status: number | null; signal?: NodeJS.Signals | null };
+  ) => { status: number | null; signal?: NodeJS.Signals | null; timedOut?: boolean };
   /** Override the explicit restart path (used by finishGuiUpdateRestart tests). */
   restartAfterUpdateFn?: (
     job: UpdateJobState,
@@ -1181,6 +1190,15 @@ async function restartAfterUpdate(
             `Service refresh failed (exit ${result.status ?? "?"}); falling back to a direct proxy start.`
             + " Run 'ocx service repair' by hand to see the reason, then 'ocx service status'.",
           );
+          if (result.timedOut) {
+            // UAC and scheduler mutation can outlive a fixed child deadline. Once the
+            // worker kills that child, ownership is ambiguous: launching a foreground
+            // proxy here can race a registration that completes moments later.
+            throw new Error(
+              "Service repair timed out with Task Scheduler state unknown; refusing a competing direct start. "
+              + "Run 'ocx service status', then 'ocx service repair' by hand.",
+            );
+          }
         }
       } finally {
         if (prevBake === undefined) delete process.env.OCX_BAKE_PORT;

--- a/src/update/job.ts
+++ b/src/update/job.ts
@@ -51,6 +51,11 @@ const RELEASE_NOTES_URL = "https://github.com/lidge-jun/opencodex/releases/lates
 const UPDATE_JOB_FILENAME = "update-job.json";
 const UPDATE_TIMEOUT_MS = 180_000;
 const RESTART_TIMEOUT_MS = 60_000;
+// A Windows `service repair` can spend up to 45s in its own serving probe after
+// Task Scheduler/ACL work. The generic 60s child ceiling can kill that valid repair
+// and launch a competing foreground proxy. Keep this below the update worker's 180s
+// ceiling while covering the measured probe plus bounded Windows setup work.
+const WINDOWS_SERVICE_REPAIR_TIMEOUT_MS = 150_000;
 const RESTART_HEALTH_TIMEOUT_MS = 30_000;
 const RESTART_STABILITY_WINDOW_MS = 15_000;
 /** Legacy active records did not persist a worker PID, so age is their only safe recovery signal. */
@@ -987,6 +992,7 @@ export interface RestartIo {
     job: UpdateJobState,
     bin: string,
     args: string[],
+    timeoutMs: number,
   ) => { status: number | null; signal?: NodeJS.Signals | null };
   /** Override the explicit restart path (used by finishGuiUpdateRestart tests). */
   restartAfterUpdateFn?: (
@@ -1155,8 +1161,11 @@ async function restartAfterUpdate(
       process.env.OCX_BAKE_PORT = String(Math.trunc(port));
       let serviceOk = false;
       try {
-        const run = io.runService ?? ((j, bin, args) => runLoggedCommand(j, bin, args, RESTART_TIMEOUT_MS));
-        const result = run(job, cmd.bin, cmd.args);
+        const repairTimeoutMs = (io.platform ?? process.platform) === "win32"
+          ? WINDOWS_SERVICE_REPAIR_TIMEOUT_MS
+          : RESTART_TIMEOUT_MS;
+        const run = io.runService ?? ((j, bin, args, timeoutMs) => runLoggedCommand(j, bin, args, timeoutMs));
+        const result = run(job, cmd.bin, cmd.args, repairTimeoutMs);
         serviceOk = result.status === 0;
         if (!serviceOk) {
           // The refresh that just failed was `ocx service repair` (serviceReinstallArgs).

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 import * as serviceModule from "../src/service";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
-import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, stableLauncherEntry, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, uninstallSystemd, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy } from "../src/service";
+import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, SERVICE_INSTALL_HEALTH_MS, SERVICE_INSTALL_HEALTH_WINDOWS_MS, serviceInstallHealthMs, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, stableLauncherEntry, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, uninstallSystemd, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy } from "../src/service";
 import type { ServiceDiagnostic } from "../src/service";
 import { definitionCarriesCredential, resolvedProxyEnv, writeServiceDefinitionFile } from "../src/service";
 import { buildWinswXml } from "../src/lib/winsw";
@@ -3142,7 +3142,55 @@ describe("service serving confirmation", () => {
         now: () => 0,
         timeoutMs: 0,
       });
+      // Exactly one. "At least one" would also pass against a version that
+      // sleeps and knocks again, which is the opposite of what a zero budget
+      // asks for — #3039 relaxed this to toBeGreaterThanOrEqual and that is
+      // precisely the assertion the grace probe must not be allowed to satisfy.
       expect(probes).toBe(1);
+    });
+
+    // #3009: a Windows cold start does NTFS ACL hardening and previous-session
+    // journal recovery before the listener exists, so the service can bind
+    // seconds after the deadline and then stay healthy. `ocx service repair`
+    // reported that as a terminal failure with exit 1, and the caller's fallback
+    // is to start a second proxy against a port that is about to be taken.
+    test("accepts a service that binds during the grace after the deadline", async () => {
+      let now = 0;
+      let probes = 0;
+      const out = await confirmServiceServing({
+        port: 10100,
+        // Answers only once the clock is past the deadline, which is the shape
+        // the report describes: healthy, just not within the budget.
+        probe: async () => { probes += 1; return now > 2_000; },
+        sleep: async ms => { now += ms; },
+        now: () => now,
+        timeoutMs: 2_000,
+      });
+      expect(out).toEqual({ ok: true, port: 10100 });
+      expect(probes).toBeGreaterThan(1);
+    });
+
+    test("still fails a service that never binds", async () => {
+      let now = 0;
+      const out = await confirmServiceServing({
+        port: 10100,
+        probe: async () => false,
+        sleep: async ms => { now += ms; },
+        now: () => now,
+        timeoutMs: 2_000,
+      });
+      expect(out).toEqual({ ok: false, port: 10100 });
+    });
+
+    // Windows is the platform the extra budget exists for; everything else keeps
+    // the original 20s so this cannot slow a healthy Linux install down. Pinned
+    // absolutely, not relatively: a relational assertion accepts 21s, and the
+    // reported service bound past 20s, so the number is the contract.
+    test("gives Windows a longer cold-start budget than the other platforms", () => {
+      expect(serviceInstallHealthMs("win32")).toBe(SERVICE_INSTALL_HEALTH_WINDOWS_MS);
+      expect(SERVICE_INSTALL_HEALTH_WINDOWS_MS).toBe(45_000);
+      expect(serviceInstallHealthMs("linux")).toBe(SERVICE_INSTALL_HEALTH_MS);
+      expect(serviceInstallHealthMs("darwin")).toBe(SERVICE_INSTALL_HEALTH_MS);
     });
 
     // A service reinstall invalidates the pidfile, so resolving the target through

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 import * as serviceModule from "../src/service";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
-import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml as buildWindowsTaskXmlProduction, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, reportServiceServing, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, SERVICE_INSTALL_HEALTH_MS, SERVICE_INSTALL_HEALTH_WINDOWS_MS, serviceInstallHealthMs, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, stableLauncherEntry, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, uninstallSystemd, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy as windowsTaskRegistrationHealthyProduction } from "../src/service";
+import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml as buildWindowsTaskXmlProduction, buildWindowsTaskXmlDocument, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, reportServiceServing, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, SERVICE_INSTALL_HEALTH_MS, SERVICE_INSTALL_HEALTH_WINDOWS_MS, serviceInstallHealthMs, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, stableLauncherEntry, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, uninstallSystemd, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy as windowsTaskRegistrationHealthyProduction } from "../src/service";
 import type { ServiceDiagnostic } from "../src/service";
 import { definitionCarriesCredential, resolvedProxyEnv, writeServiceDefinitionFile } from "../src/service";
 import { buildWinswXml } from "../src/lib/winsw";
@@ -862,10 +862,10 @@ describe("Windows service task", () => {
     expect(service).toContain("if (existsSync(windowsLauncherVbsPath())) unlinkSync(windowsLauncherVbsPath());");
   });
 
-  test("writes Task Scheduler XML with a UTF-16 BOM for schtasks", async () => {
-    const service = await Bun.file(new URL("../src/service.ts", import.meta.url)).text();
-
-    expect(service).toContain('resolvedWindowsTaskSid()');
+  test("writes Task Scheduler XML with an exact SID and UTF-16 BOM", () => {
+    const document = buildWindowsTaskXmlDocument("service.cmd", "launcher.vbs", undefined, TEST_WINDOWS_TASK_SID);
+    expect(document.charCodeAt(0)).toBe(0xFEFF);
+    expect(document).toContain(`<UserId>${TEST_WINDOWS_TASK_SID}</UserId>`);
   });
 
   test("escapes environment values that would break out of set quotes", () => {
@@ -2527,6 +2527,29 @@ describe("service repair", () => {
     });
 
     expect(calls).toEqual(["stop", "assets", "reregister", "start", "state"]);
+  });
+
+  test("repair preserves a mangled legacy path instead of adopting it", async () => {
+    const calls: string[] = [];
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const expectedLauncher = "C:\\Users\\김병준\\.opencodex\\service-launcher.vbs";
+    const reportedLauncher = "C:\\Users\\???\\.opencodex\\service-launcher.vbs";
+    const legacy = buildWindowsTaskXml("ignored.cmd", reportedLauncher, undefined, TEST_WINDOWS_TASK_SID)
+      .replace(/<SessionStateChangeTrigger>[\s\S]*?<\/SessionStateChangeTrigger>\s*/gi, "");
+
+    await expect(repairService({
+      platform: "win32",
+      diagnose: () => baseDiag,
+      assertEnv: () => {},
+      assertAuth: () => {},
+      schedulerWscript: wscript,
+      schedulerLauncher: expectedLauncher,
+      resolveExpectedUserId: () => TEST_WINDOWS_TASK_SID,
+      readSchedulerXml: () => legacy,
+      stopScheduler: () => { calls.push("stop"); },
+      reregisterScheduler: async () => { calls.push("reregister"); },
+    })).rejects.toThrow(/preserved for manual review/i);
+    expect(calls).toEqual([]);
   });
 
   test("repair leaves a healthy registration alone", async () => {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -7,14 +7,30 @@ import { pathToFileURL } from "node:url";
 import * as serviceModule from "../src/service";
 import { saveConfig } from "../src/config";
 import { windowsEnvIndirectBatchValue } from "../src/lib/win-paths";
-import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, SERVICE_INSTALL_HEALTH_MS, SERVICE_INSTALL_HEALTH_WINDOWS_MS, serviceInstallHealthMs, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, stableLauncherEntry, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, uninstallSystemd, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy } from "../src/service";
+import { assertServiceAuthEnvironment, assertServiceEnvironmentMatchesInstall, bakedServicePathsDiagnostic, confirmServiceServing, launchdListenPort, systemdListenPort, buildPlist, buildUnit, buildWindowsLauncherVbs, buildWindowsSchtasksCreateArgs, buildWindowsSchtasksCreateArgsForXml, buildWindowsServiceScript, buildWindowsTaskXml as buildWindowsTaskXmlProduction, deriveWindowsServiceDiagnostic, deriveWindowsServiceDiagnosticForCurrentUser, installFreshWindowsSchedulerSafely, installServiceSafely, launchctlLoadFailed, launchdJobMatchesPlist, normalizeServiceSubcommand, parseServiceArgs, parseServiceInstallState, planServiceCommand, prepareServiceInstall, probeServiceInstallation, readWindowsSchedulerXmlState, registerFreshWindowsSchedulerTask, removeNativeWindowsServiceForScheduler, repairService, reportServiceServing, resolveServiceListenPort, runLaunchctl, selectServiceSubcommand, SERVICE_INSTALL_HEALTH_MS, SERVICE_INSTALL_HEALTH_WINDOWS_MS, serviceInstallHealthMs, serviceLogPath, serviceStartableFromTray, serviceStatusReport, serviceRetryCommand, serviceStatusSummary, stableLauncherEntry, systemdNeedsDaemonReload, systemdServiceInstallCleanupOps, uninstallSystemd, windowsListenPort, winswListenPort, startLaunchd, windowsTaskRegistrationHealthy as windowsTaskRegistrationHealthyProduction } from "../src/service";
 import type { ServiceDiagnostic } from "../src/service";
 import { definitionCarriesCredential, resolvedProxyEnv, writeServiceDefinitionFile } from "../src/service";
 import { buildWinswXml } from "../src/lib/winsw";
 import { CONFIG_OWNER_FILE, CONFIG_UNINSTALL_MANIFEST, recordOwnedConfigPath, removeOwnedConfigState } from "../src/lib/config-ownership";
 import { serviceApiTokenFilePath } from "../src/lib/service-secrets";
 import { WindowsSchtasksError } from "../src/lib/windows-elevation";
+import { resolveCurrentWindowsPrincipal, setWindowsPrincipalRunnerForTests } from "../src/lib/windows-user-principal";
 import type { OcxConfig } from "../src/types";
+
+const TEST_WINDOWS_TASK_SID = "S-1-5-21-111-222-333-1001";
+setWindowsPrincipalRunnerForTests(() => ({
+  success: true,
+  exitCode: 0,
+  timedOut: false,
+  stdout: `${TEST_WINDOWS_TASK_SID}\nMACHINE\\tester\n`,
+}));
+resolveCurrentWindowsPrincipal(1_000);
+afterAll(() => { setWindowsPrincipalRunnerForTests(null); });
+
+const buildWindowsTaskXml = (...args: Parameters<typeof buildWindowsTaskXmlProduction>) =>
+  buildWindowsTaskXmlProduction(args[0], args[1], args[2], args[3] ?? TEST_WINDOWS_TASK_SID);
+const windowsTaskRegistrationHealthy = (...args: Parameters<typeof windowsTaskRegistrationHealthyProduction>) =>
+  windowsTaskRegistrationHealthyProduction(args[0], args[1], args[2], args[3] === undefined ? TEST_WINDOWS_TASK_SID : args[3]);
 
 const TEST_DIR = join(import.meta.dir, ".tmp-service-test");
 const previousOpenCodexHome = process.env.OPENCODEX_HOME;
@@ -585,7 +601,7 @@ describe("Windows service task", () => {
     expect(windowsTaskRegistrationHealthy(scoped, wscript, launcher, null)).toBe(false);
     expect(windowsTaskRegistrationHealthy(scoped, wscript, launcher, "MACHINE\\installer")).toBe(true);
     expect(windowsTaskRegistrationHealthy(foreign, wscript, launcher, "MACHINE\\installer")).toBe(false);
-    expect(windowsTaskRegistrationHealthy(unscoped, wscript, launcher, null)).toBe(true);
+    expect(windowsTaskRegistrationHealthy(unscoped, wscript, launcher, null)).toBe(false);
   });
 
   test("never code-page-folds an explicit session identity", () => {
@@ -606,7 +622,7 @@ describe("Windows service task", () => {
     // healthy, and repair would then leave that foreign scope in place.
     const guardWscript = "C:\\Windows\\System32\\wscript.exe";
     const guardLauncher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
-    const guardXml = buildWindowsTaskXml("ignored.cmd", guardLauncher, undefined, "")
+    const guardXml = buildWindowsTaskXml("ignored.cmd", guardLauncher, undefined, TEST_WINDOWS_TASK_SID)
       .replace(/<Command>.*?<\/Command>/, `<Command>${guardWscript}</Command>`);
     expect(windowsTaskRegistrationHealthy(guardXml, guardWscript, guardLauncher)).toBe(true);
     const foreignPrefixed = guardXml.replace(
@@ -657,7 +673,7 @@ describe("Windows service task", () => {
     expect(canonical).not.toContain("RunLevel");
 
     expect(windowsTaskRegistrationHealthy(canonical, wscript, launcher)).toBe(true);
-    expect(readWindowsSchedulerXmlState(canonical, wscript, launcher)).toMatchObject({
+    expect(readWindowsSchedulerXmlState(canonical, wscript, launcher, TEST_WINDOWS_TASK_SID)).toMatchObject({
       installed: true,
       enabled: true,
       registrationHealthy: true,
@@ -849,7 +865,7 @@ describe("Windows service task", () => {
   test("writes Task Scheduler XML with a UTF-16 BOM for schtasks", async () => {
     const service = await Bun.file(new URL("../src/service.ts", import.meta.url)).text();
 
-    expect(service).toContain('writeServiceAssetWithRetry(windowsTaskXmlPath(), `\\uFEFF${buildWindowsTaskXml(script)}`, "utf16le")');
+    expect(service).toContain('resolvedWindowsTaskSid()');
   });
 
   test("escapes environment values that would break out of set quotes", () => {
@@ -2077,7 +2093,7 @@ describe("service lifecycle cleanup ordering", () => {
     expect(assetsAt).toBeLessThan(createAt);
     expect(installWindows).not.toContain("writeFileSync(script");
     expect(assetsHelper).toContain("writeServiceAssetWithRetry(script");
-    expect(assetsHelper).toContain("writeServiceAssetWithRetry(windowsTaskXmlPath()");
+    expect(assetsHelper).toContain("windowsTaskXmlPath(),");
     // Retry helper tolerates transient Windows file locks from the just-ended task.
     expect(service).toContain('code !== "EBUSY" && code !== "EPERM" && code !== "EACCES"');
   });
@@ -2183,6 +2199,7 @@ describe("service diagnostics", () => {
     staleBakedPaths: false,
     nativeRepairAssetsOnly: false,
     diagnostics: "logs: test",
+    schedulerExpectedUserId: TEST_WINDOWS_TASK_SID,
   };
   const installedEnabled = { schedulerXml: healthyTaskXml() };
   const installedDisabled = { schedulerXml: disabledTaskXml() };
@@ -2233,7 +2250,7 @@ describe("service diagnostics", () => {
       ...base,
       schedulerXml: unscoped,
       recordedBackend: "scheduler",
-    }, deps)).toMatchObject({ viable: true, stale: false });
+    }, deps)).toMatchObject({ viable: false, stale: true });
     expect(resolutions).toBe(1);
     expect(timeouts).toEqual([30_000]);
   });
@@ -2260,7 +2277,7 @@ describe("service diagnostics", () => {
       ...base,
       schedulerXml: unscoped,
       recordedBackend: "scheduler",
-    }, deps)).toMatchObject({ viable: true, stale: false });
+    }, deps)).toMatchObject({ viable: false, stale: true });
     expect(resolutions).toBe(1);
   });
 
@@ -2483,6 +2500,33 @@ describe("service repair", () => {
     });
     // Re-registration happens after the assets exist and before the task is started.
     expect(calls).toEqual(["env", "auth", "stop", "assets", "reregister", "start", "state"]);
+  });
+
+  test("repair migrates an exact legacy account name to the preferred SID", async () => {
+    const calls: string[] = [];
+    const sid = "S-1-5-21-111-222-333-1001";
+    const name = "MACHINE\\installer";
+    const legacyNameXml = buildWindowsTaskXml(undefined, undefined, undefined, name);
+    let attemptNonce = "";
+
+    expect(windowsTaskRegistrationHealthy(legacyNameXml, undefined, undefined, [sid, name])).toBe(true);
+    await repairService({
+      platform: "win32",
+      diagnose: () => baseDiag,
+      assertEnv: () => {},
+      assertAuth: () => {},
+      resolveExpectedUserId: () => [sid, name],
+      stopScheduler: () => { calls.push("stop"); },
+      writeSchedulerAssets: () => { calls.push("assets"); },
+      readSchedulerXml: () => attemptNonce
+        ? buildWindowsTaskXml(undefined, undefined, attemptNonce, sid)
+        : legacyNameXml,
+      reregisterScheduler: async nonce => { calls.push("reregister"); attemptNonce = nonce; },
+      startScheduler: () => { calls.push("start"); },
+      writeSchedulerState: () => { calls.push("state"); },
+    });
+
+    expect(calls).toEqual(["stop", "assets", "reregister", "start", "state"]);
   });
 
   test("repair leaves a healthy registration alone", async () => {
@@ -3250,6 +3294,28 @@ describe("service serving confirmation", () => {
       expect(SERVICE_INSTALL_HEALTH_WINDOWS_MS).toBe(45_000);
       expect(serviceInstallHealthMs("linux")).toBe(SERVICE_INSTALL_HEALTH_MS);
       expect(serviceInstallHealthMs("darwin")).toBe(SERVICE_INSTALL_HEALTH_MS);
+    });
+
+    test("reports the effective Windows failure budget", async () => {
+      const errors: string[] = [];
+      const previousError = console.error;
+      const previousExitCode = process.exitCode;
+      let now = 0;
+      console.error = (...values: unknown[]) => { errors.push(values.join(" ")); };
+      try {
+        await reportServiceServing("repaired", {
+          port: 10100,
+          probe: async () => false,
+          sleep: async ms => { now += ms; },
+          now: () => now,
+          timeoutMs: SERVICE_INSTALL_HEALTH_WINDOWS_MS,
+        });
+        expect(errors.join("\n")).toContain("within 45s");
+        expect(errors.join("\n")).not.toContain("within 20s");
+      } finally {
+        console.error = previousError;
+        process.exitCode = previousExitCode ?? 0;
+      }
     });
 
     // A service reinstall invalidates the pidfile, so resolving the target through

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -489,6 +489,52 @@ describe("Windows service task", () => {
   });
 
   /**
+   * #3064: `schtasks /query /xml` converts the document through the console code
+   * page before the bytes exist, so a profile named outside that page comes back
+   * with substitution characters. An exact comparison rejected a registration this
+   * process had just created correctly, and `ocx service install` rolled it back.
+   *
+   * The tolerance has to stay narrow enough that a MANGLED path still cannot match
+   * a DIFFERENT account's path. A wildcard as wide as `[^\\/]*` leaves a fully
+   * non-ASCII segment with no anchors at all, so `...\\김병준\\...` would match
+   * `...\\Admin\\...` and this process would adopt another account's task.
+   */
+  describe("a scheduler path the console code page could not carry", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\김병준\\.opencodex\\service-launcher.vbs";
+    const healthy = (reportedLauncher: string, expectedLauncher = launcher) =>
+      windowsTaskRegistrationHealthy(
+        buildWindowsTaskXml("ignored.cmd", reportedLauncher)
+          .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`),
+        wscript,
+        expectedLauncher,
+      );
+
+    test.each([
+      ["question marks, one per character", "C:\\Users\\???\\.opencodex\\service-launcher.vbs"],
+      ["a single replacement character", "C:\\Users\\\uFFFD\\.opencodex\\service-launcher.vbs"],
+    ])("accepts a registration whose profile came back as %s", (_label, reported) => {
+      expect(healthy(reported)).toBe(true);
+    });
+
+    // The reason the tolerance is a substitution class and not a wildcard.
+    test("rejects another account's path that is merely the same shape", () => {
+      expect(healthy("C:\\Users\\Admin\\.opencodex\\service-launcher.vbs")).toBe(false);
+    });
+
+    test("rejects a path whose ASCII structure differs", () => {
+      expect(healthy("C:\\Users\\???\\.opencodex\\other-launcher.vbs")).toBe(false);
+      expect(healthy("D:\\Users\\???\\.opencodex\\service-launcher.vbs")).toBe(false);
+    });
+
+    // An expectation with nothing unrepresentable in it has nothing to forgive.
+    test("does not forgive substitutions when the expected path is pure ASCII", () => {
+      const ascii = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
+      expect(healthy("C:\\Users\\???\\.opencodex\\service-launcher.vbs", ascii)).toBe(false);
+    });
+  });
+
+  /**
    * `UserId` is optional in the schema, and omitting it makes a SessionStateChangeTrigger fire
    * for any account's session change. Scope it to the installing account when that account is
    * known. The builder is synchronous and cannot force an account lookup, so an unknown

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -863,7 +863,7 @@ describe("Windows service task", () => {
   });
 
   test("writes Task Scheduler XML with an exact SID and UTF-16 BOM", () => {
-    const document = buildWindowsTaskXmlDocument("service.cmd", "launcher.vbs", undefined, TEST_WINDOWS_TASK_SID);
+    const document = buildWindowsTaskXmlDocument("service.cmd", "launcher.vbs");
     expect(document.charCodeAt(0)).toBe(0xFEFF);
     expect(document).toContain(`<UserId>${TEST_WINDOWS_TASK_SID}</UserId>`);
   });
@@ -2535,6 +2535,7 @@ describe("service repair", () => {
     const expectedLauncher = "C:\\Users\\김병준\\.opencodex\\service-launcher.vbs";
     const reportedLauncher = "C:\\Users\\???\\.opencodex\\service-launcher.vbs";
     const legacy = buildWindowsTaskXml("ignored.cmd", reportedLauncher, undefined, TEST_WINDOWS_TASK_SID)
+      .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`)
       .replace(/<SessionStateChangeTrigger>[\s\S]*?<\/SessionStateChangeTrigger>\s*/gi, "");
 
     await expect(repairService({

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -588,6 +588,18 @@ describe("Windows service task", () => {
     expect(windowsTaskRegistrationHealthy(unscoped, wscript, launcher, null)).toBe(true);
   });
 
+  test("never code-page-folds an explicit session identity", () => {
+    const wscript = "C:\\Windows\\System32\\wscript.exe";
+    const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
+    const expected = "MACHINE\\김병준";
+    const scoped = buildWindowsTaskXml("ignored.cmd", launcher, undefined, expected)
+      .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
+    const mangled = scoped.replaceAll(expected, "MACHINE\\???");
+
+    expect(windowsTaskRegistrationHealthy(scoped, wscript, launcher, expected)).toBe(true);
+    expect(windowsTaskRegistrationHealthy(mangled, wscript, launcher, expected)).toBe(false);
+  });
+
   test("validates the registered scheduler action, trigger, principal, and settings", () => {
     // Guard first: a prefixed <t:UserId> is a real scope the unprefixed element counter cannot
     // see. Treating it as ABSENT would accept a task bound to somebody else's session as
@@ -2176,10 +2188,11 @@ describe("service diagnostics", () => {
   const installedDisabled = { schedulerXml: disabledTaskXml() };
 
   test("resolves an explicit scheduler scope once at the Windows diagnostic boundary", () => {
-    const scoped = buildWindowsTaskXml(undefined, undefined, undefined, "MACHINE\\installer");
-    const foreign = scoped.replaceAll("MACHINE\\installer", "OTHER\\account");
+    const sid = "S-1-5-21-111-222-333-1001";
+    const scoped = buildWindowsTaskXml(undefined, undefined, undefined, sid);
+    const foreign = scoped.replaceAll(sid, "S-1-5-21-999-888-777-1002");
     const unscoped = buildWindowsTaskXml(undefined, undefined, undefined, "");
-    let identity: Readonly<{ name: string }> | null = null;
+    let identity: Readonly<{ sid: string; name: string }> | null = null;
     let resolutions = 0;
     const timeouts: number[] = [];
     const deps = {
@@ -2187,7 +2200,7 @@ describe("service diagnostics", () => {
       resolvePrincipal: (timeoutMs: number) => {
         timeouts.push(timeoutMs);
         resolutions += 1;
-        identity = { name: "MACHINE\\installer" };
+        identity = { sid, name: "MACHINE\\installer" };
         return "*S-1-5-21-111-222-333-1001";
       },
     };
@@ -2197,7 +2210,7 @@ describe("service diagnostics", () => {
       schedulerXml: scoped,
       recordedBackend: "scheduler",
     }, deps);
-    expect(identity).toEqual({ name: "MACHINE\\installer" });
+    expect(identity).toEqual({ sid, name: "MACHINE\\installer" });
     expect(resolutions).toBe(1);
     expect(matching).toMatchObject({ viable: true, stale: false });
     expect(deriveWindowsServiceDiagnosticForCurrentUser({

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -755,6 +755,7 @@ describe("GUI update execution decisions", () => {
   // runService is then never called and this goes red.
   test("a non-elevated Windows update worker repairs the service instead of skipping it", async () => {
     const ranService: string[][] = [];
+    const serviceTimeouts: number[] = [];
     const spawned: Array<{ port: number }> = [];
     const job: UpdateJobState = {
       id: "svc-win-repair",
@@ -779,8 +780,9 @@ describe("GUI update execution decisions", () => {
         serviceViableFn: () => true,
         waitForPort: async () => true,
         probeProxy: async () => true,
-        runService: (_j, _bin, args) => {
+        runService: (_j, _bin, args, timeoutMs) => {
           ranService.push(args);
+          serviceTimeouts.push(timeoutMs);
           return { status: 0 };
         },
         spawnStart: (_job, _installer, port) => {
@@ -791,6 +793,7 @@ describe("GUI update execution decisions", () => {
       expect(ranService.length).toBe(1);
       expect(ranService[0]).toContain("repair");
       expect(ranService[0]).not.toContain("install");
+      expect(serviceTimeouts).toEqual([150_000]);
     } finally {
       if (prevService === undefined) delete process.env.OCX_SERVICE;
       else process.env.OCX_SERVICE = prevService;

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -828,6 +828,9 @@ describe("GUI update execution decisions", () => {
       probeProxy: async () => false,
     })).rejects.toThrow(/state unknown.*refusing a competing direct start/i);
     expect(spawned).toEqual([]);
+    const log = readUpdateJob(job.id)?.log.join("\n") ?? "";
+    expect(log).toContain("refusing a competing direct start");
+    expect(log).not.toContain("falling back to a direct proxy start");
   });
 
   test("service reinstall exit 0 with non-viable assets falls back to direct start", async () => {

--- a/tests/update-job.test.ts
+++ b/tests/update-job.test.ts
@@ -800,6 +800,36 @@ describe("GUI update execution decisions", () => {
     }
   });
 
+  test("a timed-out Windows repair never starts a competing foreground proxy", async () => {
+    const spawned: number[] = [];
+    const job: UpdateJobState = {
+      id: "svc-win-timeout",
+      status: "restarting",
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      currentVersion: "2.7.42",
+      latestVersion: "2.7.43",
+      channel: "latest",
+      installer: "npm",
+      restart: true,
+      command: "",
+      log: [],
+      releaseNotesUrl: "",
+    };
+    writeFileSync(updateJobPath(job.id), JSON.stringify(job));
+
+    await expect(restartAfterUpdateForTests(job, { port: 19010, hostname: "127.0.0.1" }, {
+      platform: "win32",
+      serviceInstalledFn: () => true,
+      serviceViableFn: () => true,
+      waitForPort: async () => true,
+      runService: () => ({ status: null, signal: "SIGTERM", timedOut: true }),
+      spawnStart: (_job, _installer, port) => { spawned.push(port ?? 0); },
+      probeProxy: async () => false,
+    })).rejects.toThrow(/state unknown.*refusing a competing direct start/i);
+    expect(spawned).toEqual([]);
+  });
+
   test("service reinstall exit 0 with non-viable assets falls back to direct start", async () => {
     const spawned: Array<{ port: number }> = [];
     const job: UpdateJobState = {

--- a/tests/windows-scheduler-install-verification.test.ts
+++ b/tests/windows-scheduler-install-verification.test.ts
@@ -13,6 +13,8 @@ import {
   windowsTaskRegistrationHealthy,
 } from "../src/service";
 
+const TEST_WINDOWS_TASK_SID = "S-1-5-21-111-222-333-1001";
+
 afterEach(() => {
   setQuerySchtasksForTests(null);
 });
@@ -27,6 +29,8 @@ describe("decodeSchtasksOutput", () => {
     const xml = buildWindowsTaskXml(
       "C:\\Users\\x\\.opencodex\\opencodex-service.cmd",
       "C:\\Users\\x\\.opencodex\\opencodex-service-launcher.vbs",
+      undefined,
+      TEST_WINDOWS_TASK_SID,
     ).replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
     const utf16 = Buffer.from(`\uFEFF${xml}`, "utf16le");
     const decoded = decodeSchtasksOutput(utf16);
@@ -35,6 +39,7 @@ describe("decodeSchtasksOutput", () => {
       decoded,
       wscript,
       "C:\\Users\\x\\.opencodex\\opencodex-service-launcher.vbs",
+      TEST_WINDOWS_TASK_SID,
     )).toBe(true);
     // Sanity: the historical utf8 mis-decode is unhealthy.
     expect(windowsTaskRegistrationHealthy(utf16.toString("utf8"))).toBe(false);
@@ -167,11 +172,11 @@ describe("formatWindowsSchedulerServiceStatus", () => {
 describe("evaluateWindowsSchedulerInstallVerification", () => {
   const wscript = "C:\\Windows\\System32\\wscript.exe";
   const launcher = "C:\\Users\\Test\\.opencodex\\opencodex-service-launcher.vbs";
-  const healthyXml = buildWindowsTaskXml("ignored.cmd", launcher)
+  const healthyXml = buildWindowsTaskXml("ignored.cmd", launcher, undefined, TEST_WINDOWS_TASK_SID)
     .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
 
   test("succeeds when task, registration, assets, and absent WinSW all hold", () => {
-    expect(windowsTaskRegistrationHealthy(healthyXml, wscript, launcher)).toBe(true);
+    expect(windowsTaskRegistrationHealthy(healthyXml, wscript, launcher, TEST_WINDOWS_TASK_SID)).toBe(true);
     const result = evaluateWindowsSchedulerInstallVerification({
       taskInstalled: true,
       xml: healthyXml,
@@ -179,6 +184,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "nonexistent",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(result).toMatchObject({
       ok: true,
@@ -198,6 +204,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "stopped",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(result.ok).toBe(false);
     expect(result.conflict).toBe(true);
@@ -213,6 +220,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "started",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(result.ok).toBe(false);
     expect(result.conflict).toBe(true);
@@ -226,6 +234,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "unknown",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(result.ok).toBe(false);
     expect(result.conflict).toBe(false);
@@ -244,6 +253,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "nonexistent",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(result.ok).toBe(false);
     expect(result.registrationHealthy).toBe(false);
@@ -259,6 +269,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "nonexistent",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(invalid.registrationHealthy).toBe(false);
     expect(invalid.registrationInvalid).toBe(true);
@@ -286,6 +297,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "nonexistent",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(withData.registrationInvalid).toBe(true);
     expect(schedulerVerificationMaySettle(withData)).toBe(false);
@@ -299,6 +311,7 @@ describe("evaluateWindowsSchedulerInstallVerification", () => {
       nativeStatus: "nonexistent",
       wscript,
       launcher,
+      expectedUserId: TEST_WINDOWS_TASK_SID,
     });
     expect(result.ok).toBe(false);
     expect(result.assetsHealthy).toBe(false);


### PR DESCRIPTION
## Summary

Rebases #3104 onto current `dev`. Same seven commits, same author, verified content-identical — see Verification. Supersedes #3104, which was approved on a head that is now 27 commits stale and red on a flake that has since been fixed.

Closes #3009. Closes #3064.

Two issues, one file (`src/service.ts`), stacked because a conflicting pair would have cost more to review than one sequence.

**#3009 — Windows cold start.** `confirmServiceServing` had a fixed 20s deadline and returned the moment the clock passed it. A Windows cold start does NTFS ACL hardening and previous-session journal recovery before the listener exists, so a service that bound a few seconds late and then stayed healthy was reported as a terminal failure with exit 1 — and the caller's fallback starts a second proxy against a port that is about to be taken. Windows gets 45s; nothing else changes.

**#3064 — non-ASCII profile path.** `schtasks /query /xml` converts through the console code page before the bytes exist, so reading as a buffer cannot recover them. A profile named outside that page comes back as `C:\Users\???\...` and the exact comparison rejected a registration this process had just created. An unrepresentable run now matches only a run of substitution characters, and every ASCII segment including every separator is matched literally, so `C:\Users\<CJK>\...` cannot match `C:\Users\Admin\...`.

## Why the original was red, and why this is not

#3104's `macos` job failed one assertion: `server local API auth > websocket passthrough refreshes pool auth for each response.create turn`. That is the cross-platform flake fixed by #3128 (`33d32b6a3`), which landed after #3104's head was cut. Rebasing onto current `dev` picks the fix up; nothing in this change touches that path.

## Verification

```
git range-diff 9d122ddb..4f691cdd origin/dev..HEAD
  1: 7b1b4ce1f = 1: 3b7cc1f00 fix(service): give a Windows cold start room to bind, without loosening zero budget
  2: b727f8f81 = 2: 68a8fb6a4 fix(service): forgive only what the code page mangled in a scheduler path
  3: 188e61861 = 3: 089598878 fix(service): bind scheduler recovery to exact SID
  4: 4d83513b4 = 4: 183e6dfaa fix(service): fail closed on ambiguous scheduler ownership
  5: 97efe6f46 = 5: adda7a574 test(service): lock scheduler ownership guards
  6: b29389a88 = 6: ed6fe19db test(service): scope scheduler verification fixtures
  7: 4f691cddc = 7: 5ea32ad00 test(service): exercise scheduler ownership oracles
```

All seven `=`: content identical, only the base moved. `src/service.ts` was the sole file changed on both sides since the merge base (dev-side commit `330470e74`), and it merged without conflict.

```
bun test tests/service.test.ts
  191 pass / 0 fail / 617 expect() calls
```

## On the contributor PRs this supersedes

#3067 (@ntdatt812) locates the #3064 defect correctly and is superseded here — its remedy needed narrowing, because compiling every unrepresentable run to `[^\\/]*` forbids a separator but allows arbitrary ASCII, so a wholly non-ASCII segment loses every anchor and one account could adopt another's scheduler task.

**#3039 (@ntdatt812) is deliberately NOT closed by this PR.** It contributed a diagnostic this rebase does not carry: it prints the time actually waited (`Math.round((elapsed() - startedAt) / 1000)`), where this prints the configured budget (`Math.trunc(healthBudgetMs / 1000)`). Since this PR also adds a post-deadline grace knock, the printed number can understate the real wait — which is the defect #3039 set out to fix. That contribution deserves its own resolution rather than a silent supersession.

## Checklist

- [x] Targets `dev`
- [x] Focused regression test for the changed subsystem passes (`tests/service.test.ts`)
- [x] Rebase verified content-identical by `git range-diff`
- [x] Original authorship preserved across all seven commits
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows service installation health checks with platform-specific startup timing and an additional recovery probe.
  * Strengthened Windows Task Scheduler registration validation using account identity information, including automatic migration of older registrations.
  * Improved compatibility with non-ASCII Windows profile paths.
  * Prevented unsafe competing service starts after a repair timeout.

* **Improvements**
  * Windows service repairs now allow more time to complete and provide manual recovery guidance when the outcome is unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->