### PR TITLE
test(auth): timestamp quota fixtures under fake clock

### DIFF
--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -2125,17 +2125,12 @@ describe("server local API auth", () => {
       expiresAt: now + CODEX_THREAD_AFFINITY_IDLE_TTL_MS + 10 * 60_000,
       chatgptAccountId: "acct-pool-a",
     });
-    updateAccountQuota("pool-a", 10, 5);
-
     const originalNow = Date.now;
-    // Pin the clock BEFORE startServer, not after. `startServer` returns synchronously but
-    // arms an async pool-quota prime (src/server/index.ts:2054-2064) that outlives its
-    // return, and that prime decides staleness with `Date.now() - quota.updatedAt >=
-    // POOL_CACHE_TTL` (src/codex/auth-api.ts:1334-1337). `updateAccountQuota` above stamped
-    // `updatedAt` with the REAL clock, so a prime that lands after a 2027 fake clock is
-    // installed sees months of cache age, fetches, and rotates the credential out from under
-    // the assertions. Installing the clock first closes the window entirely.
+    // Pin the clock before both the quota write and startServer. The startup prime compares
+    // its fake-clock read with updateAccountQuota's timestamp; writing that timestamp under
+    // the real clock still makes a fresh fixture look stale and leaves a refresh race.
     Date.now = () => now;
+    updateAccountQuota("pool-a", 10, 5);
     const server = startServer(0);
     try {
       for (const threadId of ["expired-http", "expired-compact", "expired-ws"]) {
@@ -2246,18 +2241,13 @@ describe("server local API auth", () => {
       expiresAt: now + 120_000,
       chatgptAccountId: "acct-pool-a",
     });
-    updateAccountQuota("pool-a", 10, 5);
-
     const originalNow = Date.now;
     const originalFetch = globalThis.fetch;
-    // Both the clock and the fetch stub go up before `startServer`. The async pool-quota
-    // prime it arms (src/server/index.ts:2054-2064) reads the clock AND fetches, so leaving
-    // either real for the width of two dynamic `import()` resolutions is what made this test
-    // fail on loaded CI runners while passing locally: the prime judged `pool-a` stale
-    // against a 2027 clock versus a `updatedAt` stamped in real time, then refreshed the
-    // credential before the first turn was served — so `seenAuth[0]` was already the new
-    // token. The failure diff was always the first element, never the second.
+    // The quota write, startup prime, and request turns must share one clock. Installing the
+    // fake clock only before startServer leaves updateAccountQuota stamped in real time, so
+    // the prime can still judge the fresh row stale and rotate before the first turn.
     Date.now = () => now;
+    updateAccountQuota("pool-a", 10, 5);
     globalThis.fetch = (async (input, init) => {
         const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
         if (url === "https://auth.openai.com/oauth/token") {


### PR DESCRIPTION
## Summary

- write both affected quota fixtures under the same fake clock used by the startup prime;
- keep the existing fetch stub and production behavior unchanged;
- correct the comments so the timestamp boundary is explicit.

## Why

The follow-up in #3139 moved the fake clock before `startServer`, but `updateAccountQuota` still ran first under the real clock. The asynchronous startup prime then compared a future fake-clock read with a real-clock `updatedAt`, could classify the fresh row as stale, and rotate the credential before the first request.

This reproduced as the macOS assertion failure in #3121 at `tests/server-auth.test.ts:2302`: the first request observed the refreshed credential instead of the old one. #3121 does not modify this test, so the failure is an upstream fixture race rather than a regression in that PR.

## Verification

Exact head: `1e50927f5b8a7ad6b9bca5835cc1e27d1b7f1eed`

- Bun 1.4.0: the two affected `tests/server-auth.test.ts` cases passed 5 consecutive focused runs (10 tests total, 0 failed).
- `bun run typecheck` passed.
- `git diff --check` passed.
- Tests used isolated temporary `HOME`, `OPENCODEX_HOME`, and `CODEX_HOME`; protected local runtime config hashes were unchanged.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Behavior-changing documentation is not required; this changes test setup only.
- [x] No production auth or credential behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of pool-auth WebSocket tests by ensuring quota timing uses a consistent clock during asynchronous startup.
  * Removed outdated test commentary describing a previously addressed timing race.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->