### PR TITLE
fix(service): report the wait that was actually spent, not the budget

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -740,14 +740,22 @@ export async function reportServiceServing(
   deps: Parameters<typeof confirmServiceServing>[0] = {},
 ): Promise<void> {
   const healthBudgetMs = deps.timeoutMs ?? serviceInstallHealthMs();
+  // Timed here rather than reported from the budget. confirmServiceServing knocks once
+  // more after a grace sleep whenever it waited at all, so the real wait is the budget
+  // plus that grace — and printing the budget states a number the run did not spend.
+  // What the reader is deciding is whether the service was still coming up, which is a
+  // judgement about elapsed time (#3009).
+  const now = deps.now ?? Date.now;
+  const startedAt = now();
   const serving = await confirmServiceServing({ ...deps, timeoutMs: healthBudgetMs });
+  const waitedMs = Math.max(0, now() - startedAt);
   if (serving.ok) {
     console.log(`✅ opencodex service ${verb} and serving on port ${serving.port}.`);
     return;
   }
   console.error(
-    `⚠️  Service ${verb}, but no proxy answered on port ${serving.port} within `
-    + `${Math.trunc(healthBudgetMs / 1000)}s.\n`
+    `⚠️  Service ${verb}, but no proxy answered on port ${serving.port} after `
+    + `${Math.round(waitedMs / 1000)}s.\n`
     + `   The manager registered the job; that is not the same as serving.\n`
     + `   Log:       ${serviceLogPath()}\n`
     + `   Meanwhile: ocx start   (serves in the foreground)`,

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -3320,7 +3320,13 @@ describe("service serving confirmation", () => {
       expect(serviceInstallHealthMs("darwin")).toBe(SERVICE_INSTALL_HEALTH_MS);
     });
 
-    test("reports the effective Windows failure budget", async () => {
+    // The failure line reports what the run actually spent, not what it was allowed to.
+    // With the Windows budget the loop exits at 45s and the post-deadline grace knock
+    // adds its 500ms sleep, so the real wait is 45.5s. Reporting the budget printed 45s
+    // for a 45.5s wait -- a small gap here, but the same expression understates every
+    // future grace the loop grows, and the reader is using this number to judge whether
+    // the service was still coming up (#3009).
+    test("reports the wait it actually spent, grace knock included", async () => {
       const errors: string[] = [];
       const previousError = console.error;
       const previousExitCode = process.exitCode;
@@ -3334,8 +3340,35 @@ describe("service serving confirmation", () => {
           now: () => now,
           timeoutMs: SERVICE_INSTALL_HEALTH_WINDOWS_MS,
         });
-        expect(errors.join("\n")).toContain("within 45s");
-        expect(errors.join("\n")).not.toContain("within 20s");
+        expect(now).toBe(SERVICE_INSTALL_HEALTH_WINDOWS_MS + 500);
+        expect(errors.join("\n")).toContain("after 46s");
+        expect(errors.join("\n")).not.toContain("45s");
+        expect(errors.join("\n")).not.toContain("20s");
+      } finally {
+        console.error = previousError;
+        process.exitCode = previousExitCode ?? 0;
+      }
+    });
+
+    // A caller that asked not to wait must not be told it waited: with a zero budget
+    // confirmServiceServing takes its single probe and skips the grace entirely, so the
+    // reported wait is 0 rather than the budget.
+    test("reports no wait when the caller asked not to wait", async () => {
+      const errors: string[] = [];
+      const previousError = console.error;
+      const previousExitCode = process.exitCode;
+      let now = 0;
+      console.error = (...values: unknown[]) => { errors.push(values.join(" ")); };
+      try {
+        await reportServiceServing("started", {
+          port: 10100,
+          probe: async () => false,
+          sleep: async ms => { now += ms; },
+          now: () => now,
+          timeoutMs: 0,
+        });
+        expect(now).toBe(0);
+        expect(errors.join("\n")).toContain("after 0s");
       } finally {
         console.error = previousError;
         process.exitCode = previousExitCode ?? 0;


### PR DESCRIPTION
Follow-up to #3134, which named this as the one piece of #3039 it deliberately did not carry, and said it deserved its own resolution. This is that.

## The gap

`reportServiceServing` prints the budget it allowed:

```ts
+ `${Math.trunc(healthBudgetMs / 1000)}s.\n`
```

while `confirmServiceServing` knocks once more after a 500ms grace sleep whenever it waited at all:

```ts
if (waited) {
  await sleep(500);
  if (await probe(port, hostname)) return { ok: true, port };
}
```

So a Windows run that gives up spends 45.5s and reports `within 45s`.

Half a second is not the point. The expression is wrong rather than the number: it states a figure the run did not spend, and it understates every future grace the loop grows. What the reader is deciding is whether the service was merely still coming up — which is a question about elapsed time, and #3009 is the report of exactly that misjudgement being made.

## The change

The wait is timed in `reportServiceServing`, through the same injected `now` the deps already carry:

```ts
const now = deps.now ?? Date.now;
const startedAt = now();
const serving = await confirmServiceServing({ ...deps, timeoutMs: healthBudgetMs });
const waitedMs = Math.max(0, now() - startedAt);
```

`confirmServiceServing`'s return shape and contract are untouched, so its existing tests — including the zero-budget single-probe assertion #3104 was right to restore — are untouched too. Nine lines, one file.

`Math.round` rather than `Math.trunc`: truncating 45.5s back to 45 would reintroduce the understatement this fixes.

## Tests

| test | pins |
| --- | --- |
| `reports the wait it actually spent, grace knock included` | the fake clock reaches `SERVICE_INSTALL_HEALTH_WINDOWS_MS + 500`, the line says `after 46s`, and no longer says `45s` |
| `reports no wait when the caller asked not to wait` | a zero budget takes its single probe, skips the grace, and reports `after 0s` |

The second one exists because "report the elapsed time" has an obvious wrong version — reporting the budget when nothing was waited — and the zero-budget path is where that shows.

Reverting to the budget expression fails both.

## Verification

```
bun test tests/service.test.ts   ->  183 pass, 3 skip, 6 fail
```

Those six fail identically on a clean `dev` checkout on this host (Windows) — `service listen-port bake` ×2, `service install auth preflight` ×2, `service lifecycle cleanup ordering` ×2. Compared by test name rather than by count, and none is touched by this diff.

Thank you for splitting this out instead of closing #3039 over it.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service availability failure messages now report the actual time spent waiting for confirmation.
  * Updated wording clarifies that the check failed after the reported duration.
  * Zero-second wait scenarios now display an accurate 0-second duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
