### PR TITLE
feat(anthropic): add claude-fable-5-1 with official Fable 5.1 pricing

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -336,8 +336,10 @@ export type ProviderConfigSeed = Pick<
 // same static model seed.
 // 260710 context refresh: Tier-2 evidence in
 // devlog/_plan/260710_provider_hardening/001_research_frontier.md.
-const ANTHROPIC_MODELS = ["claude-fable-5", "claude-sonnet-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
-const ANTHROPIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = { "claude-sonnet-5": 1_000_000, "claude-fable-5": 1_000_000, "claude-opus-5": 1_000_000, "claude-opus-4-8": 1_000_000, "claude-opus-4-7": 1_000_000, "claude-opus-4-6": 1_000_000, "claude-sonnet-4-6": 1_000_000, "claude-haiku-4-5": 200_000 };
+// 260902 Claude Fable 5.1 (`claude-fable-5-1`): 1M context / 128K output / adaptive thinking
+// always on, per the official models overview and pricing page (platform.claude.com).
+const ANTHROPIC_MODELS = ["claude-fable-5-1", "claude-fable-5", "claude-sonnet-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
+const ANTHROPIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = { "claude-fable-5-1": 1_000_000, "claude-sonnet-5": 1_000_000, "claude-fable-5": 1_000_000, "claude-opus-5": 1_000_000, "claude-opus-4-8": 1_000_000, "claude-opus-4-7": 1_000_000, "claude-opus-4-6": 1_000_000, "claude-sonnet-4-6": 1_000_000, "claude-haiku-4-5": 200_000 };
 
 // 260814 GLM-5.3 is registered pre-emptively alongside 5.2 everywhere 5.2 appears. Z.AI's
 // devpack "How to Switch Models" page (docs.z.ai/devpack/latest-model) lists glm-5.3 and

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -66,6 +66,10 @@ const QWEN38_MAX: Cost4 = { input: 2, output: 6, cacheRead: 0, cacheWrite: 0 };
 // Anthropic official list prices (USD / 1M tokens). Cache write uses the published 5-minute rate.
 const CLAUDE_SONNET_46: Cost4 = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 };
 const CLAUDE_OPUS_46: Cost4 = { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 };
+// Claude Fable 5.1: 10 / 50, 5m cache write 12.50. Cache hits are 0.025x base input
+// (0.25) on Fable 5.1 — NOT the 0.1x (1.00) that Fable 5 and every other family use;
+// the pricing page footnote calls this out explicitly. Verified 2026-09-02.
+const CLAUDE_FABLE_51: Cost4 = { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 };
 // Opus 5 is priced from the maintainer's confirmation that it matches the previous
 // Opus, not from a published Opus 5 page. Hence `verified-derived`, and a source
 // string that states the provenance instead of pointing at ANTHROPIC_PRICING.
@@ -91,6 +95,11 @@ const KIMI_PRICING = "https://platform.kimi.ai/docs/pricing (official table; cac
 const QWEN38_MAX_PRICING = "https://qwen.ai/blog?id=qwen3.8 (Qwen release announcement; no Model Studio billing row yet; cache rates unpublished -> 0)";
 
 export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
+  // claude-fable-5-1 has no jawcode row yet, so both Anthropic surfaces need their own
+  // overlay (the overlay lookup is keyed by the configured provider id; only the jawcode
+  // bundle collapses anthropic-apikey onto anthropic).
+  { provider: "anthropic", modelId: "claude-fable-5-1", cost4: CLAUDE_FABLE_51, source: `anthropic official Claude Fable 5.1 ${ANTHROPIC_PRICING}; cache hit = 0.025x base input`, verifiedAt: "2026-09-02", status: "verified" },
+  { provider: "anthropic-apikey", modelId: "claude-fable-5-1", cost4: CLAUDE_FABLE_51, source: `anthropic official Claude Fable 5.1 ${ANTHROPIC_PRICING}; cache hit = 0.025x base input`, verifiedAt: "2026-09-02", status: "verified" },
   // claude-opus-5 is exposed by three providers but absent from the jawcode bundle, so
   // cost resolution returned null and the Logs `~$` column rendered an em dash. The
   // model-level vendor fallback only searches jawcode metadata, never overlays, so one

--- a/tests/anthropic-hardening.test.ts
+++ b/tests/anthropic-hardening.test.ts
@@ -125,6 +125,7 @@ describe("anthropic provider hardening", () => {
 
     expect(anthropic?.modelContextWindows?.["claude-opus-4-8"]).toBe(1_000_000);
     expect(anthropic?.modelContextWindows?.["claude-opus-5"]).toBe(1_000_000);
+    expect(anthropic?.modelContextWindows?.["claude-fable-5-1"]).toBe(1_000_000);
     expect(anthropic?.modelContextWindows?.["claude-haiku-4-5"]).toBe(200_000);
   });
 });

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -737,6 +737,7 @@ describe("provider registry parity", () => {
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.defaultModel).toBe("claude-sonnet-5");
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.models).toContain("claude-sonnet-5");
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.models).toContain("claude-fable-5");
+    expect(OAUTH_PROVIDERS.anthropic.providerConfig.models).toContain("claude-fable-5-1");
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.["claude-sonnet-5"]).toBe(1_000_000);
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.["claude-opus-4-7"]).toBe(1_000_000);
     expect(OAUTH_PROVIDERS.anthropic.providerConfig.modelContextWindows?.["claude-opus-4-6"]).toBe(1_000_000);

