### PR TITLE
fix(codex): rotate accounts on wrapped quota failures

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -254,10 +254,12 @@ separates new/unbound assignment, usage-based proactive switching, and failure r
 normally keeps affinity, but `quota` may rebind it on its next request after the usage threshold is
 crossed, while pause, cooldown, reauthentication, and failure handling can clear or move routing
 independently. An unbound request has no live account binding; this can include an existing visible
-task after proxy restart or affinity reset. A pre-stream 429 or 402 retries once on an eligible
-alternate account in the same request, even when usage-based proactive switching is off. Account
-changes preserve and replay the conversation context, but provider-side prompt-cache reuse across
-accounts is not guaranteed and the cache may need to warm again.
+task after proxy restart or affinity reset. A pre-stream 429 or 402, or a 5xx response whose bounded
+body explicitly reports quota exhaustion, retries once on an eligible alternate account in the same
+request, even when usage-based proactive switching is off. The ordinary transient-5xx policy runs
+first, so a wrapped quota response may make up to three sends on the exhausted account before pool
+rotation. Account changes preserve and replay the conversation context, but provider-side
+prompt-cache reuse across accounts is not guaranteed and the cache may need to warm again.
 
 On a **401/403**, App login clears that account's process-local affinity and requires reauthentication.
 On a **429**, opencodex honors `Retry-After`, starts the account cooldown, clears affinity, and may

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -4,6 +4,24 @@ export interface OcxErrorPayload {
   code: string | null;
 }
 
+/** Canonical human-readable message paths used by Responses upstream failures. */
+export function upstreamErrorMessageFromPayload(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+  const json = payload as {
+    error?: { message?: unknown };
+    last_error?: { message?: unknown };
+    response?: {
+      error?: { message?: unknown };
+      incomplete_details?: { message?: unknown };
+    };
+  };
+  const message = json.error?.message
+    ?? json.last_error?.message
+    ?? json.response?.error?.message
+    ?? json.response?.incomplete_details?.message;
+  return typeof message === "string" ? message : undefined;
+}
+
 /** OpenAI / Codex hard block for high-risk cybersecurity activity (HTTP 400 or mid-stream). */
 export const CYBER_POLICY_ERROR_CODE = "cyber_policy";
 export const CYBER_POLICY_FALLBACK_MESSAGE = "Request blocked by the upstream cybersecurity policy.";

--- a/src/server/request-log.ts
+++ b/src/server/request-log.ts
@@ -8,6 +8,7 @@ import {
   isClientClosedMessage,
   isCyberPolicyCode,
   isCyberPolicyMessage,
+  upstreamErrorMessageFromPayload,
 } from "../lib/errors";
 import { CODEX_CONFIG_PATH, readRootTomlString } from "../codex/paths";
 import { readCodexCatalogPath } from "../codex/catalog";
@@ -794,10 +795,7 @@ function captureUpstreamErrorParsed(
       logCtx.terminalIncompleteReason = reason.trim();
     }
     if (logCtx.upstreamError) return;
