### PR TITLE
feat(codex): opt-in authless Codex Desktop routing mode (#1107)

### DIFF
--- a/devlog/_plan/260902_nonbug_adoption_backlog/060_wp6_authless_desktop.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/060_wp6_authless_desktop.md
@@ -1,0 +1,89 @@
+# wp6 — #1107 opt-in authless Codex Desktop routing mode
+
+Issue #1107 (score 71, enhancement/account-pool). No PR. Investigation by grok subagent (Hume) with
+file:line evidence; see 061 for the audit.
+
+## Facts that bound the design
+
+- Loopback injection today is Design B (root `openai_base_url`); Codex keeps its built-in `openai`
+  provider so Desktop's ChatGPT OAuth gate applies. Non-loopback injects the dedicated
+  `[model_providers.opencodex]` table with `requires_openai_auth = true` + `env_key`
+  (`src/codex/inject.ts:942-960`).
+- Codex Desktop honors `requires_openai_auth = false` on a dedicated custom provider (issue
+  diagnostic, confirmed by maintainer). There is no verified authless knob for the built-in provider;
+  do not invent one.
+- `injectCodexConfig` already strips every prior form before re-injecting (`:920-930`), and
+  `removeCodexConfig`/`restoreNativeCodex` strip the table + root re-tag + injected base url. So
+  a third loopback form is reconciled and restored by existing code.
+- Catalog: both forms write the same `model_catalog_json`; entries are slug-based, not
+  provider-tagged (`src/codex/catalog/sync.ts:286`). The "empty picker" in the issue's diagnostic is
+  the Desktop renderer's native-only allowlist (documented in `guides/codex-app-models.md` §Desktop
+  remote servers, upstream openai/codex#19694), which applies regardless of our form. Not fixable
+  here; documented, with the same workaround (`model = "<provider>/<id>"` in config.toml).
+- History: legacy provider mode runs the `apply-opencodex` history op (threads visible under the
+  `opencodex` provider); restore runs `migrate-openai`. The authless mode reuses the legacy
+  history semantics since threads are tagged `opencodex` exactly like non-loopback.
+
+## Design
+
+Config key (top-level, flat, next to the other Codex-injection switches):
+
+```json
+{ "codexDesktopAuthless": true }
+```
+
+- `src/types/config.ts`: `codexDesktopAuthless?: boolean` (doc: opt-in; loopback only; default off).
+- `src/config.ts`: `codexDesktopAuthless: z.boolean().optional().catch(undefined)` (degrade-safe
+  like `syncCodexSubagentDefaults`).
+- `src/codex/inject.ts`:
+  - `CodexRoutingTarget` gains optional `desktopAuthless?: boolean`.
+  - `standaloneCodexRoutingTarget` sets `desktopAuthless: config.codexDesktopAuthless === true &&
+    !requiresAdmissionToken`. Non-loopback (admission token required) never becomes authless; the
+    `env_key` line and `requires_openai_auth = true` stay. Client-connect targets
+    (`src/client/connect.ts`) are untouched.
+  - `buildProviderTableBlockForTarget`: `requires_openai_auth = ${target.desktopAuthless ? "false" : "true"}`;
+    `env_key` only when `requiresAdmissionToken` (unchanged).
+  - `injectCodexConfig`: `const providerTableMode = routingTarget.requiresAdmissionToken ||
+    routingTarget.desktopAuthless === true;` replaces `legacyMode` as the branch selector for
+    root re-tag + table, profile shape, journal `injectedOpenaiBaseUrl`, history op, and headline
+    (authless headline names the mode).
+  - `buildProfileFileForTarget`: same selector so the fallback profile mirrors the live form.
+- `src/server/management/config-routes.ts` `/api/settings`: GET returns
+  `codexDesktopAuthless: config.codexDesktopAuthless === true`; PUT accepts boolean, `false`
+  deletes the key, rollback on save failure; a change triggers `convergeCodexCatalog()` so the
+  next inject rewrites config.toml (same pattern as the account picker).
+- `src/cli/system-command.ts`: `ocx system settings --desktop-authless <on|off>` → PUT.
+- Docs: `guides/codex-integration.md` new subsection "Authless Codex Desktop (opt-in)" after the
+  dedicated-provider paragraph; `reference/configuration/server.md` table row. English only.
+
+## Acceptance
+
+- Default (key absent/false): byte-identical injection output to today (existing Design B and
+  non-loopback tests untouched and green).
+- Loopback + opt-in: config.toml has `model_provider = "opencodex"`, the table with
+  `requires_openai_auth = false`, no `env_key`, no root `openai_base_url`; `model_catalog_json`
+  still written; re-inject idempotent; fallback profile has the same shape.
+- Switching opt-in → off then re-inject restores Design B (root `openai_base_url`, no table);
+  `restoreNativeCodex` strips the authless form.
+- Non-loopback + opt-in: still `requires_openai_auth = true` and `env_key` (admission unchanged).
+- User-owned root `openai_base_url` is still respected in authless mode? — No: in provider-table
+  mode the root key is not ours to manage and `model_provider = "opencodex"` wins routing, matching
+  today's non-loopback behavior. The existing "user-owned" warning applies to Design B only.
+- `/api/settings` round-trips; CLI flag sends the PUT.
+- Focused: `tests/codex-inject.test.ts`, `tests/codex-inject-integration.test.ts`,
+  `tests/settings-stream-mode.test.ts`, `tests/cli-headless-parity.test.ts`; tsc; privacy.
+
+## Files
+
+- src/types/config.ts, src/config.ts, src/codex/inject.ts,
+  src/server/management/config-routes.ts, src/cli/system-command.ts,
+  docs-site/src/content/docs/guides/codex-integration.md,
+  docs-site/src/content/docs/reference/configuration/server.md,
+  tests/codex-inject.test.ts, tests/codex-inject-integration.test.ts,
+  tests/settings-stream-mode.test.ts, tests/cli-headless-parity.test.ts.
+
+## Closure
+
+PR to dev, `Closes #1107`. Close comment names the key, the CLI flag, the non-loopback guarantee,
+and the documented picker caveat.
+

--- a/devlog/_plan/260902_nonbug_adoption_backlog/061_wp6_audit_r1_synthesis.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/061_wp6_audit_r1_synthesis.md
@@ -1,0 +1,21 @@
+# wp6 audit r1 — synthesis
+
+Reviewer: grok-4.6 subagent (Hume), read-only investigation of #1107 against this tree. Verdict
+carried as **near-pass**: the dedicated-provider injector can host the mode; the residual risks are
+product, not code.
+
+Findings folded into 060:
+1. Catalog rows are slug-based and identical for both forms; the empty picker is Desktop's own
+   native-only allowlist (upstream #19694). Documented with the existing `model =` workaround; not
+   an injection bug and not solvable here.
+2. `requires_openai_auth = false` also darkens ChatGPT-gated Fast/account/usage chrome. Documented
+   as an expected cost of the mode.
+3. Restore/strip paths already handle the table (`removeOcxSection`, `stripOpencodexConfig`).
+   Disable → next inject is Design B again. Threads created while enabled stay tagged
+   `opencodex`; the legacy history op (apply/migrate) is reused.
+4. Key precedent: flat top-level boolean with `.catch(undefined)`; PATCH on `/api/settings`.
+   Subagent suggested no CLI flag; overruled — the user constraint is "opt-in must be easy", so
+   `ocx system settings --desktop-authless` is added.
+5. Non-loopback must never lose `env_key`: enforced by deriving `desktopAuthless` only when
+   `requiresAdmissionToken` is false.
+

--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -192,6 +192,48 @@ provider advertises `supports_websockets = true` only when `"websockets": true`;
 built-in provider may try WebSocket first, and a disabled proxy returns `426` so Codex falls back to
 HTTP/SSE.
 
+### Authless Codex Desktop (opt-in)
+
+Codex Desktop shows its ChatGPT login screen whenever the active provider requires OpenAI auth. If
+your OpenCodex setup never uses ChatGPT credentials (routed providers only, or a blocked
+`chatgpt.com`), you can opt out of that gate:
+
+```bash
+ocx system settings --desktop-authless on    # or "codexDesktopAuthless": true in config.json
+ocx sync                                     # rewrites ~/.codex/config.toml; restart Desktop
+```
+
+With the switch on, a loopback bind injects the dedicated provider form instead of the root
+`openai_base_url` override:
+
+```toml
+model_provider = "opencodex"
+
+[model_providers.opencodex]
+name = "OpenCodex Proxy"
+base_url = "http://127.0.0.1:10100/v1"
+wire_api = "responses"
+requires_openai_auth = false
+```
+
+Desktop then starts without a login and routes every turn through the proxy. The setting survives
+`ocx start`, restart, `ocx sync`, and `ocx ensure`; turning it off (`--desktop-authless off`) makes the
+next sync restore the default loopback form, and `ocx restore` strips it like any other injected
+routing. What to expect while it is on:
+
+- ChatGPT-gated Desktop chrome (account, usage, Fast mode) stays dark: Codex derives those surfaces
+  from the provider's auth requirement.
+- New threads are tagged with the `opencodex` provider, as on a non-loopback bind, and history is
+  handled the same way.
+- Desktop releases that filter the model picker against a native-only allowlist may show an empty
+  or `Custom` picker in this mode as well; requests still use the configured model. Set
+  `model = "<provider>/<id>"` in `config.toml` as described in
+  [Desktop remote servers](/guides/codex-app-models/#desktop-remote-servers).
+
+This only changes the Desktop login gate. Non-loopback binds keep `requires_openai_auth = true` and
+the `env_key` admission credential regardless of the switch; it never exposes an OpenCodex listener
+without authentication.
+
 ## Thread identity and history
 
 The default loopback form keeps new threads tagged with Codex's native `openai` provider, so normal

--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -26,6 +26,7 @@ runs helper features around provider requests.
 | `appOwnedMemoryBudgetMb?` | `number` | `256` | Cap in MiB for evictable app-owned logs, caches, blobs, and continuation payloads. Range 64–4096; not an RSS cap. |
 | `codexAutoStart?` | `boolean` | `true` | Let the Codex shim run `ocx ensure` before launching Codex. False makes ensure a no-op. |
 | `codexShimAutoRestore?` | `boolean` | `true` | Restore an installed shim after a completed external Codex update replaces it. Environment opt-out: `OPENCODEX_CODEX_SHIM_AUTO_RESTORE=0`. |
+| `codexDesktopAuthless?` | `boolean` | `false` | Opt-in authless Codex Desktop routing on a loopback bind: inject the dedicated `opencodex` provider with `requires_openai_auth = false` so Desktop opens without a ChatGPT login. Ignored on non-loopback binds. `ocx system settings --desktop-authless on`. See [Codex integration](/guides/codex-integration/#authless-codex-desktop-opt-in). |
 | `syncResumeHistory?` | `boolean` | `true` | Reversible Codex App history compatibility. Original metadata is backed up and restored by `ocx stop` / `ocx restore`. |
 | `shadowCallIntercept?` | `{ enabled?: boolean; model?: string; sourceModels?: string[] }` | off | Redirect recognized Codex helper/shadow calls to a chosen model while preserving the request's configured reasoning effort. The default source prefix is `gpt-5.6-luna`; older clients through 0.144.x used `gpt-5.4-mini`, which `sourceModels` can restore. |
 | `webSearchSidecar?` | `OcxWebSearchSidecarConfig` | on when usable | Web-search sidecar options. |

--- a/src/cli/system-command.ts
+++ b/src/cli/system-command.ts
@@ -13,7 +13,8 @@ import {
 
 const USAGE = `Usage:
   ocx system [status] [--json]
-  ocx system settings [--auto-start <on|off>] [--stream-mode <auto|legacy-tee|eager-relay>] [--json]
+  ocx system settings [--auto-start <on|off>] [--stream-mode <auto|legacy-tee|eager-relay>]
+      [--desktop-authless <on|off>] [--json]
   ocx system startup <health|install-service|install-shim> [--json]
   ocx system diagnostics [--json]
   ocx system sync [--json]
@@ -42,13 +43,18 @@ async function settings(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   const wantsJson = takeFlag(args, "--json");
   const autoStart = takeBooleanOption(args, "--auto-start");
   const streamMode = takeOption(args, "--stream-mode");
+  const desktopAuthless = takeBooleanOption(args, "--desktop-authless");
   rejectArgs(args, USAGE);
-  if (autoStart === undefined && streamMode === undefined) {
+  if (autoStart === undefined && streamMode === undefined && desktopAuthless === undefined) {
     const result = await runtimeRequest("/api/settings", {}, deps);
     printData(result, wantsJson, summaryLines(result));
     return;
   }
-  const body = { ...(autoStart !== undefined ? { codexAutoStart: autoStart } : {}), ...(streamMode !== undefined ? { streamMode } : {}) };
+  const body = {
+    ...(autoStart !== undefined ? { codexAutoStart: autoStart } : {}),
+    ...(streamMode !== undefined ? { streamMode } : {}),
+    ...(desktopAuthless !== undefined ? { codexDesktopAuthless: desktopAuthless } : {}),
+  };
   const result = await runtimeRequest("/api/settings", { method: "PUT", body: JSON.stringify(body) }, deps);
   printData(result, wantsJson, ["System settings updated."]);
 }

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -148,6 +148,13 @@ export interface CodexRoutingTarget {
   baseUrl: string;
   requiresAdmissionToken: boolean;
   tokenEnv: "OPENCODEX_API_AUTH_TOKEN";
+  /**
+   * Opt-in authless Codex Desktop mode (#1107): inject the dedicated provider table with
+   * `requires_openai_auth = false` so Desktop skips the ChatGPT login gate. Only ever true for
+   * loopback targets that need no admission token; non-loopback admission is a separate layer
+   * and is never weakened by this flag.
+   */
+  desktopAuthless?: boolean;
 }
 
 function validateCodexRoutingTarget(target: CodexRoutingTarget): CodexRoutingTarget {
@@ -171,17 +178,26 @@ function validateCodexRoutingTarget(target: CodexRoutingTarget): CodexRoutingTar
   return { ...target, baseUrl: `${parsed.origin}/v1` };
 }
 
+/** Provider-table form is used for non-loopback admission and for the authless Desktop opt-in. */
+function usesProviderTable(target: CodexRoutingTarget): boolean {
+  return target.requiresAdmissionToken || target.desktopAuthless === true;
+}
+
 export function standaloneCodexRoutingTarget(
   port: number,
-  config?: Pick<OcxConfig, "hostname" | "unauthenticatedLoopbackListener">,
+  config?: Pick<OcxConfig, "hostname" | "unauthenticatedLoopbackListener" | "codexDesktopAuthless">,
 ): CodexRoutingTarget {
   const loopback = config?.unauthenticatedLoopbackListener;
   const effectivePort = loopback?.enabled ? loopback.port : port;
   const hostname = loopback?.enabled ? undefined : config?.hostname;
+  const requiresAdmissionToken = loopback?.enabled ? false : shouldInjectApiAuthHeader(config);
   return {
     baseUrl: `http://${providerBaseHost(hostname)}:${effectivePort}/v1`,
-    requiresAdmissionToken: loopback?.enabled ? false : shouldInjectApiAuthHeader(config),
+    requiresAdmissionToken,
     tokenEnv: "OPENCODEX_API_AUTH_TOKEN",
+    ...(config?.codexDesktopAuthless === true && !requiresAdmissionToken
+      ? { desktopAuthless: true }
+      : {}),
   };
 }
 
@@ -296,7 +312,8 @@ function buildProviderTableBlockForTarget(
     'name = "OpenCodex Proxy"',
     `base_url = ${tomlString(target.baseUrl)}`,
     'wire_api = "responses"',
-    "requires_openai_auth = true",
+    // false only in the authless Desktop opt-in (#1107); true keeps the App/TUI account gate.
+    `requires_openai_auth = ${target.desktopAuthless === true ? "false" : "true"}`,
   ];
   if (target.requiresAdmissionToken) {
     // codex-cli 0.146+ contract (#2073): env_key sends Authorization: Bearer $VAR and
@@ -775,8 +792,8 @@ function buildProfileFileForTarget(
   const host = new URL(origin).host;
   // Design B (loopback): the reference/fallback file documents the root override form.
   // Non-loopback keeps the legacy provider-table shape (built-in provider cannot carry
-  // the x-opencodex-api-key env header).
-  if (!target.requiresAdmissionToken) {
+  // the x-opencodex-api-key env header); the authless Desktop opt-in shares that shape.
+  if (!usesProviderTable(target)) {
     const lines = [
       "# OpenCodex proxy fallback config (Design B)",
       `# Root override that points Codex's built-in openai provider at the proxy on ${host}.`,
@@ -939,11 +956,14 @@ export async function injectCodexConfig(
     ? setRootModelCatalogPath(content, catalogPath)
     : stripOpencodexCatalogPath(content);
 
-  const legacyMode = routingTarget.requiresAdmissionToken;
+  // Provider-table form: non-loopback admission (legacy) or the authless Desktop opt-in (#1107).
+  const legacyMode = usesProviderTable(routingTarget);
   let keptUserBaseUrl = false;
   if (legacyMode) {
     // Legacy (non-loopback) injection: the built-in openai provider cannot carry the
     // x-opencodex-api-key env header, so keep the opencodex provider table + root re-tag.
+    // The authless opt-in needs the same table because only a dedicated provider can carry
+    // requires_openai_auth = false.
     // 1) Root key BEFORE the first table header (must be a global, not nested under a table).
     content = setRootModelProvider(content);
     // 2) Provider table appended at EOF (position-independent).
@@ -1277,9 +1297,11 @@ export async function injectCodexConfig(
         `  Reference config: ${CODEX_PROFILE_PATH}`,
     };
   }
-  const headline = legacyMode
-    ? `Injected opencodex as default provider into Codex config.\n`
-    : `Pointed Codex's built-in openai provider at the opencodex proxy (openai_base_url).\n`;
+  const headline = routingTarget.desktopAuthless === true
+    ? `Injected opencodex as default provider into Codex config (authless Desktop mode: requires_openai_auth = false).\n`
+    : legacyMode
+      ? `Injected opencodex as default provider into Codex config.\n`
+      : `Pointed Codex's built-in openai provider at the opencodex proxy (openai_base_url).\n`;
   return {
     success: true,
     ...(nativeSubagentDefaultsWarning ? { nativeSubagentDefaultsWarning } : {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1053,6 +1053,7 @@ const configSchema = z.object({
     z.array(z.string().trim().min(1)).min(1),
   ).optional().catch(undefined),
   codexShimAutoRestore: z.boolean().optional(),
+  codexDesktopAuthless: z.boolean().optional().catch(undefined),
   pausedCodexAccountIds: z.array(z.string().regex(/^[a-zA-Z0-9._-]{1,64}$/)).optional(),
   codexAccountNamespaces: codexAccountNamespacesSchema.optional(),
   // Selection order is a preference, not a safety control like pause: a malformed

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -306,6 +306,8 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       // Absent means the historical auto-open, so the GUI can render the toggle
       // without having to know that `undefined` and `true` mean the same thing.
       oauthOpenBrowser: config.oauthOpenBrowser !== false,
+      // Absent means off (today's Design B injection), so the GUI/CLI render a plain switch.
+      codexDesktopAuthless: config.codexDesktopAuthless === true,
       startupHealth: await readStartupHealth(config),
       codexRuntime: {
         path: displayCodexRuntimePath(resolved.runtime.command),
@@ -392,14 +394,16 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       codexAccountPickerEnabled?: unknown;
       oauthOpenBrowser?: unknown;
       showCodexSparkQuota?: unknown;
+      codexDesktopAuthless?: unknown;
     };
     if (body.codexAutoStart === undefined
       && body.streamMode === undefined
       && body.appOwnedMemoryBudgetMb === undefined
       && body.codexAccountPickerEnabled === undefined
       && body.oauthOpenBrowser === undefined
-      && body.showCodexSparkQuota === undefined) {
-      return jsonResponse({ error: "provide codexAutoStart, streamMode, appOwnedMemoryBudgetMb, codexAccountPickerEnabled, oauthOpenBrowser, or showCodexSparkQuota" }, 400);
+      && body.showCodexSparkQuota === undefined
+      && body.codexDesktopAuthless === undefined) {
+      return jsonResponse({ error: "provide codexAutoStart, streamMode, appOwnedMemoryBudgetMb, codexAccountPickerEnabled, oauthOpenBrowser, showCodexSparkQuota, or codexDesktopAuthless" }, 400);
     }
     if (body.codexAutoStart !== undefined && typeof body.codexAutoStart !== "boolean") {
       return jsonResponse({ error: "codexAutoStart boolean is required" }, 400);
@@ -416,6 +420,9 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
     }
     if (body.showCodexSparkQuota !== undefined && typeof body.showCodexSparkQuota !== "boolean") {
       return jsonResponse({ error: "showCodexSparkQuota boolean is required" }, 400);
+    }
+    if (body.codexDesktopAuthless !== undefined && typeof body.codexDesktopAuthless !== "boolean") {
+      return jsonResponse({ error: "codexDesktopAuthless boolean is required" }, 400);
     }
     if (body.appOwnedMemoryBudgetMb !== undefined && (
       typeof body.appOwnedMemoryBudgetMb !== "number"
@@ -440,9 +447,12 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       hasOauthOpenBrowser: Object.hasOwn(config, "oauthOpenBrowser"),
       showCodexSparkQuota: config.showCodexSparkQuota,
       hasShowCodexSparkQuota: Object.hasOwn(config, "showCodexSparkQuota"),
+      codexDesktopAuthless: config.codexDesktopAuthless,
+      hasCodexDesktopAuthless: Object.hasOwn(config, "codexDesktopAuthless"),
     };
     const pickerWasEnabled = codexAccountPickerEnabled(config);
     let pickerIsEnabled = pickerWasEnabled;
+    const authlessWasEnabled = config.codexDesktopAuthless === true;
     try {
       if (typeof body.codexAutoStart === "boolean") {
         config.codexAutoStart = body.codexAutoStart;
@@ -469,6 +479,8 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       if (typeof body.showCodexSparkQuota === "boolean") {
         config.showCodexSparkQuota = body.showCodexSparkQuota;
       }
+      if (body.codexDesktopAuthless === true) config.codexDesktopAuthless = true;
+      else if (body.codexDesktopAuthless === false) deleteConfigTopLevelKey(config, "codexDesktopAuthless");
       pickerIsEnabled = codexAccountPickerEnabled(config);
       (deps.saveConfigPreservingClaudeCode ?? saveConfigPreservingClaudeCode)(config);
     } catch (error) {
@@ -491,13 +503,19 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       if (previousSettings.hasShowCodexSparkQuota) {
         config.showCodexSparkQuota = previousSettings.showCodexSparkQuota;
       } else deleteConfigTopLevelKey(config, "showCodexSparkQuota");
+      if (previousSettings.hasCodexDesktopAuthless) {
+        config.codexDesktopAuthless = previousSettings.codexDesktopAuthless;
+      } else deleteConfigTopLevelKey(config, "codexDesktopAuthless");
       throw error;
     }
     if (typeof body.appOwnedMemoryBudgetMb === "number") {
       configureAppOwnedMemoryBudget(resolveAppOwnedMemoryBudgetBytes(body.appOwnedMemoryBudgetMb));
       enforceAppOwnedMemoryBudget();
     }
-    const catalogRefresh = pickerWasEnabled !== pickerIsEnabled
+    // The authless switch changes the injected config.toml shape, so converge now rather than
+    // waiting for the next start; the injector re-reads config and rewrites the form.
+    const authlessIsEnabled = config.codexDesktopAuthless === true;
+    const catalogRefresh = pickerWasEnabled !== pickerIsEnabled || authlessWasEnabled !== authlessIsEnabled
       ? await convergeCodexCatalog()
       : undefined;
     const catalogRefreshPending = catalogRefresh
@@ -513,6 +531,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
       oauthOpenBrowser: config.oauthOpenBrowser !== false,
       catalogRefreshPending,
       showCodexSparkQuota: config.showCodexSparkQuota === true,
+      codexDesktopAuthless: authlessIsEnabled,
       startupHealth: await readStartupHealth(config),
     });
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -631,6 +631,13 @@ export interface OcxConfig {
   /** Restore an installed shim after a stable external Codex update replaces it. Default true. */
   codexShimAutoRestore?: boolean;
   /**
+   * Opt-in authless Codex Desktop routing (#1107). On a loopback bind, inject the dedicated
+   * `[model_providers.opencodex]` table with `requires_openai_auth = false` instead of the root
+   * `openai_base_url` override, so Desktop opens without a ChatGPT login. Default off; ignored on
+   * non-loopback binds, whose admission token contract is unchanged.
+   */
+  codexDesktopAuthless?: boolean;
+  /**
    * Compatibility mode: temporarily rewrite Codex resume-history metadata while the proxy is active
    * so Codex App can show old OpenAI chats and opencodex-created exec chats under its default
    * interactive-source/provider filters. Default true; originals are backed up and restored by

--- a/tests/codex-inject-integration.test.ts
+++ b/tests/codex-inject-integration.test.ts
@@ -701,6 +701,59 @@ describe("injectCodexConfig integration (Design B)", () => {
     expect(readFileSync(join(codexHome, "config.toml"), "utf8")).toBe(original);
   });
 
+  test("authless Desktop opt-in (#1107): loopback injects the table with requires_openai_auth = false, idempotently", () => {
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+
+    const r = runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true }));
+    expect(r.status).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload.success).toBe(true);
+    expect(String(payload.message)).toContain("authless Desktop mode");
+
+    const first = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(first).toContain('model_provider = "opencodex"');
+    expect(first).toContain("[model_providers.opencodex]");
+    expect(first).toContain('base_url = "http://127.0.0.1:10100/v1"');
+    expect(first).toContain("requires_openai_auth = false");
+    expect(first).not.toContain("env_key");
+    expect(first).not.toContain("openai_base_url");
+
+    expect(runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true })).status).toBe(0);
+    expect(readFileSync(join(codexHome, "config.toml"), "utf8")).toBe(first);
+    expect(readFileSync(join(codexHome, "opencodex.config.toml"), "utf8")).toContain("requires_openai_auth = false");
+  });
+
+  test("authless Desktop opt-in: turning it off restores Design B on the next inject, and restore strips it", () => {
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+
+    expect(runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true })).status).toBe(0);
+    expect(readFileSync(join(codexHome, "config.toml"), "utf8")).toContain("requires_openai_auth = false");
+
+    expect(runInject(codexHome, ocxHome).status).toBe(0);
+    const back = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(back).toContain('openai_base_url = "http://127.0.0.1:10100/v1"');
+    expect(back).not.toContain("[model_providers.opencodex]");
+    expect(back).not.toContain('model_provider = "opencodex"');
+    expect(back.match(/Auto-injected by opencodex/g)?.length).toBe(1);
+
+    expect(runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true })).status).toBe(0);
+    expect(runRestore(codexHome, ocxHome).status).toBe(0);
+    const restored = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(restored).not.toContain("opencodex");
+    expect(restored).toContain('model = "gpt-5.5"');
+  });
+
+  test("authless Desktop opt-in never weakens non-loopback admission", () => {
+    writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+
+    const r = runInject(codexHome, ocxHome, JSON.stringify({ hostname: "192.168.1.20", codexDesktopAuthless: true }));
+    expect(r.status).toBe(0);
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain("requires_openai_auth = true");
+    expect(config).toContain('env_key = "OPENCODEX_API_AUTH_TOKEN"');
+    expect(config).not.toContain("requires_openai_auth = false");
+  });
+
   test("non-loopback hostname still uses the legacy provider-table injection", () => {
     writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
 

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -28,6 +28,46 @@ describe("Codex config injection", () => {
     );
   });
 
+  describe("authless Codex Desktop opt-in (#1107)", () => {
+    test("default target on loopback stays Design B and byte-identical", () => {
+      const target = standaloneCodexRoutingTarget(10100, {});
+      expect(target.desktopAuthless).toBeUndefined();
+      expect(buildProfileFile(target, null)).toBe(buildProfileFile(10100, null));
+      expect(buildProviderTableBlock(target)).toContain("requires_openai_auth = true");
+    });
+
+    test("loopback opt-in emits the provider table with requires_openai_auth = false and no env_key", () => {
+      const target = standaloneCodexRoutingTarget(10100, { codexDesktopAuthless: true });
+      expect(target).toMatchObject({ requiresAdmissionToken: false, desktopAuthless: true });
+      const block = buildProviderTableBlock(target);
+      expect(block).toContain("[model_providers.opencodex]");
+      expect(block).toContain('base_url = "http://127.0.0.1:10100/v1"');
+      expect(block).toContain("requires_openai_auth = false");
+      expect(block).not.toContain("env_key");
+      const profile = buildProfileFile(target, "/tmp/opencodex-catalog.json");
+      expect(profile).toContain('model_provider = "opencodex"');
+      expect(profile).toContain("requires_openai_auth = false");
+      expect(profile).not.toContain("openai_base_url");
+    });
+
+    test("non-loopback binds ignore the opt-in: admission env_key and requires_openai_auth = true stay", () => {
+      const target = standaloneCodexRoutingTarget(10100, { hostname: "192.168.1.20", codexDesktopAuthless: true });
+      expect(target.desktopAuthless).toBeUndefined();
+      expect(target.requiresAdmissionToken).toBe(true);
+      const block = buildProviderTableBlock(target);
+      expect(block).toContain("requires_openai_auth = true");
+      expect(block).toContain('env_key = "OPENCODEX_API_AUTH_TOKEN"');
+    });
+
+    test("the unauthenticated loopback listener still honors the opt-in", () => {
+      const target = standaloneCodexRoutingTarget(10100, {
+        codexDesktopAuthless: true,
+        unauthenticatedLoopbackListener: { enabled: true, port: 10199 },
+      });
+      expect(target).toMatchObject({ baseUrl: "http://127.0.0.1:10199/v1", desktopAuthless: true });
+    });
+  });
+
   test("explicit HTTPS target emits exact provider destination and admission env", () => {
     const target = {
       baseUrl: "https://hub.example.test/v1",

--- a/tests/settings-stream-mode.test.ts
+++ b/tests/settings-stream-mode.test.ts
@@ -338,6 +338,42 @@ describe("PUT /api/settings", () => {
     expect(config.codexAccountNamespaces).toEqual({ main: "@main" });
   });
 
+  test("codexDesktopAuthless (#1107): absent reports false, enable persists and converges once, disable deletes the key", async () => {
+    const config = baseConfig();
+    const absent = await (await getSettings(config))!.json() as { codexDesktopAuthless?: boolean };
+    expect(absent.codexDesktopAuthless).toBe(false);
+
+    let convergences = 0;
+    let saved: OcxConfig | undefined;
+    const on = await putSettings(config, { codexDesktopAuthless: true }, {
+      saveConfigPreservingClaudeCode: next => { saved = next; },
+      createManagementConvergeCodex: catalogConvergenceFactory(() => { convergences += 1; }),
+    });
+    expect(on!.status).toBe(200);
+    expect(await on!.json()).toMatchObject({ codexDesktopAuthless: true });
+    expect(saved?.codexDesktopAuthless).toBe(true);
+    expect(convergences).toBe(1);
+
+    const same = await putSettings(config, { codexDesktopAuthless: true }, {
+      saveConfigPreservingClaudeCode: () => {},
+      createManagementConvergeCodex: catalogConvergenceFactory(() => { convergences += 1; }),
+    });
+    expect(same!.status).toBe(200);
+    expect(convergences).toBe(1);
+
+    const off = await putSettings(config, { codexDesktopAuthless: false }, {
+      saveConfigPreservingClaudeCode: next => { saved = next; },
+      createManagementConvergeCodex: catalogConvergenceFactory(() => { convergences += 1; }),
+    });
+    expect(off!.status).toBe(200);
+    expect(await off!.json()).toMatchObject({ codexDesktopAuthless: false });
+    expect(Object.hasOwn(saved!, "codexDesktopAuthless")).toBe(false);
+    expect(convergences).toBe(2);
+
+    const bad = await putSettings(config, { codexDesktopAuthless: "yes" });
+    expect(bad!.status).toBe(400);
+  });
+
   test("account-picker disable does not initialize an empty namespace map", async () => {
     const config = baseConfig();
     let convergences = 0;


### PR DESCRIPTION
## Summary

- Adds `codexDesktopAuthless` (default off), the opt-in from #1107. On a loopback bind the injector writes the dedicated `[model_providers.opencodex]` table with `requires_openai_auth = false` (root `model_provider` re-tag, no `env_key`) instead of the Design B root `openai_base_url` override, so Codex Desktop opens without the ChatGPT login gate while every turn still routes through the proxy. Codex Desktop honoring `requires_openai_auth = false` on a dedicated provider is the behavior the issue diagnostic confirmed.
- Default behavior is byte-identical to today: absent/false keeps Design B, and every existing inject/restore test is untouched. The mode reuses the existing provider-table branch (`usesProviderTable(target)` = admission token required OR authless opt-in), so reconciliation on `ocx start`/sync/ensure, the fallback profile, the journal, and the history operation all follow the same path as non-loopback today.
- Non-loopback safety: `desktopAuthless` is derived only when no admission token is required, so a non-loopback bind keeps `requires_openai_auth = true` and the `env_key` admission credential regardless of the switch. Client-connect routing targets are untouched.
- Disable/restore: turning the switch off makes the next inject restore Design B (table stripped, root override back); `ocx restore` strips the authless form like any injected routing.
- Opt-in surfaces: `/api/settings` GET reports it, PUT accepts a boolean (false deletes the key, rollback on save failure, change triggers one catalog convergence so config.toml is rewritten without waiting for a restart); `ocx system settings --desktop-authless <on|off>`.
- Docs: new "Authless Codex Desktop (opt-in)" section in `guides/codex-integration.md` (states the dark ChatGPT-gated chrome, the `opencodex` thread tag, and the upstream Desktop native-only picker allowlist caveat with the existing `model =` workaround) and a `server.md` table row.

Closes #1107

## Verification

- `bun x tsc --noEmit` clean.
- `bun run privacy:scan` passed.
- Focused: `bun test tests/codex-inject.test.ts tests/codex-inject-integration.test.ts tests/settings-stream-mode.test.ts` → 108 pass / 0 fail. New cases: default target byte-identical; loopback opt-in emits table + `requires_openai_auth = false` + no `env_key` (unit and subprocess inject), idempotent re-inject, fallback profile mirrors the form; opt-in off → Design B restored on next inject; `ocx restore` strips it; non-loopback + opt-in keeps `requires_openai_auth = true` + `env_key`; unauthenticated loopback listener still honors the opt-in; settings GET/PUT round-trip, single convergence per change, 400 on non-boolean.
- Full suite runs in CI on this PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

