### PR TITLE
fix(combo): apply the combo default effort the target can actually reach

### DIFF
--- a/src/codex/catalog/aggregation.ts
+++ b/src/codex/catalog/aggregation.ts
@@ -8,7 +8,7 @@ import { clearModelCache, DEFAULT_MODEL_CACHE_TTL_MS, getFreshCached, getStaleCa
 import { buildModelsRequest, resolveModelsAuthToken } from "../../oauth";
 import type { OcxConfig, OcxProviderConfig } from "../../types";
 import { modelInList } from "../../types";
-import { CODEX_REASONING_LEVELS, codexEffortRank, configuredReasoningEfforts, modelRecordValue, sanitizeCodexReasoningEfforts } from "../../reasoning-effort";
+import { CODEX_REASONING_LEVELS, codexEffortRank, configuredReasoningEfforts, modelRecordValue, resolveEffortAtOrBelow, sanitizeCodexReasoningEfforts } from "../../reasoning-effort";
 import { getModelMetadata, getModelMetadataCaseInsensitive, listModelMetadata, resolveMetadataProvider } from "../../generated/model-metadata";
 import { enrichProviderFromRegistry, shouldCaseFoldMetadataModelId } from "../../providers/derive";
 import { getProviderRegistryEntry } from "../../providers/registry";
@@ -77,20 +77,16 @@ export function intersectStrings(values: readonly string[][]): string[] {
   return [...new Set(values[0])].filter(value => rest.every(set => set.has(value)));
 }
 
+/**
+ * The catalog's view of a combo's default effort. Delegates to the shared leaf
+ * resolver so the request path (src/combos/request.ts) cannot drift from what the
+ * catalog advertised (#3108).
+ */
 export function effectiveComboDefault(
   configured: string | null | undefined,
   common: readonly string[],
 ): string | undefined {
-  if (!configured) return undefined;
-  if (configured && common.includes(configured)) return configured;
-  const requestedRank = codexEffortRank(configured);
-  const ranked = common
-    .map(effort => ({ effort, rank: codexEffortRank(effort) }))
-    .filter(item => item.rank >= 0)
-    .sort((a, b) => a.rank - b.rank);
-  if (ranked.length === 0) return undefined;
-  const atOrBelow = ranked.filter(item => item.rank <= requestedRank);
-  return atOrBelow.at(-1)?.effort ?? ranked[0]!.effort;
+  return resolveEffortAtOrBelow(configured, common);
 }
 
 /**

--- a/src/combos/request.ts
+++ b/src/combos/request.ts
@@ -1,4 +1,5 @@
 import type { OcxComboDefaultEffort, OcxComboTarget, OcxConfig } from "../types";
+import { resolveEffortAtOrBelow } from "../reasoning-effort";
 import { resolveComboId } from "./types";
 
 const warnedUnsupportedDefaults = new Set<string>();
@@ -72,7 +73,18 @@ export function concreteComboRequestBody(
   if (!needsDefault) return clone;
   // Picker availability treats an unknown ladder as a wildcard, but runtime
   // injection stays fail-closed until this concrete target advertises support.
-  if (!targetReasoningEfforts?.includes(defaultEffort)) {
+  //
+  // Support is not literal membership. The catalog advertises the combo's default
+  // through effectiveComboDefault, which keeps the highest supported rung at or
+  // below the request rather than dropping it. Testing membership here meant a
+  // combo configured for `max` against a target topping out at `high` sent no
+  // effort at all, so the provider default applied and the turn ran at `none`
+  // while the catalog still advertised `max` (#3108). Resolve the same way the
+  // catalog did.
+  const resolvedEffort = targetReasoningEfforts === undefined
+    ? undefined
+    : resolveEffortAtOrBelow(defaultEffort, targetReasoningEfforts);
+  if (!resolvedEffort) {
     const key = `${target.provider}/${target.model}:${defaultEffort}`;
     if (!warnedUnsupportedDefaults.has(key)) {
       warnedUnsupportedDefaults.add(key);
@@ -86,9 +98,9 @@ export function concreteComboRequestBody(
     return clone;
   }
   if (reasoning === undefined) {
-    clone.reasoning = { effort: defaultEffort };
+    clone.reasoning = { effort: resolvedEffort };
   } else {
-    clone.reasoning = { ...(reasoning as Record<string, unknown>), effort: defaultEffort };
+    clone.reasoning = { ...(reasoning as Record<string, unknown>), effort: resolvedEffort };
   }
   return clone;
 }

--- a/src/reasoning-effort.ts
+++ b/src/reasoning-effort.ts
@@ -80,6 +80,38 @@ export function codexEffortRank(effort: string): number {
   return CODEX_REASONING_ORDER.indexOf(effort);
 }
 
+/**
+ * Resolve a requested effort against the rungs a target actually supports, never
+ * raising above the request.
+ *
+ * Returns the request itself when supported, otherwise the highest supported rung
+ * at or below it, otherwise the lowest supported rung, and `undefined` when the
+ * supported set contains no rankable rung at all (including the empty ladder, which
+ * is how a no-reasoning model is expressed).
+ *
+ * This lives here rather than beside its first caller because two very different
+ * planes need the same answer: the catalog advertises a combo's default effort, and
+ * the request path injects one. When they disagreed, the catalog promised `max` and
+ * the runtime silently sent nothing, so the provider default applied instead (#3108).
+ * `reasoning-effort.ts` is a leaf — its only import is `./types` — so the request
+ * path can share this without pulling the catalog plane along.
+ */
+export function resolveEffortAtOrBelow(
+  requested: string | null | undefined,
+  supported: readonly string[],
+): string | undefined {
+  if (!requested) return undefined;
+  if (supported.includes(requested)) return requested;
+  const requestedRank = codexEffortRank(requested);
+  const ranked = supported
+    .map(effort => ({ effort, rank: codexEffortRank(effort) }))
+    .filter(item => item.rank >= 0)
+    .sort((a, b) => a.rank - b.rank);
+  if (ranked.length === 0) return undefined;
+  const atOrBelow = ranked.filter(item => item.rank <= requestedRank);
+  return atOrBelow.at(-1)?.effort ?? ranked[0]!.effort;
+}
+
 export function modelRecordValue<T>(record: Record<string, T> | undefined, modelId: string): T | undefined {
   if (!record) return undefined;
   if (Object.prototype.hasOwnProperty.call(record, modelId)) return record[modelId];

--- a/tests/combos.test.ts
+++ b/tests/combos.test.ts
@@ -293,11 +293,40 @@ describe("combo request cloning", () => {
     ).reasoning).toEqual({ summary: "concise", effort: "high" });
   });
 