--- a/tests/usage-cost.test.ts
+++ b/tests/usage-cost.test.ts
@@ -176,6 +176,29 @@ describe("resolveMatchedPrice", () => {
     expect(price!.cost4).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
   });
 
+  // Claude Fable 5.1 (2026-09-02): 10 / 50 / 12.50 cache write, and a cache-hit rate of
+  // 0.025x base input (0.25) rather than the 0.1x every other family uses. There is no
+  // jawcode row yet, so both Anthropic surfaces resolve from the shipped overlay; an
+  // account-pool log label must collapse onto the same price.
+  test("claude-fable-5-1 resolves to the official Fable 5.1 price on both Anthropic surfaces", () => {
+    const COST4 = { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 };
+    for (const provider of ["anthropic", "anthropic-apikey"]) {
+      const price = resolveMatchedPrice(provider, "claude-fable-5-1");
+      expect(price, provider).toMatchObject({
+        provider,
+        modelId: "claude-fable-5-1",
+        cost4: COST4,
+        source: "expected",
+        status: "verified",
+      });
+      expect(price?.sourceRef).toContain("platform.claude.com");
+      expect(price?.sourceRef).toContain("0.025x");
+    }
+    expect(resolveMatchedPrice("anthropic-pb51d9b", "claude-fable-5-1")?.cost4).toEqual(COST4);
+    // The cheaper cache-hit rate must not leak onto Fable 5, which stays at 0.1x.
+    expect(resolveMatchedPrice("anthropic", "claude-fable-5")?.cost4.cacheRead).toBe(1);
+  });
+
   test("17b. model-level fallback: openai provider gets gpt prices from the openai bundle", () => {
     const price = resolveMatchedPrice("openai", "gpt-5.5");
     expect(price).not.toBeNull();
@@ -269,11 +292,13 @@ describe("resolveMatchedPrice", () => {
     expect(resolveMatchedPrice("openrouter", "anthropic-claude-3.5-sonnet")).toBeNull();
   });
 
-  test("16. shipped overlay membership: 56 keys, including Opus 5 and compatibility prices", () => {
-    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(56);
+  test("16. shipped overlay membership: 58 keys, including Fable 5.1, Opus 5 and compatibility prices", () => {
+    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(58);
     expect(EXPECTED_PRICE_OVERLAYS.some(row => row.status === "unverified")).toBe(false);
     const keys = new Set(EXPECTED_PRICE_OVERLAYS.map(row => `${row.provider}/${row.modelId}`));
     for (const expected of [
+      "anthropic/claude-fable-5-1",
+      "anthropic-apikey/claude-fable-5-1",
       "anthropic/claude-opus-5",
       "cursor/claude-opus-5",
       "kiro/claude-opus-5",


### PR DESCRIPTION
## Summary

Claude Fable 5.1 shipped on 2026-09-02. This registers the new model id and ships its official price so the Logs / usage `~$` column prices it instead of rendering an em dash.

- `src/providers/registry.ts`: add `claude-fable-5-1` to `ANTHROPIC_MODELS` (both the `anthropic` OAuth and `anthropic-apikey` surfaces spread this list) with a 1,000,000 context window. `defaultModel` is unchanged (`claude-sonnet-5`).
- `src/usage/expected-prices.ts`: new `CLAUDE_FABLE_51` tuple — **$10 input / $50 output / $12.50 5-minute cache write / $0.25 cache hit** (USD per 1M tokens) — with `verified` overlay rows for `anthropic` and `anthropic-apikey` (`verifiedAt: 2026-09-02`). Two rows are needed because the overlay lookup is keyed by the configured provider id and there is no jawcode/models.dev row for this model yet; only the jawcode bundle collapses `anthropic-apikey` onto `anthropic`.
- Note the cache-hit rate: the pricing page footnote says cache hits and refreshes on Claude Fable 5.1 (and Mythos 5.1) are priced at **0.025x** base input, not the standard 0.1x. So `cacheRead` is 0.25, while Fable 5 stays at 1.00. The regression test asserts both so the cheaper rate cannot leak onto Fable 5.
- Not touched: Cursor / Kiro / Antigravity catalogs (none of those providers expose Fable 5.1 yet), the adaptive-thinking table in `src/adapters/anthropic.ts` (the `fable` family entry already covers 5.1 via `claudeFamilyVersion`), and Claude Mythos 5.1 (limited availability, not in the registry).

Source: https://platform.claude.com/docs/en/about-claude/pricing and https://platform.claude.com/docs/en/about-claude/models/overview (API id `claude-fable-5-1`, 1M context, 128K max output, adaptive thinking always on), read in a signed-in browser session on 2026-09-02.

## Verification

- `bun test tests/usage-cost.test.ts tests/anthropic-hardening.test.ts tests/provider-registry-parity.test.ts` — 130 pass / 0 fail. Includes the new `claude-fable-5-1 resolves to the official Fable 5.1 price on both Anthropic surfaces` test (exact overlay on `anthropic` + `anthropic-apikey`, account-pool log label `anthropic-pb51d9b` collapsing onto the same price, Fable 5 cache-hit still 1.00), overlay membership bumped 56 → 58, and the registry/context-window assertions.
- `bun -e` smoke: `resolveMatchedPrice("anthropic" | "anthropic-apikey", "claude-fable-5-1")` returns `{ input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 }`, `source: "expected"`, `status: "verified"`.
- The full local suite and CI were intentionally not awaited before merging, per maintainer instruction for this pricing hotfix; the change is data-only (registry list, one price tuple, tests).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Not needed: model catalog and pricing data only, no user-facing docs change.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (None touched: no auth, credentials, workflows, or release automation; `privacy:scan`-safe.)

