### PR TITLE
feat(router): summarize compaction on the default provider when no canonical openai route exists

### DIFF
--- a/devlog/_plan/260902_nonbug_adoption_backlog/030_wp3_compaction_provider.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/030_wp3_compaction_provider.md
@@ -1,0 +1,138 @@
+# wp3 — #2901 compaction provider selection
+
+Issue #2901 (score 58), no implementation PR. Reported on 2.31.0/macOS by a user
+running GitHub Copilot as their only provider.
+
+## What actually happens
+
+Ordinary turns route to GHCP. Compaction alone returns:
+
+```
+404 Model gpt-5.6-sol requires the canonical openai provider.
+Run: ocx provider add openai && ocx sync && ocx restart
+```
+
+The path is short and every step is in the current tree:
+
+1. `handleResponsesCompact` calls the ordinary router —
+   `route = routeModel(config, raw.model, evidenceFromBody(raw))`
+   (`src/server/responses/compact.ts:512`).
+2. `routeModel` reserves every bare `gpt-*`/`o1-`/`o3-`/`o4-` id for the canonical
+   provider: `isBareOpenAiFamilyModel` (`src/router.ts:510-513`) is checked at
+   `:701`, **before** configured model lists and `defaultProvider` at `:749-752`.
+   With no enabled `openai` row it throws `NoEnabledOpenAiProviderError`
+   (`:706`, class at `:468-475`).
+3. `compact.ts:513-519` turns any router throw into the 404 the user sees.
+
+`compactProvider` is only ever `route.provider` (`compact.ts:595`). There is no
+`compactModel`/`compactProvider` config key anywhere in the tree.
+
+## Why the existing mitigations do not reach it
+
+**#2858 compact handoff.** `compactHandoffRoutes` (`compact.ts:164`) remembers a
+model that *demonstrably compacted this thread*, and it is only written by
+`rememberCompactHandoffRoute` after a successful compaction
+(`compact.ts:1095,1106`). A GHCP-only user never records an entry, because their
+first compaction dies at step 3. The map is a quota-failover aid, not a
+bootstrap.
+
+**#636 catalog suppression.** `src/codex/catalog/sync.ts:1674-1676` already stops
+advertising bare `gpt-*` rows when only non-OpenAI providers are configured,
+precisely so they cannot hard-404. That fix covers the model *picker*. It cannot
+cover compaction, because the Codex client chooses the compaction model itself
+rather than taking it from the served catalog.
+
+So the established project position is already: **a bare native id that cannot
+route should not become a hard failure for a user who never configured OpenAI.**
+This issue is the same rule applied to the one surface #636 could not reach.
+
+## The machinery for the fix already exists
+
+`core.ts:3587-3588` computes
+`routedCompaction = parsed._compactionRequest === true && !isCanonicalOpenAiForwardProvider(route.provider)`,
+and when true it strips tools, web-search, tool choice and structured output, runs
+the routed model as a plain summarizer, and lets the bridge append the synthetic
+compaction item (`src/responses/compaction.ts`). Compacting on a non-OpenAI
+provider is a supported, exercised path.
+
+The only thing missing is that a *bare native id* never reaches it: the router
+refuses before any of that runs.
+
+## Design: fall back rather than add a setting
+
+The issue title asks for a setting. A setting is the worse answer here.
+
+A config key requires the user to discover that compaction is a separate routing
+decision, learn a new key name, and edit JSON — after hitting an error whose text
+tells them to install a provider they deliberately do not want. The failure is
+total (the conversation cannot continue), so the remedy should not be homework.
+
+Instead: when a compaction request carries a bare native model and no canonical
+`openai` provider is enabled, route it the way the user's ordinary turns already
+route, and let the existing routed-compaction path summarize.
+
+**This cannot change behavior for any working configuration.** The fallback is
+reachable only where `routeModel` throws `NoEnabledOpenAiProviderError` today —
+i.e. only where the current outcome is a hard 404. A user with an enabled
+`openai` provider takes the identical branch they take now. That is why this
+needs no opt-in flag: there is no behavior to preserve, only an error to replace.
+
+## Audit amendment (A1)
+
+The first plan was too narrow. A source audit found that the v1 compact handler is
+not the only entry point: v2 `compaction_trigger` requests enter
+`handleResponsesInner`, whose initial `routeModel` call fails before the existing
+`routedCompaction` bridge can run. The implementation must therefore use one
+compaction-only routing helper from both entry points.
+
+The helper may fall back only for an unqualified bare OpenAI-family model when
+the canonical `openai` provider is absent or disabled and the configured default
+provider is active. It must rethrow for account-qualified selectors such as
+`side/gpt-5.5`, policy/combo routes, disabled or missing defaults, and every
+other router error. This preserves exact account routing and keeps ordinary
+turns on today's path.
+
+## File change map
+
+| File | Action | Change |
+|------|--------|--------|
+| `src/router.ts` | MODIFY | add a compaction-only route helper that preserves the native reservation for ordinary requests and permits the narrowly gated default-provider fallback described above; retain route-decision metadata with a distinct reason |
+| `src/server/responses/compact.ts` | MODIFY | call the shared helper for v1 compact routing and log one sanitized substitution line when the helper selects the configured default |
+| `src/server/responses/core.ts` | MODIFY | call the same helper for the initial v2 `compaction_trigger` route, while leaving ordinary and recovery/model-change routes on ordinary routing |
+| `docs-site/.../guides/` (compaction reference) | MODIFY | document that a bare native compaction model falls back to the configured default when no canonical OpenAI provider is enabled |
+| `tests/router.test.ts` | MODIFY | prove helper-only fallback, account namespace fail-closed behavior, and unchanged ordinary `routeModel` behavior |
+| `tests/responses-compaction-routing.test.ts` | MODIFY | regressions for v1 and v2 entry points, canonical OpenAI preservation, non-native errors, and one-time logging |
+
+## Scope boundary
+
+IN: the compaction fallback for the v1 `/v1/responses/compact` handler and v2
+`compaction_trigger` turn, its log line, docs, and tests.
+
+OUT: a `compactProvider`/`compactModel` config key. If an operator later wants to
+*pin* compaction to a specific model while having a working `openai` provider,
+that is a genuine feature and a separate cycle; it is not what unblocks #2901.
+OUT: changing `isBareOpenAiFamilyModel` or the router's native reservation, which
+is load-bearing for ordinary turns.
+
+## Accept criteria
+
+1. **GHCP-only config, bare native compaction model: both entry points succeed**
+   and are summarized by the configured provider. Activation: a config with no
+   `openai` row, a v1 compact request and a v2 `compaction_trigger` request for
+   `gpt-5.6-sol`, asserting non-404 status and that the routed provider received
+   the turn.
+2. **A working openai config is untouched.** Activation: the same request with an
+   enabled canonical provider still routes to it; assert the provider chosen is
+   the canonical one and no fallback log fires.
+3. **Other router failures still 404.** Activation: an unroutable non-native model
+   id still returns the original error, proving the catch is narrow.
+4. **Exact account selectors remain fail-closed.** Activation: with a configured
+   `side` account namespace but no canonical `openai`, `side/gpt-5.5` still
+   returns `NoEnabledOpenAiProviderError` and never reaches the default provider.
+5. The substitution is logged once with both model ids, without persisting
+   credentials or raw request bodies.
+
+## Verifier
+
+`bun x tsc --noEmit` plus the focused router and compaction tests. Full suite
+forbidden.

