### PR TITLE
fix(usage): price aggregator models spelled vendor/model

### DIFF
--- a/src/usage/cost.ts
+++ b/src/usage/cost.ts
@@ -319,7 +319,8 @@ function resolveModelLevelPrice(provider: string, modelId: string): MatchedPrice
   // dots where the catalog uses dashes (kiro "claude-opus-4.6" vs anthropic
   // "claude-opus-4-6"). No fuzzy matching beyond this one normalization.
   const found = findVendorCostByModelId(modelId)
-    ?? (modelId.includes(".") ? findVendorCostByModelId(modelId.replaceAll(".", "-")) : undefined);
+    ?? (modelId.includes(".") ? findVendorCostByModelId(modelId.replaceAll(".", "-")) : undefined)
+    ?? vendorPrefixedCost(modelId);
   if (!found) return null;
   return {
     provider,
@@ -329,6 +330,36 @@ function resolveModelLevelPrice(provider: string, modelId: string): MatchedPrice
     source: "jawcode",
     status: "verified-derived",
   };
+}
+
+/**
+ * Aggregators spell a model as `<vendor>/<model>` — CommandCode serves
+ * `deepseek/deepseek-v4-flash`, and OpenRouter-shaped presets do the same. The cost
+ * catalog stores the bare id, so the exact lookup above misses a price that is present and
+ * every request through such a provider reports no cost at all (#3136).
+ *
+ * Retrying on the tail is only safe while the prefix AGREES with the vendor the matched row
+ * belongs to. `findVendorCostByModelId` returns whichever vendor `COST_VENDOR_PRIORITY`
+ * reaches first, so an unchecked strip would happily price `openai/claude-opus-4-6` from
+ * Anthropic's row — a number that looks authoritative and is wrong. Requiring agreement
+ * keeps the failure closed for a genuinely mismatched id.
+ *
+ * Comparison is normalized because the same vendor is spelled differently across catalogs:
+ * `x-ai/grok-4.6` resolves to vendor `xai`. Dashes and case are the only variance seen;
+ * anything beyond that stays a miss.
+ */
+function vendorPrefixedCost(modelId: string): ReturnType<typeof findVendorCostByModelId> {
+  const slash = modelId.indexOf("/");
+  if (slash <= 0 || slash === modelId.length - 1) return undefined;
+  const claimedVendor = modelId.slice(0, slash);
+  const tail = modelId.slice(slash + 1);
+  // A tail that is itself slashed is not a vendor prefix we understand; leave it alone.
+  if (tail.includes("/")) return undefined;
+  const found = findVendorCostByModelId(tail)
+    ?? (tail.includes(".") ? findVendorCostByModelId(tail.replaceAll(".", "-")) : undefined);
+  if (!found) return undefined;
+  const normalize = (value: string): string => value.toLowerCase().replaceAll("-", "");
+  return normalize(found.provider) === normalize(claimedVendor) ? found : undefined;
 }
 
 function isEstimated(usage: OcxUsage, usageStatus: UsageStatus, priceStatus: ExpectedPriceStatus | "verified"): boolean {

--- a/tests/usage-cost.test.ts
+++ b/tests/usage-cost.test.ts
@@ -1199,3 +1199,47 @@ describe("provider cost overlay (user-configured)", () => {
     refreshUserCostOverlays({ providers: {} } as unknown as OcxConfig);
   });
 });