-  test("omits combo defaults for unset, unsupported, and unknown target capabilities", () => {
+  test("omits combo defaults for unset, no-reasoning, and unknown target capabilities", () => {
     expect(concreteComboRequestBody({ model: "combo/x" }, target, null, ["high"]).reasoning).toBeUndefined();
+    // An explicitly empty ladder is how a no-reasoning model is expressed.
     expect(concreteComboRequestBody({ model: "combo/x" }, target, "high", []).reasoning).toBeUndefined();
+    // An unknown ladder stays fail-closed: the picker treats it as a wildcard, runtime injection does not.
     expect(concreteComboRequestBody({ model: "combo/x" }, target, "high", undefined).reasoning).toBeUndefined();
-    expect(concreteComboRequestBody({ model: "combo/x" }, target, "high", ["low", "medium"]).reasoning).toBeUndefined();
+  });
+
+  /**
+   * #3108: a combo configured for `max` routed to a target whose ladder tops out lower
+   * sent NO effort at all, so the provider default applied and the turn ran at `none` —
+   * while the catalog advertised `max` for that same combo, because
+   * effectiveComboDefault downgrades to the nearest supported rung instead of dropping.
+   * The request path now resolves the same way the catalog did.
+   */
+  test("a combo default above the target ladder is downgraded, not dropped (#3108)", () => {
+    expect(concreteComboRequestBody({ model: "combo/x" }, target, "max", ["low", "medium", "high"]).reasoning)
+      .toEqual({ effort: "high" });
+    expect(concreteComboRequestBody({ model: "combo/x" }, target, "high", ["low", "medium"]).reasoning)
+      .toEqual({ effort: "medium" });
+    // Exact support is still passed through untouched.
+    expect(concreteComboRequestBody({ model: "combo/x" }, target, "max", ["high", "max"]).reasoning)
+      .toEqual({ effort: "max" });
+    // Never raises: a request below everything supported takes the lowest rung, not a higher one.
+    expect(concreteComboRequestBody({ model: "combo/x" }, target, "low", ["high", "max"]).reasoning)
+      .toEqual({ effort: "high" });
+    // A caller-supplied effort still wins over the combo default.
+    expect(concreteComboRequestBody(
+      { model: "combo/x", reasoning: { effort: "low" } }, target, "max", ["low", "medium", "high"],
+    ).reasoning).toEqual({ effort: "low" });
+    // The resolved rung merges into a partial reasoning object rather than replacing it.
+    expect(concreteComboRequestBody(
+      { model: "combo/x", reasoning: { summary: "concise" } }, target, "max", ["low", "high"],
+    ).reasoning).toEqual({ summary: "concise", effort: "high" });
   });
 
   test("debug-warns once per unsupported or unknown combo default", () => {


### PR DESCRIPTION
## Summary

A combo with a default reasoning level of `max` routed to `deepseek-v4-pro` sent `none`, while selecting the same model directly with `max` sent `max`.

`concreteComboRequestBody` tested literal membership — `targetReasoningEfforts?.includes(defaultEffort)` — and dropped the default on a miss. With nothing on the wire the provider's own default applied, which reads as `none`.

The catalog never agreed with that. `effectiveComboDefault` (`src/codex/catalog/aggregation.ts`) resolves a combo's advertised default to the highest supported rung **at or below** the request rather than dropping it, so the served catalog promised `max` for a combo whose requests were silently carrying no effort at all.

The fix is one shared resolver instead of two disagreeing rules. `resolveEffortAtOrBelow` moves into `src/reasoning-effort.ts` and both planes call it.

**Why that file.** The obvious move — importing `effectiveComboDefault` straight from `aggregation.ts` — is not available. `aggregation.ts` already imports `src/combos`, so the reverse import closes a cycle; and it pulls `node:child_process`, `src/oauth`, `src/codex/model-cache`, and `src/adapters/cursor/live-models`, all of which would land on the request path through `src/server/responses/core.ts → src/combos`. `reasoning-effort.ts` is a genuine leaf (its only import is `./types`) and already owns `codexEffortRank`, the exact primitive the resolver needs.

Two behaviors deliberately do not change: an **unknown** ladder (`undefined`) stays fail-closed, and an **explicitly empty** ladder still means the model takes no reasoning effort.

Closes #3108.

## Verification

Exact head `86dddcf5b`:

- `bun test tests/combos.test.ts` — **44 pass, 0 fail**, 229 expect() calls.
- `bun test tests/core-lab-boundary.test.ts tests/combo-management-api.test.ts` — **45 pass, 0 fail**. The boundary suite is the one that would catch the import mistake described above.
- `bun test tests/codex-catalog.test.ts` — **255 pass, 0 fail**, confirming the catalog plane behaves identically after `effectiveComboDefault` became a delegation.
- **Red-green verified.** Restoring the old `includes()` check turns the new case red (43 pass / 1 fail) and the fix returns it to green.

One existing assertion changed rather than being added to: `concreteComboRequestBody(..., "high", ["low", "medium"])` previously expected `undefined`. That assertion was pinning the defect — it is the exact shape #3108 reports — so it now expects `{ effort: "medium" }`. The unset, empty-ladder, and unknown-ladder cases in that test are untouched.

Full-suite and typecheck coverage is left to CI on this exact head.

## Checklist

- [x] Targets `dev`
- [x] Focused regression added next to the existing combo request-cloning tests
- [x] Import boundary checked explicitly; `tests/core-lab-boundary.test.ts` green
- [x] No credential, auth, workflow, or release-automation surface touched
- [x] No config or schema change; no new dependency



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combo reasoning defaults now resolve to the closest supported effort level.
  * Higher requested levels are safely downgraded rather than omitted or exceeding available capabilities.
  * Exact matches and caller-supplied reasoning preferences continue to be honored.

* **Bug Fixes**
  * Improved handling of partial reasoning settings and unsupported effort ladders.
  * Requests now retain a valid reasoning level whenever one can be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->