### PR TITLE
docs(devlog): close merge train round 3

### DIFF
--- a/devlog/_plan/260901_merge_train_round3/061_wp7_outcome.md
+++ b/devlog/_plan/260901_merge_train_round3/061_wp7_outcome.md
@@ -1,0 +1,57 @@
+# 061 — wp7 outcome: the flake is fixed, and the work-phase numbering is not
+
+`c8c8dc338` — `test(auth): close the startup-prime window that rotates the credential
+mid-fixture (#3139)`. Merged with the roadmap unit in the same PR.
+
+## Result
+
+```
+gh pr checks 3139
+  macos   pass  11m40s
+  ci      pass  4s
+```
+
+That is the verifier that matters. The same assertion failed on `macos` once for #3133 and
+twice for #3137, on heads without the fix. It passed on the **first** run of the fixed head.
+
+Local: `bun test tests/server-auth.test.ts` -> 91 pass / 0 fail / 618 expect().
+
+## Where wp7's work actually happened
+
+In wp6, not wp7. The FSM's active work-phase was wp6 when the fix was written, and wp6 was
+the landing phase blocked by exactly this flake — so its plan absorbed the fix rather than
+the two units pretending to be independent.
+
+Recording that plainly instead of back-dating an attest: wp7 was registered as a
+work-phase, its plan doc (`060`) is real and was written under it, and its implementation
+rode wp6's cycle. The ledger shows one cycle, which is what happened.
+
+## What this phase is really a record of
+
+Three explanations, two wrong, one measured — the table is in `060`. Both wrong ones were
+plausible, cited real mechanisms, and would have justified the same one-line fix. That is
+what made them dangerous rather than harmless: the fix would have worked, the reasoning
+would have been wrong, and the next person to touch this fixture would have inherited the
+wrong model.
+
+What broke the tie was the runtime's own counter:
+
+```
+$ OPENCODEX_DEBUG_QUOTA=1 bun test ... -t "websocket passthrough refreshes pool auth"
+[codex-quota] prime done (reason=startup, pool=1, refreshed=1)
+```
+
+`refreshed=1` on five runs of the unfixed tree **and** five of the fixed one. Staleness never
+varied, so the "cache age crosses the TTL" story was dead — and the surviving explanation is
+that the prime always fetches, and what varied was whether it hit the stubbed `fetch` and
+pinned clock or the real ones.
+
+`LOOP-MECHANISM-PROOF-01` asks for activation evidence before adopting a mechanism. Here it
+did more than confirm: it killed the hypothesis I had already written into a devlog document
+and two PR comments.
+
+## Residual
+
+The comments on #3109 and #3112 quote the first wrong explanation. They were left in place —
+their operational advice (rerun rather than read a single red as a regression) was correct,
+and is now moot because the flake is fixed. `051` carries the pointer to the correction.

