### PR TITLE
fix(cli): let an explicit different --port start a sibling (rebase of #3144)

### DIFF
--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -836,6 +836,34 @@ export const DISPATCH_ALIASES: ReadonlyMap<string, string> = aliasTargets;
 
 /** Resolve the runner key for a command, following registry aliases to the
  * canonical runner. Returns undefined when the command is unknown. */
+/** What `handleStart` does about a live proxy it found before binding. */
+export type StartOwnerDecision = "refuse" | "service-stay-out" | "sibling";
+
+/**
+ * Pure decision for `handleStart` when the pre-bind probe found a live proxy.
+ *
+ * The #3106 guard exists so a bare `start` cannot shadow a healthy configured-port
+ * proxy with an ephemeral-port copy. An interactive `--port X` naming a DIFFERENT
+ * port than the live proxy's is an explicit sibling request, not that shadow — and
+ * refusing it also broke every spawned-launcher test on a machine running a real
+ * proxy, because the probe reaches the machine-global port across sandbox homes.
+ * The service wrapper always passes the configured port and keeps its exact
+ * stay-out-of-the-way semantics: it never takes the sibling path.
+ */
+export function decideStartWithLiveOwner(input: {
+  livePort: number;
+  requestedPort: number | undefined;
+  ocxService: string | undefined;
+}): StartOwnerDecision {
+  const sibling = input.requestedPort !== undefined
+    && input.requestedPort !== input.livePort
+    // Only the exact "1" sentinel is service context — the same check syncCleanup
+    // uses — so an env value like "0" or "false" cannot reach the stay-out path.
+    && input.ocxService !== "1";
+  if (sibling) return "sibling";
+  return input.ocxService === "1" ? "service-stay-out" : "refuse";
+}
+
 export function resolveDispatchCommand(command: string | undefined): string | undefined {
   if (command === undefined) return undefined;
   if (Object.prototype.hasOwnProperty.call(commandRunners, command)) return command;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,7 +49,7 @@ import {
 } from "./tray-proxy";
 import { requestBoundSystemRestart } from "./system-restart-client";
 import { installCrashGuards } from "../lib/crash-guard";
-import { dispatchCommand } from "./dispatch";
+import { dispatchCommand , decideStartWithLiveOwner } from "./dispatch";
 import { findAvailablePort, isAddrInUse, PortUnavailableError, shouldPersistSelectedPort, waitForPortAvailable } from "../server/ports";
 import { findLiveProxy, probeHostname, type LiveProxy } from "../server/proxy-liveness";
 import { createReadinessGate } from "../server/readiness";
@@ -253,36 +253,33 @@ async function handleStart(options: { block?: boolean } = {}) {
   // shutdown then left no runtime record for discovery at all. `handleEnsure`
   // already passes this; `handleStart` is the path that did not.
   const owner = await findProxyOwnerBeforeJournalRecovery({ probeConfiguredPort: true });
-  // An interactive `ocx start --port X` where X is NOT the live proxy's port is an explicit
-  // sibling request, not the #3106 shadow: that fix targets a bare `start` (or the service
-  // wrapper, which always passes the configured port) silently landing on an ephemeral port.
-  // The blanket refusal here also broke real workflows — with any proxy on the configured
-  // port, no second instance could be started on a different port, and every spawned-launcher
-  // test on a machine running a real proxy failed its startup wait. The service branch keeps
-  // its exact semantics: OCX_SERVICE requests never take the sibling path.
-  const explicitSiblingPort = owner.live !== null
-    && requestedPort !== undefined
-    && requestedPort !== owner.live.port
-    && process.env.OCX_SERVICE !== "1";
-  if (owner.live && !explicitSiblingPort) {
-    // Service-wrapper context (opencodex-service.cmd `:loop`): a healthy proxy from
-    // ANY source means the requested port is already served. Exit 0 so the wrapper's
-    // `if %ERRORLEVEL% NEQ 0` retry loop terminates instead of respawning every 5s
-    // against a listener it can never claim (observed as an endless
-    // "Proxy already running" service.log loop).
-    // Only the exact "1" sentinel takes this path — the same check syncCleanup
-    // uses — so an env value like "0" or "false" cannot bypass the conflict error.
-    if (process.env.OCX_SERVICE === "1") {
+  if (owner.live) {
+    // Rationale and the full decision table live on `decideStartWithLiveOwner`.
+    const decision = decideStartWithLiveOwner({
+      livePort: owner.live.port,
+      requestedPort,
+      ocxService: process.env.OCX_SERVICE,
+    });
+    if (decision === "service-stay-out") {
+      // Service-wrapper context (opencodex-service.cmd `:loop`): a healthy proxy from
+      // ANY source means the requested port is already served. Exit 0 so the wrapper's
+      // `if %ERRORLEVEL% NEQ 0` retry loop terminates instead of respawning every 5s
+      // against a listener it can never claim (observed as an endless
+      // "Proxy already running" service.log loop).
       console.log(`Proxy already running (PID ${owner.live.pid ?? owner.pidSnapshot ?? "unknown"}, port ${owner.live.port}); service wrapper staying out of the way.`);
       process.exit(0);
     }
-    console.error(`⚠️  Proxy already running (PID ${owner.live.pid ?? owner.pidSnapshot ?? "unknown"}, port ${owner.live.port}). Use 'ocx stop' first.`);
-    process.exit(1);
-  }
-  if (owner.live && explicitSiblingPort) {
-    // Honest about the one side effect the sibling shares with any start: this home's Codex
-    // config is re-pointed at the new port when injection applies.
-    console.warn(`Proxy already running on port ${owner.live.port}; starting a second instance on requested port ${requestedPort}.`);
+    if (decision === "refuse") {
+      console.error(`⚠️  Proxy already running (PID ${owner.live.pid ?? owner.pidSnapshot ?? "unknown"}, port ${owner.live.port}). Use 'ocx stop' first.`);
+      process.exit(1);
+    }
+    // Sibling path. Honest about the side effects it shares with any start in this home:
+    // the new instance takes over this home's ocx.pid / runtime-port.json while it runs,
+    // and re-points this home's Codex config at the new port when injection applies.
+    console.warn(
+      `Proxy already running on port ${owner.live.port}; starting a second instance on requested port ${requestedPort}. `
+      + `The new instance takes over this home's pid/runtime records and Codex config while it runs.`,
+    );
   }
 
   const clientState = readClientConnectionState();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -253,7 +253,18 @@ async function handleStart(options: { block?: boolean } = {}) {
   // shutdown then left no runtime record for discovery at all. `handleEnsure`
   // already passes this; `handleStart` is the path that did not.
   const owner = await findProxyOwnerBeforeJournalRecovery({ probeConfiguredPort: true });
-  if (owner.live) {
+  // An interactive `ocx start --port X` where X is NOT the live proxy's port is an explicit
+  // sibling request, not the #3106 shadow: that fix targets a bare `start` (or the service
+  // wrapper, which always passes the configured port) silently landing on an ephemeral port.
+  // The blanket refusal here also broke real workflows — with any proxy on the configured
+  // port, no second instance could be started on a different port, and every spawned-launcher
+  // test on a machine running a real proxy failed its startup wait. The service branch keeps
+  // its exact semantics: OCX_SERVICE requests never take the sibling path.
+  const explicitSiblingPort = owner.live !== null
+    && requestedPort !== undefined
+    && requestedPort !== owner.live.port
+    && process.env.OCX_SERVICE !== "1";
+  if (owner.live && !explicitSiblingPort) {
     // Service-wrapper context (opencodex-service.cmd `:loop`): a healthy proxy from
     // ANY source means the requested port is already served. Exit 0 so the wrapper's
     // `if %ERRORLEVEL% NEQ 0` retry loop terminates instead of respawning every 5s
@@ -267,6 +278,11 @@ async function handleStart(options: { block?: boolean } = {}) {
     }
     console.error(`⚠️  Proxy already running (PID ${owner.live.pid ?? owner.pidSnapshot ?? "unknown"}, port ${owner.live.port}). Use 'ocx stop' first.`);
     process.exit(1);
+  }
+  if (owner.live && explicitSiblingPort) {
+    // Honest about the one side effect the sibling shares with any start: this home's Codex
+    // config is re-pointed at the new port when injection applies.
+    console.warn(`Proxy already running on port ${owner.live.port}; starting a second instance on requested port ${requestedPort}.`);
   }
 
   const clientState = readClientConnectionState();

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { CLI_COMMANDS } from "../src/cli/registry";
-import { DISPATCH_ALIASES, DISPATCH_COMMANDS, dispatchCommand, resolveDispatchCommand } from "../src/cli/dispatch";
+import { DISPATCH_ALIASES, DISPATCH_COMMANDS, dispatchCommand, resolveDispatchCommand, decideStartWithLiveOwner } from "../src/cli/dispatch";
 import type { CliDispatchDeps } from "../src/cli/dispatch";
 import { runGuiCommand } from "../src/cli/gui";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -220,15 +220,36 @@ describe("start probes the configured port before shadowing it (source-level)", 
    * `--port` that differs from the live proxy's port. That is not the shadow the guard
    * targets (a bare `start` landing on an ephemeral port); it broke starting a second
    * instance on another port, and every spawned-launcher test on a machine running a
-   * real proxy timed out its startup wait. Source-level for the same reason as above.
+   * real proxy timed out its startup wait. The decision is a pure function so the whole
+   * matrix runs at runtime here; the source oracle below only pins that handleStart
+   * actually routes through it.
    */
-  test("an explicit different --port takes the sibling path instead of the refusal", () => {
-    expect(cliSource).toContain("requestedPort !== owner.live.port");
-    // The service wrapper always passes the configured port and must keep its exact
-    // stay-out-of-the-way semantics, so the sibling path is gated off for it.
-    const sibling = cliSource.slice(cliSource.indexOf("const explicitSiblingPort"));
-    expect(sibling.slice(0, 400)).toContain('process.env.OCX_SERVICE !== "1"');
-    expect(sibling.slice(0, 400)).toContain("requestedPort !== undefined");
+  test("the live-owner decision matrix", () => {
+    // Bare start: the #3106 shadow — still refused.
+    expect(decideStartWithLiveOwner({ livePort: 10100, requestedPort: undefined, ocxService: undefined }))
+      .toBe("refuse");
+    // Explicit port equal to the live proxy's: same conflict — still refused.
+    expect(decideStartWithLiveOwner({ livePort: 10100, requestedPort: 10100, ocxService: undefined }))
+      .toBe("refuse");
+    // Explicit DIFFERENT port, interactive: the sibling request this fix restores.
+    expect(decideStartWithLiveOwner({ livePort: 10100, requestedPort: 65301, ocxService: undefined }))
+      .toBe("sibling");
+    // Service wrapper keeps its exact stay-out semantics on both port shapes.
+    expect(decideStartWithLiveOwner({ livePort: 10100, requestedPort: 10100, ocxService: "1" }))
+      .toBe("service-stay-out");
+    expect(decideStartWithLiveOwner({ livePort: 10100, requestedPort: 8080, ocxService: "1" }))
+      .toBe("service-stay-out");
+    // Only the exact "1" sentinel is service context — "0"/"false" cannot reach stay-out.
+    expect(decideStartWithLiveOwner({ livePort: 10100, requestedPort: 8080, ocxService: "0" }))
+      .toBe("sibling");
+    expect(decideStartWithLiveOwner({ livePort: 10100, requestedPort: undefined, ocxService: "false" }))
+      .toBe("refuse");
+  });
+
+  test("handleStart routes its live-owner branch through the shared decision", () => {
+    expect(cliSource).toContain("decideStartWithLiveOwner({");
+    // No leftover inline refusal that could bypass the tested decision.
+    expect(cliSource).not.toContain("explicitSiblingPort");
   });
 
   test("the probe option still gates on an explicit true", () => {

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -215,6 +215,22 @@ describe("start probes the configured port before shadowing it (source-level)", 
     }
   });
 
+  /**
+   * The #3106 guard refused start whenever ANY live proxy existed, ignoring an explicit
+   * `--port` that differs from the live proxy's port. That is not the shadow the guard
+   * targets (a bare `start` landing on an ephemeral port); it broke starting a second
+   * instance on another port, and every spawned-launcher test on a machine running a
+   * real proxy timed out its startup wait. Source-level for the same reason as above.
+   */
+  test("an explicit different --port takes the sibling path instead of the refusal", () => {
+    expect(cliSource).toContain("requestedPort !== owner.live.port");
+    // The service wrapper always passes the configured port and must keep its exact
+    // stay-out-of-the-way semantics, so the sibling path is gated off for it.
+    const sibling = cliSource.slice(cliSource.indexOf("const explicitSiblingPort"));
+    expect(sibling.slice(0, 400)).toContain('process.env.OCX_SERVICE !== "1"');
+    expect(sibling.slice(0, 400)).toContain("requestedPort !== undefined");
+  });
+
   test("the probe option still gates on an explicit true", () => {
     // A truthy-but-not-true default would silently probe for callers that pass
     // nothing, which is a different behavior than the one asserted above.

--- a/tests/cli-ready.test.ts
+++ b/tests/cli-ready.test.ts
@@ -850,12 +850,15 @@ describe("handleStart OCX_SERVICE exit guard (source-level)", () => {
   const cliSource = readFileSync(join(import.meta.dir, "../src/cli/index.ts"), "utf8");
 
   test("an already-live proxy exits 0 in OCX_SERVICE context", () => {
-    expect(cliSource).toMatch(/process\.env\.OCX_SERVICE === "1"/);
-    expect(cliSource).toMatch(/process\.exit\(0\)/);
-    const guard = cliSource.match(/if\s*\(process\.env\.OCX_SERVICE === "1"\)\s*\{[\s\S]{0,400}?process\.exit\(0\)/);
-    expect(guard, "OCX_SERVICE guard must exit 0 when the port is already served").not.toBeNull();
-    const nonService = cliSource.match(/Proxy already running[\s\S]{0,200}?process\.exit\(1\)/);
-    expect(nonService, "non-service path keeps the exit 1 conflict error").not.toBeNull();
+    // The `OCX_SERVICE === "1"` comparison moved into `decideStartWithLiveOwner`
+    // (src/cli/dispatch.ts), where the sentinel semantics are asserted at runtime
+    // across the whole matrix (tests/cli-dispatch.test.ts). This oracle pins the
+    // exits that the decision routes to: stay-out exits 0, the conflict exits 1.
+    expect(cliSource).toMatch(/decideStartWithLiveOwner\(\{/);
+    const stayOut = cliSource.match(/decision === "service-stay-out"[\s\S]{0,800}?process\.exit\(0\)/);
+    expect(stayOut, "the service stay-out decision must exit 0 when the port is already served").not.toBeNull();
+    const nonService = cliSource.match(/Proxy already running[\s\S]{0,300}?process\.exit\(1\)/);
+    expect(nonService, "non-service refusal keeps the exit 1 conflict error").not.toBeNull();
   });
 
   test("service.ts teardown kills surviving wrapper processes on stop", () => {


### PR DESCRIPTION
## Summary

Maintainer rebase of **#3144** by @olddonkey onto current `dev` — all three commits cherry-picked with author credit preserved, no conflicts.

`ocx start --port <n>` refused to start when another proxy was already live, even when the requested port was **different** from the running one. An explicit, different port is an unambiguous request for a sibling instance, so it now starts one instead of refusing. The refusal is preserved where it belongs: same port, or no explicit port.

The two follow-up commits are the author's own review response — moving the start-decision test from source-text matching to a runtime evaluation, and updating the `OCX_SERVICE` exit oracle to match the routed decision. Both are improvements to how the behavior is proven, not to the behavior.

## Verification

Exact head `1afbee0a1`:

- `bun test ./tests/cli-dispatch.test.ts ./tests/cli-ready.test.ts` — **91 pass, 0 fail**, 306 expect() calls.

Full-suite and typecheck coverage is left to CI on this exact head.

## Checklist

- [x] Targets `dev`
- [x] Author credit preserved across all three commits
- [x] No unresolved review threads on the original
- [x] The refusal path is narrowed, not removed — same-port and implicit-port launches still refuse
- [x] No credential, auth, workflow, or release-automation surface touched

