### PR TITLE
fix(responses): surface provider 413 as terminal context overflow

### DIFF
--- a/docs-site/src/content/docs/reference/architecture.md
+++ b/docs-site/src/content/docs/reference/architecture.md
@@ -150,6 +150,12 @@ upstream WS responses keep the downstream SSE contract and bypass `tee()` throug
 single-reader relay (4 MiB per raw/enveloped frame and an 8 MiB producer queue). Queue overflow
 closes the upstream and emits a terminal downstream `response.failed` event followed by `[DONE]`.
 
+When a provider rejects a streaming request with HTTP 413 before SSE begins, OpenCodex emits one
+terminal `response.failed` event with `context_length_exceeded` instead of relaying the retryable
+unknown status. This lets Codex stop its reconnect loop and apply its own context-compaction policy
+on the next turn. OpenCodex does not silently delete prompts or images; reduce the current input or
+retry after compaction. Non-streaming API callers continue to receive the provider's HTTP 413.
+
 Codex context compaction works for routed models. `server/responses/compact.ts` handles
 `POST /v1/responses/compact` by running an internal routed summarization turn and returning compacted
 history, while `responses/parser.ts` and `bridge.ts` handle remote compaction v2

--- a/src/server/responses/context-overflow.ts
+++ b/src/server/responses/context-overflow.ts
@@ -1,0 +1,49 @@
+import { bridgeToResponsesSSE } from "../../bridge";
+import type { TranslatorBudget } from "../../lib/translator-budget";
+import type { AdapterEvent } from "../../types";
+
+export const PROVIDER_INPUT_TOO_LARGE_MESSAGE =
+  "The provider rejected this turn because its input exceeds the provider size or context limit. Reduce the current input or compact the conversation before retrying.";
+
+async function* contextOverflowEvents(): AsyncGenerator<AdapterEvent> {
+  yield {
+    type: "error",
+    message: PROVIDER_INPUT_TOO_LARGE_MESSAGE,
+    status: 413,
+    errorType: "invalid_request_error",
+    code: "context_length_exceeded",
+    retryable: false,
+  };
+}
+
+/**
+ * Convert a pre-stream provider 413 into the terminal Responses event Codex understands.
+ *
+ * Codex treats an HTTP 413 as an unexpected, retryable transport failure and resends the
+ * same oversized body through its reconnect budget. A `response.failed` event carrying
+ * `context_length_exceeded` is instead terminal and marks the client context as full, so
+ * its next-turn compaction policy can run. The message is proxy-owned on purpose: upstream
+ * 413 bodies can echo request data and are not needed to classify an unambiguous status.
+ */
+export function streamingContextOverflowResponse(
+  modelId: string,
+  translatorBudget: TranslatorBudget,
+): Response {
+  return new Response(bridgeToResponsesSSE(
+    contextOverflowEvents(),
+    modelId,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    2_000,
+    { translatorBudget },
+  ), {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -370,6 +370,7 @@ import {
 } from "../responses-undeclared-tool-guard";
 import { createGithubCopilotResponsesBlockRewrite } from "../github-copilot-responses-repair";
 import { responsesJsonToSseStream } from "../responses-json-events";
+import { streamingContextOverflowResponse } from "./context-overflow";
 import { guardTerminalEventStream } from "./terminal-guard";
 import {
   emptyCompletionRetryEnabled,
@@ -2102,7 +2103,7 @@ export async function handleComboResponses(
   comboId: string,
   config: OcxConfig,
   logCtx: RequestLogContext,
-  options: HandleResponsesOptions,
+  options: HandleResponsesOptions & { translatorBudget: TranslatorBudget },
 ): Promise<Response> {
   const requestedModel = typeof (rawBody as { model?: unknown } | null)?.model === "string"
     ? (rawBody as { model: string }).model
@@ -2451,6 +2452,12 @@ export async function handleComboResponses(
       code: failure.upstreamCode,
     }) === "stop") {
       adoptFailedChildLog(childLog);
+      if (
+        failure.response.status === 413
+        && (rawBody as { stream?: unknown } | null)?.stream === true
+      ) {
+        return streamingContextOverflowResponse(requestedModel, options.translatorBudget);
+      }
       return lastFailure;
     }
     console.warn(
@@ -2463,6 +2470,12 @@ export async function handleComboResponses(
     });
     if (!nextPick) adoptFailedChildLog(childLog);
     pick = nextPick;
+  }
+  if (
+    lastFailure?.status === 413
+    && (rawBody as { stream?: unknown } | null)?.stream === true
+  ) {
+    return streamingContextOverflowResponse(requestedModel, options.translatorBudget);
   }
   return lastFailure!;
 }
@@ -3097,6 +3110,12 @@ async function handleResponsesInner(
       // instead of treating the first incompatible candidate as the end of the chain. The
       // distinct code is what lets the fallback layer tell the two apart -- an upstream
       // `context_length_exceeded` still stops, because retrying it elsewhere is guesswork.
+      if (clientRequestedStream && !options.comboAttempt) {
+        return streamingContextOverflowResponse(
+          parsed._responseModelId ?? parsed.modelId,
+          translatorBudget,
+        );
+      }
       return formatErrorResponse(
         413,
         "input_admission_refused",
@@ -4432,6 +4451,12 @@ async function handleResponsesInner(
       // The bounded reader owns the original body, deadline, abort settlement, and lock.
       // Unsafe partial data falls back to #452's non-empty status-only JSON.
       const errorText = await readDisplaySafeErrorText(upstreamResponse, upstream.signal, "");
+      if (upstreamResponse.status === 413 && clientRequestedStream) {
+        return streamingContextOverflowResponse(
+          parsed._responseModelId ?? parsed.modelId,
+          translatorBudget,
+        );
+      }
       return formatPassthroughUpstreamError(upstreamResponse.status, errorText, {
         statusText: upstreamResponse.statusText,
         headers,
@@ -5985,6 +6010,12 @@ async function handleResponsesInner(
         );
       } finally {
         cleanupUpstreamAbort();
+      }
+      if (upstreamResponse.status === 413 && clientRequestedStream && !options.comboAttempt) {
+        return streamingContextOverflowResponse(
+          parsed._responseModelId ?? parsed.modelId,
+          translatorBudget,
+        );
       }
       if (!isFixedCodexAccount(authCtx)) {
         recordSubagentQuotaFailureForThreadSpawn(

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -626,6 +626,39 @@ response headers/status and any 429 key rotations are handled eagerly. A failure
 SSE starts returns non-2xx JSON; once headers have started the final response, a generation failure
 is emitted as `response.failed` SSE.
 
+### Pre-stream provider input overflow
+
+A provider HTTP 413 received before streaming starts is unambiguous request-size refusal, but raw
+relay is not compatible with Codex: Codex classifies the unknown status as retryable and resends the
+same oversized turn through its reconnect budget. For a streaming Responses caller, OpenCodex
+therefore converts the final 413 (after any adapter-owned bounded image retry) into one HTTP-200 SSE
+`response.failed` event with `error.code = context_length_exceeded` and `retryable = false`. Codex
+recognizes that terminal contract, marks the context as full, and can run its own compaction policy
+on the next turn. Combo routing treats 413 as a stop condition and performs the conversion only at
+the outer client boundary, so the failed target is never recorded as a successful combo attempt.
+
+Non-streaming callers retain the original 413 status/body contract. The proxy never silently drops
+prompts or images: it does not own the client's transcript, and deleting input would hide data that
+was never analyzed. The streaming error message is proxy-owned and bounded instead of relaying the
+upstream 413 body, which may echo request content.
+
+[Decision Log]
+- 목적과 의도: Stop Codex from replaying a provider-rejected oversized turn and hand the failure
+  to the client's existing context-compaction semantics.
+- 기존 구현 및 제약 조건: Providers can reject before SSE starts; Codex retries raw HTTP 413,
+  while it recognizes terminal `response.failed` `context_length_exceeded`; the proxy cannot edit
+  Codex's persisted transcript safely.
+- 검토한 주요 대안: Relay 413 unchanged; return HTTP 400 JSON; silently remove media or old turns;
+  synthesize a successful assistant warning.
+- 선택한 방식: Preserve 413 for non-streaming clients, but map the final streaming 413 to one
+  redacted non-retryable Responses failure at the outer request boundary.
+- 다른 대안 대신 이 방식을 선택한 이유: Raw 413 causes a retry loop, HTTP JSON does not enter
+  Codex's context-window path, and silent deletion or fake success loses user intent without fixing
+  transcript ownership.
+- 장점, 단점 및 영향: Codex stops reconnecting and can compact on the next turn; no input is
+  silently lost. The failed turn itself is not auto-replayed, and callers must retry after Codex
+  compacts or reduce the current input.
+
 Kiro transient HTTP 429 recovery is coordinated process-wide after the first throttle: healthy
 traffic remains parallel, but throttled followers wait behind one abort-aware probe and share a
 deadline that is re-checked after every sleep. Event-stream `ThrottlingException` records the same

--- a/tests/responses-context-overflow.test.ts
+++ b/tests/responses-context-overflow.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import { startServer } from "../src/server";
+import { PROVIDER_INPUT_TOO_LARGE_MESSAGE } from "../src/server/responses/context-overflow";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+let testDir = "";
+let previousOcxHome: string | undefined;
+const upstreams: Array<ReturnType<typeof Bun.serve>> = [];
+
+beforeEach(() => {
+  previousOcxHome = process.env.OPENCODEX_HOME;
+  testDir = mkdtempSync(join(tmpdir(), "ocx-context-overflow-"));
+  process.env.OPENCODEX_HOME = testDir;
+});
+
+afterEach(() => {
+  for (const upstream of upstreams.splice(0)) upstream.stop(true);
+  if (previousOcxHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousOcxHome;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+function upstreamStatus(status: number, onHit?: () => void): ReturnType<typeof Bun.serve> {
+  const upstream = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch() {
+      onHit?.();
+      return Response.json({
+        detail: "request body too large; echoed private request marker should-not-reach-client",
+      }, { status });
+    },
+  });
+  upstreams.push(upstream);
+  return upstream;
+}
+
+function upstream413(onHit?: () => void): ReturnType<typeof Bun.serve> {
+  return upstreamStatus(413, onHit);
+}
+
+function provider(
+  adapter: "openai-responses" | "openai-chat" | "anthropic",
+  upstream: ReturnType<typeof Bun.serve>,
+): OcxProviderConfig {
+  return {
+    adapter,
+    baseUrl: `${String(upstream.url).replace(/\/$/, "")}/v1`,
+    authMode: "key",
+    apiKey: "test-context-overflow-key",
+    allowPrivateNetwork: true,
+    defaultModel: "kimi-k3",
+  };
+}
+
+function config(providers: Record<string, OcxProviderConfig>): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: Object.keys(providers)[0]!,
+    providers,
+  } as OcxConfig;
+}
+
+function request(serverUrl: string, model: string, stream: boolean, input?: unknown): Promise<Response> {
+  return fetch(new URL("/v1/responses", serverUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model,
+      stream,
+      input: input ?? [{
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "oversized turn" }],
+      }],
+    }),
+  });
+}
+
+async function responseFailed(response: Response): Promise<Record<string, unknown>> {
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toContain("text/event-stream");
+  const text = await response.text();
+  expect(text).not.toContain("should-not-reach-client");
+  const frame = text.split("\n\n").find(block => block.startsWith("event: response.failed\n"));
+  expect(frame).toBeDefined();
+  const data = frame!.split("\n").find(line => line.startsWith("data: "))?.slice(6);
+  expect(data).toBeDefined();
+  return (JSON.parse(data!) as { response: Record<string, unknown> }).response;
+}
+
+describe("Responses provider input overflow", () => {
+  test("streaming passthrough and translated adapters emit a terminal context failure", async () => {
+    for (const adapter of ["openai-responses", "openai-chat"] as const) {
+      const upstream = upstream413();
+      saveConfig(config({ target: provider(adapter, upstream) }));
+      const server = startServer(0);
+      try {
+        const failed = await responseFailed(await request(String(server.url), "target/kimi-k3", true));
+        expect(failed.status).toBe("failed");
+        expect(failed.retryable).toBe(false);
+        expect(failed.error).toEqual({
+          message: PROVIDER_INPUT_TOO_LARGE_MESSAGE,
+          type: "invalid_request_error",
+          code: "context_length_exceeded",
+        });
+        expect(failed.last_error).toEqual(failed.error);
+      } finally {
+        await server.stop(true);
+      }
+    }
+  });
+
+  test("non-streaming callers retain the upstream 413 status and body", async () => {
+    const upstream = upstream413();
+    saveConfig(config({ target: provider("openai-responses", upstream) }));
+    const server = startServer(0);
+    try {
+      const response = await request(String(server.url), "target/kimi-k3", false);
+      expect(response.status).toBe(413);
+      expect(await response.json()).toEqual({
+        detail: "request body too large; echoed private request marker should-not-reach-client",
+      });
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("local input admission uses the same terminal streaming contract without upstream I/O", async () => {
+    let hits = 0;
+    const upstream = upstream413(() => { hits += 1; });
+    const target = provider("openai-chat", upstream);
+    target.modelContextWindows = { "kimi-k3": 1 };
+    saveConfig(config({ target }));
+    const server = startServer(0);
+    try {
+      const failed = await responseFailed(await request(
+        String(server.url),
+        "target/kimi-k3",
+        true,
+        [{ type: "message", role: "user", content: [{ type: "input_text", text: "x ".repeat(100) }] }],
+      ));
+      expect((failed.error as { code?: string }).code).toBe("context_length_exceeded");
+      expect(hits).toBe(0);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("the bounded Anthropic image retry runs once before the terminal failure", async () => {
+    let hits = 0;
+    const upstream = upstream413(() => { hits += 1; });
+    saveConfig(config({ target: provider("anthropic", upstream) }));
+    const server = startServer(0);
+    try {
+      const failed = await responseFailed(await request(
+        String(server.url),
+        "target/kimi-k3",
+        true,
+        [{
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "inspect" },
+            {
+              type: "input_image",
+              image_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+            },
+          ],
+        }],
+      ));
+      expect((failed.error as { code?: string }).code).toBe("context_length_exceeded");
+      expect(hits).toBe(2);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("unrelated passthrough HTTP failures keep their status and body", async () => {
+    for (const status of [400, 503]) {
+      const upstream = upstreamStatus(status);
+      saveConfig(config({ target: provider("openai-responses", upstream) }));
+      const server = startServer(0);
+      try {
+        const response = await request(String(server.url), "target/kimi-k3", true);
+        expect(response.status).toBe(status);
+        expect(await response.json()).toEqual({
+          detail: "request body too large; echoed private request marker should-not-reach-client",
+        });
+      } finally {
+        await server.stop(true);
+      }
+    }
+  });
+
+  test("a combo stops on 413 and does not dispatch a second oversized target", async () => {
+    let firstHits = 0;
+    let secondHits = 0;
+    const first = upstream413(() => { firstHits += 1; });
+    const second = upstream413(() => { secondHits += 1; });
+    const next = config({
+      first: provider("openai-chat", first),
+      second: provider("openai-chat", second),
+    });
+    next.combos = {
+      fallback: {
+        strategy: "failover",
+        targets: [
+          { provider: "first", model: "kimi-k3" },
+          { provider: "second", model: "kimi-k3" },
+        ],
+      },
+    };
+    saveConfig(next);
+    const server = startServer(0);
+    try {
+      const failed = await responseFailed(await request(String(server.url), "combo/fallback", true));
+      expect((failed.error as { code?: string }).code).toBe("context_length_exceeded");
+      expect(firstHits).toBe(1);
+      expect(secondHits).toBe(0);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- convert a confirmed streaming Responses input-size 413 into one terminal `response.failed` with `context_length_exceeded`, so Codex stops its 5/5 reconnect loop and can apply next-turn compaction
- cover local input admission, direct passthrough, translated adapters, exhausted Anthropic image tightening, and the outer combo boundary without silently deleting prompts or images
- preserve non-streaming 413 status/body fidelity and unrelated 4xx/5xx behavior; use a bounded proxy-owned failure message so an upstream 413 body cannot echo request content
- document the transport decision and user-visible continuation behavior

## Verification

Exact head `6d5eea6a163106232242af14335f69f34ca6cad5` on base `22a643a00b5974fa53b084a04491f60d56ec9ee2`:

- exact-head cross-platform CI — passed, including all four Linux shards, macOS, keyring checks, npm-global checks, storage policy, typecheck/gates, and React Doctor
- `bun run typecheck` — passed
- `bun test ./tests/responses-context-overflow.test.ts` — 6 passed, 0 failed
- translator-budget production contract — 1 passed, 0 failed
- `bun run test:changed` — 2,887 passed, 4 skipped, 0 failed across 147 import-connected files
- `cd docs-site && bun run build` — passed, 409 pages built
- local full repository suite — 16,952 passed, 16 skipped, with only the three `shutdown-launcher.test.ts` 20-second startup timeouts failing under the constrained runner; the same three failures reproduced unchanged on clean `origin/dev` at `22a643a00b5974fa53b084a04491f60d56ec9ee2`
- `git diff --check origin/dev...HEAD` — passed
- all local validation used isolated temporary `HOME`, `OPENCODEX_HOME`, and `CODEX_HOME`, `nice -n 10`, and no more than two CPUs; protected runtime configuration hashes remained unchanged

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Streaming 413 bodies are not relayed; non-streaming compatibility stays unchanged.

Closes #3170.