+
+describe("aggregator vendor-prefixed model ids (#3136)", () => {
+  // CommandCode serves "deepseek/deepseek-v4-flash"; the cost catalog stores the bare id.
+  // The exact lookup missed a price that is present, so every request through such a
+  // provider reported no cost at all.
+  test("a vendor-prefixed id resolves to the same price as its bare id", () => {
+    const bare = resolveMatchedPrice("deepseek", "deepseek-v4-flash");
+    const prefixed = resolveMatchedPrice("commandcode-api", "deepseek/deepseek-v4-flash");
+    expect(bare?.cost4).toBeDefined();
+    expect(prefixed?.cost4).toEqual(bare!.cost4);
+    // Derived, not claimed as an exact catalog row for that provider.
+    expect(prefixed?.status).toBe("verified-derived");
+    expect(prefixed?.jawcodeProvider).toBe("deepseek");
+  });
+
+  test("the vendor prefix is compared after normalization, so x-ai matches xai", () => {
+    // The same vendor is spelled differently across catalogs. Dashes and case are the
+    // only variance this normalizes; anything further stays a miss.
+    expect(resolveMatchedPrice("openrouter", "x-ai/grok-4.6")?.cost4).toBeDefined();
+  });
+
+  test("a prefix that disagrees with the matched vendor stays unpriced", () => {
+    // This is the assertion that keeps the fix from becoming a mispricing.
+    // findVendorCostByModelId returns whichever vendor COST_VENDOR_PRIORITY reaches
+    // first, so an unchecked strip would price a Claude model from Anthropic's row while
+    // the caller named OpenAI - a number that looks authoritative and is wrong.
+    expect(resolveMatchedPrice("openrouter", "openai/claude-opus-4-6")).toBeNull();
+  });
+
+  test("an unknown tail is still unpriced rather than guessed", () => {
+    expect(resolveMatchedPrice("openrouter", "google/gemini-3.6-pro")).toBeNull();
+  });
+
+  test("unprefixed ids are unchanged", () => {
+    expect(resolveMatchedPrice("deepseek", "deepseek-v4-flash")?.cost4).toBeDefined();
+    expect(resolveMatchedPrice("deepseek", "not-a-real-model-xyz")).toBeNull();
+  });
+
+  test("a doubly-slashed id is not treated as a vendor prefix", () => {
+    // Only one prefix segment is understood; deeper paths are left alone rather than
+    // being peeled until something matches.
+    expect(resolveMatchedPrice("openrouter", "a/deepseek/deepseek-v4-flash")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Every request through CommandCode showed no cost at all: `"cost": { "kind": "unavailable" }`.

Price resolution ends at `findVendorCostByModelId`, which matches a catalog row **exactly** (one normalization, dots to dashes). CommandCode is an aggregator, so it spells models as `<vendor>/<model>` — and the catalog stores the bare id. Executed against the shipped catalog:

    deepseek/deepseek-v4-flash  -> undefined
    deepseek-v4-flash           -> { provider: "deepseek", cost: { input: 0.14, output: 0.28, ... } }

The price was there the whole time. The vendor prefix was the only thing between the row and the lookup. `resolveMetadataProvider("commandcode-api")` returns `undefined`, so the bundled-metadata path did not rescue it either.

**Not a CommandCode bug.** The same probe: `anthropic/claude-opus-4-6`, `openai/gpt-5.6`, and `deepseek/deepseek-v4-flash` were all unpriced while their bare tails all priced. Any aggregator whose own provider is absent from the cost catalog loses pricing for every model it serves.

## Why this is not just a prefix strip

`findVendorCostByModelId` returns whichever vendor `COST_VENDOR_PRIORITY` reaches first, so the tail alone does not tell you which vendor you got. Probing agreement:

| id | tail resolves to | prefix agrees |
|---|---|---|
| `deepseek/deepseek-v4-flash` | `deepseek` | yes |
| `anthropic/claude-opus-4-6` | `anthropic` | yes |
| `x-ai/grok-4.6` | `xai` | **spelling differs** |
| `google/gemini-3.6-pro` | none | — |

A blind strip would price `openai/claude-opus-4-6` from Anthropic's row — a number that renders as authoritative and is wrong. So the retry requires the prefix to **agree** with the matched vendor, normalized for dashes and case so `x-ai` and `xai` are the same vendor while a genuine disagreement fails closed.

Closes #3136.

## Verification

Exact head `849e66518`:

- `bun test ./tests/usage-cost.test.ts` — **81 pass, 0 fail**, 428 expect() calls, including six new cases.
- `bun test ./tests/cost-scoring.test.ts ./tests/user-cost-overlay-coderabbit-regressions.test.ts ./tests/gemini-37-flash-migration.test.ts ./tests/provider-cost-overlay-config.test.ts ./tests/cost-cap-unknown-evidence.test.ts` — **82 pass, 0 fail**.

**Red-green on both halves**, because each protects a different failure:

- Removing the retry → the CommandCode case goes red (80/1).
- Removing the *vendor-agreement check* → the mispricing case goes red (80/1). That assertion is what stops the fix from becoming a worse bug than the one it fixes.

Full-suite and typecheck coverage is left to CI on this exact head.

## Checklist

- [x] Targets `dev`
- [x] Root cause proven by executing against the real catalog, not by reading
- [x] Regression covers the fix, the mispricing risk, the unknown tail, the unprefixed path, and a doubly-slashed id
- [x] Fails closed on vendor disagreement rather than guessing a price
- [x] No credential, auth, workflow, or release-automation surface touched