-    const message = json?.error?.message
-      ?? json?.last_error?.message
-      ?? json?.response?.error?.message
-      ?? json?.response?.incomplete_details?.message;
+    const message = upstreamErrorMessageFromPayload(parsed);
     if (typeof message === "string" && message.trim()) {
       logCtx.upstreamError = redactSecretString(message).slice(0, 500);
       return;

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -241,6 +241,10 @@ import {
 } from "../lifecycle";
 import { redactSecretString, sanitizeLogMetadataString } from "../../lib/redact";
 import { readBoundedResponseBody } from "../../lib/bounded-body";
+import {
+  isRateLimitOrQuotaFailureMessage,
+  upstreamErrorMessageFromPayload,
+} from "../../lib/errors";
 import type { AdmissionLease } from "../../lib/admission";
 import { supportedLadderFor } from "../effort-policy";
 import { isThreadSpawnRequest } from "../effort-policy";
@@ -904,8 +908,40 @@ async function shouldRetryCodexPoolAccountModel400(
 }
 
 /** Pre-stream quota/billing rejections that warrant one alternate-account attempt (#584). */
-export function shouldRetryCodexPoolAccountQuota(response: Response): boolean {
-  return response.status === 402 || response.status === 429;
+function codexQuotaFailureMessage(body: string): string | undefined {
+  try {
+    const payload = JSON.parse(body) as unknown;
+    const canonical = upstreamErrorMessageFromPayload(payload);
+    if (canonical !== undefined) return canonical;
+    if (typeof payload === "string") return payload;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+    const record = payload as Record<string, unknown>;
+    if (typeof record.message === "string") return record.message;
+    return typeof record.error === "string" ? record.error : undefined;
+  } catch {
+    // Plain-text gateways remain supported. Valid JSON is inspected only at recognized
+    // message fields so echoed request content elsewhere cannot trigger account cooldown.
+    return body;
+  }
+}
+
+export async function shouldRetryCodexPoolAccountQuota(
+  response: Response,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  if (response.status === 402 || response.status === 429) return true;
+  if (response.status < 500 || response.status >= 600) return false;
+  try {
+    // Reject malformed UTF-8 instead of matching quota words around replacement characters.
+    const body = await readBoundedResponseBody(response.clone(), { signal, fatalUtf8: true });
+    const message = body.displaySafe && !body.truncated
+      ? codexQuotaFailureMessage(body.text)
+      : undefined;
+    return message !== undefined
+      && isRateLimitOrQuotaFailureMessage(message);
+  } catch {
+    return false;
+  }
 }
 
 interface CodexPoolAccountRetryArgs {
@@ -1130,6 +1166,19 @@ async function retryCodexPoolOnAlternateAccount(
     }
   }
   if (retryAuthCtx?.kind !== "pool" && retryAuthCtx?.kind !== "main-pool") {
+    // A body-confirmed quota response may arrive under HTTP 5xx. Without an alternate,
+    // the ordinary terminal recorder sees only that wire status and would misclassify it
+    // as transient, leaving the exhausted account immediately selectable next turn.
+    if (outcomeStatus !== firstResponse.status && (outcomeStatus === 429 || outcomeStatus === 402)) {
+      recordCodexUpstreamOutcome(config, firstAuthCtx.accountId, outcomeStatus, {
+        ...codexQuotaOutcomeMeta(firstResponse),
+        threadId: firstAuthCtx.affinityKey,
+        modelId: route.modelId,
+        probeLeaseId: codexProbeLeaseId(firstAuthCtx),
+        probeQuotaScope: codexProbeQuotaScope(firstAuthCtx),
+        writerGeneration: firstAuthCtx.writerGeneration,
+      });
+    }
     return { kind: "no-alternate" };
   }
 
@@ -4255,9 +4304,14 @@ async function handleResponsesInner(
         options.abortSignal,
       )) {
         poolRetryOutcome = 400;
-      } else if (!authCtx.fixedAccount && shouldRetryCodexPoolAccountQuota(upstreamResponse)) {
+      } else if (!authCtx.fixedAccount && await shouldRetryCodexPoolAccountQuota(
+        upstreamResponse,
+        options.abortSignal,
+      )) {
         // Pre-stream only: once SSE has begun, mid-stream quota stays terminal.
-        poolRetryOutcome = upstreamResponse.status;
+        // ChatGPT sometimes wraps quota exhaustion in a generic 5xx. Normalize only
+        // body-confirmed cases to quota evidence so cooldown and rotation both apply.
+        poolRetryOutcome = upstreamResponse.status >= 500 ? 429 : upstreamResponse.status;
       }
 
       if (poolRetryOutcome !== undefined) {

--- a/tests/codex-quota-rejection.test.ts
+++ b/tests/codex-quota-rejection.test.ts
@@ -71,8 +71,76 @@ describe("Codex pre-stream quota rejection classification", () => {
     [429, true],
     [400, false],
     [503, false],
-  ])("selects pool-account retries synchronously for HTTP %i", (status, expected) => {
-    expect(shouldRetryCodexPoolAccountQuota(new Response(null, { status }))).toBe(expected);
+  ])("selects pool-account retries by HTTP %i", async (status, expected) => {
+    await expect(shouldRetryCodexPoolAccountQuota(new Response(null, { status }))).resolves.toBe(expected);
+  });
+
+  test("recognizes a quota message wrapped in HTTP 5xx without consuming the response", async () => {
+    const body = JSON.stringify({ error: { message: "The usage limit has been reached" } });
+    const response = new Response(body, { status: 502 });
+
+    await expect(shouldRetryCodexPoolAccountQuota(response)).resolves.toBe(true);
+    expect(await response.text()).toBe(body);
+  });
+
+  test("does not match quota wording echoed outside JSON error.message", async () => {
+    const response = Response.json({
+      error: { message: "upstream server error" },
+      request: { input: "Explain the usage limit" },
+    }, { status: 502 });
+    await expect(shouldRetryCodexPoolAccountQuota(response)).resolves.toBe(false);
+  });
+
+  test.each([
+    ["error.message", { error: { message: "The usage limit has been reached" } }],
+    ["last_error.message", { last_error: { message: "The usage limit has been reached" } }],
+    ["response.error.message", { response: { error: { message: "The usage limit has been reached" } } }],
+    ["response.incomplete_details.message", {
+      response: { incomplete_details: { message: "The usage limit has been reached" } },
+    }],
+  ])("recognizes the canonical %s upstream message path", async (_path, payload) => {
+    await expect(shouldRetryCodexPoolAccountQuota(
+      Response.json(payload, { status: 502 }),
+    )).resolves.toBe(true);
+  });
+
+  test.each([
+    ["JSON string", JSON.stringify("The usage limit has been reached")],
+    ["top-level message", JSON.stringify({ message: "The usage limit has been reached" })],
+    ["string error", JSON.stringify({ error: "The usage limit has been reached" })],
+  ])("recognizes the valid %s fallback shape", async (_shape, body) => {
+    await expect(shouldRetryCodexPoolAccountQuota(
+      new Response(body, { status: 502 }),
+    )).resolves.toBe(true);
+  });
+
+  test("recognizes a plain-text quota failure", async () => {
+    const response = new Response("The usage limit has been reached", { status: 502 });
+    await expect(shouldRetryCodexPoolAccountQuota(response)).resolves.toBe(true);
+  });
+
+  test.each([
+    [502, JSON.stringify({ error: { message: "upstream server error" } })],
+    [503, JSON.stringify({ error: { message: "servers overloaded" } })],
+    [502, "x".repeat(BOUNDED_BODY_MAX_BYTES + 1)],
+  ])("keeps unrelated or oversized HTTP %i failures transient", async (status, body) => {
+    await expect(shouldRetryCodexPoolAccountQuota(new Response(body, { status }))).resolves.toBe(false);
+  });
+
+  test("fails closed for malformed UTF-8 and an already-aborted read", async () => {
+    const malformed = new Uint8Array([
+      0x54, 0x68, 0x65, 0x20, 0xff, 0x20, 0x75, 0x73, 0x61, 0x67, 0x65, 0x20, 0x6c, 0x69, 0x6d, 0x69, 0x74,
+    ]);
+    await expect(shouldRetryCodexPoolAccountQuota(
+      new Response(malformed, { status: 502 }),
+    )).resolves.toBe(false);
+
+    const controller = new AbortController();
+    controller.abort();
+    await expect(shouldRetryCodexPoolAccountQuota(
+      new Response("The usage limit has been reached", { status: 502 }),
+      controller.signal,
+    )).resolves.toBe(false);
   });
 
   test.each([

--- a/tests/responses-account-label.test.ts
+++ b/tests/responses-account-label.test.ts
@@ -6,7 +6,11 @@ import { fallbackCodexAccountLogLabel } from "../src/codex/account-label";
 import { saveCodexAccountCredential } from "../src/codex/account-store";
 import { clearAccountQuota, updateAccountQuota } from "../src/codex/auth-api";
 import { MAIN_CODEX_ACCOUNT_ID } from "../src/codex/main-account";
-import { clearCodexUpstreamHealth, clearThreadAccountMap } from "../src/codex/routing";
+import {
+  clearCodexUpstreamHealth,
+  clearThreadAccountMap,
+  getCodexUpstreamHealth,
+} from "../src/codex/routing";
 import type { RequestLogContext } from "../src/server/request-log";
 import { handleResponses } from "../src/server/responses";
 import type { OcxConfig } from "../src/types";
@@ -142,6 +146,66 @@ describe("Responses account usage attribution", () => {
       expect(bearers).toEqual(["Bearer pool-a-access-token", "Bearer pool-b-access-token"]);
       expect(logCtx.accountLogLabel).toBe(fallbackCodexAccountLogLabel("pool-b"));
       expect(logCtx.activeAttempt?.accountLogLabel).toBe(fallbackCodexAccountLogLabel("pool-b"));
+    });
+  });
+
+  test("a quota message wrapped in HTTP 502 cools the account and retries an alternate", async () => {
+    await withPoolHome(async () => {
+      const config = poolConfig(["pool-a", "pool-b"]);
+      for (const id of ["pool-a", "pool-b"]) {
+        savePoolCredential(id);
+        updateAccountQuota(id, id === "pool-a" ? 10 : 20);
+      }
+      const bearers: string[] = [];
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const bearer = new Headers(init?.headers).get("authorization") ?? "";
+        bearers.push(bearer);
+        if (bearer === "Bearer pool-a-access-token") {
+          return Response.json({ error: { message: "The usage limit has been reached" } }, {
+            status: 502,
+          });
+        }
+        return completedResponse("pool-b-response");
+      }) as typeof fetch;
+
+      const response = await handleResponses(request(), config, { model: "", provider: "" }, {});
+
+      expect(response.status).toBe(200);
+      expect(bearers).toEqual([
+        "Bearer pool-a-access-token",
+        "Bearer pool-a-access-token",
+        "Bearer pool-a-access-token",
+        "Bearer pool-b-access-token",
+      ]);
+      expect(getCodexUpstreamHealth("pool-a")).toMatchObject({
+        lastFailureStatus: 429,
+        cooldownSource: "default",
+      });
+      expect(getCodexUpstreamHealth("pool-a")?.cooldownUntil).toBeGreaterThan(Date.now());
+    });
+  });
+
+  test("a wrapped quota failure cools a sole account when no alternate exists", async () => {
+    await withPoolHome(async () => {
+      const config = poolConfig(["pool-a"]);
+      savePoolCredential("pool-a");
+      updateAccountQuota("pool-a", 10);
+      let sends = 0;
+      globalThis.fetch = (async () => {
+        sends += 1;
+        return Response.json({ error: { message: "The usage limit has been reached" } }, {
+          status: 502,
+        });
+      }) as typeof fetch;
+
+      const response = await handleResponses(request(), config, { model: "", provider: "" }, {});
+
+      expect(response.status).toBe(502);
+      expect(sends).toBe(3);
+      expect(getCodexUpstreamHealth("pool-a")).toMatchObject({
+        cooldownSource: "default",
+      });
+      expect(getCodexUpstreamHealth("pool-a")?.cooldownUntil).toBeGreaterThan(Date.now());
     });
   });
 });


