### PR TITLE
fix(client): tell the dashboard it is a client

### DIFF
--- a/src/client/machine-listener.ts
+++ b/src/client/machine-listener.ts
@@ -118,7 +118,14 @@ export function startMachineListener(
         ? issueGuiSession(req, config, managementAuth, { trustedTailscaleIngress: false })
         : null;
       if (url.pathname === "/opencodex-session" && session) return serveSessionBootstrap(session);
-      const gui = serveGuiFile(url.pathname, undefined, session ?? undefined);
+      // State the role, exactly as the standalone/hub server does (src/server/index.ts).
+      // The GUI decides whether a machine plane exists from this tag alone
+      // (gui/src/api-targets.ts `isConnectedRuntime`): without it `discoverApiTargets`
+      // returns standalone targets and never queries /api/machine/status, so a connected
+      // client renders as a plain install — no hub usage scope, no "this machine" panel,
+      // no connected-client list. This listener only ever serves a connected client, so
+      // the role is a constant here rather than a config read.
+      const gui = serveGuiFile(url.pathname, undefined, session ?? undefined, "client");
       if (gui) return gui;
       if (url.pathname === "/") {
         return Response.json({

--- a/tests/client-machine-listener.test.ts
+++ b/tests/client-machine-listener.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Server } from "bun";
 import { startMachineListener } from "../src/client/machine-listener";
+import { serveGuiFile } from "../src/server/gui-static";
 import type { OcxClientConnectionConfig } from "../src/types";
 import type { ManagementAuthState } from "../src/server/management-auth";
 
@@ -153,5 +154,43 @@ describe("client machine listener", () => {
 
   test("refuses startup without matching durable connected state", () => {
     expect(() => startMachineListener(0, { managementAuthState: authState() })).toThrow(/requires connected client state/);
+  });
+});
+
+describe("the served document states the client role", () => {
+  // The GUI decides whether a machine plane exists from this tag alone
+  // (gui/src/api-targets.ts `isConnectedRuntime` / `discoverApiTargets`). A missing tag is
+  // not cosmetic: discovery returns standalone targets immediately and never queries
+  // /api/machine/status, so a connected client renders as a plain install — no hub usage
+  // scope, no "this machine" panel, no connected-client list.
+  //
+  // Asserted against `serveGuiFile` directly rather than over HTTP, because the listener
+  // falls through to a JSON payload when `gui/dist` is absent, and a checkout without a
+  // GUI build would make an HTTP-level assertion pass vacuously.
+  test("the client dashboard document carries the role tag", () => {
+    const dist = mkdtempSync(join(tmpdir(), "ocx-gui-dist-"));
+    try {
+      writeFileSync(join(dist, "index.html"), "<!doctype html><html><head></head><body></body></html>");
+      const response = serveGuiFile("/", dist, undefined, "client");
+      expect(response).not.toBeNull();
+      return response!.text().then(html => {
+        expect(meta(html, "opencodex-runtime-role")).toBe("client");
+      });
+    } finally {
+      rmSync(dist, { recursive: true, force: true });
+    }
+  });
+
+  test("the listener asks for the client role rather than leaving it undefined", () => {
+    // Source-level, deliberately: the call is what carries the role, and the HTTP path
+    // cannot show it in a checkout with no GUI build. Reading the file keeps the
+    // assertion honest in both cases.
+    const source = readFileSync(
+      join(import.meta.dir, "..", "src", "client", "machine-listener.ts"),
+      "utf8",
+    );
+    const call = /serveGuiFile\(([^)]*)\)/.exec(source);
+    expect(call, "machine-listener no longer calls serveGuiFile").not.toBeNull();
+    expect(call![1]).toContain('"client"');
   });
 });


### PR DESCRIPTION
## Summary

- The machine listener served the dashboard without the `opencodex-runtime-role` meta tag, so a **connected client rendered as a plain standalone install**.
- The tag is load-bearing, not decoration. `gui/src/api-targets.ts` reads it in `isConnectedRuntime()`, and `discoverApiTargets()` returns standalone targets immediately when it is anything other than `client` — deliberately, so a user who never enabled remote hub issues no request to a remote-hub endpoint. On a real client that shortcut fired every time: discovery never queried `/api/machine/status`, so there was no hub usage scope on Usage, no "this machine" panel on Startup, no connected-client list on Integrations, and no pairing form.
- `src/server/index.ts:1963` already passes `config.runtimeRole` on the same call. This listener only ever serves a connected client, so the role is a constant here rather than a config read.

Found while documenting what a connected client actually shows, which is how the gap surfaced: the documentation claimed a two-plane dashboard the running code could not produce.

## Verification

Verified by hand on a live listener with a real `gui/dist`, before and after:

- **Before:** the served document carried only the session meta. The dashboard showed the standalone layout.
- **After:** `<meta name="opencodex-runtime-role" content="client">` is present and the two-plane UI appears — "Disconnect from hub" in the sidebar and the "Connect this dashboard to the hub" pairing form.

Tests:

- `bun test tests/client-machine-listener.test.ts` — 6 pass, 0 fail.
- `bun test tests/client-machine-listener.test.ts tests/core-lab-boundary.test.ts` — 23 pass, 0 fail.
- `bun x tsc --noEmit` — clean.

Both new tests were driven red against the unfixed call before the fix landed. The listener-level one reads the source rather than the HTTP response on purpose: the listener falls through to a JSON payload when `gui/dist` is absent, so an HTTP-level assertion would pass vacuously in a checkout with no GUI build. The document-level one covers `serveGuiFile` directly with a temporary dist.

No full suite, per the no-local-suite policy.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed — behavior returns to what the docs already describe; no user-facing contract changes.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The tag is non-secret by design (it names a topology the operator configured), and it is what keeps a standalone install from probing remote-hub endpoints. Admission is unchanged: the machine API still requires a GUI session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GUI behavior when connected through a machine listener by correctly identifying the client runtime role.
  - Ensured served GUI pages include the appropriate client metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->