### PR TITLE
docs(reference): document the readyz protocol fields and the remote-hub config keys

### DIFF
--- a/docs-site/src/content/docs/reference/cli/lifecycle.md
+++ b/docs-site/src/content/docs/reference/cli/lifecycle.md
@@ -161,11 +161,18 @@ command exits 0 only when healthy and 1 otherwise, making it suitable for servic
 
 Check post-sync readiness through the unauthenticated `GET /readyz` endpoint. It returns `200` when
 ready, or `503` with `Retry-After: 1` for `pending` and terminal `failed`. Its sanitized HTTP identity
-is `{service, version, uptime, pid, port, status}`. Old proxies without `/readyz` fail closed as
-`unreachable`; `/healthz` is separate liveness, not readiness. The command performs one probe by
+is `{service, version, uptime, pid, port, status}` plus the remote-hub protocol fields
+`{protocol, minimumClientProtocol, managementUrl}`. `protocol` is the hub protocol this proxy
+speaks and `minimumClientProtocol` the oldest client it still accepts, so a client can refuse an
+incompatible pairing before sending anything else. `managementUrl` is the origin a client should
+use for the management plane: the configured `hub.managementPublicOrigin` when `runtimeRole` is
+`hub`, and otherwise the origin the request itself arrived on. A readiness request with no
+HTTP(S) origin is rejected rather than answered with a guess. Old proxies without `/readyz` fail
+closed as `unreachable`; `/healthz` is separate liveness, not readiness. The command performs one probe by
 default; `--wait` polls until ready or timeout, but exits immediately when it observes the terminal `failed` state. The
 default timeout is 45 seconds; `--timeout <seconds>` requires `--wait` and accepts positive integer seconds from 1–300.
-CLI JSON emits `{ready, status, pid, port}`, where `status` is `ready`, `pending`, `failed`, or
+The CLI's own `--json` output is deliberately narrower than the HTTP body: it emits
+`{ready, status, pid, port}`, where `status` is `ready`, `pending`, `failed`, or
 `unreachable`. Exit codes are 0 for ready; 1 for not-ready, pending, failed, timeout, or
 unreachable; and 64 for invalid arguments.
 

--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -266,3 +266,15 @@ intended account and workload.
 ## Remote Hub keys and defaults
 
 `runtimeRole` defaults to `standalone`. A hub uses `hub.managementPublicOrigin`, loopback-only `hub.managementIngress` (`enabled:false` when absent), and exact `remoteGui.allowedTailscaleUsers` (empty when absent). A client data key lives in `service-api-token`, never `config.json`; rotation may temporarily create `service-api-token.prev`. Usage stores are not mirrored.
+
+| Key | Type | Default when absent | What it does |
+| --- | --- | --- | --- |
+| `hub.managementPublicOrigin` | string | unset | The canonical browser-reachable management origin a hub advertises, for example the HTTPS origin Tailscale Serve prints. It is what `/readyz` reports as `managementUrl` while `runtimeRole` is `hub`; with it unset the hub falls back to whatever origin each request arrived on, so a client behind a different frontend can be handed an address it cannot reach. |
+| `hub.managementIngress` | `{enabled:false}` or `{enabled:true, port}` | `{enabled:false}` | An extra management-only listener for a local HTTPS frontend. The hostname is not configurable: when enabled the socket always binds `127.0.0.1`, and only GUI, session-bootstrap, and management API routes are admitted. Data-plane routes are rejected before dispatch. |
+| `remoteGui.allowedTailscaleUsers` | string[] | `[]` (empty — nobody) | Exact Tailscale login identities allowed to be issued an automatic remote GUI session. The `Tailscale-User-Login` header is trusted **only** on the separate management ingress; an empty list means no remote identity can mint a session, which is the safe default rather than an oversight. Identities are compared exactly, so a typo silently denies access. |
+| `remoteGui.allowInsecureHttp` | boolean | unset | **Retired — has no effect.** It once permitted a one-time pairing exchange over non-loopback plaintext HTTP. A pairing grant now crosses loopback or authenticated HTTPS only. The key is still parsed so an existing `config.json` keeps loading (the schema is strict, and dropping the key outright would make an older config fail to load entirely); a persisted `true` is reported once and then ignored. Remove it from your config. |
+
+A hub that is reachable from a browser needs `hub.managementPublicOrigin` and at least one entry
+in `remoteGui.allowedTailscaleUsers`. Setting the origin without the user list produces a hub that
+advertises itself correctly and then refuses every session; setting the user list without the
+origin produces sessions pointed at whichever origin the request happened to use.


### PR DESCRIPTION
## Summary

Two of the four follow-ups tracked by #3158 are documentation debt and close here. T2 and T3 are behaviour gaps and stay open.

**T19 — `/readyz` protocol negotiation fields.** The remote-hub work added `protocol`, `minimumClientProtocol`, and `managementUrl` to the readiness body (`src/server/index.ts` spreads `readyProtocolMetadata`), but `reference/cli/lifecycle.md` still described the older six-field shape. A client author reading the reference had no way to know negotiation metadata was there. The page now names the three fields, says what each is for, and explains that `managementUrl` is `hub.managementPublicOrigin` when `runtimeRole` is `hub` and the observed request origin otherwise. It also states explicitly that the CLI's `--json` output is narrower than the HTTP body, which previously read as a contradiction between two adjacent sentences.

**T21 — three undocumented config keys.** `hub.managementPublicOrigin` and `remoteGui.allowedTailscaleUsers` were named only in passing inside a `runtimeRole` sentence; `remoteGui.allowInsecureHttp` appeared nowhere. Each now has a table row with type, default when absent, and the failure mode of getting it wrong — including the pairing that setting the origin without the user list produces a hub that advertises itself correctly and then refuses every session.

**One correction worth flagging.** The plan for this change assumed `allowInsecureHttp` was a live security-relevant opt-out and should be documented with a warning. Reading `src/types/config.ts` and `src/server/gui-session.ts` shows it is **retired**: it grants nothing, a pairing grant now crosses loopback or authenticated HTTPS only, and the key is still parsed solely so an older `config.json` keeps loading under a strict schema. It is documented as retired, with an instruction to remove it — documenting it as an active setting would have been actively misleading.

Refs #3158 (T19, T21).

## Verification

Exact head `12ee15157`:

- English source pages only; `git diff --stat` is two files, +22/-3.
- `rg` confirms all four remote-hub keys and the three readiness fields now appear in their reference pages.
- `bun test tests/docs-bun-source-requirement.test.ts` — 1 pass, 0 fail.
- No source change, so no behavioural regression surface. The docs build runs in CI's `gates` job.

**Locales are deliberately untouched.** The tr/ja/fr/ru/zh-cn `server.md` pages already carry the `runtimeRole` sentence and do not contradict the English source; adding an English-only table to translated pages would be worse than the current gap. That translation work is not attempted here.

## Checklist

- [x] Targets `dev`
- [x] Documentation only — no source, config, schema, or dependency change
- [x] English source pages; translated locales left consistent rather than half-translated
- [x] No credential, auth, workflow, or release-automation surface touched
- [x] Claims verified against `src/server/index.ts`, `src/remote/protocol.ts`, `src/types/config.ts`, and `src/server/gui-session.ts` rather than from the issue text



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented remote-hub protocol metadata returned by the `/readyz` endpoint.
  * Clarified that requests without an HTTP(S) origin are rejected, while CLI JSON output remains unchanged.
  * Added reference information for remote hub configuration keys and defaults.
  * Documented requirements for browser-accessible hubs and clarified that the retired insecure HTTP setting has no effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->