--- a/devlog/_plan/260902_nonbug_adoption_backlog/031_wp3_audit_r1_synthesis.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/031_wp3_audit_r1_synthesis.md
@@ -1,0 +1,70 @@
+# wp3 audit R1 — #2901 compaction provider selection
+
+## Verdict
+
+NEAR-PASS after plan amendment. The reported failure is real and the existing
+routed-compaction bridge is the correct destination, but the initial plan's
+`compact.ts`-only change would leave v2 `compaction_trigger` requests broken.
+The amendment makes the routing decision shared and keeps its fallback narrowly
+scoped to the failing, unqualified native-model case.
+
+## Evidence reviewed
+
+- `src/server/responses/compact.ts` routes the v1 handler through `routeModel`
+  before it can choose the synthetic routed-compaction path.
+- `src/server/responses/core.ts` performs a separate initial `routeModel` call
+  in `handleResponsesInner`; its later `routedCompaction` branch cannot run if
+  that call throws.
+- `src/router.ts` raises `NoEnabledOpenAiProviderError` both for bare native
+  model ids and for exact Codex account namespaces. The latter is an explicit
+  account-selection boundary and must not be treated as a generic fallback.
+- `src/server/responses/core.ts` already strips the private trigger and appends
+  `COMPACT_PROMPT` for noncanonical routed compaction, so no new provider-side
+  compaction protocol is needed.
+- `src/codex/catalog/sync.ts` suppresses bare native rows in non-OpenAI-only
+  catalogs, confirming that a bare native id without a canonical route is not a
+  supported ordinary-turn destination; it does not cover client-selected
+  compaction models.
+
+## Accepted blockers and dispositions
+
+1. **Missing v2 coverage — accepted.** Add a shared `routeCompactionModel`
+   (name may follow repository conventions) and invoke it for both v1 compact
+   routing and the initial v2 compaction route. Add an activation test that
+   exercises the real `handleResponses` path with `compaction_trigger`.
+2. **Account namespace over-catch — accepted.** Do not catch every
+   `NoEnabledOpenAiProviderError`. The fallback predicate must require an
+   unqualified bare OpenAI-family id and an active configured default provider;
+   exact account-qualified ids and all other routing errors rethrow.
+3. **Ordinary routing regression — accepted.** Keep `routeModel` unchanged for
+   non-compaction requests and assert that the same GHCP-only native id still
+   throws there. The new helper is an explicit request-surface choice, not a
+   global relaxation of native model ownership.
+4. **Configuration-key alternative — rejected for this cycle.** A pinning key
+   would solve a different problem (choosing among working providers) and would
+   add setup burden to a request currently failing solely because of an invalid
+   native reservation. The fallback changes only a hard failure and is therefore
+   safer than introducing a new default-on routing preference.
+5. **Logging/privacy — accepted with guardrails.** Emit at most one warning from
+   the v1/v2 request path, using sanitized model labels and no body, token, or
+   account data. The route-decision reason remains the machine-readable audit
+   signal for tests and request logs.
+
+## Activation matrix
+
+| Case | Expected result |
+| --- | --- |
+| GHCP-only + bare `gpt-*` + v1 compact | default provider receives routed summary |
+| GHCP-only + bare `gpt-*` + v2 trigger | same routed summary bridge succeeds |
+| canonical `openai` enabled + bare native id | canonical route unchanged; no fallback |
+| configured account namespace + `side/gpt-*` | original canonical-auth error; no fallback |
+| non-native unknown model | original 404/error unchanged |
+| ordinary `/v1/responses` + GHCP-only bare native id | original native reservation error |
+
+## Residual risk
+
+The default provider may advertise a model alias that differs from the bare
+native id. The helper must preserve the caller's model id as the routed model
+unless the normal route result supplies an explicit effective id; focused tests
+should assert the actual upstream body and provider, not merely a successful
+HTTP status.

