### PR TITLE
docs(devlog): record the objective closeout and worktree realignment

### DIFF
--- a/devlog/_plan/260901_remote_hub_restack/131_worktree_state.md
+++ b/devlog/_plan/260901_remote_hub_restack/131_worktree_state.md
@@ -1,0 +1,18 @@
+# 131 — 워크트리 정리 상태
+
+유닛이 끝난 뒤 이 워크트리(`/Users/jun/.codex/worktrees/89ca/opencodex`)를
+`dev` 최신(`b27bab041`)에 맞췄다.
+
+`codex/remote-hub-restack-roadmap`은 #3149로 스쿼시 머지됐다. 스쿼시라 로컬
+브랜치의 39개 커밋이 `dev`의 커밋 하나와 조상 관계를 갖지 않아 fast-forward가
+되지 않는다. 내용은 동일하다 — `git diff origin/dev HEAD -- devlog/`가 빈
+출력이다.
+
+그래서 리셋 대신 이렇게 했다:
+
+- `codex/remote-hub-restack-roadmap-archive` — 원래 39커밋 히스토리를 보존.
+  스쿼시가 지운 커밋 단위 기록이 필요할 때 여기 있다.
+- `codex/remote-hub-closeout` — `origin/dev`에서 새로 시작한 현재 브랜치.
+
+`git reset --hard`는 쓰지 않았다. 스쿼시 머지 후의 갈라짐은 파괴적 명령으로
+풀 문제가 아니라 브랜치를 하나 더 만들면 되는 문제다.

--- a/devlog/_plan/260901_remote_hub_restack/140_objective_closeout.md
+++ b/devlog/_plan/260901_remote_hub_restack/140_objective_closeout.md
@@ -26,3 +26,9 @@
 P2 4건 — T2 인증된 models 경로, T3 관리 ingress의 GUI health, T19 readiness
 응답 문서화, T21 신규 config 키 문서화. 그리고 `shutdown-launcher`의
 SIGINT 워치독 플레이크. 전부 이 유닛의 잔업이 아니라 다음 유닛의 입력이다.
+
+## 이 문서의 랜딩 경로
+
+`131_worktree_state.md`와 이 문서는 `codex/remote-hub-closeout`에서 작성해
+PR로 `dev`에 올린다. 스쿼시 머지 이후 워크트리를 `origin/dev`에서 다시 시작한
+브랜치라, 여기 커밋은 `dev`와 선형 관계를 갖는다.

--- a/devlog/_plan/260901_remote_hub_restack/140_objective_closeout.md
+++ b/devlog/_plan/260901_remote_hub_restack/140_objective_closeout.md
@@ -1,0 +1,28 @@
+# 140 — 목표 종료 확인
+
+## 최종 판정: DONE
+
+열 건이 `dev`에 랜딩했고 한 건은 중복으로 닫았다. `dev` HEAD `b27bab041`.
+
+| PR | 상태 |
+| --- | --- |
+| #2771 #2772 #2776 #2777 #2781 #2786 #2789 | MERGED (스택 7단계) |
+| #3147 | MERGED (`dev` websocket flake 근본 수정) |
+| #3149 | MERGED (로드맵 유닛) |
+| #3159 | MERGED (머지 트레인 클로즈아웃) |
+| #3143 | CLOSED (#3147과 중복, 크레딧 기록) |
+
+## 제약 준수
+
+- **로컬 전체 스위트 미실행.** 실행한 테스트는 두 번뿐이다:
+  `bun test tests/server-auth.test.ts`(91 pass, #3147 검증)와
+  `bun test tests/core-lab-boundary.test.ts tests/repo-hygiene.test.ts`
+  (29 pass, 머지 후 `dev` 구조 불변식). 둘 다 파일 지정 포커스 실행이다.
+- **모든 푸시 `--no-verify`.**
+- **`dev`/`main`/`preview` 직접 푸시 0건.** 열한 건 전부 PR 경로다.
+
+## 미해결로 남긴 것 (#3158)
+
+P2 4건 — T2 인증된 models 경로, T3 관리 ingress의 GUI health, T19 readiness
+응답 문서화, T21 신규 config 키 문서화. 그리고 `shutdown-launcher`의
+SIGINT 워치독 플레이크. 전부 이 유닛의 잔업이 아니라 다음 유닛의 입력이다.


### PR DESCRIPTION
## Summary

- Final two notes for the remote-hub restack unit, written after the merge train finished.
- `131_worktree_state.md` records how this worktree was realigned after #3149 squash-merged: the 39-commit local branch shares no ancestry with the single squashed commit, so it was archived as `codex/remote-hub-restack-roadmap-archive` and a fresh branch was cut from `origin/dev` instead of resetting anything.
- `140_objective_closeout.md` is the objective closeout: the eleven-PR disposition table, the constraint record (which focused tests ran, that no full suite ran, that every landing went through a PR), and what was deliberately left for #3158.

Docs only.

## Verification

No full suite, per policy. The two focused runs this unit did are named in the closeout note: `bun test tests/server-auth.test.ts` (91 pass, verifying #3147) and `bun test tests/core-lab-boundary.test.ts tests/repo-hygiene.test.ts` (29 pass, verifying merged `dev` keeps the structural invariants `AGENTS.md` names). This PR changes no code, so it inherits that state.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (this PR is the documentation).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults — no code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Korean-language project notes documenting branch synchronization, preserved history, and worktree status.
  * Added an objective closeout record summarizing completed work, merged changes, compliance notes, and deferred issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->