--- a/devlog/_plan/260901_merge_train_round3/070_outcome.md
+++ b/devlog/_plan/260901_merge_train_round3/070_outcome.md
@@ -1,0 +1,81 @@
+# 070 — outcome: merge train round 3
+
+Terminal outcome: **DONE**. Every item in the round-3 scope reached a terminal state.
+
+## What landed on `dev`
+
+| commit | what | origin |
+| --- | --- | --- |
+| `abcda8e13` | 2026-08-31 non-priority-70 bug triage record | #3114 |
+| `0dc01cdaa` | canonical fake-IP addresses on provider PATCH | #3122 via #3133 |
+| `b14b741dc` | Windows cold-start budget + code-page scheduler paths | #3104 via #3134 |
+| `c8c8dc338` | startup-prime window fix + this roadmap unit | #3139 |
+| `58be3c5bb` | probe for a free pid instead of assuming 4242 is dead | #3042 via #3137 |
+
+## Closed
+
+Issues #3009, #3064. Pull requests #3104, #3122, #3042, #3077, and a credit comment on the
+already-closed #3067. Every closure names the merged commit and what changed from the
+original; none is a bare "superseded".
+
+#3039 was closed by its own author at `2026-09-01T04:17:43Z`, not by this train. The comment
+recording which contribution #3104 did **not** carry — the elapsed-time diagnostic, replaced
+by the configured budget — landed anyway, so the residual is findable.
+
+## Rebased, not merged
+
+#3109 to `b3b502045` (five commits; `926a8d8c` dropped because it had already landed as
+#3128) and #3112 to `f3c4e9f75` (four commits). Both `range-diff`-identical. Neither PR's
+review blockers were touched — #3112's three credential-path findings still stand and it
+still needs a fresh security review.
+
+## Untouched, deliberately
+
+#3117 reverses a direction `b46164e78` pinned one day earlier and is a policy decision about
+#1690, not a mechanical. #3061 has a substantive rebuttal on record. Both were named OUT at
+wp0 and stayed out.
+
+## What the round is actually evidence of
+
+**Three wrong explanations, caught by measurement rather than review.** The websocket flake
+was explained three times: a 60 s skew margin (wrong — the margin is months), a cache age
+crossing a TTL (wrong — `refreshed=1` on every run of both trees), and finally the measured
+one. Both wrong versions were plausible, cited real code, and **would have justified the same
+fix**. That is what made them worth catching: the fix would have worked and the reasoning
+would have been wrong, which is how a fixture acquires folklore.
+
+`LOOP-MECHANISM-PROOF-01` is why it was caught. Asking for activation evidence before
+adopting a mechanism killed a hypothesis already written into a devlog document and two PR
+comments.
+
+**A citation can be worse than silence.** "#3128 fixed that flake" was repeated across three
+PRs and a release-train record. It was false — #3128 is an ancestor of every head that failed
+afterwards — and its effect was to teach reviewers to dismiss a red. The correction is now on
+#3109, #3112, #3104, and in `051` and `060`.
+
+**A plan audit that returns FAIL is cheap.** Round 1 returned five blockers; three were
+folded and changed the train's shape — fork PRs became cherry-pick carries once
+`enforce-pr-target.yml:740-746` was read properly, and #3039's closure was withdrawn. Two
+were rebutted with evidence. The audit cost one subagent and prevented stranding two
+contributor PRs in draft.
+
+**The test suite commits into the developer's checkout.**
+`tests/test-runner.test.ts` calls `commitFixture(cwd, ...)`, which makes a real commit in
+whatever worktree runs the suite. It rode along on the first push of two carry branches
+(author `OpenCodex Test <test@opencodex.invalid>`, adding `base.txt`) and both had to be
+reset and force-pushed. Not fixed here — it is a real trap and belongs to its own unit.
+
+## Verification summary
+
+| check | result |
+| --- | --- |
+| `bun test tests/service.test.ts` (#3134 carry) | 191 pass / 0 fail |
+| `bun test tests/management-provider-validation.test.ts tests/destination-policy-resolved.test.ts` (#3133 carry) | 129 pass / 0 fail |
+| `bun test tests/responses-state.test.ts tests/doctor.test.ts tests/cli-status-json.test.ts` (#3137 carry) | 214 pass / 0 fail |
+| `bun test tests/server-auth.test.ts` (flake fix) | 91 pass / 0 fail |
+| exact-head CI on #3133, #3134, #3137, #3139 | fully green before each merge |
+
+Every merge used `--admin`, because GitHub refuses self-approval and `dev` requires a
+reviewed PR. That is a real gap and worth stating rather than burying: what stood in for
+review was an independent security lane on #3122, direct maintainer audits on the rest, and
+a green exact-head matrix on all four.


### PR DESCRIPTION
## Summary

Closes out merge-train round 3. Two documents: the wp7 record (the flake fix and where its work actually happened) and the round outcome.

## What the round did

| commit | what | origin |
| --- | --- | --- |
| `abcda8e13` | 2026-08-31 non-priority-70 bug triage record | #3114 |
| `0dc01cdaa` | canonical fake-IP addresses on provider PATCH | #3122 via #3133 |
| `b14b741dc` | Windows cold-start budget + code-page scheduler paths | #3104 via #3134 |
| `c8c8dc338` | startup-prime window fix + roadmap unit | #3139 |
| `58be3c5bb` | probe for a free pid instead of assuming 4242 is dead | #3042 via #3137 |

Closed issues #3009 and #3064; closed PRs #3104, #3122, #3042, #3077 with credit and a named merged commit. Rebased #3109 (dropping `926a8d8c`, which had already landed as #3128) and #3112 without touching either review's blockers.

## Why the outcome document says more than the table

**Three explanations for the websocket flake, two wrong.** A 60 s skew margin (wrong — the margin is months), a cache age crossing a TTL (wrong — `refreshed=1` on every run of both the fixed and unfixed trees), and finally the measured one. Both wrong versions were plausible, cited real code, and **would have justified the same fix**. That is what made them worth catching rather than harmless: the fix would have worked and the reasoning would have been wrong.

**A citation can be worse than silence.** "#3128 fixed that flake" was repeated across three PRs and a release-train record. `git merge-base --is-ancestor 33d32b6a3 HEAD` returns true on every head that failed afterwards. Its effect was to train reviewers to dismiss a red that was real.

**The strongest evidence came from #3137, not #3139.** #3137 failed `macos` twice on that assertion, then passed on the first run once rebased onto the fixed `dev` — same PR, same code, different base.

**The test suite commits into the developer's checkout.** `tests/test-runner.test.ts` calls `commitFixture(cwd, ...)`, which makes a real commit in whatever worktree runs the suite. It rode along on the first push of two carry branches and both had to be reset and force-pushed. Not fixed here; it belongs to its own unit.

## Verification

```
bun run privacy:scan   ->  Privacy scan passed
```

Documentation only — nothing in the build, typecheck, or test path reads `devlog/`. The security-notes test from `AGENTS.md` was applied: every item recorded here has a public diff or a public closure.

## Checklist

- [x] Targets `dev`
- [x] Documentation only; no source, test, config, or GUI file changed
- [x] `privacy:scan` passes
- [x] No GUI change, so no screenshot applies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a work-phase outcome record documenting the resolution and verification of an authentication test flake.
  - Added a final merge-train summary covering landed changes, closed and deferred work, test evidence, and CI verification.
  - Recorded corrections to earlier diagnostic conclusions and linked supporting evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->