### PR TITLE
fix(cli): route ocx models new-policy and new-arrivals to the runtime module

### DIFF
--- a/src/cli/models-runtime-subcommands.ts
+++ b/src/cli/models-runtime-subcommands.ts
@@ -1,0 +1,34 @@
+/**
+ * The `ocx models` subcommands that live in `models-runtime` and talk to the
+ * management API, rather than editing `config.json` directly.
+ *
+ * This list is shared rather than duplicated on purpose. `handleModels` in
+ * `models.ts` decides which names to hand to the runtime module, and
+ * `handleModelsRuntimeCommand` decides which names it answers. When those two
+ * lists were written out separately, `new-policy` and `new-arrivals` were
+ * implemented and documented but never routed, so both failed with
+ * "Unexpected argument(s)" (#3094).
+ *
+ * It lives in its own leaf module so `models.ts` can read the set without
+ * statically importing `models-runtime` — that import is deliberately dynamic
+ * to keep the management-API client off the `ocx models add` path.
+ */
+export const MODELS_RUNTIME_SUBCOMMANDS = [
+  "live",
+  "edit",
+  "enable",
+  "disable",
+  "provider",
+  "selected",
+  "preset",
+  "new-policy",
+  "new-arrivals",
+  "context",
+  "shadow",
+] as const;
+
+export type ModelsRuntimeSubcommand = (typeof MODELS_RUNTIME_SUBCOMMANDS)[number];
+
+export function isModelsRuntimeSubcommand(value: string | undefined): value is ModelsRuntimeSubcommand {
+  return MODELS_RUNTIME_SUBCOMMANDS.includes(value as ModelsRuntimeSubcommand);
+}

--- a/src/cli/models-runtime.ts
+++ b/src/cli/models-runtime.ts
@@ -12,6 +12,7 @@ import {
   takeOption,
   type RuntimeApiDeps,
 } from "./runtime-api";