--- a/docs-site/src/content/docs/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/reference/proxy-formats.md
@@ -285,6 +285,16 @@ conversation.
 | Canonical ChatGPT or official OpenAI route | Forwards the request to the native `/responses/compact` endpoint with the resolved account and model authentication |
 | Other routed model | Runs an internal, non-streaming, no-tools compaction turn with a `compaction_trigger`; requires exactly one synthetic `compaction` item whose `encrypted_content` is an `ocx1:` envelope; decodes that summary into v1 replacement history |
 
+Codex names a bare OpenAI-family model (for example `gpt-5.6-sol`) for its compaction turns
+regardless of which provider the operator routes ordinary turns to. Ordinary requests reserve
+such ids for the canonical `openai` provider. On the compaction surface only — `POST
+/v1/responses/compact` and a `POST /v1/responses` turn carrying a `compaction_trigger` — a bare
+native model with no enabled canonical `openai` provider falls back to the configured
+`defaultProvider` as the summarizer instead of returning 404. The fallback applies only when the
+default provider is enabled and is not itself an OpenAI-family entry; account-qualified selectors
+such as `side/gpt-5.6-sol` still fail closed. The proxy logs one notice per provider when this
+fallback engages. Configurations with an enabled canonical `openai` provider are unchanged.
+
 Native compact responses are buffered with a 32 MiB maximum, including responses whose declared
 `Content-Length` already exceeds the limit. The compact-specific failures include:
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -265,6 +265,25 @@ function warnIfBaseUrlDiscarded(providerName: string, userBaseUrl: string, effec
   );
 }
 
