### PR TITLE
test(combo): update the failover e2e assertion the effort fix invalidated

### DIFF
--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -2205,7 +2205,13 @@ describe("server combo failover 030 activation matrix", () => {
     expect(response.status).toBe(200);
     expect(JSON.stringify(bodies[0]!.body)).not.toContain("data:image/png");
     expect(JSON.stringify(bodies[1]!.body)).toContain("data:image/png");
-    expect(bodies[0]!.body.reasoning_effort).toBeUndefined();
+    // #3108: the combo default is resolved against each target's ladder rather than
+    // dropped on an exact-membership miss. This combo's advertised default IS "low" —
+    // the catalog intersects member ladders (a: ["low"], b: ["low","high"]) to ["low"]
+    // and effectiveComboDefault("high", ["low"]) yields "low" — so sending "low" to the
+    // first target is what the served catalog promised. Previously nothing was sent and
+    // the provider default silently applied.
+    expect(bodies[0]!.body.reasoning_effort).toBe("low");
     expect(bodies[1]!.body.reasoning_effort).toBe("high");
 
     clearComboSelectionState();


### PR DESCRIPTION
## Summary

CI on `dev` caught one assertion #3172 should have updated and did not: `tests/server-combo-failover-e2e.test.ts > fresh child reparsing recomputes vision and effort per target` expected the first target to receive **no** `reasoning_effort`.

That expectation encoded the defect #3172 fixed. In that fixture the combo's members advertise `a: ["low"]` and `b: ["low", "high"]`, so the catalog intersects them to `["low"]` and `effectiveComboDefault("high", ["low"])` resolves to `low` — the served catalog advertises `low` for this combo. The old request path tested literal membership, missed, and sent nothing, so the provider default applied. Sending `low` to the first target is what the catalog promised all along.

The assertion is updated to `"low"` with a comment recording why, rather than the fix being reverted. The second target still receives `high`, which is what that half of the test was really checking.

This is the follow-up to #3172 (`7386b52`). No source change.

## Verification

Exact head:

- `bun test tests/server-combo-failover-e2e.test.ts` — **74 pass, 0 fail**, 453 expect() calls. The failing case reproduced locally before the change and passes after.
- `bun test tests/combos.test.ts tests/combo-stream-preflight.test.ts tests/combo-child-headers.test.ts` — **51 pass, 0 fail**.

Found by CI on the merged `dev` head rather than by local review — the scoped local runs for #3172 covered `tests/combos.test.ts` and the catalog and boundary suites, but not this end-to-end failover file.

## Checklist

- [x] Targets `dev`
- [x] Test-only change; no source, config, schema, or dependency change
- [x] The corrected expectation is explained in the test itself, so the next reader does not re-assert the old behavior
- [x] No credential, auth, workflow, or release-automation surface touched