+import { isModelsRuntimeSubcommand } from "./models-runtime-subcommands";
 
 const USAGE = `Usage:
   ocx models live [--provider <name>] [--json]
@@ -321,6 +322,9 @@ async function shadow(argv: string[], deps: RuntimeApiDeps): Promise<void> {
 }
 
 export async function handleModelsRuntimeCommand(sub: string, argv: string[], deps: RuntimeApiDeps = {}): Promise<number | null> {
+  // The dispatch below and MODELS_RUNTIME_SUBCOMMANDS must name the same set;
+  // tests/cli-models-runtime-dispatch.test.ts fails if they drift (#3094).
+  if (!isModelsRuntimeSubcommand(sub)) return null;
   let action: (() => Promise<void>) | undefined;
   if (sub === "live") action = () => live(argv, deps);
   else if (sub === "edit") action = () => edit(argv, deps);

--- a/src/cli/models.ts
+++ b/src/cli/models.ts
@@ -12,6 +12,7 @@ import {
   modelRecordValue,
 } from "../reasoning-effort";
 import { encodedModelIdCollides, resolveSlugSelection, routedSlug } from "../providers/slug-codec";
+import { isModelsRuntimeSubcommand } from "./models-runtime-subcommands";
 import { knownModelIdsForProvider } from "../router";
 import { findLiveProxy } from "../server/proxy-liveness";
 import { modelInList, type OcxConfig, type OcxCustomModel } from "../types";
@@ -445,7 +446,7 @@ export async function handleModels(args: string[]): Promise<void> {
     handleCustomList(rest);
     return;
   }
-  if (["live", "edit", "enable", "disable", "provider", "selected", "preset", "context", "shadow"].includes(subcommand ?? "")) {
+  if (isModelsRuntimeSubcommand(subcommand)) {
     const { handleModelsRuntimeCommand } = await import("./models-runtime");
     const code = await handleModelsRuntimeCommand(subcommand!, rest);
     if (code !== null) process.exitCode = code;

--- a/tests/cli-models-runtime-dispatch.test.ts
+++ b/tests/cli-models-runtime-dispatch.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { MODELS_RUNTIME_SUBCOMMANDS, isModelsRuntimeSubcommand } from "../src/cli/models-runtime-subcommands";
+import { MODELS_RUNTIME_USAGE, handleModelsRuntimeCommand } from "../src/cli/models-runtime";
+
+/**
+ * #3094: `ocx models new-policy` and `ocx models new-arrivals` were implemented in
+ * models-runtime.ts, listed in its USAGE, and documented on the docs site, but
+ * handleModels in models.ts routed a separately written array that omitted them. Both
+ * commands reached handleConfiguredModels instead and died with
+ * "Unexpected argument(s)".
+ *
+ * The repair removed the duplication: one exported set is the routing decision on both
+ * sides. These tests pin the general form of the defect, not just the two names, so a
+ * future runtime subcommand added without touching the shared set fails here.
+ */
+describe("models runtime subcommand dispatch (#3094)", () => {
+  test("every documented runtime subcommand is in the shared routing set", () => {
+    // USAGE is the user-facing contract: "  ocx models <sub> ..." per line.
+    const documented = new Set<string>();
+    for (const line of MODELS_RUNTIME_USAGE.split("\n")) {
+      const match = /^\s+ocx models ([a-z-]+)/.exec(line);
+      if (match?.[1]) documented.add(match[1]);
+    }
+    // `ocx models <enable|disable> ...` is written as an alternation in USAGE.
+    if (MODELS_RUNTIME_USAGE.includes("ocx models <enable|disable>")) {
+      documented.add("enable");
+      documented.add("disable");
+    }
+    expect(documented.size).toBeGreaterThan(0);
+    const missing = [...documented].filter(sub => !isModelsRuntimeSubcommand(sub));
+    expect(missing).toEqual([]);
+  });
+
+  test("new-policy and new-arrivals are routed, not swallowed by the configured-models path", () => {
+    expect(isModelsRuntimeSubcommand("new-policy")).toBe(true);
+    expect(isModelsRuntimeSubcommand("new-arrivals")).toBe(true);
+  });
+
+  test("handleModels routes exactly the shared set to the runtime module", () => {
+    // Reading the source keeps this honest without booting the CLI: the dispatch must
+    // consult the shared predicate rather than re-listing names inline.
+    const source = readFileSync(new URL("../src/cli/models.ts", import.meta.url), "utf8");
+    expect(source).toContain("isModelsRuntimeSubcommand(subcommand)");
+    // The old inline array is what allowed the drift; it must not come back.
+    expect(source).not.toMatch(/\["live",\s*"edit"/);
+  });
+
+  test("handleModelsRuntimeCommand returns null for a name outside the set", async () => {
+    expect(await handleModelsRuntimeCommand("definitely-not-a-subcommand", [])).toBeNull();
+  });
+
+  test("the shared set has no duplicates", () => {
+    expect(new Set(MODELS_RUNTIME_SUBCOMMANDS).size).toBe(MODELS_RUNTIME_SUBCOMMANDS.length);
+  });
+});
+


### PR DESCRIPTION
## Summary

`ocx models new-policy` and `ocx models new-arrivals` are implemented, listed in the runtime module's USAGE, and documented on the docs site — but neither was reachable. Both failed with `Unexpected argument(s)` and exit 1.

Two lists named the same set and only one was kept current:

- `handleModelsRuntimeCommand` (`src/cli/models-runtime.ts:332-333`) handles `new-policy` and `new-arrivals`.
- `handleModels` (`src/cli/models.ts:448`) routed a separately written inline array that omitted them, so both names fell through to `handleConfiguredModels`, which rejects unknown arguments.

The fix removes the duplication rather than adding the two names to the second copy. A new leaf module owns the set and both sides consult it, so the next runtime subcommand cannot be added without being routed.

The set lives in its own file rather than being exported from `models-runtime.ts` on purpose: `models.ts` imports that module dynamically to keep the management-API client off the `ocx models add` path, and importing a constant from it would have made that import static.

Closes #3094.

## Verification

Exact head `c3776de95`:

- `bun test tests/cli-models-runtime-dispatch.test.ts` — **5 pass, 0 fail**, 8 expect() calls.
- `bun test tests/cli-models-reasoning.test.ts tests/cli-headless-parity.test.ts` — **60 pass, 0 fail** (the adjacent CLI suites that exercise the two dispatchers).
- **Red-green verified.** Removing `"new-policy"` from the shared set turns the new file red (3 pass / 2 fail) and restoring it returns it to green, so the regression genuinely covers the defect rather than passing vacuously.

The new test pins the general form of the bug, not just the two names: it parses the runtime module's own USAGE text and asserts every documented subcommand is in the shared routing set, asserts `models.ts` consults the shared predicate, and asserts the old inline array cannot come back.

Full-suite and typecheck coverage is left to CI on this exact head.

## Checklist

- [x] Targets `dev`
- [x] Focused regression test added next to the existing CLI suites
- [x] No new dependencies, no config or schema change
- [x] No credential, auth, workflow, or release-automation surface touched
- [x] User-facing behavior now matches what `docs-site/src/content/docs/guides/model-routing.md` already documents, so no docs change is required



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing for model runtime commands in the CLI.
  * Fixed handling of recognized commands such as `new-policy` and `new-arrivals`.
  * Unknown model subcommands are now handled cleanly without unintended dispatch behavior.

* **Tests**
  * Added coverage to verify supported commands, routing behavior, and duplicate-free command recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->