### PR TITLE
test(quota): move the malformed-plan pool test onto the #3198 contract

### DIFF
--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -1858,6 +1858,12 @@ describe("fetchProviderQuotaReports", () => {
     expect(JSON.stringify(openai?.aggregation)).not.toMatch(/(?:total|consumed|remaining)Weight|projectedUsedPercent/i);
   });
 
+  // #3198 changed what "tolerate" means here: an uncalibrated plan — a name the weight map
+  // does not list, or a malformed non-string value like the `{ tier: "pro" }` below (both
+  // normalize to undefined via codexPlanKey) — is now counted at the baseline seat weight
+  // instead of being excluded from the aggregate. Exclusion silently overstated coverage;
+  // baseline counting is the visibly conservative estimate. The account still shows up in
+  // `unknownPlanAccounts` so the operator can see the estimate is conservative for that seat.
   test("pool reports tolerate a malformed persisted plan through cache and aggregation", async () => {
     saveCodexAccountCredential("added", {
       accessToken: "added-access",
@@ -1886,12 +1892,14 @@ describe("fetchProviderQuotaReports", () => {
 
     const refreshed = await fetchProviderQuotaReports(config, true);
     const openai = refreshed.reports.find(row => row.provider === "openai");
-    expect(openai?.quota.weeklyPercent).toBe(11);
+    // Both seats weigh the same (malformed -> baseline, "plus" -> calibrated baseline), so the
+    // blend of 77 and 11 lands at 44 — not the 11 the old exclusion contract produced.
+    expect(openai?.quota.weeklyPercent).toBe(44);
     expect(openai?.aggregation).toMatchObject({
-      includedAccounts: 1,
-      excludedAccounts: 1,
+      includedAccounts: 2,
+      excludedAccounts: 0,
       unknownPlanAccounts: 1,
-      incomplete: true,
+      incomplete: false,
       currentAccount: { quota: { weeklyPercent: 77 } },
     });
     expect(openai?.aggregation?.currentAccount).not.toHaveProperty("plan");


### PR DESCRIPTION
## Summary

`tests/provider-quota.test.ts` — "pool reports tolerate a malformed persisted plan through cache and aggregation" — has failed deterministically on every clean `dev` checkout since #3198 landed:

```
1889 |     expect(openai?.quota.weeklyPercent).toBe(11);
Expected: 11
Received: 44
```

#3198 deliberately stopped excluding uncalibrated Codex plans from the pool capacity estimate — a plan the weight map does not list now counts at the baseline seat weight, because exclusion silently overstated the coverage an operator was reading. It updated `tests/provider-capacity.test.ts` (+102 lines) and the GUI tests, but this one test still asserted the old exclusion shape: malformed-plan account dropped, weekly `11`, `excludedAccounts: 1`, `incomplete: true`. Under the new contract both seats weigh the same, so the blend of 77 and 11 lands at `44`, both accounts are included, and coverage is complete.

## Why the test moves, not the production code

The test's plan is a malformed **non-string** (`{ tier: "pro" }`), not merely an unlisted name — so the honest question was whether malformed values deserve to keep the old exclusion. They are not a separate axis: `codexPlanKey` normalizes a non-string to `undefined` exactly like an unlisted name (the tolerance `095a9a5b7` established), and #3198 routes every undefined key to the baseline weight. Re-splitting malformed from unknown here would reintroduce the distinction #3198 just collapsed, two days after it was deliberately collapsed.

What the account still surfaces is `unknownPlanAccounts: 1` — the observable that tells the operator the estimate is conservative for that seat — and the test's cache half already pins it. The new expectations were derived from the contract (`incomplete` is now `includedAccounts < totalAccounts`; equal weights blend 77/11 to 44) rather than pasted from the failing run, and a comment on the test records the #3198 semantics so the next contract change finds its rationale in place.

## Verification

- `tests/provider-quota.test.ts` — 110 pass / 0 fail (was 109/1 on clean `dev`; reproduced at `c17bc94c2` and `52d941640` with zero changes before this fix).
- `tests/provider-capacity.test.ts` — untouched, still green alongside.
- `bun run test` — **17080 pass, 0 fail, exit 0**; all six serial lanes green.
- `bun run typecheck` / `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


## Adversarial review round (`d24055a3a`)

An independent multi-agent review of the first commit surfaced eleven findings — no wrong assertion values (three agents re-derived all four numbers by executing the aggregator), but one factual error in my own comment and several coverage holes. All eleven are addressed:

- **The comment stated a wrong mechanism at a wrong layer.** On this integration path the malformed plan never reaches `codexPlanKey`: `poolAccountDto` strips it via `codexPlanValue`, so aggregation sees an *absent* plan — and an unlisted string name normalizes to a defined key that fails the weight-map lookup, not to `undefined`. Rewritten to state both routes; reference normalized to `#3155 (PR #3198)` like the ten sibling sites; the fourth prose copy of the policy rationale replaced with a pointer.
- **Assertions grew where regressions could ship green:** the per-window `weekly` flags (what the dashboard actually renders per bar), `JSON.stringify(refreshed)` free of the malformed value, the sibling's weight-field anti-leak regex, and the cached half now pins the identity contract (`toBe` on the aggregation object) instead of re-reading a field of the object asserted one line up. The load-bearing mocked `plan_type` precedence is documented at the mock.
- **Renamed** to what the test now pins — "count a malformed persisted plan at baseline and keep it out of the public shape" — since "through cache and aggregation" was false on both nouns.
- **GUI gains the one missing pairing** (`incomplete: false` + `unknownPlanAccounts: 1`, the #3155 reporter's fully-included pool). Mutation-checked: gating the uncalibrated notice under the `incomplete` branch fails only the new test while every prior fixture passes — exactly the silent-hide the review predicted.

Re-verified at `d24055a3a`: `bun run test` — **17080 pass, 0 fail, exit 0**; `tests/provider-quota.test.ts` 110/0; `gui/tests/provider-capacity-shell.test.tsx` 12/0; typecheck and privacy:scan pass.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated quota aggregation to include malformed or unlisted plans using the baseline seat weight.
  * Pool reports now accurately reflect affected accounts and no longer mark results as incomplete when these plans are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