### PR DESCRIPTION
## Summary

ChatGPT can report account quota exhaustion as HTTP 502 with an error message such as `The usage limit has been reached`. The Responses pool treated that status as a transient upstream failure, so it retried the exhausted account and returned the 502 without cooling the account or trying an alternate. Codex then surfaced the empty terminal path as `adapter_eof`.

This change inspects only bounded, display-safe pre-stream 5xx responses in the Codex pool-auth path. When the extracted upstream message is quota-shaped, it normalizes that pool outcome to the existing quota path, records the cooldown, clears affinity, and uses the existing bounded alternate-account retry. A sole exhausted account is also cooled when no alternate exists.

Message extraction now has one canonical helper shared with request logging for these existing payload shapes:

- `error.message`
- `last_error.message`
- `response.error.message`
- `response.incomplete_details.message`

The quota gate additionally accepts legacy string-shaped JSON and plain-text gateway errors. Canonical fields take precedence, preventing unrelated echoed request content from triggering rotation. Request-log rendering remains limited to canonical fields.

The provider documentation now describes wrapped-quota rotation and its current retry cost.

## Verification

Post-rebase checks at `83da9dfd3`:

- `bun <typescript>/bin/tsc --noEmit` — passed.
- `bun scripts/privacy-scan.ts` — passed.
- `git diff --check origin/dev...HEAD` — passed.