+/**
+ * One notice per provider id: the destination is an operator-configured key
+ * (never a caller-supplied string), so the log carries no request content.
+ */
+const compactionFallbackWarnings = new Set<string>();
+function warnCompactionDefaultProviderFallbackOnce(providerName: string): void {
+  if (compactionFallbackWarnings.has(providerName)) return;
+  compactionFallbackWarnings.add(providerName);
+  console.warn(
+    `compaction: no enabled canonical "openai" provider for the native compaction model;`
+    + ` summarizing through default provider "${providerName}" instead (#2901).`,
+  );
+}
+
+/** Test seam: forget which compaction fallbacks have been announced. */
+export function resetCompactionFallbackWarningsForTests(): void {
+  compactionFallbackWarnings.clear();
+}
+
 function usableResolvedApiKey(apiKey: string | undefined): string | undefined {
   const resolved = resolveEnvValue(apiKey);
   return typeof resolved === "string" && resolved.trim().length > 0 ? resolved : undefined;
@@ -578,6 +597,7 @@ function routeModelInternal(
   modelId: string,
   bypassCombos: boolean,
   policyEvidence?: PolicyRequestEvidence,
+  allowCompactionNativeFallback = false,
 ): RouteResult {
   const slash = modelId.indexOf("/");
   // Policy namespace is system-reserved: an explicit `policy/<id>` or a
@@ -703,6 +723,28 @@ function routeModelInternal(
     if (provider && provider.disabled !== true) {
       return routeResult(config, OPENAI_CODEX_PROVIDER_ID, provider, modelId, "native", "native-family");
     }
+    // Codex chooses a bare native model for compaction even when the operator's
+    // ordinary route is a third-party provider. Keep the native reservation
+    // unchanged for ordinary turns; only the explicit compaction surface may
+    // use the configured default as its summarizer destination.
+    if (allowCompactionNativeFallback
+      && config.defaultProvider !== OPENAI_CODEX_PROVIDER_ID
+      && config.defaultProvider !== LEGACY_CHATGPT_PROVIDER_ID
+      && config.defaultProvider !== LEGACY_OPENAI_MULTI_PROVIDER_ID
+      && hasOwnProvider(config.providers, config.defaultProvider)) {
+      const defaultProvider = config.providers[config.defaultProvider];
+      if (defaultProvider.disabled !== true) {
+        warnCompactionDefaultProviderFallbackOnce(config.defaultProvider);
+        return routeResult(
+          config,
+          config.defaultProvider,
+          defaultProvider,
+          modelId,
+          "default-provider",
+          "compaction-default-provider",
+        );
+      }
+    }
     throw new NoEnabledOpenAiProviderError(modelId);
   }
 
@@ -755,12 +797,7 @@ function routeModelInternal(
   throw new Error(`No provider configured for model: ${modelId}`);
 }
 
-export function routeModel(
-  config: OcxConfig,
-  modelId: string,
-  policyEvidence?: PolicyRequestEvidence,
-): RouteResult {
-  const route = routeModelInternal(config, modelId, false, policyEvidence);
+function routeWithDecisionTrace(config: OcxConfig, modelId: string, route: RouteResult): RouteResult {
   // Policy routes carry a full evaluation trace already; never rebuild it.
   if (route.routeDecision) return route;
   const accountRef = route.codexAccountNamespace;
@@ -783,6 +820,31 @@ export function routeModel(
       : undefined,
   });
   return route;
+}
+
+export function routeModel(
+  config: OcxConfig,
+  modelId: string,
+  policyEvidence?: PolicyRequestEvidence,
+): RouteResult {
+  const route = routeModelInternal(config, modelId, false, policyEvidence);
+  return routeWithDecisionTrace(config, modelId, route);
+}
+
+/**
+ * Route a client-selected compaction model. Codex may send a bare native model
+ * even when its ordinary turns are configured for another provider; in that
+ * one case the configured default provider is a safe summarizer destination.
+ * This helper is intentionally separate so ordinary requests retain the
+ * canonical OpenAI reservation and exact account selectors remain fail-closed.
+ */
+export function routeCompactionModel(
+  config: OcxConfig,
+  modelId: string,
+  policyEvidence?: PolicyRequestEvidence,
+): RouteResult {
+  const route = routeModelInternal(config, modelId, false, policyEvidence, true);
+  return routeWithDecisionTrace(config, modelId, route);
 }
 
 /** Resolve a combo-selected provider/model target without consulting public combo aliases again. */

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -9,7 +9,7 @@ import { parseRequest } from "../../responses/parser";
 import { buildCompactV1Output, COMPACT_PROMPT, decodeCompactionSummary, extractCompactUserMessages } from "../../responses/compaction";
 import { FORWARD_HEADERS, sanitizeReasoningInputContent } from "../../adapters/openai-responses";
 import { expandPreviousResponseInput, previousResponseProviderState, rememberResponseState } from "../../responses/state";
-import { NoEligiblePolicyCandidateError, routeModel } from "../../router";
+import { NoEligiblePolicyCandidateError, routeCompactionModel } from "../../router";
 import { evidenceFromBody } from "../../routing/request-evidence";
 import {
   advanceComboAfterFailure,
@@ -509,7 +509,10 @@ export async function handleResponsesCompact(
     // Compact requests route through the same policy evaluation as normal
     // turns, so body-derived evidence (tools/image) must reach the first
     // evaluation too - not only the later handleResponses dispatch.
-    route = routeModel(config, raw.model, evidenceFromBody(raw));
+    // Codex selects a bare native model for compaction even when the operator
+    // routes ordinary turns elsewhere (#2901); the compaction-scoped router
+    // may land that on the configured default provider instead of 404.
+    route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
   } catch (err) {
     if (err instanceof NoEligiblePolicyCandidateError) {
       // Persist the evaluation trace (per-candidate exclusions + the

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -58,6 +58,7 @@ import {
 import {
   comboRouteDecisionTrace,
   NoEligiblePolicyCandidateError,
+  routeCompactionModel,
   routeConcreteModel,
   routeModel,
   type RouteResult,
@@ -2832,9 +2833,15 @@ async function handleResponsesInner(
 
   let route: RouteResult;
   try {
+    // A `compaction_trigger` turn may name a bare native model the operator has
+    // no canonical OpenAI route for (#2901). Only the initial compaction route
+    // may fall back to the configured default provider; combo attempts and the
+    // later fallback/recovery re-routes keep the ordinary reservation.
     const resolveRoute = (modelId: string) => options.comboAttempt
       ? routeConcreteModel(config, modelId)
-      : routeModel(config, modelId, evidenceFromBody(parsed._rawBody));
+      : parsed._compactionRequest === true
+        ? routeCompactionModel(config, modelId, evidenceFromBody(parsed._rawBody))
+        : routeModel(config, modelId, evidenceFromBody(parsed._rawBody));
     const _sci = config.shadowCallIntercept;
     let shadowRoute: RouteResult | undefined;
     if (_sci?.enabled && _sci.model && isShadowSourceModel(parsed.modelId, _sci.sourceModels)) {

--- a/tests/responses-compaction-routing.test.ts
+++ b/tests/responses-compaction-routing.test.ts
@@ -725,6 +725,112 @@ describe("routed compaction for key-mode openai-responses (#422)", () => {
   });
 });
 
+describe("bare native compaction model without canonical openai (#2901)", () => {
+  /** A GitHub-Copilot-style operator: one third-party provider, no `openai` row at all. */
+  function copilotOnlyConfig(): OcxConfig {
+    return {
+      defaultProvider: "gw",
+      providers: {
+        gw: {
+          adapter: "openai-chat",
+          baseUrl: "https://api.githubcopilot.com",
+          authMode: "key",
+          apiKey: "ghu_test",
+          models: ["gpt-5.6-sol"],
+        },
+      },
+    } as unknown as OcxConfig;
+  }
+
+  function chatCompletionPayload(text: string): Record<string, unknown> {
+    return {
+      choices: [{ index: 0, message: { role: "assistant", content: text }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    };
+  }
+
+  test("v2 compaction_trigger turn summarizes through the default provider instead of 404", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (url: unknown, init?: RequestInit) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      return jsonResponse(chatCompletionPayload("handoff summary"));
+    }) as typeof fetch;
+
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+    const res = await handleResponses(
+      compactionRequest(baseCompactionBody({ model: "gpt-5.6-sol" })),
+      copilotOnlyConfig(),
+      logCtx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.url.startsWith("https://api.githubcopilot.com")).toBe(true);
+    expect(calls[0]!.body.model).toBe("gpt-5.6-sol");
+    // Still the summarizer contract: no private trigger leaks to the third-party gateway.
+    expect(JSON.stringify(calls[0]!.body)).not.toContain("compaction_trigger");
+    expect(JSON.stringify(calls[0]!.body.messages)).toContain("CONTEXT CHECKPOINT COMPACTION");
+    expect(logCtx.provider).toBe("gw");
+    expect(logCtx.routeDecision?.selected).toMatchObject({ provider: "gw", reason: "compaction-default-provider" });
+    const json = await res.json() as { output?: Array<{ type?: string }> };
+    expect((json.output ?? []).filter(item => item.type === "compaction").length).toBe(1);
+  });
+
+  test("v1 /responses/compact takes the same fallback", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = (async () => {
+      upstreamCalls += 1;
+      return jsonResponse(chatCompletionPayload("handoff summary"));
+    }) as typeof fetch;
+
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+    const res = await handleResponsesCompact(
+      compactionRequest(baseCompactionBody({ model: "gpt-5.6-sol" })),
+      copilotOnlyConfig(),
+      logCtx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(upstreamCalls).toBe(1);
+    expect(logCtx.provider).toBe("gw");
+    expect(logCtx.requestedModel).toBe("gpt-5.6-sol");
+  });
+
+  test("ordinary turns on the same config keep the canonical-openai reservation", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = (async () => {
+      upstreamCalls += 1;
+      return jsonResponse(chatCompletionPayload("must not be reached"));
+    }) as typeof fetch;
+
+    const body = baseCompactionBody({ model: "gpt-5.6-sol" });
+    body.input = (body.input as Array<Record<string, unknown>>).filter(item => item.type !== "compaction_trigger");
+    const res = await handleResponses(compactionRequest(body), copilotOnlyConfig(), { model: "", provider: "" });
+
+    expect(res.status).toBe(404);
+    expect(upstreamCalls).toBe(0);
+  });
+
+  test("an account-qualified native selector still fails closed on compaction", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = (async () => {
+      upstreamCalls += 1;
+      return jsonResponse(chatCompletionPayload("must not be reached"));
+    }) as typeof fetch;
+
+    const config = copilotOnlyConfig();
+    (config as { codexAccountNamespaces?: Record<string, string> }).codexAccountNamespaces = { side: "side-account-id" };
+    const res = await handleResponsesCompact(
+      compactionRequest(baseCompactionBody({ model: "side/gpt-5.6-sol" })),
+      config,
+      { model: "", provider: "" },
+    );
+
+    expect(res.status).toBe(404);
+    expect(upstreamCalls).toBe(0);
+  });
+});
+
 describe("compaction terminal handling (#422)", () => {
   test("an upstream failure does not become an empty compaction", async () => {
     globalThis.fetch = (async () => jsonResponse({

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mapReasoningEffort } from "../src/reasoning-effort";
-import { NoEnabledOpenAiProviderError, routeModel } from "../src/router";
+import { NoEnabledOpenAiProviderError, routeCompactionModel, routeModel } from "../src/router";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 
 describe("routeModel registry effort defaults", () => {
@@ -697,5 +697,78 @@ describe("routeModel blocked model redirect", () => {
       reason: "blocked-model-redirect",
     });
     expect(routed.routeDecision?.requestedModel).toBe("side/gpt-5.6-terra");
+  });
+});
+
+describe("routeCompactionModel (#2901)", () => {
+  const ghcpOnly: OcxConfig = {
+    port: 10100,
+    defaultProvider: "github-copilot",
+    providers: {
+      "github-copilot": {
+        adapter: "openai-chat",
+        baseUrl: "https://api.githubcopilot.com",
+        authMode: "key",
+        apiKey: "ghu_test",
+        models: ["gpt-5.6-sol", "claude-opus-4-6"],
+      },
+    },
+    codexAccountNamespaces: { side: "side-account-id" },
+  };
+
+  test("falls back to the configured default provider only on the compaction surface", () => {
+    // Ordinary turns keep today's reservation: a bare native id without canonical openai is terminal.
+    expect(() => routeModel(ghcpOnly, "gpt-5.6-sol")).toThrow(NoEnabledOpenAiProviderError);
+    expect(routeCompactionModel(ghcpOnly, "gpt-5.6-sol")).toMatchObject({
+      providerName: "github-copilot",
+      modelId: "gpt-5.6-sol",
+      routeKind: "default-provider",
+      routeReason: "compaction-default-provider",
+    });
+    expect(routeCompactionModel(ghcpOnly, "gpt-5.6-sol").routeDecision?.selected).toMatchObject({
+      provider: "github-copilot",
+      model: "gpt-5.6-sol",
+      reason: "compaction-default-provider",
+    });
+  });
+
+  test("keeps exact account selectors and canonical-openai configs unchanged", () => {
+    // An account-qualified native selector names a credential; it must stay fail-closed.
+    expect(() => routeCompactionModel(ghcpOnly, "side/gpt-5.6-sol")).toThrow(NoEnabledOpenAiProviderError);
+    // With canonical openai enabled the compaction route is identical to the ordinary one.
+    const withOpenAi: OcxConfig = {
+      ...ghcpOnly,
+      providers: {
+        ...ghcpOnly.providers,
+        openai: { adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex", authMode: "forward" },
+      },
+    };
+    expect(routeCompactionModel(withOpenAi, "gpt-5.6-sol")).toMatchObject({
+      providerName: "openai",
+      routeReason: "native-family",
+    });
+    // Same destination as the ordinary router; the decision trace carries a fresh id/timestamp.
+    const { routeDecision: _a, ...compactionRoute } = routeCompactionModel(withOpenAi, "gpt-5.6-sol");
+    const { routeDecision: _b, ...ordinaryRoute } = routeModel(withOpenAi, "gpt-5.6-sol");
+    expect(compactionRoute).toEqual(ordinaryRoute);
+  });
+
+  test("does not resurrect a disabled, missing, or legacy default provider", () => {
+    const disabledDefault: OcxConfig = {
+      ...ghcpOnly,
+      providers: { "github-copilot": { ...ghcpOnly.providers["github-copilot"]!, disabled: true } },
+    };
+    expect(() => routeCompactionModel(disabledDefault, "gpt-5.6-sol")).toThrow(NoEnabledOpenAiProviderError);
+    const missingDefault: OcxConfig = { ...ghcpOnly, defaultProvider: "nowhere" };
+    expect(() => routeCompactionModel(missingDefault, "gpt-5.6-sol")).toThrow(NoEnabledOpenAiProviderError);
+    const openAiDefaultDisabled: OcxConfig = {
+      ...ghcpOnly,
+      defaultProvider: "openai",
+      providers: {
+        ...ghcpOnly.providers,
+        openai: { adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex", authMode: "forward", disabled: true },
+      },
+    };
+    expect(() => routeCompactionModel(openAiDefaultDisabled, "gpt-5.6-sol")).toThrow(NoEnabledOpenAiProviderError);
   });
 });


### PR DESCRIPTION
## Summary

- Closes #2901. Codex names a bare OpenAI-family model (`gpt-5.6-sol`, ...) for its compaction turns regardless of which provider the operator routes ordinary turns to. `routeModel` reserves those ids for the canonical `openai` provider, so a GitHub Copilot-only (or any non-OpenAI-only) operator received 404 on every compaction even though the `routedCompaction` summarizer bridge in `core.ts` could already serve them.
- Adds `routeCompactionModel` in `src/router.ts`: identical to `routeModel` except that, when the bare-native branch has no enabled canonical `openai` provider, it may land on `config.defaultProvider` (own provider, enabled, not an OpenAI-family entry) with `routeReason: "compaction-default-provider"`. Ordinary `routeModel` is untouched.
- Wires it into both compaction entrypoints: v1 `POST /v1/responses/compact` (`compact.ts`) and the initial v2 `compaction_trigger` route in `handleResponsesInner` (`core.ts`). Combo attempts, later fallback/recovery re-routes, ordinary turns, and account-qualified selectors (`side/gpt-*`) keep today's behaviour. No new config key; configurations with an enabled canonical `openai` provider are byte-for-byte unchanged.
- One `console.warn` per provider id when the fallback engages; the message carries only the operator-configured provider id, no request content or model strings from the caller.
- Docs: `docs-site/src/content/docs/reference/proxy-formats.md` compaction section documents the fallback and its limits. Plan/audit notes under `devlog/_plan/260902_nonbug_adoption_backlog/`.

## Verification

- `bun x tsc --noEmit` — clean.
- `bun test tests/router.test.ts tests/responses-compaction-routing.test.ts tests/responses-compaction.test.ts` — 107 pass / 0 fail. New coverage: `routeCompactionModel (#2901)` (fallback only via the helper; `side/gpt-5.6-sol` still throws; disabled/missing/legacy default still throws; canonical-openai config identical to `routeModel`) and `bare native compaction model without canonical openai (#2901)` (v2 trigger → 200 with summarizer prompt and no trigger leaked to the gateway; v1 compact → 200; ordinary turn on the same config still 404; account-qualified selector still 404).
- `bun run privacy:scan` — passed.
- Full suite intentionally left to CI per maintainer instruction (no local full suite this campaign).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No credential path touched; account-qualified native selectors remain fail-closed; the new log line contains only the operator-configured provider id.)

