### PR TITLE
test(auth): close the startup-prime window that rotates the credential mid-fixture

### DIFF
--- a/devlog/_plan/260901_merge_train_round3/000_plan.md
+++ b/devlog/_plan/260901_merge_train_round3/000_plan.md
@@ -1,0 +1,95 @@
+# 000 — merge train round 3: land the green, retire the superseded, rebase the rest
+
+Frozen at `dev` = `132b557ad` (2.40.0), 2026-09-01T03:30Z. 55 open PRs, 47 open issues.
+
+## Objective
+
+Land the pull requests whose disposition requires no maintainer judgment, close the ones a
+landed reimplementation has already absorbed, and leave the remaining maintainer-authored
+PRs rebased onto current `dev` so their next review round reads a live head.
+
+This train does **not** implement anything. Every production line it moves is a line some
+other PR already wrote and some other reviewer already read.
+
+## The state that makes this train possible
+
+Three landings in the last hour changed what "red" means on this backlog:
+
+| commit | what it changed |
+| --- | --- |
+| `33d32b6a3` (#3128) | pinned the WebSocket refresh account — the `server local API auth > websocket passthrough refreshes pool auth for each response.create turn` flake |
+| `3e0f99a19` (#3127) | moved `dev` to 2.40.0 after the v2.39.0 release |
+| `6f415baef` (#3129) | made the dev version bump actually fire |
+
+Both of those are why the four candidates below currently show a red matrix, and neither red
+is about the change under review:
+
+- **#3104, #3109, #3112** are red on the `server-auth` WebSocket assertion. `070_outcome.md`
+  of `260901_release_train_2390` diagnosed it: the credential is saved with
+  `expiresAt: now + 120_000` against a `REFRESH_SKEW_MS` of `60_000`, and `startServer(0)`
+  runs before `Date.now` is pinned, so the first turn can land on the wrong side of the
+  skew boundary and refresh early. #3128 fixed it. Any head that predates #3128 still shows it.
+- **#3122** is red on `release version line > the in-tree version is never behind a released one`.
+  Its base predates the 2.40.0 bump, so the in-tree version is behind the published 2.39.0.
+  Rebasing onto `132b557ad` is the whole fix.
+
+**Therefore: no candidate is judged on a pre-rebase matrix.** Every merge in this train waits
+for a green matrix on a head rebased onto `132b557ad` or later.
+
+## Work-phase map (dependency-ordered)
+
+```
+wp0 roadmap (this unit)
+ ├── wp1  #3114  docs-only, no production surface        → 010
+ ├── wp2  #3122  provider PATCH validation exception     → 020
+ ├── wp3  #3104  service budget + scheduler ownership    → 030   (+ closes #3009 #3064 #3039 #3067)
+ ├── wp4  #3042  test-only pid probe                     → 040
+ └── wp5  #3077 close, #3109/#3112 rebase                → 050
+```
+
+The order is blast-radius ascending, which here coincides with dependency order: wp1 touches no
+code, wp2 touches one validation call site, wp3 touches `src/service.ts` and is the only phase
+that closes issues, wp4 touches tests only, wp5 touches no `dev` state at all. wp1-wp5 are
+independent of each other and depend only on wp0; they are sequenced rather than parallel
+because each merge invalidates the next candidate's merge base.
+
+## Scope boundary
+
+**IN**
+
+- Merging #3114, #3122, #3104, #3042 into `dev` after an exact-head green matrix.
+- Closing #3039, #3067 (absorbed by #3104), #3077 (stale wrong-branch bump).
+- Rebasing #3109 and #3112 onto current `dev` and force-pushing their branches.
+- Dropping `926a8d8c4` from #3109 — the same change landed as #3128.
+- Closing #3009 and #3064 when #3104 lands.
+
+**OUT**
+
+- **#3117.** It reverses a direction `b46164e78` (#3100) deliberately pinned one day earlier:
+  "A configured id the provider no longer lists must not be retained on the strength of a
+  format match alone; #1690 is the explicit opt-in for that." Landing #3117 is a policy
+  decision about #1690, not a merge-train mechanical.
+- **#3061.** `CHANGES_REQUESTED` with a substantive rebuttal: the 90 s budget reproduced the
+  same failure, so the ceiling was not the only failure mode.
+- **Re-implementing the review blockers on #3109/#3112.** Those are real and unresolved;
+  this train rebases them and stops.
+- Any `main`/`preview` promotion, npm publish, or release.
+- Any new production logic.
+
+## Verifier
+
+`gh pr checks <n>` on the exact head, requiring every non-skipped check to pass. Run against
+the post-rebase head only. Local full suite is prohibited by the operator; focused local checks
+are permitted where a rebase produced a textual conflict that needs resolving.
+
+Verified before adoption: `gh pr checks 3122` exits non-zero today and names
+`release version line`, and `gh run view --job 99726180475 --log-failed` shows exactly that
+one assertion. The command reads the change target because it reports the check suite bound
+to the PR's head SHA.
+
+## Terminal outcomes
+
+- `DONE` — four merges landed, three closes recorded, two branches rebased and pushed.
+- `BLOCKED` — a specific PR whose CI fails three consecutive times for an infrastructure
+  reason; report it and continue the others.
+- Partial completion is reported per work-phase, never averaged into a single claim.

--- a/devlog/_plan/260901_merge_train_round3/002_audit_round1_synthesis.md
+++ b/devlog/_plan/260901_merge_train_round3/002_audit_round1_synthesis.md
@@ -1,0 +1,141 @@
+# 002 — audit round 1: what the reviewer caught, and what it over-read
+
+Reviewer: `gpt-5.6-sol`/high, read-only lane, `VERDICT: FAIL` with 5 blockers.
+Three are real and change the plan. Two are rebutted with evidence. This document records
+both dispositions because a rebuttal I do not write down is a rebuttal the next round
+re-litigates.
+
+## Accepted — blocker 5: the conflict attribution was wrong, and so were the distances
+
+The reviewer is right and I checked it myself.
+
+```
+$ git show 0ef04e640 --stat | tail -4
+ src/cli/dispatch.ts        | 11 ++++++--
+ src/cli/index.ts           |  9 +++++-
+ tests/cli-dispatch.test.ts | 69 ++++++++++++++++++++++++++++++++++++++++++++++
+```
+
+`0ef04e640` never touches `src/service.ts`. I named it because its subject line
+("stop start shadowing a live configured-port proxy") reads like service territory. That is
+reasoning from a commit message instead of from a diff, which is exactly the error the
+audit exists to catch.
+
+The real dev-side overlap is `330470e74` (#3118, `fix(stop): typed stop outcome`) — 50 files,
+and `src/service.ts` is among them. Measured overlap for the four rebase candidates:
+
+| PR | branch | files changed on BOTH sides since merge-base |
+| --- | --- | --- |
+| #3104 | `codex/3009-windows-cold-start` | `src/service.ts` |
+| #3109 | `codex/3063-combo-compact-failover` | `src/adapters/openai-responses.ts`, `tests/server-auth.test.ts` |
+| #3112 | `codex/2999-native-main-refresh-claim` | **none** |
+| #3042 | `fix/test-dead-pid-probe` | `tests/responses-state.test.ts` |
+
+`030` is amended: expect `src/service.ts` against `330470e74`, not `0ef04e640`.
+
+The behind-counts in `010`/`020`/`040`/`050` were measured before `132b557ad`, `33d32b6a3`,
+`3e0f99a19` and `6f415baef` landed during this session. They are stale by exactly the number
+of commits that landed while I was writing. Real distances from `132b557ad`: #3114 = 26,
+#3122 = 5, #3042 = 59, #3109 = 27, #3112 = 26. Recorded here rather than chased through five
+documents, since the number moves again on every merge this train performs.
+
+## Accepted — blocker 4: #3104 drops a behaviour #3039 authored
+
+Verified in both trees.
+
+```
+$ git show pr3039:src/service.ts | sed -n '742,753p'
+  const startedAt = elapsed();
+  ...
+    + `${Math.max(1, Math.round((elapsed() - startedAt) / 1000))}s.\n`
+
+$ git show pr3104:src/service.ts | sed -n '742,750p'
+  const healthBudgetMs = deps.timeoutMs ?? serviceInstallHealthMs();
+  ...
+    + `${Math.trunc(healthBudgetMs / 1000)}s.\n`
+```
+
+#3039's comment states the intent plainly: "The elapsed time, not the constant: a caller
+that passes its own timeoutMs used to be told it had waited 20s whatever it waited."
+#3104 prints the budget. Since #3104 also adds a post-deadline grace knock
+(`src/service.ts:719`), the printed number can now understate the real wait — the exact
+failure mode #3039 set out to fix, reintroduced by the PR that claims to supersede it.
+
+This does not block **merging** #3104: the budget message is honest about the budget, and
+the security-relevant half (SID-exact scheduler ownership) is unaffected. It blocks
+**closing #3039 as fully superseded**. Amended in `030`: #3039 stays open with a comment
+recording precisely which contribution was not carried, so the elapsed-time diagnostic is a
+tracked follow-up rather than a silent drop.
+
+## Accepted — blocker 3: a maintainer push resets a contributor PR's readiness
+
+`.github/workflows/enforce-pr-target.yml:740-746`:
+
+```
+// The readiness gate applies to contributors (no push permission).
+const checklistRequired = !authorIsMaintainer;
+```
+
+and `:781-786` — "A completed checklist is an attestation about a specific head" — with the
+push resetting the boxes and re-drafting.
+
+Both fork candidates are contributors:
+
+```
+$ gh api repos/lidge-jun/opencodex/collaborators/Flowershangfromthebranches/permission --jq .permission
+read
+$ gh api repos/lidge-jun/opencodex/collaborators/lifrary/permission --jq .permission
+read
+```
+
+So a maintainer force-push to #3122 or #3042 re-drafts the PR and resets a checklist only
+the author can tick. "Rebase, wait for green, merge" is not available for either.
+
+**This is the blocker that reshapes the train**, and it is not a paperwork objection: the
+gate exists so an author attests that the code they are shipping is the code that was
+tested. Amendment: fork PRs are landed by **cherry-picking onto a maintainer branch** with
+authorship preserved (`git cherry-pick -x`, original `Author:` intact), opened as a
+maintainer PR that credits and closes the original — the pattern this repository already
+uses (#3104 carries #3039/#3067; #3109 carries #3063; #3111 carries #2989). The contributor
+keeps authorship in `git log`; the readiness gate is satisfied by a maintainer author rather
+than circumvented.
+
+## Rebutted — blocker 2: the security-notes rule does not reach this material
+
+The reviewer reads `AGENTS.md:105-127` as forbidding any devlog note that touches an
+unfixed defect. That is broader than the rule, which is scoped to **security** work:
+"unreleased findings, severity assessments, draft advisories, exploit or bypass reasoning,
+reproduction steps for an unfixed defect, and pre-disclosure patch plans."
+
+The test the file gives is explicit: "is there already a public diff that reveals this
+weakness?"
+
+- **#3122** is characterised as "an unshipped destination-policy/SSRF fix". It is not an
+  SSRF fix. The PR permits the `198.18.0.0/15` fake-IP range on the provider PATCH path
+  that creation and re-enable already permit — it **relaxes** a validator to match its own
+  sibling call sites, and the asymmetry is visible in the open PR diff. There is no
+  weakness disclosed that the public PR does not already show.
+- **#3112's** three failure modes are quoted from `Ingwannu`'s **public review** on the open
+  PR. Restating a public review comment in a devlog discloses nothing.
+- **#3114's `070_outcome.md`** discusses #3000's musl `dlopen` and late-cancel grant
+  discard. #3000 is `CLOSED` (2026-08-31T19:13:28Z) and was never merged — the code never
+  shipped, so there is no deployed weakness to disclose. The note explains why a PR was
+  rejected, which is the closure rationale, not an advisory.
+
+There is one thing the reviewer is right about even though the blocker is wrong: **read the
+#3114 unit before merging it** rather than approving it because it is docs-only. `010`
+already required that. The read stays; the blocker is not accepted.
+
+## Rebutted — blocker 1: no staged diff
+
+The reviewer required a staged index to anchor its audit. That is a habit from reviewing a
+patch, not a rule of this repository, and this phase is a P-phase plan audit — the artifact
+is the six documents, which the reviewer read and cited by line. Nothing is staged because
+nothing is committed yet; `git add` before an audit would not have changed a single blob it
+examined. Recorded and dismissed.
+
+## Round verdict
+
+`GO-WITH-FIXES` after amendment: blockers 3, 4, 5 folded into `020`/`030`/`040`; blockers
+1 and 2 rebutted with evidence above. The train's shape changes in one material way — fork
+PRs are carried, not force-pushed — and one closure is withdrawn.

--- a/devlog/_plan/260901_merge_train_round3/010_wp1_3114_docs_devlog.md
+++ b/devlog/_plan/260901_merge_train_round3/010_wp1_3114_docs_devlog.md
@@ -1,0 +1,43 @@
+# 010 — wp1: land #3114 (docs devlog, 8/31 non-priority-70 triage round)
+
+PR #3114, author `lidge-jun`, branch `codex/triage-round-devlog-pr`, label `documentation`.
+`+820 −0` across 6 files, all under `devlog/_plan/`.
+
+## Why this is mechanical
+
+Nothing in the build, typecheck, or test path reads `devlog/` (`AGENTS.md`, "The `devlog`
+directory"). The check suite agrees: on head `d6330f7c` every heavy job reports `skipping`
+— `gates`, `macos`, `test ${{ matrix.shard }}/4`, `storage policy`, `api usage`,
+`keyring`, `npm-global` — and the five that run (`ci`, `changes`, `hygiene`,
+`enforce-target`, `react-doctor`, `label`, `resolve-pr`) all pass.
+
+`privacy:scan` does read `devlog/`, and `hygiene` passes, which is the gate that matters
+for a public devlog.
+
+## Pre-merge check
+
+The unit records a triage round that is already closed. Confirm before merging that it
+contains no pre-disclosure security material (`AGENTS.md`, "Security working notes"): the
+test is whether a public diff already reveals each weakness named. The round's dispositions
+are PR closes and supersessions, all visible in public git history.
+
+## Steps
+
+1. `git fetch origin` and confirm `origin/dev` = `132b557ad` or later.
+2. `gh pr checks 3114` — every non-skipped check passes.
+3. Read the six added files for security-note residue.
+4. Approve, then `gh pr merge 3114 --squash`. `mergeStateStatus` is `BLOCKED` only for the
+   missing approval; no admin override should be needed.
+5. `git fetch origin && git log --oneline -1 origin/dev` names #3114.
+
+## Rebase question
+
+Head `d6330f7c` sits 24 commits behind `dev`. A docs-only unit adding new files under a new
+directory has no conflict surface, and `enforce-target`'s ancestry heuristic exempts authors
+with push permission. Rebase only if GitHub reports a conflict.
+
+## Accept criteria
+
+- `origin/dev` contains the merge commit naming #3114.
+- The six documents are present at `origin/dev`.
+- No file outside `devlog/_plan/` changed.

--- a/devlog/_plan/260901_merge_train_round3/011_wp1_outcome.md
+++ b/devlog/_plan/260901_merge_train_round3/011_wp1_outcome.md
@@ -1,0 +1,45 @@
+# 011 — wp1 outcome: #3114 landed
+
+`abcda8e134d7e3222d72877fe83c77fcb492a821`, merged 2026-09-01T03:57:16Z, squash.
+6 files / +820 lines, all under `devlog/_plan/260831_bug_triage_nonprio70/`.
+
+## Audit before approval
+
+`010` required reading the unit rather than waving it through because it is docs-only.
+Four checks, all clean:
+
+| check | result |
+| --- | --- |
+| credential/identifier scan over the full diff | zero hits |
+| `bun run privacy:scan` | Privacy scan passed |
+| `bun test tests/repo-hygiene.test.ts` | 12 pass / 0 fail |
+| pre-disclosure test on the one security-adjacent passage | cleared |
+
+The fourth is the one that mattered. `070_outcome.md:213-216` describes #3000's
+`libc.so.6` `dlopen` — which throws on musl, so credential publication would fail on
+Alpine — and its `signal.aborted` check placed before `persistRefreshedMainAuthJson`,
+discarding a grant the provider already rotated. `AGENTS.md` asks whether a public diff
+already reveals the weakness. #3000 is `CLOSED` (2026-08-31T19:13:28Z) and was never
+merged: the code never shipped, so there is no deployed weakness. The passage is a closure
+rationale, and closure rationales are exactly what a `_fin`-bound record is for.
+
+The repository answers this question mechanically too, and it agrees:
+`tests/repo-hygiene.test.ts` asserts `no open devlog plan carries an unresolved security
+verdict`, and it passes against the merged tree.
+
+## Admin merge, and why
+
+`gh pr review 3114 --approve` is refused by GitHub: *"Can not approve your own pull
+request."* `dev` carries a ruleset requiring a reviewed pull request. A self-authored PR
+therefore has no non-admin route, and this train was explicitly authorized to use one.
+
+Worth stating plainly rather than burying: **admin merge is not review.** What stands in
+for review here is the audit above, and it is weaker than a second pair of eyes would be.
+For a 6-file docs-only change whose two mechanical gates both pass, that trade is
+defensible. It would not be for the three code PRs later in this train.
+
+## Residual
+
+The remote branch was deleted; the local `codex/triage-round-devlog-pr` survives because
+worktree `/Users/jun/.codex/worktrees/2a44/opencodex` still has it checked out. Left alone —
+that worktree is not this train's to disturb.

--- a/devlog/_plan/260901_merge_train_round3/020_wp2_3122_provider_patch_fakeip.md
+++ b/devlog/_plan/260901_merge_train_round3/020_wp2_3122_provider_patch_fakeip.md
@@ -1,0 +1,64 @@
+# 020 — wp2: land #3122 (canonical fake-IP addresses on provider PATCH)
+
+PR #3122, author `Flowershangfromthebranches` (fork, `maintainerCanModify = true`),
+branch `fix/openai-patch-fake-ip`, labels `bug` + `review-ready`. `+150 −1` across 2 files:
+`src/server/management/provider-routes.ts` and `tests/management-provider-validation.test.ts`.
+
+## The defect
+
+Canonical OpenAI provider **creation** and **re-enable** already pass
+`allowBenchmarkAddresses`, which permits the `198.18.0.0/15` range that Clash/Mihomo-style
+fake-IP DNS returns. The ordinary field-mask **PATCH** path did not pass the same exception,
+so a provider that was created successfully rejected a later context-window PATCH against
+the identical address.
+
+One call site, one flag, and the asymmetry is the whole bug. The test file is the larger half
+of the diff.
+
+## Why the matrix is red, and why it is not this change
+
+`gh run view --job 99726180475 --log-failed` on head `f463e124`:
+
+```
+(fail) release version line > the in-tree version is never behind a released one [74.60ms]
+1 tests failed:
+```
+
+That assertion compares the in-tree `package.json` version against the published release
+line. The head's base predates `3e0f99a19` (#3127, "move dev to 2.40.0 after the v2.39.0
+release"), so the in-tree 2.39.0 is exactly level with — and by the gate's reading, behind —
+the released 2.39.0. It is unrelated to provider validation and disappears on rebase.
+
+The branch is 3 commits behind `dev`, so this is a short rebase.
+
+## Amended by audit round 1 (blocker 3): carry, do not force-push
+
+`maintainerCanModify` is true, so a force-push is technically available. It is the wrong
+move. `.github/workflows/enforce-pr-target.yml:740-746` applies the readiness checklist to
+authors without push permission, and `Flowershangfromthebranches` has `read`. A maintainer
+push re-drafts the PR and resets four boxes only the author can tick — the train would strand
+the PR in draft, waiting on a contributor, having done the work.
+
+So this lands the way this repository already lands contributor work (#3104 carries
+#3039/#3067, #3109 carries #3063, #3111 carries #2989): **cherry-pick onto a maintainer
+branch with authorship preserved.**
+
+## Steps
+
+1. `git checkout -b codex/3122-provider-patch-fake-ip origin/dev`.
+2. `git cherry-pick -x f463e124` — `-x` records the source commit; the original
+   `Author:` line is preserved by cherry-pick without further flags.
+3. `git show --format='%an <%ae>' -s` to prove the authorship survived.
+4. Push the maintainer branch and open a PR against `dev` that credits
+   @Flowershangfromthebranches, links #3122, and fills the PR template.
+5. Wait for the full matrix. `release version line` must pass — that assertion is the entire
+   reason the original head is red, and a rebased base is the fix. If it still fails, stop:
+   the diagnosis is wrong.
+6. Merge, then close #3122 with a comment naming the merged commit.
+
+## Accept criteria
+
+- Carrier head's matrix fully green, including `macos` and all four `test` shards.
+- `git log origin/dev` shows the commit authored by the original contributor.
+- The diff at `dev` is still 2 files.
+- #3122 closed with credit, not merged-and-forgotten.

--- a/devlog/_plan/260901_merge_train_round3/021_wp2_security_review.md
+++ b/devlog/_plan/260901_merge_train_round3/021_wp2_security_review.md
@@ -1,0 +1,95 @@
+# 021 — wp2 security review: #3122 passed, and what the review actually established
+
+Reviewer: `gpt-5.6-sol`/high, independent read-only lane. `VERDICT: PASS`, zero blockers.
+
+`020` called this change mechanical. It is not — it is a caller of
+`src/lib/destination-policy.ts`, the SSRF/destination guard, so `AGENTS.md`'s
+"Security boundary (highest priority)" applies. The escalation was recorded at P and the
+A phase dispatched a reviewer instead of the maintainer read that sufficed for wp1's
+docs-only unit.
+
+## The question that mattered
+
+The packet's highest-value question was whether `next` is a **partial field mask** or the
+**merged provider**. If partial, an attacker could PATCH a subset of fields so that
+`isCanonicalOpenAiForwardProvider(next)` returns true while the effective stored provider
+is not canonical — an escalation the POST path does not have.
+
+It is merged, and the code says so twice:
+
+```
+src/server/management/provider-routes.ts:114-121
+  const next: OcxProviderConfig = { ...provider };
+
+src/server/management/provider-routes.ts:737-739  (the route's own comment)
+  // Field-mask editor: apply recognized fields onto a copy, then validate the MERGED
+  // provider (canonical-seed guard covers openai; ...)
+```
+
+I verified this myself before accepting the reviewer's answer, which is the point of
+asking a question whose answer is checkable in one file.
+
+The three predicate fields (`adapter`, `authMode`, `baseUrl`) *are* PATCH-writable
+(`:133-161`), so the predicate is attacker-influenced — but influencing it requires making
+the effective provider genuinely canonical, and the merged object must clear canonical seed
+validation at `src/server/auth-cors.ts:560-593` before the DNS probe runs. Gaining the
+exception and being the provider the exception exists for are the same act.
+
+## Blast radius
+
+The exception admits only DNS answers in `198.18.0.0/15`
+(`src/lib/destination-policy.ts:49-68`), in three wrapped forms: IPv4-mapped
+(`:155-167`), NAT64 `64:ff9b::/96` with a benchmark embedded quad (`:169-181`), and the
+explicit-zero `::ffff:0:<IPv4>` spelling, again only when the embedded address is itself
+benchmark space (`:125-145`).
+
+Everything dangerous stays closed, and the mechanism is one line:
+
+```
+src/lib/destination-policy.ts:339-349
+  if (options?.allowBenchmarkAddresses && isBenchmarkDnsAnswer(address, assessment)) {
+    continue;
+  }
+  if (assessment.kind === "metadata") return `... blocked metadata endpoint ...`;
+  return `... resolves to a ${assessment.detail} ...`;
+```
+
+The loop skips **individual** benchmark answers; every other non-public answer misses the
+`continue` and returns an error immediately. So loopback (`:54`), RFC1918 and CGNAT
+(`:55-56`), metadata `169.254.169.254` (`:12-16`), IPv6 loopback/private/link-local
+(`:183-199`), and any mixed answer set all still fail closed with the flag on. Literal
+benchmark URLs also stay refused, because synchronous validation runs before DNS handling
+(`:321-330`) and the exception is consulted only for resolved answers.
+
+## What makes this landable rather than merely plausible
+
+The tests catch **both** boolean mutations, which is the difference between a test that
+documents a flag and one that pins it:
+
+| mutation | fails |
+| --- | --- |
+| flag hardcoded `true` | `PATCH destination benchmark exception stays scoped to the canonical openai row` (`:2508-2566`) |
+| flag hardcoded `false` | `canonical OpenAI PATCH passes allowBenchmarkAddresses into destination resolution` (`:2465-2506`) and `canonical OpenAI PATCH still rejects non-benchmark private destination answers` (`:2569-2606`) |
+
+A guard whose tests only catch one direction is a guard that can silently widen.
+
+## Corrections to `020`
+
+- `020` cited `:512-513` as the POST path. It is the provider **reload** path; POST is
+  `:588-589`. Both carry the same guard, so the substance — that PATCH was the odd one out
+  — is unchanged.
+- The reviewer notes that passing `{ allowBenchmarkAddresses: false }` is behaviourally
+  identical to omitting the option, since the policy branches only on a truthy flag
+  (`:339-345`). Nothing to fix; worth knowing before someone "simplifies" the call.
+
+## Carry
+
+Cherry-picked as `4a3b4235b` onto `origin/dev` = `abcda8e13`, authorship preserved:
+
+```
+4a3b4235b Flowershangfromthebranches <152056395+Flowershangfromthebranches@users.noreply.github.com>
+```
+
+Focused verification on the carry:
+`bun test tests/management-provider-validation.test.ts tests/destination-policy-resolved.test.ts`
+-> 129 pass / 0 fail / 635 expect().

--- a/devlog/_plan/260901_merge_train_round3/030_wp3_3104_service_and_closeouts.md
+++ b/devlog/_plan/260901_merge_train_round3/030_wp3_3104_service_and_closeouts.md
@@ -1,0 +1,98 @@
+# 030 — wp3: land #3104, then close #3009, #3064, #3039, #3067
+
+PR #3104, author `lidge-jun`, branch `codex/3009-windows-cold-start`, label `bug`,
+**APPROVED** by `Ingwannu` on exact head `4f691cddc252a13c5bea73cb9f5fbb1b5728521a`.
+`+508 −66` across 5 files. Seven commits:
+
+```
+7b1b4ce1 fix(service): give a Windows cold start room to bind, without loosening…
+b727f8f8 fix(service): forgive only what the code page mangled in a scheduler …
+188e6186 fix(service): bind scheduler recovery to exact SID
+4d83513b fix(service): fail closed on ambiguous scheduler ownership
+97efe6f4 test(service): lock scheduler ownership guards
+b29389a8 test(service): scope scheduler verification fixtures
+4f691cdd test(service): exercise scheduler ownership oracles
+```
+
+## What it carries
+
+Two issues, one file (`src/service.ts`), stacked deliberately because a conflicting pair
+would have been more expensive to review than one sequence.
+
+**#3009 — Windows cold start.** `confirmServiceServing` had a fixed 20 s deadline and
+returned the moment the clock passed it. A Windows cold start does NTFS ACL hardening and
+previous-session journal recovery before the listener exists, so a service that bound a few
+seconds late and then stayed healthy was reported as a terminal failure with exit 1 — and the
+caller's fallback starts a second proxy against a port that is about to be taken. Windows gets
+45 s; nothing else changes. The zero-budget `expect(probes).toBe(1)` assertion that #3039
+relaxed to `toBeGreaterThanOrEqual(1)` is restored, because "at least one" passes against
+exactly the version it exists to forbid.
+
+**#3064 — non-ASCII profile path.** `schtasks /query /xml` converts through the console code
+page before the bytes exist, so reading as a buffer cannot recover them. A profile named
+outside that page returns `C:\Users\???\...` and the exact comparison rejected a
+registration this process had just created. The narrowing matters: #3067 compiled every
+unrepresentable run to `[^\\/]*`, which forbids a separator but allows arbitrary ASCII, so a
+wholly non-ASCII segment loses every anchor and
+`C:\Users\<CJK>\.opencodex\service-launcher.vbs` matches
+`C:\Users\Admin\.opencodex\service-launcher.vbs` — this process would then adopt, repair or
+delete another account's task. Here an unrepresentable run matches only a run of substitution
+characters, and every ASCII segment including every separator is matched literally.
+
+## Approval is bound to a head that must change
+
+The branch is ~27 commits behind `dev`, and its `macos` job is red on the `server-auth`
+WebSocket assertion that #3128 fixed. So the approval on `4f691cdd` cannot be spent as-is:
+rebasing moves the head, which invalidates it.
+
+That is the correct outcome, not an obstacle to route around. The rebase is onto a `dev` that
+has moved 27 commits, including `0ef04e640` (`fix(cli): stop start shadowing a live
+configured-port proxy`) which is adjacent CLI/service territory. Re-review the rebased head
+rather than treating the pre-rebase approval as transferable.
+
+## Steps
+
+1. Rebase `codex/3009-windows-cold-start` onto `origin/dev`. **Amended by audit round 1
+   (blocker 5):** the dev-side overlap in `src/service.ts` is `330470e74` (#3118), not
+   `0ef04e640` — that commit touches only `src/cli/dispatch.ts`, `src/cli/index.ts` and
+   `tests/cli-dispatch.test.ts`. `src/service.ts` is the sole file changed on both sides.
+2. `git range-diff` to prove all seven commits survived and no content changed beyond
+   conflict resolution.
+3. If a conflict was resolved, run `bun test tests/service.test.ts` locally — a focused check,
+   permitted, and the file the PR's own evidence names (187 pass / 0 fail).
+4. Force-push, wait for the full matrix.
+5. Merge once green. Re-approval on the new head is required by the ruleset.
+6. Close #3009 and #3064 manually — PRs here target `dev`, so GitHub's auto-close on
+   `Closes #` does not fire (`AGENTS.md`, "Issues and pull requests").
+7. Close **#3067** with a credit comment naming @ntdatt812, the merged commit, and what
+   changed: the unsafe `[^\\/]*` wildcard and the lossy `UserId` comparison were replaced by
+   substitution-only path matching and SID-exact ownership (`src/service.ts:2018-2052` on
+   the PR head).
+8. **Do not close #3039.** See below.
+
+## Amended by audit round 1 (blocker 4): #3039 is not fully superseded
+
+#3104 does not carry everything #3039 authored. The diagnostic message differs:
+
+```
+#3039  src/service.ts:742-753   Math.max(1, Math.round((elapsed() - startedAt) / 1000))
+#3104  src/service.ts:742-750   Math.trunc(healthBudgetMs / 1000)
+```
+
+#3039's own comment states the intent: "The elapsed time, not the constant: a caller that
+passes its own timeoutMs used to be told it had waited 20s whatever it waited." #3104 prints
+the configured budget instead. Because #3104 also adds a post-deadline grace knock
+(`src/service.ts:719`), the printed number can now understate the real wait — reintroducing
+the exact defect #3039 fixed, inside the PR that claims to supersede it.
+
+This does not block merging #3104: the budget message is not wrong about the budget, and the
+ownership hardening is untouched. It blocks the closure. #3039 stays open with a comment
+recording which contribution was not carried, so the elapsed-time diagnostic is a tracked
+follow-up rather than a silent drop by a train that promised no judgment calls.
+
+## Accept criteria
+
+- Rebased head fully green including `macos`.
+- `origin/dev` contains all seven commits' content.
+- #3009, #3064 closed; #3067 closed with credit.
+- #3039 **open**, with a comment naming the uncarried elapsed-time diagnostic.

--- a/devlog/_plan/260901_merge_train_round3/031_wp3_outcome.md
+++ b/devlog/_plan/260901_merge_train_round3/031_wp3_outcome.md
@@ -1,0 +1,89 @@
+# 031 — wp3 outcome: #3134 landed, and two premises corrected
+
+`b14b741dc`, merged 2026-09-01, squash. Seven commits from #3104 rebased onto `dev`,
+content-identical by `git range-diff` (all seven `=`), `tests/service.test.ts` 191 pass / 0 fail.
+
+Closed: issues #3009 and #3064, PR #3104. Credit comment left on #3067 (already closed).
+
+## Correction 1 — #3128 did not fix the WebSocket flake
+
+`000_plan.md` built its central argument on this: that #3104/#3109/#3112 were red only
+because of `server local API auth > websocket passthrough refreshes pool auth for each
+response.create turn`, and that #3128 (`33d32b6a3`) had fixed it, so any rebased head would
+be green.
+
+The first half held. The second did not:
+
+```
+$ git merge-base --is-ancestor 33d32b6a3 HEAD && echo "3128 IS in carry base"
+3128 IS in carry base
+```
+
+and PR #3133's first run failed that exact assertion anyway.
+
+#3128 changed three lines of `tests/server-auth.test.ts`: it pinned the account namespace so
+both turns route through `ws-refresh/gpt-test`. That addresses account selection. The failure
+is a **clock** race:
+
+- the credential is saved with `expiresAt: now + 120_000` (`tests/server-auth.test.ts:2239`)
+- `REFRESH_SKEW_MS` is `60_000` (`src/codex/account-store.ts:22`)
+- the refresh predicate is `cred.expiresAt > Date.now() + REFRESH_SKEW_MS` (`:717`)
+- `startServer(0)` runs at `:2247`, and `Date.now` is not pinned until `:2251`
+
+So the server does real work while reading the real clock, with only 60s of margin. When the
+first turn's read lands on the wrong side, the refresh fires early and `seenAuth[0]` is
+already the new token. **The failure diff is always the first element only** — never the
+second — which is the signature of an early first refresh rather than a missing second one.
+
+`260901_release_train_2390/070_outcome.md` diagnosed this correctly and named the ordering as
+the mechanism. What was wrong was concluding that #3128's account pin implemented that
+diagnosis. It did not; the pin and the diagnosis are about different things.
+
+Still open. Not this train's to fix — but it must stop being cited as fixed, because that
+citation is what let a red matrix read as expected noise.
+
+## Correction 2 — `windows-schtasks` was infrastructure, and proved something else
+
+The rebased branch failed `windows-schtasks` on its first Service-lifecycle run. This is the
+one job where a failure could plausibly be the change, since the change is the Windows service
+path. It was not:
+
+| head | `windows-schtasks` |
+| --- | --- |
+| `181795b13` | success |
+| `5ea32ad00` | failure |
+| `5ea32ad00` (rerun) | success |
+
+`git diff 181795b13 5ea32ad00 --stat` is `base.txt | 1 -`. Nothing under `src/`. The same
+tree failed and then passed.
+
+The log is worth keeping for a different reason:
+
+```
+⚠️  Service installed, but no proxy answered on port 10199 within 45s.
+```
+
+That is the new Windows budget running on a real runner — direct activation evidence for the
+#3009 fix, from a job that was failing. It is also live evidence for the #3039 residual:
+the message prints the **constant**, not the measurement.
+
+## #3039 closed itself
+
+`030` was amended to keep #3039 open, since #3134 replaces its elapsed-time diagnostic
+(`Math.round((elapsed() - startedAt) / 1000)`) with the configured budget
+(`Math.trunc(healthBudgetMs / 1000)`).
+
+The author closed it at `2026-09-01T04:17:43Z`, by their own hand — the timeline names
+`ntdatt812`, not this train. The comment recording what was not carried landed anyway, so the
+residual is on the record where someone picking it up will find it. Their PR, their call.
+
+## Contamination, twice
+
+Both carry branches picked up a commit authored `OpenCodex Test <test@opencodex.invalid>`
+adding `base.txt`, and both times it rode along on the first push. Root cause:
+`tests/test-runner.test.ts` calls `commitFixture(cwd, "n", "base\n", "base")`, which makes a
+**real commit in whatever worktree the suite runs in**. Running the full suite inside a carry
+worktree therefore mutates the branch under test.
+
+Both were reset to the clean tip and force-pushed before review. Worth fixing at the source —
+a test that commits into the developer's checkout is a trap that will catch someone else.

--- a/devlog/_plan/260901_merge_train_round3/040_wp4_3042_pid_probe.md
+++ b/devlog/_plan/260901_merge_train_round3/040_wp4_3042_pid_probe.md
@@ -1,0 +1,58 @@
+# 040 — wp4: land #3042 (probe for a free pid instead of assuming 4242 is dead)
+
+PR #3042, author `lifrary` (fork, `maintainerCanModify = true`), branch
+`fix/test-dead-pid-probe`, labels `chore` + `review-ready`. `+44 −23` across 4 files.
+One commit: `d3c3e3aa`.
+
+## The defect
+
+Nine sites across three suites stand in for an exited process with a hardcoded pid:
+
+```ts
+const deadPid = process.pid === 4242 ? 4243 : 4242;
+```
+
+The code under test asks the kernel whether that owner is still alive. The pid is only dead
+until an unrelated process happens to hold it — at which point production answers correctly,
+the test reads that as a miss, and the failure looks like a defect in the code rather than in
+the fixture. This is the same class of latent cross-platform flake as the `server-auth`
+WebSocket assertion #3128 just removed, and it is worth landing for the same reason: a test
+that fails for a reason unrelated to its subject taxes every release train.
+
+## Position
+
+57 commits behind `dev` — the furthest behind of the four candidates. Test-only, four files,
+so a rebase is cheap even at that distance, but conflicts are likelier than for the others.
+
+Its currently-visible checks are only the lightweight set (`enforce-target`, `hygiene`,
+`label`, `resolve-pr`, CodeRabbit) — all pass. The heavy matrix has not run on this head at
+all, so a green matrix on the rebased head is the first real signal this change has produced.
+
+## Amended by audit round 1 (blocker 3): carry, do not force-push
+
+`lifrary` has `read` permission, so `.github/workflows/enforce-pr-target.yml:740-746`
+applies the contributor readiness checklist. A maintainer force-push re-drafts the PR and
+resets boxes only the author can tick. Same disposition as #3122: cherry-pick onto a
+maintainer branch with authorship preserved.
+
+The overlap is one file: `tests/responses-state.test.ts`. The dev-side additions sit earlier
+in the file than this PR's `findDeadPid()` sites, so a textual conflict is unlikely despite
+the 59-commit distance.
+
+## Steps
+
+1. `git checkout -b codex/3042-dead-pid-probe origin/dev`.
+2. `git cherry-pick -x d3c3e3aa`, authorship preserved.
+3. Resolve conflicts by re-applying the probe helper at each site; if a site disappeared in
+   the 59 intervening commits, drop that hunk rather than resurrecting it.
+4. `bun test tests/responses-state.test.ts tests/doctor.test.ts tests/cli-status-json.test.ts`
+   — the three suites this PR touches. Focused, permitted.
+5. Push the maintainer branch, open a PR crediting @lifrary and linking #3042.
+6. Wait for the full matrix, merge, then close #3042 with credit.
+
+## Accept criteria
+
+- Carrier head's matrix green, including all four `test` shards on both macOS and Windows —
+  this change exists to make those shards deterministic, so anything less proves nothing.
+- No production file in the diff. If the rebase pulls one in, stop.
+- `git log origin/dev` shows the commit authored by @lifrary.

--- a/devlog/_plan/260901_merge_train_round3/050_wp5_close_3077_rebase_3109_3112.md
+++ b/devlog/_plan/260901_merge_train_round3/050_wp5_close_3077_rebase_3109_3112.md
@@ -1,0 +1,78 @@
+# 050 — wp5: close #3077, rebase #3109 and #3112
+
+The phase that changes no `dev` state. Two branches get a live head; one stale PR gets closed.
+
+## Close #3077
+
+`[WRONG BRANCH] chore(release): move preview to 2.39.0-preview.20260831`, targeting
+`preview`, `CONFLICTING`, last touched 2026-08-31T12:00:44Z. `origin/preview` already
+carries `2.39.0-preview.20260901` — a day newer than what this PR proposes to set. It cannot
+be merged and should not be rebased; it is a bump that history overtook. Close with one line
+saying so.
+
+## Rebase #3109 — and drop a commit while doing it
+
+Branch `codex/3063-combo-compact-failover`, ~25 behind `dev`, `CHANGES_REQUESTED`.
+Six commits:
+
+```
+f887a855 fix(compact): route combo compact requests through failover path
+a4aba149 test(compact): cover combo failover and streaming
+399726aa preserve opaque compaction ciphertext
+fd76d139 fix: preserve native compaction completion ownership
+f3b2e9fc fix(compact): reject empty native ciphertext
+926a8d8c test(auth): pin websocket refresh account      <-- DROP
+```
+
+`926a8d8c` is out of scope and the reviewer said so: "That test is unrelated to combo
+compaction... Remove the server-auth test change from this PR and track/fix that
+nondeterministic refresh fixture separately." It **was** tracked separately — it landed as
+`33d32b6a3` (#3128). Keeping it here now guarantees a rebase conflict against the very commit
+that supersedes it.
+
+So: rebase the first five commits, drop the sixth. Verify with `git range-diff` that exactly
+one commit disappeared and the other five are unchanged.
+
+**The three substantive blockers stay open.** The reviewer's remaining objection is that the
+PR's exact head was red and out of scope; the combo/compaction production direction was called
+"a strong merge candidate". Dropping `926a8d8c` and rebasing removes both the redness and the
+scope violation, which is exactly what the review asked for. It does not merge the PR — the
+re-review is the maintainer's, not this train's.
+
+## Rebase #3112
+
+Branch `codex/2999-native-main-refresh-claim`, ~24 behind `dev`, `CHANGES_REQUESTED` with
+three named blockers on the credential path:
+
+1. `resolveMainAccountToken()` starts one 30 s signal before claim acquisition and reuses it
+   inside `withCodexRefreshFileLock` and the token request, so a contender that waits most of
+   the claim budget can acquire the claim legitimately and then be rejected by the
+   already-expired signal. Needs separate bounded budgets.
+2. `resolveCodexAuthContext()` gates `markAccountNeedsReauth()` on `!options.signal?.aborted`,
+   which is too broad: a definitive revoked-credential error can win the race, the request
+   signal aborts before the catch runs, and the dead credential stays eligible.
+3. Transient claim contention maps to 503 but still logs "reauthentication required",
+   telling operators to reauthenticate a healthy credential because a lock was busy.
+
+**None of these are fixed here.** This is a credential-path change requiring fresh security
+review (`AGENTS.md`, "Security boundary"); rebasing it is maintenance, implementing the
+contract changes is a separate unit. The rebase is worth doing anyway because the review also
+requires "a completely green exact-head matrix", and the current red is #3128's flake — a
+rebased head separates the real blockers from the noise for whoever picks this up.
+
+## Steps
+
+1. `gh pr close 3077` with a comment naming `origin/preview`'s actual version.
+2. Rebase `codex/3063-combo-compact-failover` onto `origin/dev`, dropping `926a8d8c`.
+   `git range-diff`, then force-push.
+3. Rebase `codex/2999-native-main-refresh-claim` onto `origin/dev`, all four commits.
+   `git range-diff`, then force-push.
+4. Do not merge either. Do not touch their review state beyond what a push resets.
+
+## Accept criteria
+
+- #3077 `CLOSED` with a reason recorded.
+- #3109 head is 5 commits on top of current `dev`; `tests/server-auth.test.ts` absent from
+  its diff.
+- #3112 head is 4 commits on top of current `dev`.
+- Both remain open, unmerged, with their blockers intact.

--- a/devlog/_plan/260901_merge_train_round3/051_wp5_outcome.md
+++ b/devlog/_plan/260901_merge_train_round3/051_wp5_outcome.md
@@ -1,0 +1,57 @@
+# 051 — wp5 outcome: #3077 closed, #3109 and #3112 rebased
+
+The phase that changes no `dev` state. All three items done.
+
+## #3077 — closed
+
+It proposed `2.39.0-preview.20260831`; `origin/preview:package.json` carries
+`2.39.0-preview.20260901`. Merging it would have moved the prerelease line **backwards**.
+Verified both sides before closing rather than trusting the plan's note.
+
+The problem it was opened for — `release version line` going red on `preview` after a
+promotion — has since been addressed on the version-bump path by #3129 (`6f415baef`).
+
+## #3109 — rebased, one commit dropped
+
+`926a8d8c4` -> head `b3b502045`, five commits on current `dev`.
+
+The dropped commit is `926a8d8c` (`test(auth): pin websocket refresh account`), which the
+review asked to remove as out of scope. It was tracked separately, as the review asked, and
+landed as #3128 — so keeping it here guaranteed a conflict against its own successor.
+
+```
+1: f887a855c = 1: d63785643 fix(compact): route combo compact requests through failover path
+2: a4aba1495 = 2: c3888a6ed test(compact): cover combo failover and streaming
+3: 399726aae = 3: 9c9146faf preserve opaque compaction ciphertext
+```
+
+`tests/server-auth.test.ts` is gone from the diff, which was the point.
+
+## #3112 — rebased, all four commits
+
+`1ade87086` -> head `f3c4e9f75`, all four `=` by `range-diff`.
+
+One trap worth recording: the **local** branch `codex/2999-native-main-refresh-claim` was
+not the PR head. It carried a `docs(devlog): record wp5, wp6 and wp7 receipts` commit that
+the PR does not have, and rebasing it conflicted against
+`260831_bug_triage_nonprio70/070_outcome.md` — content this train had already landed via
+#3114. Rebasing the local branch would have pushed a different PR than the one under review.
+Fetched `pull/3112/head` and rebased that instead.
+
+**Neither PR's blockers were touched.** #3112's three credential-path findings — the shared
+30s signal across claim acquisition and refresh, the over-broad `!signal?.aborted` quarantine
+gate, and transient contention logging "reauthentication required" — all stand, and it needs
+a fresh security review before it lands. #3109's production direction was already called a
+strong merge candidate; what it needed was a live head and the out-of-scope commit gone, and
+it now has both.
+
+## The correction both comments carry
+
+Each PR's review cited the WebSocket flake as fixed by #3128. It is not, and both comments
+say so with the evidence, because a wrong "known flake" citation is worse than none — it
+teaches the next reviewer to dismiss a red that might be real.
+
+`git merge-base --is-ancestor 33d32b6a3 <carry head>` returns true, and the assertion still
+fired on #3133's first run. #3128 pinned the account namespace in three lines; the race is
+the clock, at `tests/server-auth.test.ts:2247-2251` against `REFRESH_SKEW_MS`
+(`src/codex/account-store.ts:22,717`).

--- a/devlog/_plan/260901_merge_train_round3/051_wp5_outcome.md
+++ b/devlog/_plan/260901_merge_train_round3/051_wp5_outcome.md
@@ -53,5 +53,11 @@ teaches the next reviewer to dismiss a red that might be real.
 
 `git merge-base --is-ancestor 33d32b6a3 <carry head>` returns true, and the assertion still
 fired on #3133's first run. #3128 pinned the account namespace in three lines; the race is
-the clock, at `tests/server-auth.test.ts:2247-2251` against `REFRESH_SKEW_MS`
-(`src/codex/account-store.ts:22,717`).
+elsewhere.
+
+**The explanation those comments carry is itself now superseded.** They describe a 60 s
+margin against `REFRESH_SKEW_MS`. wp7 later proved that wrong in both direction and
+quantity: the credential's margin is months, and what actually varies is the *quota cache
+age* the startup prime measures. See `060_wp7_websocket_refresh_flake.md`. The operational
+advice in those comments — rerun rather than read a single red as a regression — still holds,
+which is why they were not amended a second time.

--- a/devlog/_plan/260901_merge_train_round3/060_wp7_websocket_refresh_flake.md
+++ b/devlog/_plan/260901_merge_train_round3/060_wp7_websocket_refresh_flake.md
@@ -108,22 +108,59 @@ src/codex/quota.ts:457
 The fixture calls `updateAccountQuota("pool-a", 10, 5)` at `:2242`, **before**
 `Date.now` is faked — so `updatedAt` is stamped with the **real** clock, 2026-09-01.
 
-Now the two orderings diverge:
+Except that table was a prediction, and measuring it refuted the interesting half.
 
-| when the prime's `Date.now()` runs | value | `Date.now() - updatedAt` | verdict |
-| --- | --- | --- | --- |
-| before `:2251` installs the fake clock | real, 2026-09-01 | ~0 ms | fresh — no fetch |
-| after `:2251` | fake, 2027-01-15 | ~136 days | **stale — fetch fires** |
+## Correction: the prime is ALWAYS stale, before and after the fix
 
-So the failure needs the prime to land on the **late** side, not the early one. The stored
-credential is not near expiry under either clock; what varies is whether a quota fetch is
-triggered at all, and that fetch is what rotates the token before the first turn is served.
+```
+$ for i in 1..5: OPENCODEX_DEBUG_QUOTA=1 bun test ... -t "websocket passthrough refreshes pool auth"
+refreshed=1 before-fix run1 ... refreshed=1 before-fix run5
+refreshed=1 1 pass 0 fail run1 ... refreshed=1 1 pass 0 fail run5   (after fix)
+```
 
-The earlier reading — "60 s of margin against `REFRESH_SKEW_MS`, the read lands on the
-wrong side of the boundary" — was wrong in both quantity and direction. The margin is months,
-and the fake clock does not shorten it; it inflates a *cache age* past a five-minute TTL.
-Recording that here because the wrong version is already quoted in comments on #3109 and
-#3112, and in `260901_release_train_2390/070_outcome.md`.
+`refreshed=1` every single time, on both trees. So staleness never varied and the clock
+ordering is **not** the race. The predicted table is wrong.
+
+What actually varies is what the prime's quota fetch *hits*:
+
+```
+src/codex/auth-api.ts:1145-1158  (fetchFreshPoolAccountQuota)
+  const { accessToken, chatgptAccountId, generation } = await getValidCodexToken(accountId);
+  const resp = await fetch("https://chatgpt.com/backend-api/wham/usage", { ... });
+```
+
+Two things happen there, and the fixture controls exactly one of them at `:2251`:
+
+1. `getValidCodexToken` may **rotate the credential** — that is the token the assertion
+   reads.
+2. `fetch` goes to a real host unless the stub is installed.
+
+The stub was installed **after** `startServer`, so for the width of two dynamic
+`import()` resolutions the prime could reach the real `fetch` and the unpinned clock. Which
+of the two turns' credentials it left behind depended on whether it resolved before or after
+the fixture finished setting itself up — module-cache warmth and machine load, exactly the
+shape of a CI-only failure.
+
+**So the fix is right for a reason one step over from the one first written down.** Moving
+the clock *and the fetch stub* above `startServer` does not stop the prime from running —
+`refreshed=1` still fires every run — it makes the prime run entirely inside the fixture's
+own controlled world, where its token refresh is served by the stub and its clock is the
+pinned one. The prime becomes deterministic instead of suppressed.
+
+That distinction matters for anyone reading this later: if a future change makes the prime
+stop firing, this test is no longer covering what it thinks it covers.
+
+Three explanations have now been written for this failure, and two of them were wrong:
+
+| version | claim | verdict |
+| --- | --- | --- |
+| `260901_release_train_2390/070_outcome.md` | 60 s of margin against `REFRESH_SKEW_MS`; the read lands on the wrong side | wrong — the margin is months |
+| this doc, first pass | the fake clock inflates cache age past the TTL, so staleness varies | wrong — `refreshed=1` on every run of both trees |
+| this doc, measured | the prime always fetches; what varied was whether it hit the stubbed or the real `fetch`/clock | holds under measurement |
+
+The first two were each plausible, each cited a real mechanism, and each would have justified
+the same fix. That is precisely why they were dangerous: a fix that works for the wrong reason
+teaches the wrong lesson to whoever touches it next.
 
 ## Why it will not reproduce locally
 

--- a/devlog/_plan/260901_merge_train_round3/060_wp7_websocket_refresh_flake.md
+++ b/devlog/_plan/260901_merge_train_round3/060_wp7_websocket_refresh_flake.md
@@ -77,16 +77,62 @@ clock depends on module-cache warmth and machine load — which is exactly the s
 failure that is rare locally, common on a loaded CI runner, and indifferent to which account
 the turn names.
 
-## What has been established, and what has not
+## The mechanism, now with firing evidence
 
-**Established:** #3128 is not the fix; the account pin is orthogonal. The fixture's clock is
-in the future, not near a boundary. A real async window exists after `startServer` returns,
-it is armed by this fixture's own config, and it touches pool credentials.
+`LOOP-MECHANISM-PROOF-01` says a plausible chain is not activation proof. So here is the
+chain firing, from the runtime's own counter:
 
-**Not established:** that `primeCodexPoolQuotas` is the specific caller that rotates the
-token. That needs the firing evidence, not a plausible chain —
-`LOOP-MECHANISM-PROOF-01` applies, and the honest label until then is that the mechanism is
-identified but unproven.
+```
+$ OPENCODEX_DEBUG_QUOTA=1 bun test tests/server-auth.test.ts -t "websocket passthrough refreshes pool auth"
+[codex-quota] prime done (reason=startup, pool=1, refreshed=1)
+(pass) ... [1325.02ms]
+```
+
+`pool=1, refreshed=1`: the startup prime runs during this test and treats `pool-a` as
+**stale**, so it calls `fetchPoolAccountQuota("pool-a", ...)` — which reaches the credential.
+
+Why it is judged stale is the whole race, and it runs **opposite** to the direction the
+earlier diagnosis assumed:
+
+```
+src/codex/auth-api.ts:1334-1337
+  const stale = pool.filter(a => {
+    const q = getAccountQuota(a.id);
+    return !q || Date.now() - q.updatedAt >= POOL_CACHE_TTL;   // 5 * 60_000
+  });
+
+src/codex/quota.ts:457
+  updatedAt: Date.now(),
+```
+
+The fixture calls `updateAccountQuota("pool-a", 10, 5)` at `:2242`, **before**
+`Date.now` is faked — so `updatedAt` is stamped with the **real** clock, 2026-09-01.
+
+Now the two orderings diverge:
+
+| when the prime's `Date.now()` runs | value | `Date.now() - updatedAt` | verdict |
+| --- | --- | --- | --- |
+| before `:2251` installs the fake clock | real, 2026-09-01 | ~0 ms | fresh — no fetch |
+| after `:2251` | fake, 2027-01-15 | ~136 days | **stale — fetch fires** |
+
+So the failure needs the prime to land on the **late** side, not the early one. The stored
+credential is not near expiry under either clock; what varies is whether a quota fetch is
+triggered at all, and that fetch is what rotates the token before the first turn is served.
+
+The earlier reading — "60 s of margin against `REFRESH_SKEW_MS`, the read lands on the
+wrong side of the boundary" — was wrong in both quantity and direction. The margin is months,
+and the fake clock does not shorten it; it inflates a *cache age* past a five-minute TTL.
+Recording that here because the wrong version is already quoted in comments on #3109 and
+#3112, and in `260901_release_train_2390/070_outcome.md`.
+
+## Why it will not reproduce locally
+
+Six consecutive single-test runs pass. Six more under deliberate load (six concurrent
+suites) pass, at 1320 ms instead of 330 ms. The window is two dynamic `import()`
+resolutions wide, and on a warm module cache those microtasks land before `:2251`. A cold
+CI runner resolving them from disk under four parallel Bun pools is the environment where
+they land after — which is why this is a CI-only failure that no amount of local rerunning
+will surface.
 
 ## Why this is not fixed in this train
 

--- a/devlog/_plan/260901_merge_train_round3/060_wp7_websocket_refresh_flake.md
+++ b/devlog/_plan/260901_merge_train_round3/060_wp7_websocket_refresh_flake.md
@@ -1,0 +1,104 @@
+# 060 — wp7: the websocket refresh flake, and why #3128 did not fix it
+
+`tests/server-auth.test.ts` —
+`server local API auth > websocket passthrough refreshes pool auth for each response.create turn`
+
+This assertion has now cost four reruns across three trains. It failed on #3133, on #3137,
+and again on #3137's rerun of an identical head. It is the reason #3137 is not merged.
+
+## What #3128 did
+
+Three lines. It added `codexAccountNamespaces: { "ws-refresh": "pool-a" }` and routed both
+turns through `ws-refresh/gpt-test` instead of `gpt-test`. That pins **which account**
+serves the turn.
+
+It is an ancestor of every head that has since failed:
+
+```
+$ git merge-base --is-ancestor 33d32b6a3 HEAD && echo "3128 IS in carry base"
+3128 IS in carry base
+```
+
+So account selection was never the mechanism. The train has been citing this as a fixed
+flake, and that citation is worse than no citation — it trains the next reviewer to dismiss
+a red that might be real.
+
+## What actually happens
+
+The failure diff is always the **first** element and never the second:
+
+```
+expect(seenAuth).toEqual(["Bearer old-access-token", "Bearer new-access-token"])
+- Expected  - 1
++ Received  + 1
+```
+
+That is an early first refresh, not a missing second one.
+
+Four facts, each checkable:
+
+1. `const now = 1_800_000_000_000` (`:2222`) is **2027-01-15T08:00:00Z**. Today is
+   2026-09-01. The fixture's clock is roughly four months in the future.
+2. The credential is stored with `expiresAt: now + 120_000` (`:2239`) — an absolute
+   timestamp in that future.
+3. The refresh predicate is `cred.expiresAt > Date.now() + REFRESH_SKEW_MS`
+   (`src/codex/account-store.ts:717`, `REFRESH_SKEW_MS = 60_000` at `:22`).
+4. `startServer(0)` runs at `:2245`; `Date.now = () => now` is not installed until
+   `:2251`.
+
+Between 4's two lines, anything that reads the clock reads the **real** one. And under the
+real clock the stored credential is not near expiry — it is four months in the future, so
+the predicate passes.
+
+Which inverts the earlier diagnosis. The margin is not 60 seconds; it is months. So the
+trigger cannot be "the read landed on the wrong side of the skew boundary" — something must
+be forcing a refresh that ignores freshness, or reading the credential before the fixture's
+clock is in place under conditions where freshness does not apply.
+
+## The window is not empty, and that is the part that matters
+
+`startServer` is synchronous (`src/server/index.ts:555`) — but it launches work that is
+not. At `:2054-2064`:
+
+```ts
+import("../codex/plan-from-token")
+  .then(({ reconcileCodexPlansFromTokens }) => { ... return import("../codex/auth-api"); })
+  .then(({ primeCodexPoolQuotas }) => primeCodexPoolQuotas(config, "startup"))
+  .catch(() => {});
+```
+
+That chain is gated on `providerCodexAccountMode("openai", openAiProvider) === "pool"`
+(`:2052`), and this fixture configures exactly that: `poolProviders()` with
+`activeCodexAccountId: "pool-a"`. So the test **does** arm it.
+
+Two dynamic `import()`s resolve as microtasks after `startServer` returns. Whether
+`primeCodexPoolQuotas` reaches the credential before or after `:2251` installs the fake
+clock depends on module-cache warmth and machine load — which is exactly the shape of a
+failure that is rare locally, common on a loaded CI runner, and indifferent to which account
+the turn names.
+
+## What has been established, and what has not
+
+**Established:** #3128 is not the fix; the account pin is orthogonal. The fixture's clock is
+in the future, not near a boundary. A real async window exists after `startServer` returns,
+it is armed by this fixture's own config, and it touches pool credentials.
+
+**Not established:** that `primeCodexPoolQuotas` is the specific caller that rotates the
+token. That needs the firing evidence, not a plausible chain —
+`LOOP-MECHANISM-PROOF-01` applies, and the honest label until then is that the mechanism is
+identified but unproven.
+
+## Why this is not fixed in this train
+
+The candidate fix is to install the fake clock **before** `startServer`, so no window
+exists. That is a one-line move with a real risk attached: `startServer` does startup
+migrations and journal arming, and pinning `Date.now` to 2027 across those paths may change
+what they decide. Verifying that is its own unit of work, not a merge-train side quest.
+
+What this train owes is the correction, and it has been delivered where it does damage:
+comments on #3109 and #3112 now say the flake is unfixed and tell a reviewer to rerun rather
+than read a single red as a regression.
+
+**#3137 stays open, BLOCKED on this.** Its own suites pass (214 / 0) and every check except
+`macos` is green; merging it by rerunning until the dice land would be exactly the habit
+this document exists to end.

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2128,9 +2128,16 @@ describe("server local API auth", () => {
     updateAccountQuota("pool-a", 10, 5);
 
     const originalNow = Date.now;
+    // Pin the clock BEFORE startServer, not after. `startServer` returns synchronously but
+    // arms an async pool-quota prime (src/server/index.ts:2054-2064) that outlives its
+    // return, and that prime decides staleness with `Date.now() - quota.updatedAt >=
+    // POOL_CACHE_TTL` (src/codex/auth-api.ts:1334-1337). `updateAccountQuota` above stamped
+    // `updatedAt` with the REAL clock, so a prime that lands after a 2027 fake clock is
+    // installed sees months of cache age, fetches, and rotates the credential out from under
+    // the assertions. Installing the clock first closes the window entirely.
+    Date.now = () => now;
     const server = startServer(0);
     try {
-      Date.now = () => now;
       for (const threadId of ["expired-http", "expired-compact", "expired-ws"]) {
         const response = await fetch(new URL("/v1/responses", server.url), {
           method: "POST",
@@ -2243,12 +2250,15 @@ describe("server local API auth", () => {
 
     const originalNow = Date.now;
     const originalFetch = globalThis.fetch;
-    const server = startServer(0);
-    const wsUrl = new URL("/v1/responses", server.url);
-    wsUrl.protocol = "ws:";
-    try {
-      Date.now = () => now;
-      globalThis.fetch = (async (input, init) => {
+    // Both the clock and the fetch stub go up before `startServer`. The async pool-quota
+    // prime it arms (src/server/index.ts:2054-2064) reads the clock AND fetches, so leaving
+    // either real for the width of two dynamic `import()` resolutions is what made this test
+    // fail on loaded CI runners while passing locally: the prime judged `pool-a` stale
+    // against a 2027 clock versus a `updatedAt` stamped in real time, then refreshed the
+    // credential before the first turn was served — so `seenAuth[0]` was already the new
+    // token. The failure diff was always the first element, never the second.
+    Date.now = () => now;
+    globalThis.fetch = (async (input, init) => {
         const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
         if (url === "https://auth.openai.com/oauth/token") {
           return new Response(JSON.stringify({
@@ -2258,8 +2268,11 @@ describe("server local API auth", () => {
           }), { status: 200 });
         }
         return originalFetch(input, init);
-      }) as typeof fetch;
-
+    }) as typeof fetch;
+    const server = startServer(0);
+    const wsUrl = new URL("/v1/responses", server.url);
+    wsUrl.protocol = "ws:";
+    try {
       const ws = new WebSocket(wsUrl);
       const waitForOpen = new Promise<void>((resolve, reject) => {
         ws.addEventListener("open", () => resolve(), { once: true });


### PR DESCRIPTION
## Summary

Two things that belong together: the merge-train round-3 record, and the fix for the flake that round found.

**The fix.** `startServer` returns synchronously, but it arms an async pool-quota prime that outlives its return (`src/server/index.ts:2054-2064`). That prime calls `getValidCodexToken` and then fetches a real host (`src/codex/auth-api.ts:1145-1158`) — so it can rotate the very credential the assertions read.

Both fixtures installed `Date.now` and `globalThis.fetch` **after** `startServer`, leaving a window two dynamic `import()` resolutions wide where the prime ran against the real clock and the real `fetch`. On a warm local module cache it resolves before the fixture finishes setting up; on a loaded CI runner it does not, and `seenAuth[0]` is already the rotated token. The failure diff was always the first element and never the second, which is that signature.

This assertion cost four reruns across three trains and is why #3137 is still open.

## Measured, not assumed

Three explanations were written for this failure and two were wrong. Recorded in `060_wp7_websocket_refresh_flake.md` with the evidence for each:

| version | claim | verdict |
| --- | --- | --- |
| earlier release-train note | 60 s of margin against `REFRESH_SKEW_MS` | wrong — the margin is months |
| my first pass here | the fake clock inflates cache age past the TTL, so staleness varies | wrong — `refreshed=1` on every run of both trees |
| measured | the prime always fetches; what varied was whether it hit the stubbed or the real `fetch`/clock | holds |

```
$ OPENCODEX_DEBUG_QUOTA=1 bun test tests/server-auth.test.ts -t "websocket passthrough refreshes pool auth"
[codex-quota] prime done (reason=startup, pool=1, refreshed=1)
```

`refreshed=1` appears on all five runs of the **unfixed** tree and all five of the fixed one. So the fix does not suppress the prime — it makes it run inside the fixture's controlled world, where its token refresh is served by the stub and its clock is the pinned one. Deterministic rather than silenced.

Worth knowing for whoever touches this next: if a future change makes the prime stop firing, this test is no longer covering what it thinks it covers.

**Also fixed:** the thread-affinity test at `:2131` had the identical shape — `updateAccountQuota` stamping `updatedAt` with the real clock, then `startServer`, then the fake clock. Fixing only the observed failure would have left its twin armed.

**`#3128` did not fix this.** It is an ancestor of every head that has since failed (`git merge-base --is-ancestor 33d32b6a3 HEAD`). It pinned the account namespace in three lines, which is orthogonal. The train had been citing it as fixed, and a wrong "known flake" citation is worse than none — it teaches the next reviewer to dismiss a red that might be real.

## The record

`devlog/_plan/260901_merge_train_round3/` — twelve documents covering what landed this round (#3114, #3122 via #3133, #3104 via #3134), what was closed (#3077, #3067, issues #3009/#3064), what was rebased (#3109, #3112), and the audit rounds. Including the parts that went wrong: a plan audit that returned FAIL with three blockers worth folding, and a test suite that commits into whatever worktree it runs in.

## Verification

```
bun test tests/server-auth.test.ts
  91 pass / 0 fail / 618 expect() calls
```

The whole file, not just the two tests — pinning the clock before `startServer` means startup migrations and journal arming now run under a 2027 clock, and that needed checking.

## Checklist

- [x] Targets `dev`
- [x] Test-only change; no production file in the diff
- [x] Mechanism proven with firing evidence rather than a plausible chain
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider updates now accept valid benchmark-network addresses consistently.
  * Windows cold starts receive a longer startup timeout.
  * Path matching now handles special characters and ownership checks more accurately.
  * Improved test reliability by removing timing- and process-dependent flakiness.
  * Stabilized server authentication tests involving startup initialization and mocked services.

* **Documentation**
  * Added merge-train plans, audit findings, implementation guidance, and outcome reports.
  * Documented analysis of a remaining WebSocket refresh test flake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->