Focused tests on the identical change tree before rebasing onto current `dev`:

- `bun test tests/codex-quota-rejection.test.ts tests/responses-account-label.test.ts tests/request-log.test.ts` — 116 passed, 0 failed.
- `bun test tests/core-lab-boundary.test.ts` — 17 passed, 0 failed.

A post-rebase focused rerun was queued but not executed because another repository test run held the per-user Bun lock. None of the 102 incoming `dev` commits changed the six files in this PR.

The broader `bun scripts/test.ts --changed=dev` run was not green under the parallel Windows environment: 2,754 tests passed and 67 unrelated tests failed, primarily from 5-second timeouts and filesystem/state interference. All modified test files passed in the focused runs above.

## Limitations

- Existing transient-5xx retry policy runs before pool classification, so a wrapped quota 502 can make three sends on the exhausted account before rotating. Short-circuiting that separate retry layer is outside this PR.
- Non-JSON plain-text gateway errors are matched against the whole body using the existing quota-message matcher.
- Lenient JSON string shapes are accepted only by this bounded quota gate; user-visible request logging continues to use canonical message fields.
- Recovery remains pre-stream only. Partially streamed requests are not replayed.

## Checklist

- [x] Targets `dev` and keeps the change scoped to wrapped quota classification and recovery.
- [x] Adds focused unit and integration coverage, including alternate and sole-account paths.
- [x] Updates provider documentation; no release note is needed for this internal recovery correction.
- [x] Adds no dependencies, configuration keys, schema changes, or credential logging.
- [x] Reviews the bounded body read and message extraction for unsafe or echoed-content matches.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
