### PR TITLE
fix(catalog): read GitHub Copilot context window metadata

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -1195,9 +1195,15 @@ export function catalogHintsFromModelsApiItem(providerName: string, item: Provid
   const metadata = plainRecord(item.metadata);
   const capabilityRecord = plainRecord(metadata?.capabilities) ?? plainRecord(item.capabilities);
   const limits = plainRecord(metadata?.limits);
+  const capabilityLimits = plainRecord(plainRecord(item.capabilities)?.limits);
   const contextWindow =
     positiveSafeInteger(
       limits?.max_context_length,
+      // GitHub Copilot reports the live context window here instead of in the metadata or
+      // top-level fields used by other OpenAI-compatible catalogs (#3156). Keep the existing
+      // metadata field authoritative when both are present: adding this provider-specific
+      // fallback must not change previously recognized providers.
+      capabilityLimits?.max_context_window_tokens,
       metadata?.context_length,
       item.context_length,
       item.context_size,

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -5366,6 +5366,49 @@ describe("Codex catalog routed normalization", () => {
     expect(routed?.context_window).toBe(64_000);
   });
 
+  test("GitHub Copilot capabilities preserve the live context window (#3156)", async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      data: [{
+        id: "copilot-wide-model",
+        capabilities: {
+          limits: { max_context_window_tokens: 1_000_000 },
+        },
+      }, {
+        id: "copilot-existing-metadata",
+        metadata: { limits: { max_context_length: 256_000 } },
+        capabilities: {
+          limits: { max_context_window_tokens: 1_000_000 },
+        },
+      }, {
+        id: "copilot-invalid-window",
+        capabilities: {
+          limits: { max_context_window_tokens: -1 },
+        },
+      }],
+    }))) as typeof fetch;
+
+    const models = await gatherRoutedModels({
+      port: 10100,
+      defaultProvider: "github-copilot",
+      providers: {
+        "github-copilot": {
+          adapter: "openai-chat",
+          baseUrl: "https://api.githubcopilot.com",
+          apiKey: "sk-test",
+        },
+      },
+    });
+    const routed = buildCatalogEntries(nativeTemplate(), [], models)
+      .find(entry => entry.slug === "github-copilot/copilot-wide-model");
+
+    expect(models.find(model => model.id === "copilot-wide-model")?.contextWindow).toBe(1_000_000);
+    expect(routed?.context_window).toBe(1_000_000);
+    expect(routed?.max_context_window).toBe(1_000_000);
+    expect(routed?.auto_compact_token_limit).toBe(900_000);
+    expect(models.find(model => model.id === "copilot-existing-metadata")?.contextWindow).toBe(256_000);
+    expect(models.find(model => model.id === "copilot-invalid-window")?.contextWindow).toBeUndefined();
+  });
+
   test("liveModels false preserves configured catalog metadata without live fetch", async () => {
     let fetchCalls = 0;
     globalThis.fetch = (() => {


### PR DESCRIPTION
## Summary

- read GitHub Copilot's live context-window field at `capabilities.limits.max_context_window_tokens`
- preserve the existing metadata precedence when both old and Copilot-shaped fields are present
- reject malformed/non-positive values through the existing safe-integer boundary
- add an end-to-end routed catalog regression for accepted, conflicting, and invalid Copilot payloads

## Root cause

The live-model parser recognized `metadata.limits.max_context_length`, `metadata.context_length`, and top-level compatibility fields, but GitHub Copilot publishes the value under `capabilities.limits.max_context_window_tokens`. The value was therefore lost before catalog construction and Codex fell back to the conservative 128K window.

## Verification

Exact head `486b2f99f3182acf055274755ade9c6571203ac9`:

- focused Copilot regression: 1 passed, 0 failed
- `bun test tests/codex-catalog.test.ts`: 255 passed, 0 failed
- `bun run typecheck`: this branch and an unmodified `dev` worktree both report the same three pre-existing `fetch(..., { timeout })` type errors in `src/server/claude-messages.ts` and `src/server/responses/fetch-helpers.ts`; this diff adds no type errors
- all local runs used isolated `HOME`, `OPENCODEX_HOME`, and `CODEX_HOME`, `nice -n 10`, and a two-CPU affinity

Full exact-head CI is still required before merge.

Closes #3156.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live model discovery for GitHub Copilot by recognizing context-window limits reported through capabilities.
  * Preserved explicitly configured context-window values when they differ from live discovery data.
  * Ignored invalid negative context-window values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->