### PR TITLE
test: probe for a free pid instead of assuming 4242 is dead (carry of #3042)

### DIFF
--- a/tests/cli-status-json.test.ts
+++ b/tests/cli-status-json.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isConnectionRefused, isUncleanExitEvidence, proxyHealthFailureReason, resolveStatusPid, selectListenTarget } from "../src/cli/status";
+import { findDeadPid } from "./helpers/dead-pid";
 
 const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const cliPath = join(repoRoot, "src", "cli", "index.ts");
@@ -431,7 +432,7 @@ describe("unclean prior exit evidence", () => {
 describe("status reports stale process records end to end", () => {
   const seed = (home: string, opts: { pid?: number; runtime?: boolean; port: number }): void => {
     writeFileSync(join(home, "config.json"), JSON.stringify({ port: opts.port, codexAutoStart: false }), "utf8");
-    const pid = opts.pid ?? (process.pid === 4242 ? 4243 : 4242);
+    const pid = opts.pid ?? findDeadPid();
     if (opts.pid !== 0) writeFileSync(join(home, "ocx.pid"), String(pid), "utf8");
     if (opts.runtime) {
       writeFileSync(join(home, "runtime-port.json"), JSON.stringify({ pid, port: opts.port, hostname: "127.0.0.1" }), "utf8");
@@ -519,7 +520,7 @@ describe("status reports stale process records end to end", () => {
     await new Promise<void>(resolve => { occupied.listen(0, "127.0.0.1", () => resolve()); });
     const occupiedPort = (occupied.address() as AddressInfo).port;
     try {
-      const pid = process.pid === 4242 ? 4243 : 4242;
+      const pid = findDeadPid();
       writeFileSync(join(home, "config.json"), JSON.stringify({ port: occupiedPort, codexAutoStart: false }), "utf8");
       writeFileSync(join(home, "ocx.pid"), String(pid), "utf8");
       writeFileSync(join(home, "runtime-port.json"), JSON.stringify({ pid, port: freePort, hostname: "127.0.0.1" }), "utf8");

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -30,6 +30,7 @@ import {
   LOCAL_MANAGEMENT_READ_PATHS,
   verifyLocalManagementReadCapability,
 } from "../src/lib/local-management-capability";
+import { findDeadPid } from "./helpers/dead-pid";
 
 const TEST_DIR = join(import.meta.dir, ".tmp-doctor-test");
 const TEST_CODEX_HOME = join(TEST_DIR, "codex");
@@ -802,7 +803,7 @@ describe("doctor reclaim wiring (end to end)", () => {
   });
 
   const seedStaleTemp = (): string => {
-    const deadPid = process.pid === 4242 ? 4243 : 4242;
+    const deadPid = findDeadPid();
     const path = join(tempHome, `responses-state.json.ocx.${deadPid}.1.tmp`);
     writeFileSync(path, "abandoned snapshot");
     const old = new Date(Date.now() - 48 * 60 * 60 * 1_000);
@@ -867,7 +868,7 @@ describe("doctor reports an unclean prior proxy exit", () => {
   const deadPid = (): number => {
     const spawned = spawnSync(process.execPath, ["-e", ""], { encoding: "utf8" });
     const pid = spawned.pid;
-    return typeof pid === "number" && pid > 0 ? pid : (process.pid === 4242 ? 4243 : 4242);
+    return typeof pid === "number" && pid > 0 ? pid : findDeadPid();
   };
 
   // Port 9 is the discard port: nothing listens, so the health probe is refused rather

--- a/tests/helpers/dead-pid.ts
+++ b/tests/helpers/dead-pid.ts
@@ -1,0 +1,32 @@
+/**
+ * A pid that is genuinely free, probed rather than assumed.
+ *
+ * Several suites need a pid that stands in for a process that has exited: stale
+ * `ocx.pid` records, abandoned response-state temps, doctor's reclaim paths. The
+ * code under test asks the kernel whether that owner is still alive, so a
+ * hardcoded "dead" pid is only dead until some unrelated process happens to hold
+ * it — and then the production code answers correctly, the test reads that as a
+ * miss, and the failure looks like a defect in the feature.
+ *
+ * That is not hypothetical. On the macOS host where this helper was written, pid
+ * 4242 was `liveactivitiesd`, and every suite that assumed it dead failed at once:
+ * `periodic reclaim frees abandoned temps`, both `doctor reclaim wiring` cases and
+ * both `status reports stale process records` cases. `tests/responses-state.test.ts`
+ * already probed for a free pid inline, with a comment naming this exact hazard;
+ * this helper is that probe, shared instead of copied.
+ *
+ * ESRCH is the only answer that proves absence. A successful `kill(pid, 0)` means
+ * the process is alive, and EPERM means it is alive but owned by somebody else —
+ * both disqualify the candidate.
+ */
+export function findDeadPid(): number {
+  for (let candidate = 4242; candidate < 5242; candidate += 1) {
+    if (candidate === process.pid) continue;
+    try {
+      process.kill(candidate, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return candidate;
+    }
+  }
+  throw new Error("no free pid in [4242, 5242) to stand in for a dead owner");
+}

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { BULK_DURABLE_IO_BUDGET_MS } from "./helpers/test-budget";
+import { findDeadPid } from "./helpers/dead-pid";
 import {
   closeSync,
   existsSync,
@@ -2526,7 +2527,7 @@ describe("Responses previous_response_id state", () => {
 
   test("recovers only old response-state temps owned by dead processes", () => {
     const old = new Date(Date.now() - 60 * 60 * 1_000);
-    const deadPid = process.pid === 4242 ? 4243 : 4242;
+    const deadPid = findDeadPid();
     const stale = join(home, `responses-state.json.ocx.${deadPid}.1.tmp`);
     const live = join(home, "responses-state.json.ocx.5252.2.tmp");
     const current = join(home, `responses-state.json.ocx.${process.pid}.3.tmp`);
@@ -2560,21 +2561,7 @@ describe("Responses previous_response_id state", () => {
     symlinkSync(realSnapshot, join(home, "responses-state.json"));
 
     // This test drives the REAL load path, whose sweep probes live pids with kill(pid, 0).
-    // A hardcoded "dead" pid can collide with a live process on a shared CI runner, so
-    // probe for a genuinely dead one instead (ESRCH). EPERM means alive-but-not-ours.
-    let deadPid = -1;
-    for (let candidate = 4242; candidate < 5242; candidate++) {
-      if (candidate === process.pid) continue;
-      try {
-        process.kill(candidate, 0);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ESRCH") {
-          deadPid = candidate;
-          break;
-        }
-      }
-    }
-    expect(deadPid).toBeGreaterThan(0);
+    const deadPid = findDeadPid();
     const stranded = join(realDir, `responses-state.json.ocx.${deadPid}.1.tmp`);
     writeFileSync(stranded, "private state");
     const old = new Date(Date.now() - 60 * 60 * 1_000);
@@ -2588,7 +2575,7 @@ describe("Responses previous_response_id state", () => {
   });
 
   test("stale temp recovery is best-effort when unlink fails", () => {
-    const deadPid = process.pid === 4242 ? 4243 : 4242;
+    const deadPid = findDeadPid();
     const path = join(home, `responses-state.json.ocx.${deadPid}.1.tmp`);
     writeFileSync(path, "private state");
     const old = new Date(Date.now() - 60 * 60 * 1_000);
@@ -2653,7 +2640,7 @@ describe("Responses previous_response_id state", () => {
     // schedulePersist site sits downstream of, so a process had its only look BEFORE it
     // wrote anything. Here nothing touches the continuation store at all.
     const old = new Date(Date.now() - 60 * 60 * 1_000);
-    const deadPid = process.pid === 4242 ? 4243 : 4242;
+    const deadPid = findDeadPid();
     const stale = join(home, `responses-state.json.ocx.${deadPid}.1.tmp`);
     const young = join(home, "responses-state.json.ocx.6262.4.tmp");
     for (const path of [stale, young]) writeFileSync(path, "private state");
@@ -2751,7 +2738,7 @@ describe("Responses previous_response_id state", () => {
     // Report and reclaim must share one predicate. If they drift, doctor tells an operator
     // to reclaim files it will then refuse to touch (or vice versa).
     const old = new Date(Date.now() - 60 * 60 * 1_000);
-    const deadPid = process.pid === 4242 ? 4243 : 4242;
+    const deadPid = findDeadPid();
     const stale = join(home, `responses-state.json.ocx.${deadPid}.1.tmp`);
     const live = join(home, "responses-state.json.ocx.5252.2.tmp");
     const young = join(home, "responses-state.json.ocx.6262.3.tmp");


### PR DESCRIPTION
## Summary

Carries #3042 (author @lifrary) onto current `dev`. The commit is the author's, cherry-picked with `-x`; authorship is preserved.

Closes #3042 once this lands.

Nine sites across three suites stood in for an exited process with a hardcoded pid:

```ts
const deadPid = process.pid === 4242 ? 4243 : 4242;
```

The code under test asks the kernel whether that owner is still alive, so the pid is only dead until an unrelated process happens to hold it. Production then answers correctly, the test reads that as a miss, and the failure looks like a defect in the feature rather than in the fixture.

That is not hypothetical. The helper's own comment records the day it happened: on the author's macOS host pid 4242 was `liveactivitiesd`, and every suite assuming it dead failed at once — `periodic reclaim frees abandoned temps`, both `doctor reclaim wiring` cases, and both `status reports stale process records` cases.

## What it does

Adds `tests/helpers/dead-pid.ts` and routes the three suites through it. The discrimination that matters is in the catch:

```ts
try {
  process.kill(candidate, 0);
} catch (error) {
  if ((error as NodeJS.ErrnoException).code === "ESRCH") return candidate;
}
```

`ESRCH` is the only answer that proves absence. A successful `kill(pid, 0)` means alive, and `EPERM` means alive but owned by somebody else — a naive probe reads that second one as free, which would reintroduce the same bug in a new form. It also skips `process.pid` and throws rather than returning a wrong answer if the whole window is occupied.

This is not a new abstraction: `tests/responses-state.test.ts` already probed for a free pid inline, with a comment naming this exact hazard. The helper is that probe, shared instead of copied — which is why that file is a net deletion.

## Why it is carried rather than rebased in place

@lifrary has `read` permission, and `.github/workflows/enforce-pr-target.yml:740-746` applies the contributor readiness checklist to authors without push permission. A maintainer force-push would re-draft the PR and reset four boxes only the author can tick, stranding it in draft after the work was done.

## Verification

```
bun test tests/responses-state.test.ts tests/doctor.test.ts tests/cli-status-json.test.ts
  214 pass / 0 fail / 686 expect() calls
```

The cherry-pick applied without conflict despite 59 commits of distance; the only file changed on both sides since the merge base was `tests/responses-state.test.ts`, and the dev-side additions sit elsewhere in it.

## Checklist

- [x] Targets `dev`
- [x] Test-only; no production file in the diff
- [x] The three affected suites pass on the carry
- [x] Original authorship preserved
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by dynamically selecting confirmed inactive process IDs.
  * Strengthened coverage for stale-process, fallback-port, and snapshot recovery scenarios.
  * Reduced dependence on fixed process ID values and environment-specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->