### PR TITLE
fix(codex): retry caller main after pool rejection (carry of #3135)

### DIFF
--- a/src/codex/auth-context.ts
+++ b/src/codex/auth-context.ts
@@ -547,7 +547,15 @@ export async function resolveCodexAuthContext(
     if (resolution.status === "expired") throw new CodexThreadAffinityExpiredError(resolution.accountId);
     const selected = resolution.status === "selected" ? resolution.accountId : null;
     if (!selected) {
-      if (requestScopedMainCredential && fixedAccountId === undefined && !options.excludeAccountId) {
+      // A retry that excluded a failed Pool account may still use the validated caller-owned
+      // main credential. Treating every exclusion as if main itself had failed strands a healthy
+      // native bearer after the first Pool attempt. Preserve the exactly-once boundary by refusing
+      // this fallback only when the excluded credential is main.
+      if (
+        requestScopedMainCredential
+        && fixedAccountId === undefined
+        && options.excludeAccountId !== MAIN_CODEX_ACCOUNT_ID
+      ) {
         return await resolveCallerOwnedMainContext();
       }
       if (fixedAccountId !== undefined) {

--- a/src/codex/auth-context.ts
+++ b/src/codex/auth-context.ts
@@ -566,7 +566,11 @@ export async function resolveCodexAuthContext(
         throw new CodexMainProfileDrainingError();
       }
       throw new CodexPoolAuthenticationError(
-        modelEligibleAccountIds ? "No eligible Codex account supports this model" : undefined,
+        modelEligibleAccountIds?.size === 0
+          ? "No eligible Codex account supports this model"
+          : modelEligibleAccountIds
+            ? "Codex accounts that support this model are currently unavailable"
+            : undefined,
       );
     }
     accountId = selected;

--- a/src/codex/auth-context.ts
+++ b/src/codex/auth-context.ts
@@ -491,6 +491,7 @@ export async function resolveCodexAuthContext(
     const excludeAccountIds = nativeMainReadsForbidden
       ? new Set([MAIN_CODEX_ACCOUNT_ID])
       : undefined;
+    const mainModelGrantUnobserved = excludeAccountIds?.has(MAIN_CODEX_ACCOUNT_ID) === true;
     const entitlementSnapshot = options.modelId && ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(options.modelId)
       ? await (options.resolveCodexModelEntitlements ?? resolveCodexModelEntitlements)(config, {
         excludeAccountIds,
@@ -566,11 +567,11 @@ export async function resolveCodexAuthContext(
         throw new CodexMainProfileDrainingError();
       }
       throw new CodexPoolAuthenticationError(
-        modelEligibleAccountIds?.size === 0
+        modelEligibleAccountIds === undefined
+          ? undefined
+          : entitledAccountIds?.size === 0 && !mainModelGrantUnobserved
           ? "No eligible Codex account supports this model"
-          : modelEligibleAccountIds
-            ? "Codex accounts that support this model are currently unavailable"
-            : undefined,
+          : "Codex accounts that support this model are currently unavailable",
       );
     }
     accountId = selected;

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -382,7 +382,10 @@ async function resolveAlternateCompactContext(args: {
       requestScopedMainCredential: hasForwardableCodexBearer(req.headers, config),
       beginCodexAccountSelection: codexAccountSelectionForTurn(turnAdmissionLease),
     });
-    if (!authCtx.accountId || authCtx.accountId === excludeAccountId) return null;
+    // Caller-owned main has no Pool account id. It is still a valid one-shot alternate after a
+    // stored account fails; resolveCodexAuthContext already prevents returning it when main is the
+    // excluded credential.
+    if (authCtx.accountId === excludeAccountId) return null;
     const provider = applyCodexAuthContextToProvider(route.provider, authCtx, route.codexAccountMode);
     const headers = new Headers({ "content-type": "application/json" });
     const selected = headersForCodexAuthContext(req.headers, authCtx);

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -982,7 +982,7 @@ interface CodexPoolAccountRetryArgs {
   stream: boolean;
   onResponse?: (
     response: Response,
-    authCtx: Extract<CodexAuthContext, { kind: "pool" | "main-pool" }>,
+    authCtx: CodexAuthContext,
     request: Awaited<ReturnType<ReturnType<typeof resolveAdapter>["buildRequest"]>>,
   ) => void;
 }
@@ -990,7 +990,7 @@ interface CodexPoolAccountRetryArgs {
 type CodexPoolAccountRetryResult =
   | {
     kind: "retried";
-    authCtx: Extract<CodexAuthContext, { kind: "pool" | "main-pool" }>;
+    authCtx: CodexAuthContext;
     request: Awaited<ReturnType<ReturnType<typeof resolveAdapter>["buildRequest"]>>;
     upstreamResponse: Response;
     selectedForwardHeaders: Headers;
@@ -999,7 +999,7 @@ type CodexPoolAccountRetryResult =
   | {
     kind: "transport";
     error: unknown;
-    authCtx: Extract<CodexAuthContext, { kind: "pool" | "main-pool" }>;
+    authCtx: CodexAuthContext;
   };
 
 /** Keep retry-stage entitlement snapshots inside the native-main selection fence. */
@@ -1166,7 +1166,14 @@ async function retryCodexPoolOnAlternateAccount(
       throw error;
     }
   }
-  if (retryAuthCtx?.kind !== "pool" && retryAuthCtx?.kind !== "main-pool") {
+  // A validated request-owned main bearer is a real alternate when the failed credential was a
+  // stored Pool account. It has no Pool account id to promote or cool, but it can own this one
+  // bounded replay. The resolver already refuses it when main itself is the excluded credential.
+  if (
+    retryAuthCtx?.kind !== "pool"
+    && retryAuthCtx?.kind !== "main-pool"
+    && retryAuthCtx?.kind !== "main"
+  ) {
     // A body-confirmed quota response may arrive under HTTP 5xx. Without an alternate,
     // the ordinary terminal recorder sees only that wire status and would misclassify it
     // as transient, leaving the exhausted account immediately selectable next turn.
@@ -1293,6 +1300,9 @@ async function retryCodexPoolOnAlternateAccount(
       retrySendCount += 1;
       args.onResponse?.(upstreamResponse, retryAuthCtx, request);
       if (!retrySameConfirmedAccount || retrySendCount >= maxRetrySends) break;
+      // Caller-owned main is an alternate-account replay and can never enter the bounded
+      // same-stored-account 400 loop above. Keep that invariant explicit for the account-id reads.
+      if (retryAuthCtx.kind === "main") break;
       if (!await shouldRetryCodexPoolAccountModel400(
         upstreamResponse,
         route.modelId,
@@ -4358,7 +4368,12 @@ async function handleResponsesInner(
           passthroughEstimate,
           stream: parsed.stream,
           onResponse: (response, retryAuthCtx, retryRequest) => {
-            captureAffinityResponse(response, retryAuthCtx, retryRequest, true);
+            captureAffinityResponse(
+              response,
+              retryAuthCtx,
+              retryRequest,
+              retryAuthCtx.kind !== "main",
+            );
           },
         });
         if (retry.kind === "transport") {

--- a/tests/codex-auth-context.test.ts
+++ b/tests/codex-auth-context.test.ts
@@ -1218,6 +1218,45 @@ describe("Codex auth context", () => {
     expect(cfg.activeCodexAccountPinned).toBe(MAIN_CODEX_ACCOUNT_ID);
   });
 
+  test("a failed Pool account may fall back once to the validated caller-owned main credential", async () => {
+    const cfg = config();
+    cfg.codexAccounts = [
+      { id: "pool-a", email: "pool-a@example.test", isMain: false, chatgptAccountId: "pool-account" },
+    ];
+    const inbound = new Headers({
+      authorization: "Bearer caller-keyring-token",
+      "chatgpt-account-id": "caller-keyring-account",
+    });
+    const emptyEntitlements: CodexModelEntitlementSnapshot = {
+      modelsByAccount: new Map(),
+      confirmedAccountIds: new Set(),
+      credentialIdentities: new Map(),
+    };
+    let directEntitlementChecks = 0;
+    const options = {
+      requestScopedMainCredential: true,
+      modelId: "gpt-daybreak-blue-latest",
+      resolveCodexModelEntitlements: async () => emptyEntitlements,
+      isDirectCallerEntitledToCodexModel: async () => {
+        directEntitlementChecks += 1;
+        return true;
+      },
+    };
+
+    await expect(resolveCodexAuthContext(inbound, cfg, "pool", {
+      ...options,
+      excludeAccountId: "pool-a",
+    })).resolves.toMatchObject({ kind: "main", accountId: null });
+    expect(directEntitlementChecks).toBe(1);
+
+    // If main itself was the failed credential, the retry must not loop back to it.
+    await expect(resolveCodexAuthContext(inbound, { ...cfg, codexAccounts: [] }, "pool", {
+      ...options,
+      excludeAccountId: MAIN_CODEX_ACCOUNT_ID,
+    })).rejects.toThrow("Codex accounts that support this model are currently unavailable");
+    expect(directEntitlementChecks).toBe(1);
+  });
+
   test("selects pool auth independently of the routed provider", async () => {
     saveCodexAccountCredential("pool-a", {
       accessToken: "pool_token",

--- a/tests/codex-auth-context.test.ts
+++ b/tests/codex-auth-context.test.ts
@@ -657,6 +657,25 @@ describe("Codex auth context", () => {
       .rejects.toThrow("Codex accounts that support this model are currently unavailable");
     await expect(resolve(["gpt-5.6-sol"]))
       .rejects.toThrow("No eligible Codex account supports this model");
+
+    const mainExcludedSnapshot: CodexModelEntitlementSnapshot = {
+      modelsByAccount: new Map(),
+      confirmedAccountIds: new Set(),
+      credentialIdentities: new Map(),
+    };
+    await expect(resolveCodexAuthContext(new Headers(), cfg, "pool", {
+      excludeAccountId: "pool-a",
+      modelId: "gpt-daybreak-blue-latest",
+      beginCodexAccountSelection: () => ({
+        mainProfileDraining: true,
+        claimMainProfile: () => false,
+        release: () => {},
+      }),
+      resolveCodexModelEntitlements: async (_config, options) => {
+        expect(options?.excludeAccountIds?.has(MAIN_CODEX_ACCOUNT_ID)).toBeTrue();
+        return mainExcludedSnapshot;
+      },
+    })).rejects.toThrow("Codex accounts that support this model are currently unavailable");
   });
 
   test("auth resolution preserves per-model detours without replacing ordinary affinity", async () => {

--- a/tests/codex-auth-context.test.ts
+++ b/tests/codex-auth-context.test.ts
@@ -634,6 +634,31 @@ describe("Codex auth context", () => {
     });
   });
 
+  test("account-gated routing distinguishes an unavailable grant from no grant", async () => {
+    const cfg = config();
+    saveCodexAccountCredential("pool-a", {
+      accessToken: "pool-token",
+      refreshToken: "pool-refresh",
+      expiresAt: Date.now() + 5 * 60_000,
+      chatgptAccountId: "pool-account",
+    });
+    const snapshot = (models: string[]): CodexModelEntitlementSnapshot => ({
+      modelsByAccount: new Map([["pool-a", new Set(models)]]),
+      confirmedAccountIds: new Set(["pool-a"]),
+      credentialIdentities: new Map(),
+    });
+    const resolve = (models: string[]) => resolveCodexAuthContext(new Headers(), cfg, "pool", {
+      excludeAccountId: "pool-a",
+      modelId: "gpt-daybreak-blue-latest",
+      resolveCodexModelEntitlements: async () => snapshot(models),
+    });
+
+    await expect(resolve(["gpt-daybreak-blue-latest"]))
+      .rejects.toThrow("Codex accounts that support this model are currently unavailable");
+    await expect(resolve(["gpt-5.6-sol"]))
+      .rejects.toThrow("No eligible Codex account supports this model");
+  });
+
   test("auth resolution preserves per-model detours without replacing ordinary affinity", async () => {
     const cfg = config();
     cfg.accountPoolStrategy = "round-robin";

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -3078,6 +3078,121 @@ describe("server local API auth", () => {
     }
   });
 
+  test.each([429, 402] as const)(
+    "a pre-stream %i from the only Pool account retries once with the validated caller main",
+    async rejection => {
+      setDebugSettings({ debug: true });
+      const model = "gpt-daybreak-blue-latest";
+      const observed: Array<{ authorization: string | null; accountId: string | null }> = [];
+      const harness = await startPoolRetryHarness((_accountId, request) => {
+        observed.push({
+          authorization: request.headers.get("authorization"),
+          accountId: request.headers.get("chatgpt-account-id"),
+        });
+        if (observed.length === 1) {
+          return new Response(JSON.stringify({ error: { message: "pool account unavailable" } }), {
+            status: rejection,
+            headers: { "content-type": "application/json", "retry-after": "60" },
+          });
+        }
+        return Response.json({ id: "caller-main-success", status: "completed", output: [] });
+      }, {
+        secondAccount: false,
+        modelRosterByAccount: {
+          "acct-pool-a": [model],
+          "acct-caller-main": [model],
+        },
+      });
+      try {
+        const response = await harness.request({
+          model,
+          headers: { "chatgpt-account-id": "acct-caller-main" },
+        });
+        expect(response.status).toBe(200);
+        expect((await response.json() as { id: string }).id).toBe("caller-main-success");
+        expect(observed).toEqual([
+          { authorization: "Bearer pool-a-token", accountId: "acct-pool-a" },
+          { authorization: "Bearer inbound-token", accountId: "acct-caller-main" },
+        ]);
+        expect(harness.dispatches).toEqual(["acct-pool-a", "acct-caller-main"]);
+        expect(loadConfig().activeCodexAccountId).toBe("pool-a");
+        const affinity = getDebugLogEntries()
+          .map(entry => entry.line)
+          .filter(line => line.startsWith("[ocx:codex:affinity] "))
+          .map(line => JSON.parse(line.slice("[ocx:codex:affinity] ".length)) as {
+            status: number;
+            authKind: string;
+            credentialSubstituted: boolean;
+          });
+        expect(affinity.slice(-2)).toEqual([
+          expect.objectContaining({ status: rejection, authKind: "pool", credentialSubstituted: true }),
+          expect.objectContaining({ status: 200, authKind: "main", credentialSubstituted: false }),
+        ]);
+      } finally {
+        await stopPoolRetryHarness(harness);
+      }
+    },
+    { timeout: SERVER_BUDGET_MS },
+  );
+
+  test.each([429, 402] as const)(
+    "compact %i from the only Pool account retries once with the validated caller main",
+    async rejection => {
+      const model = "gpt-daybreak-blue-latest";
+      const observed: Array<{ authorization: string | null; accountId: string | null }> = [];
+      const harness = await startPoolRetryHarness((_accountId, request) => {
+        observed.push({
+          authorization: request.headers.get("authorization"),
+          accountId: request.headers.get("chatgpt-account-id"),
+        });
+        if (observed.length === 1) {
+          return new Response(JSON.stringify({ error: { message: "pool account unavailable" } }), {
+            status: rejection,
+            headers: { "content-type": "application/json", "retry-after": "60" },
+          });
+        }
+        return new Response([
+          "event: response.output_item.done",
+          'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"compaction","encrypted_content":"gAAAAAB-caller-main"}}',
+          "",
+          "event: response.completed",
+          'data: {"type":"response.completed","response":{"status":"completed","output":[]}}',
+          "",
+          "data: [DONE]",
+          "",
+        ].join("\n"), {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }, {
+        secondAccount: false,
+        modelRosterByAccount: {
+          "acct-pool-a": [model],
+          "acct-caller-main": [model],
+        },
+      });
+      try {
+        const response = await harness.request({
+          model,
+          path: "/v1/responses/compact",
+          headers: { "chatgpt-account-id": "acct-caller-main" },
+        });
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+          output: [{ type: "compaction", encrypted_content: "gAAAAAB-caller-main" }],
+        });
+        expect(observed).toEqual([
+          { authorization: "Bearer pool-a-token", accountId: "acct-pool-a" },
+          { authorization: "Bearer inbound-token", accountId: "acct-caller-main" },
+        ]);
+        expect(harness.dispatches).toEqual(["acct-pool-a", "acct-caller-main"]);
+        expect(loadConfig().activeCodexAccountId).toBe("pool-a");
+      } finally {
+        await stopPoolRetryHarness(harness);
+      }
+    },
+    { timeout: SERVER_BUDGET_MS },
+  );
+
   test("#584: Retry-After cools the first account even when its account retry fails", async () => {
     const harness = await startPoolRetryHarness(accountId => accountId === "acct-pool-a"
       ? new Response(JSON.stringify({ error: { message: "rate limited" } }), {

--- a/tests/subagent-fallback-handle-responses.test.ts
+++ b/tests/subagent-fallback-handle-responses.test.ts
@@ -263,6 +263,7 @@ async function postDirectCodex(
   config: OcxConfig,
   body: Record<string, unknown>,
   options: Parameters<typeof handleResponses>[3] = {},
+  headers: HeadersInit = {},
 ): Promise<Response> {
   return handleResponses(
     new Request("http://localhost/v1/responses", {
@@ -270,6 +271,7 @@ async function postDirectCodex(
       headers: {
         "content-type": "application/json",
         authorization: "Bearer caller-codex-token",
+        ...headers,
       },
       body: JSON.stringify(body),
     }),
@@ -1774,6 +1776,57 @@ describe("account-gated retry entitlement boundary", () => {
     expect(fetchCalls).toBe(3);
     expect(mainExclusions).toEqual([true, true, true]);
     expect(selectionReleases).toBe(3);
+  });
+
+  test("a lost Pool model grant retries once with the validated caller-owned main credential", async () => {
+    const now = 1_800_000_000_000;
+    Date.now = () => now;
+    installPoolCredential("pool-a", "pool_acc_a", now);
+    const cfg = retryConfig();
+    let entitlementCalls = 0;
+    const observed: Array<{ authorization: string | null; accountId: string | null }> = [];
+    let callerRosterReads = 0;
+    globalThis.fetch = (async (input, init) => {
+      const url = new URL(String(input));
+      const headers = new Headers(init?.headers);
+      if (url.pathname.endsWith("/models")) {
+        callerRosterReads += 1;
+        expect(headers.get("authorization")).toBe("Bearer caller-codex-token");
+        expect(headers.get("chatgpt-account-id")).toBe("caller-main-account");
+        return Response.json({
+          models: [{ slug: model, supported_in_api: true, visibility: "list" }],
+        });
+      }
+      observed.push({
+        authorization: headers.get("authorization"),
+        accountId: headers.get("chatgpt-account-id"),
+      });
+      return observed.length === 1
+        ? unsupportedCodexModelResponse(model)
+        : Response.json({ id: "caller-main-success", status: "completed", output: [] });
+    }) as typeof fetch;
+
+    const response = await postDirectCodex(
+      cfg,
+      { model, input: "hello", stream: false },
+      {
+        resolveCodexModelEntitlements: async () => {
+          entitlementCalls += 1;
+          return entitlementCalls === 1
+            ? entitlementSnapshot({ "pool-a": [model] })
+            : entitlementSnapshot({ "pool-a": ["gpt-5.6-sol"] });
+        },
+      },
+      { "chatgpt-account-id": "caller-main-account" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(observed).toEqual([
+      { authorization: "Bearer pool-a_token", accountId: "pool_acc_a" },
+      { authorization: "Bearer caller-codex-token", accountId: "caller-main-account" },
+    ]);
+    expect(callerRosterReads).toBe(1);
+    expect(entitlementCalls).toBe(3);
   });
 
   test("a first-refresh programmer error cancels the 400 and releases its quota probe", async () => {


### PR DESCRIPTION
## Summary

Maintainer rebase carry of **#3135** by @luvs01 — all three commits cherry-picked onto current `dev` with author credit preserved.

- Distinguishes an account-gated model with no confirmed grant from one whose granted accounts are temporarily unavailable.
- When a stored Pool account loses a gated-model grant or returns a pre-stream quota rejection, the request's already-validated caller-owned main credential may serve as the single bounded alternate.
- Never loops back to main when main itself is the excluded credential. Exact-account selection and the stored-account 401 refresh/replay budget are unchanged.
- Records caller-owned main retries as passthrough credentials in affinity diagnostics rather than claiming a stored credential was substituted.

**This is not superseded by #3166.** That question was checked explicitly. #3166 (`75090d4e`) fixed *initial selection* — keeping a healthy request-owned `__main__` pin so Pool discovery does not persist an exhausted stored account before the first send. This is the *post-rejection retry*, and the gap was still present in the landed tree: `src/codex/auth-context.ts` refused the fallback on any `excludeAccountId`, and `src/server/responses/compact.ts` still dropped on `!authCtx.accountId`. #3166's own description called the two complementary.

## Security review

Credential-selection change, so `MAINTAINERS.md` requires explicit review. Performed on this exact head by reading the diff:

- The fallback narrows from "no exclusion at all" to "the exclusion is not main itself" — `options.excludeAccountId !== MAIN_CODEX_ACCOUNT_ID`. The exactly-once boundary is preserved by that condition, not by the absence of exclusions.
- The caller credential is still checked against its own authenticated model roster before use, is used for one alternate send, and never enters Pool affinity, health, or promotion state.
- The new `mainModelGrantUnobserved` flag only changes which of two *error messages* is returned; it does not widen who may serve a request.
- No credential is persisted, logged, or copied into stored-account state.

## Conflict resolution

One conflict in `src/server/responses/core.ts` and one in `tests/codex-auth-context.test.ts`, both against work that landed this week.

The `core.ts` conflict is the interesting one: #3176 added a 5xx quota-outcome recorder inside the `no-alternate` branch, and this PR widens the condition guarding that same branch to admit `main`. **Both are kept** — the guard now excludes `pool`, `main-pool`, and `main`, and the recorder stays inside it. Taking either side alone would have silently dropped a fix.

The test conflict was purely additive: #3166 added request-owned-pin cases, this PR added caller-main fallback cases. Both are retained.

## Verification

Exact head `e280397a3`:

- `bun test ./tests/codex-auth-context.test.ts` — **70 pass, 0 fail**, 278 expect() calls. That count includes both authors' cases, which is the proof the merge kept both.

Full-suite and typecheck coverage is left to CI on this exact head.

## Checklist

- [x] Targets `dev`
- [x] Author credit preserved across all three commits
- [x] Security review recorded above, on this head, before merge
- [x] Conflict resolution documented rather than silently taking one side
- [x] No credential persisted, logged, or promoted into stored-account state

