### PR TITLE
feat(providers): opt-in OS keychain storage for provider API keys (#1221)

### DIFF
--- a/devlog/_plan/260902_nonbug_adoption_backlog/090_wp9_keychain_keys.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/090_wp9_keychain_keys.md
@@ -1,0 +1,41 @@
+# wp9 — #1221 opt-in OS keychain storage for provider API keys (slice 1)
+
+Issue #1221 (score 61). Investigation by grok subagent (Kierkegaard); see 091. Findings that bound
+the design: `resolveEnvValue(x.apiKey)` is called at 24 sync sites (router, quota ×15, compact ×2,
+catalog, sidecar ×2, images, lab, oauth/index) and adapters read `provider.apiKey` from the routed
+clone; `@napi-rs/keyring` ships a sync `Entry` so the request path stays sync; save/backup paths
+are plaintext-free automatically once `apiKey` on disk is a reference; `key-failover` and
+`addProviderApiKey` write `candidate.key` back — with references in the pool that stays a
+reference.
+
+## Design
+
+- Reference syntax: `apiKey: "keychain:<provider>"` (pool entries: `keychain:<provider>/<id>`).
+  Keyring service `opencodex.provider-api-key.v1`, account = the part after `keychain:`.
+- `src/providers/key-store.ts` (new): `isKeychainReference`, `resolveProviderApiKey(value)` (env
+  ref → env; keychain ref → sync `Entry.getPassword()` with a process cache; failure → `undefined`
+  + one warning per account, never plaintext fallback), `storeProviderKeyInKeychain` /
+  `restoreProviderKeyFromKeychain` (async, write then read-back verify; refuse when unavailable),
+  `clearKeychainCacheForTests`. Entry factory injectable.
+- Funnel: every `resolveEnvValue(<x>.apiKey)` site → `resolveProviderApiKey`; `maskApiKey`
+  returns keychain refs verbatim (non-secret) like env refs.
+- Management: `POST /api/providers/keychain` body `{ name, action: "store" | "restore" }` and
+  `GET /api/providers/keychain?name=` → `{ store: "keychain" | "file" | "env", available }`.
+  `store`: moves the active key and every plaintext pool entry into the keychain, rewrites
+  config with references, verifies read-back first (keychain unavailable → 503, config untouched).
+  `restore`: reads back, writes plaintext, deletes the keychain items.
+- CLI: `ocx provider keychain <name> [store|restore|status] [--json]`.
+- Docs: providers.md "Storing keys in the OS keychain" + note on services/headless sessions.
+
+## Out of slice
+Dashboard control, global default, DPAPI-specific handling beyond what napi provides, per-request
+async resolution.
+
+## Acceptance
+- Plain/env keys: identical behavior (existing tests untouched).
+- `keychain:` ref resolves through a mock Entry at routing (`routedProviderConfig`), quota, compact.
+- Unavailable keyring at request time → key undefined, one warning, no plaintext written.
+- store: config rewritten to refs, pool refs, read-back verified; restore reverses; failure leaves config.
+- `maskApiKey("keychain:x")` verbatim; `hasApiKey` true.
+- tsc, privacy, focused tests: new `tests/provider-key-store.test.ts`, `tests/provider-api-keys.test.ts` (if exists), `tests/router*.test.ts` sanity.
+

--- a/devlog/_plan/260902_nonbug_adoption_backlog/091_wp9_audit_r1_synthesis.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/091_wp9_audit_r1_synthesis.md
@@ -1,0 +1,10 @@
+# wp9 audit r1 — synthesis
+
+Reviewer: grok-4.6 subagent (Kierkegaard). Verdict: resolver funnel first; keychain write must not
+re-serialize plaintext through failover/save. Adopted: single sync resolver, sync `Entry`, fail
+closed at request time, refuse opt-in when the keyring is unavailable, references in pool entries
+so failover persists references only. Deviation from the suggestion to split write path into a
+second PR: the write path here is a server-side store/restore that verifies read-back before
+touching config, which removes the plaintext-rewrite hazard the reviewer flagged; the dashboard
+control is what is deferred.
+

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -76,7 +76,7 @@ differing backup and rewrites known legacy namespaced selected ids to bare ids.
 | `promptCacheKey?` | `boolean` | Provider-wide `openai-chat` opt-in for forwarding a `prompt_cache_key`. The adapter forwards the key it is given and never invents one, but the key is not always the caller's: Claude Messages translation derives one from `metadata.user_id`, or from a model/system/tools cohort when no metadata is sent. Default off. Enable only when the upstream documents support, because strict gateways may reject the unknown field with HTTP 400. |
 | `preserveResponsesReasoningContent?` | `boolean` | Keep plaintext reasoning content on replayed Responses reasoning items instead of blanking it (blanking is the ChatGPT backend's rule). Enable for upstreams whose contract accepts reasoning replay, such as DeepSeek. Proxy-minted `ocxr1` envelopes are always stripped. |
 | `disabled?` | `boolean` | Keep the provider on disk but exclude it from routing and model/catalog listings. |
-| `apiKey?` | `string` | API key, or an `${ENV_VAR}` / `$ENV_VAR` reference resolved at request time. |
+| `apiKey?` | `string` | API key, an `${ENV_VAR}` / `$ENV_VAR` reference, or a `keychain:<provider>` reference written by `ocx provider keychain <name> store`. References resolve at request time. See [Storing keys in the OS keychain](#storing-keys-in-the-os-keychain). |
 | `apiKeyTransport?` | `"x-api-key" \| "bearer"` | Anthropic key header style. Defaults to native `x-api-key`; valid only for key-auth `anthropic` providers. |
 | `apiKeyPool?` | `ApiKeyPoolEntry[]` | Multi-key pool. `apiKey` mirrors the active entry; each item has `id`, `key`, optional `label`, and optional numeric `addedAt`. |
 | `defaultModel?` | `string` | Model used when this provider is selected without an explicit model. |
@@ -566,6 +566,33 @@ same mapping applies to a native `vercel/<model-id>` selector: use the encoded
 model key.
 
 ## Static model allowlists
+
+## Storing keys in the OS keychain
+
+By default a provider's `apiKey` and `apiKeyPool` sit in `config.json` (mode 0600, atomic writes).
+If you would rather keep the key material out of the file, move it into the OS credential store:
+
+```bash
+ocx provider keychain deepseek status    # store: file | env | keychain, and whether the keychain answers
+ocx provider keychain deepseek store     # move active key + pool into the OS keychain
+ocx provider keychain deepseek restore   # bring the plaintext back and delete the keychain items
+```
+
+The same operations are `GET`/`POST /api/providers/keychain`. After `store`, `config.json` holds
+`"apiKey": "keychain:deepseek"` (pool entries `keychain:deepseek/<id>`) and the secret lives under the
+`opencodex.provider-api-key.v1` service in macOS Keychain, Windows Credential Manager, or the Linux
+Secret Service. Backups of `config.json` therefore carry references only. Key rotation and failover
+keep working: pool entries compare by reference, so a rotation never writes plaintext back.
+
+Before touching the config, `store` writes and reads back every entry; if the keychain is unavailable
+or the read-back does not match, it refuses with 503 and leaves the file as it was. At request time
+a reference that cannot be read yields no credential and one warning per key — there is no plaintext
+fallback, by design.
+
+When not to opt in: a proxy running as a headless service (systemd, launchd, Task Scheduler) or in a
+container usually has no unlocked keychain session, so requests would fail closed. Use an
+`${ENV_VAR}` reference in the service environment there instead. Env references are left untouched
+by `store`.
 
 Set `liveModels: false` to expose only `models`. If `models` is empty or omitted, the provider exposes
 no routed models. Live discovery rejects more than 4 MiB or 2,000 raw model rows before caching;

--- a/src/cli/provider-runtime.ts
+++ b/src/cli/provider-runtime.ts
@@ -30,7 +30,8 @@ const USAGE = `Usage:
   ocx provider quota [--refresh] [--json]
   ocx provider presets [--json]
   ocx provider account-mode <pool|direct> [--json]
-  ocx provider selected <name> [--set <model,model...>] [--clear] [--json]`;
+  ocx provider selected <name> [--set <model,model...>] [--clear] [--json]
+  ocx provider keychain <name> [status|store|restore] [--json]`;
 
 function cleared(value: string | undefined): string | undefined {
   return value === "-" ? "" : value;
@@ -181,6 +182,28 @@ async function selected(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   printData(result, wantsJson, [`${name}: ${models.length ? models.join(", ") : "all models"}`]);
 }
 
+async function keychain(argv: string[], deps: RuntimeApiDeps): Promise<void> {
+  const args = [...argv];
+  const name = args.shift()?.trim();
+  const wantsJson = takeFlag(args, "--json");
+  const action = (args.shift() ?? "status").toLowerCase();
+  if (!name) throw new CliUsageError("provider name is required", USAGE);
+  if (!["status", "store", "restore"].includes(action)) throw new CliUsageError(`unknown keychain action ${action}`, USAGE);
+  rejectArgs(args, USAGE);
+  if (action === "status") {
+    const result = await runtimeRequest<Record<string, unknown>>(`/api/providers/keychain?name=${encodeURIComponent(name)}`, {}, deps);
+    printData(result, wantsJson, summaryLines(result));
+    return;
+  }
+  const result = await runtimeRequest<Record<string, unknown>>("/api/providers/keychain", {
+    method: "POST",
+    body: JSON.stringify({ name, action }),
+  }, deps);
+  printData(result, wantsJson, [action === "store"
+    ? `${name}: API key moved to the OS keychain; config.json now holds a keychain: reference.`
+    : `${name}: API key restored to config.json; keychain entries removed.`]);
+}
+
 export async function handleProviderRuntimeCommand(sub: string, argv: string[], deps: RuntimeApiDeps = {}): Promise<number | null> {
   const handlers: Record<string, (args: string[], deps: RuntimeApiDeps) => Promise<void>> = {
     edit,
@@ -190,6 +213,7 @@ export async function handleProviderRuntimeCommand(sub: string, argv: string[], 
     presets,
     "account-mode": accountMode,
     selected,
+    keychain,
   };
   const handler = handlers[sub];
   if (!handler) return null;

--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -2,7 +2,8 @@ import { execFileSync } from "node:child_process";
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
 import { delimiter, dirname, join, resolve } from "node:path";
-import { atomicWriteFile, expandUserPath, getConfigDir, resolveEnvValue, websocketsEnabled } from "../../config";
+import { atomicWriteFile, expandUserPath, getConfigDir, websocketsEnabled } from "../../config";
+import { resolveProviderApiKey } from "../../providers/key-store";
 import { CODEX_CONFIG_PATH, CODEX_MODELS_CACHE_PATH, DEFAULT_CATALOG_PATH, readRootTomlString, resolveCodexConfigPath } from "../paths";
 import {
   clearModelCache,
@@ -1269,7 +1270,7 @@ function observedModelsAuthResolver(
     resolve(name, provider) {
       if (provider.authMode === "forward") return { apiKey: undefined, observed: true };
       if (provider.authMode !== "oauth") {
-        return { apiKey: resolveEnvValue(provider.apiKey), observed: true };
+        return { apiKey: resolveProviderApiKey(provider.apiKey), observed: true };
       }
 
       const observation = observeActiveOAuthAccessToken(name, authStoreBuffer);

--- a/src/images/plan.ts
+++ b/src/images/plan.ts
@@ -1,7 +1,7 @@
 import type { OcxConfig, OcxParsedRequest, OcxProviderConfig } from "../types";
 import { toolChoiceToolPredicate } from "../types";
 import type { ImageBridgePlan, VideoBridgePlan } from "./types";
-import { resolveEnvValue } from "../config";
+import { resolveProviderApiKey } from "../providers/key-store";
 import { getValidAccessToken } from "../oauth/index";
 import { getProviderRegistryEntry } from "../providers/registry";
 import { IMAGE_GEN_TOOL_NAME, VIDEO_GEN_TOOL_NAME, isVideoGenName } from "./synthetic-tool";
@@ -37,7 +37,7 @@ export function findXaiProvider(config: OcxConfig): { name: string; provider: Oc
  */
 export function resolveXaiImageApiKey(provider: OcxProviderConfig): string | undefined {
   if (provider.authMode === "oauth") return undefined;
-  const apiKey = resolveEnvValue(provider.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(provider.apiKey)?.trim();
   return apiKey || undefined;
 }
 

--- a/src/lib/lab-live-route-production.ts
+++ b/src/lib/lab-live-route-production.ts
@@ -8,6 +8,7 @@
  * @internal host integration only
  */
 import { resolveEnvValue } from "../config";
+import { resolveProviderApiKey } from "../providers/key-store";
 import {
   getValidAccessTokenSnapshot,
   OAuthLoginRequiredError,
@@ -75,7 +76,7 @@ async function buildLabProviderAuthHeaders(
       throw new TransportError("harness_failure", "oauth refresh unavailable");
     }
   } else {
-    const apiKey = resolveEnvValue(provider.apiKey)?.trim();
+    const apiKey = resolveProviderApiKey(provider.apiKey)?.trim();
     if (!apiKey) throw new TransportError("auth_blocked", "missing api key");
     if (provider.adapter === "anthropic" && provider.apiKeyTransport === "x-api-key") {
       headers["x-api-key"] = apiKey;

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1,7 +1,8 @@
 import type { KiroOAuthMetadata, OAuthController, OAuthCredentials } from "./types";
 import { parseCallbackInput } from "./callback-server";
 import type { OcxConfig, OcxProviderConfig, RefreshPolicy } from "../types";
-import { ConfigMutationLockError, loadConfig, resolveEnvValue, saveConfig } from "../config";
+import { ConfigMutationLockError, loadConfig, saveConfig } from "../config";
+import { resolveProviderApiKey } from "../providers/key-store";
 import { maskEmail } from "../lib/privacy";
 import { KiroTokenRefreshError, environmentKiroRoutingMetadata, loginKiro, refreshKiroToken, settleKiroLoginTransaction } from "./kiro";
 import {
@@ -1043,7 +1044,7 @@ export async function resolveModelsAuthToken(name: string, prov: OcxProviderConf
       return undefined;
     }
   }
-  return resolveEnvValue(prov.apiKey);
+  return resolveProviderApiKey(prov.apiKey);
 }
 
 function modelDiscoveryTransportSeed(providerName: string, prov: OcxProviderConfig): OcxProviderConfig {

--- a/src/providers/api-keys.ts
+++ b/src/providers/api-keys.ts
@@ -24,7 +24,9 @@ function isEnvReference(value: string): boolean {
 }
 
 export function maskApiKey(value: string): string {
-  if (isEnvReference(value)) return value;
+  // Env and keychain references carry no secret material; show them verbatim so an operator
+  // can tell where the key lives.
+  if (isEnvReference(value) || value.startsWith("keychain:")) return value;
   if (value.length <= 8) return "****";
   return `${value.slice(0, 4)}****${value.slice(-4)}`;
 }

--- a/src/providers/key-store.ts
+++ b/src/providers/key-store.ts
@@ -1,0 +1,197 @@
+import { createRequire } from "node:module";
+import { resolveEnvValue, saveConfigPreservingClaudeCode } from "../config";
+import type { OcxConfig, OcxProviderConfig } from "../types";
+
+/**
+ * Opt-in OS keychain storage for provider API keys (#1221).
+ *
+ * `config.json` keeps only a reference (`keychain:<provider>` for the active key,
+ * `keychain:<provider>/<pool id>` for pool entries); the secret lives in the OS credential store
+ * under one service name. Reads are synchronous on purpose: `routedProviderConfig` and the
+ * quota/compaction/catalog callers are all sync, and `@napi-rs/keyring` ships a sync `Entry`.
+ *
+ * Policy: a reference that cannot be resolved fails closed (no key) and is warned once per
+ * account; nothing ever rewrites plaintext into config or its backups. Opting in verifies the
+ * keychain by writing and reading back before the config is touched, so an unavailable store
+ * (headless service, locked session) refuses rather than half-migrating.
+ */
+
+export const KEYCHAIN_REFERENCE_PREFIX = "keychain:";
+export const PROVIDER_KEYCHAIN_SERVICE = "opencodex.provider-api-key.v1";
+
+export interface ProviderKeychainEntry {
+  getPassword(): string | null;
+  setPassword(password: string): void;
+  deletePassword(): boolean;
+}
+
+export type ProviderKeychainEntryFactory = (service: string, account: string) => ProviderKeychainEntry;
+
+const nodeRequire = createRequire(import.meta.url);
+
+function defaultEntryFactory(service: string, account: string): ProviderKeychainEntry {
+  const { Entry } = nodeRequire("@napi-rs/keyring") as { Entry: new (s: string, a: string) => ProviderKeychainEntry };
+  return new Entry(service, account);
+}
+
+let entryFactory: ProviderKeychainEntryFactory = defaultEntryFactory;
+const resolvedCache = new Map<string, string>();
+const warnedAccounts = new Set<string>();
+
+/** Test seam: swap the OS entry for an in-memory one and drop caches. */
+export function setProviderKeychainEntryFactoryForTests(factory: ProviderKeychainEntryFactory | null): void {
+  entryFactory = factory ?? defaultEntryFactory;
+  resolvedCache.clear();
+  warnedAccounts.clear();
+}
+
+export function isKeychainReference(value: string | undefined): value is string {
+  return typeof value === "string" && value.startsWith(KEYCHAIN_REFERENCE_PREFIX) && value.length > KEYCHAIN_REFERENCE_PREFIX.length;
+}
+
+function keychainAccount(reference: string): string {
+  return reference.slice(KEYCHAIN_REFERENCE_PREFIX.length);
+}
+
+function readKeychain(account: string): string | undefined {
+  const cached = resolvedCache.get(account);
+  if (cached !== undefined) return cached;
+  try {
+    const value = entryFactory(PROVIDER_KEYCHAIN_SERVICE, account).getPassword();
+    if (typeof value === "string" && value.trim()) {
+      resolvedCache.set(account, value);
+      return value;
+    }
+  } catch {
+    // fall through to the single warning below
+  }
+  if (!warnedAccounts.has(account)) {
+    warnedAccounts.add(account);
+    console.warn(`[opencodex] provider key reference keychain:${account} could not be read from the OS keychain; requests for this provider have no credential until the keychain is available (no plaintext fallback)`);
+  }
+  return undefined;
+}
+
+/**
+ * Single resolver for provider key material: env references, keychain references, or the
+ * literal value. Every request-time read of `apiKey` goes through here.
+ */
+export function resolveProviderApiKey(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (isKeychainReference(value)) return readKeychain(keychainAccount(value));
+  return resolveEnvValue(value);
+}
+
+export type ProviderKeyStoreKind = "keychain" | "env" | "file" | "none";
+
+export function providerKeyStoreKind(provider: Pick<OcxProviderConfig, "apiKey"> | undefined): ProviderKeyStoreKind {
+  const key = provider?.apiKey;
+  if (!key) return "none";
+  if (isKeychainReference(key)) return "keychain";
+  if (/^\$\{?\w+\}?$/.test(key)) return "env";
+  return "file";
+}
+
+/** Probe the OS keychain with a throwaway account: write, read back, delete. */
+export function probeProviderKeychain(): { available: true } | { available: false; reason: string } {
+  const account = `probe-${process.pid}-${Date.now()}`;
+  try {
+    const entry = entryFactory(PROVIDER_KEYCHAIN_SERVICE, account);
+    entry.setPassword("ok");
+    const back = entry.getPassword();
+    try { entry.deletePassword(); } catch { /* best effort */ }
+    if (back !== "ok") return { available: false, reason: "keychain read-back did not match" };
+    return { available: true };
+  } catch (error) {
+    return { available: false, reason: error instanceof Error ? error.message : "keychain unavailable" };
+  }
+}
+
+function writeVerified(account: string, secret: string): void {
+  const entry = entryFactory(PROVIDER_KEYCHAIN_SERVICE, account);
+  entry.setPassword(secret);
+  if (entry.getPassword() !== secret) throw new Error(`keychain read-back mismatch for ${account}`);
+}
+
+/**
+ * Move a provider's active key and every plaintext pool entry into the OS keychain and rewrite
+ * config with references. All keychain writes are verified before config changes; on any
+ * failure the entries written so far are deleted and config is left untouched.
+ */
+export function storeProviderKeyInKeychain(config: OcxConfig, name: string): { ok: true; moved: number } | { ok: false; error: string; status: number } {
+  const provider = config.providers[name];
+  if (!provider) return { ok: false, error: "unknown provider", status: 404 };
+  if (provider.authMode === "oauth" || provider.authMode === "forward") {
+    return { ok: false, error: "provider does not use API-key auth", status: 400 };
+  }
+  const probe = probeProviderKeychain();
+  if (!probe.available) return { ok: false, error: `OS keychain unavailable: ${probe.reason}`, status: 503 };
+
+  const written: string[] = [];
+  const planned: Array<() => void> = [];
+  const pool = provider.apiKeyPool ?? [];
+  try {
+    for (const entry of pool) {
+      if (isKeychainReference(entry.key)) continue;
+      const secret = resolveEnvValue(entry.key);
+      if (!secret) continue; // unresolved env reference stays as-is
+      const account = `${name}/${entry.id}`;
+      writeVerified(account, secret);
+      written.push(account);
+      planned.push(() => { entry.key = `${KEYCHAIN_REFERENCE_PREFIX}${account}`; });
+    }
+    if (provider.apiKey && !isKeychainReference(provider.apiKey)) {
+      const active = pool.find(e => e.key === provider.apiKey || (isKeychainReference(e.key) && false));
+      const secret = resolveEnvValue(provider.apiKey);
+      if (secret) {
+        if (active) {
+          // Mirror the pool reference so failover keeps comparing equal strings.
+          planned.push(() => { provider.apiKey = `${KEYCHAIN_REFERENCE_PREFIX}${name}/${active.id}`; });
+        } else {
+          writeVerified(name, secret);
+          written.push(name);
+          planned.push(() => { provider.apiKey = `${KEYCHAIN_REFERENCE_PREFIX}${name}`; });
+        }
+      }
+    }
+  } catch (error) {
+    for (const account of written) {
+      try { entryFactory(PROVIDER_KEYCHAIN_SERVICE, account).deletePassword(); } catch { /* best effort */ }
+    }
+    return { ok: false, error: `OS keychain write failed: ${error instanceof Error ? error.message : "unknown"}`, status: 503 };
+  }
+  for (const apply of planned) apply();
+  resolvedCache.clear();
+  warnedAccounts.clear();
+  saveConfigPreservingClaudeCode(config);
+  return { ok: true, moved: written.length };
+}
+
+/** Reverse of `storeProviderKeyInKeychain`: read every reference back, write plaintext, delete items. */
+export function restoreProviderKeyFromKeychain(config: OcxConfig, name: string): { ok: true; restored: number } | { ok: false; error: string; status: number } {
+  const provider = config.providers[name];
+  if (!provider) return { ok: false, error: "unknown provider", status: 404 };
+  const pool = provider.apiKeyPool ?? [];
+  const resolved = new Map<string, string>();
+  const refs = [provider.apiKey, ...pool.map(e => e.key)].filter(isKeychainReference);
+  for (const ref of refs) {
+    const account = keychainAccount(ref);
+    if (resolved.has(account)) continue;
+    let value: string | null = null;
+    try { value = entryFactory(PROVIDER_KEYCHAIN_SERVICE, account).getPassword(); } catch { value = null; }
+    if (!value) return { ok: false, error: `OS keychain has no readable secret for ${ref}; config left unchanged`, status: 503 };
+    resolved.set(account, value);
+  }
+  for (const entry of pool) {
+    if (isKeychainReference(entry.key)) entry.key = resolved.get(keychainAccount(entry.key))!;
+  }
+  if (isKeychainReference(provider.apiKey)) provider.apiKey = resolved.get(keychainAccount(provider.apiKey))!;
+  for (const account of resolved.keys()) {
+    try { entryFactory(PROVIDER_KEYCHAIN_SERVICE, account).deletePassword(); } catch { /* best effort */ }
+  }
+  resolvedCache.clear();
+  warnedAccounts.clear();
+  saveConfigPreservingClaudeCode(config);
+  return { ok: true, restored: resolved.size };
+}
+

--- a/src/providers/openai-sidecar.ts
+++ b/src/providers/openai-sidecar.ts
@@ -1,4 +1,4 @@
-import { resolveEnvValue } from "../config";
+import { resolveProviderApiKey } from "./key-store";
 import {
   CodexPoolAuthenticationError,
   headersForCodexAuthContext,
@@ -198,7 +198,7 @@ export function selectOpenAiImagesProvider(config: OcxConfig): OpenAiImagesProvi
     && provider.authMode !== "forward"
     && provider.baseUrl.replace(/\/+$/, "") === "https://api.openai.com/v1"
   ) {
-    const apiKey = resolveEnvValue(provider.apiKey)?.trim();
+    const apiKey = resolveProviderApiKey(provider.apiKey)?.trim();
     if (apiKey) selection.keyed = { providerName: OPENAI_API_PROVIDER_ID, provider, apiKey };
   }
   return selection;
@@ -236,7 +236,7 @@ export function selectImagesProvider(config: OcxConfig): OpenAiImagesProviderSel
     };
   }
 
-  const apiKey = resolveEnvValue(provider.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(provider.apiKey)?.trim();
   if (!apiKey) {
     return { forwardCandidates: [], error: `images.provider "${providerName}" has no usable API key` };
   }

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -9,7 +9,7 @@ import type { StoredAccountQuota } from "../codex/quota";
 import { isMainAccountIdentityGenerationLive } from "../codex/main-account-cache";
 import { MAIN_CODEX_ACCOUNT_ID } from "../codex/main-account";
 import { codexPlanKey } from "../codex/plan";
-import { resolveEnvValue } from "../config";
+import { resolveProviderApiKey } from "./key-store";
 import { getValidAccessToken, getValidAccessTokenForAccount } from "../oauth";
 import { getAccountCredential, getAccountSet, getCredential } from "../oauth/store";
 import { antigravityUserAgent } from "../adapters/client-fingerprint";
@@ -153,7 +153,7 @@ function cacheKey(config: OcxConfig): string {
   const providers = Object.entries(config.providers)
     .map(([name, provider]) => {
       const resolvedKey = typeof provider.apiKey === "string"
-        ? resolveEnvValue(provider.apiKey)?.trim()
+        ? resolveProviderApiKey(provider.apiKey)?.trim()
         : undefined;
       const activeKeyId = resolvedKey ? apiKeyPoolEntryId(resolvedKey) : "none";
       return `${name}:${provider.adapter}:${provider.authMode ?? "key"}:${providerCodexAccountMode(name, provider) ?? "none"}:${provider.disabled === true ? "off" : "on"}:${provider.baseUrl}:${activeKeyId}`;
@@ -370,7 +370,7 @@ function firstFinite(record: Record<string, unknown> | null, names: string[]): n
 async function fetchA6apiQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   // Never send a configured API key to a lookalike host or through a redirect.
   if (!isCanonicalA6apiBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const headers = { Accept: "application/json", Authorization: `Bearer ${apiKey}` } as const;
   const [subscriptionResponse, tokenResponse] = await Promise.all([
@@ -464,7 +464,7 @@ function parseOpenCodeGoUsageWindow(value: unknown): { percent: number; resetAt?
 async function fetchOpenCodeGoQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   // Never send a configured API key when the provider destination is not the built-in Go endpoint.
   if (!isCanonicalOpenCodeGoBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(OPENCODE_GO_USAGE_URL, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -510,7 +510,7 @@ async function fetchOpenCodeGoQuota(provider: string, config: OcxProviderConfig)
 async function fetchOpenRouterQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   // Never send a configured API key to a lookalike host or through a redirect.
   if (!isCanonicalOpenRouterBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(`${OPENROUTER_BASE_URL}/key`, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -557,7 +557,7 @@ async function fetchOpenRouterQuota(provider: string, config: OcxProviderConfig)
  */
 async function fetchDeepSeekQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalDeepSeekBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(`${DEEPSEEK_BASE_URL}/user/balance`, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -602,7 +602,7 @@ async function fetchDeepSeekQuota(provider: string, config: OcxProviderConfig): 
  */
 async function fetchClineQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalClineBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(`${CLINE_BASE_URL}/api/v1/users/me/plan/usage-limits`, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -750,7 +750,7 @@ function parseZaiQuotaLegacyFields(data: Record<string, unknown> | null): Provid
  */
 async function fetchZaiQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalZaiBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const normalized = normalizedBaseUrl(config.baseUrl);
   const monitorHost = normalized === ZAI_BASE_URL || normalized === `${ZAI_BASE_URL}/api/coding/paas/v4`
@@ -793,7 +793,7 @@ async function fetchZaiQuota(provider: string, config: OcxProviderConfig): Promi
  */
 async function fetchMinimaxQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalMinimaxBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const cnHost = normalizedBaseUrl(config.baseUrl)?.startsWith("https://api.minimaxi.com");
   const remainsUrl = cnHost ? "https://api.minimaxi.com/v1/token_plan/remains" : MINIMAX_REMAINS_URL;
@@ -837,7 +837,7 @@ async function fetchMinimaxQuota(provider: string, config: OcxProviderConfig): P
  */
 async function fetchMoonshotQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalMoonshotBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const host = normalizedBaseUrl(config.baseUrl)?.startsWith("https://api.moonshot.cn") ? "https://api.moonshot.cn/v1" : MOONSHOT_BASE_URL;
   const response = await fetch(`${host}/users/me/balance`, {
@@ -881,7 +881,7 @@ async function fetchMoonshotQuota(provider: string, config: OcxProviderConfig): 
  */
 async function fetchVeniceQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalVeniceBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(`${VENICE_BASE_URL}/billing/balance`, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -924,7 +924,7 @@ async function fetchVeniceQuota(provider: string, config: OcxProviderConfig): Pr
  */
 async function fetchSyntheticQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalSyntheticBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(`${SYNTHETIC_BASE_URL}/quotas`, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -972,7 +972,7 @@ async function fetchSyntheticQuota(provider: string, config: OcxProviderConfig):
  */
 async function fetchDeepInfraQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalDeepInfraBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(`${DEEPINFRA_BASE_URL}/payment/checklist?compute_owed=true`, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -1014,7 +1014,7 @@ async function fetchDeepInfraQuota(provider: string, config: OcxProviderConfig):
  */
 async function fetchNeuralwattQuota(provider: string, config: OcxProviderConfig): Promise<ProviderQuotaProbeResult> {
   if (!isCanonicalNeuralwattBaseUrl(config.baseUrl)) return null;
-  const apiKey = resolveEnvValue(config.apiKey)?.trim();
+  const apiKey = resolveProviderApiKey(config.apiKey)?.trim();
   if (!apiKey) return null;
   const response = await fetch(`${NEURALWATT_BASE_URL}/quota`, {
     headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
@@ -1810,7 +1810,7 @@ async function resolveKimiQuotaBearer(config: OcxProviderConfig): Promise<string
   // ACTIVE key only: silently walking apiKeyPool when the primary env reference is
   // unresolved would render a quota bar for a DIFFERENT account than the one routing
   // requests — a wrong meter is worse than no meter.
-  const primary = resolveEnvValue(config.apiKey)?.trim();
+  const primary = resolveProviderApiKey(config.apiKey)?.trim();
   return primary || null;
 }
 
@@ -1917,7 +1917,7 @@ async function resolveCommandCodeQuotaBearer(config: OcxProviderConfig): Promise
   }
   // ACTIVE key only: a quota bar for a different account than the one routing
   // requests is a wrong meter, not a helpful one.
-  return resolveEnvValue(config.apiKey)?.trim() || null;
+  return resolveProviderApiKey(config.apiKey)?.trim() || null;
 }
 
 /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,7 +9,7 @@ import {
 } from "./combos";
 import type { NormalizedComboConfig } from "./combos/types";
 import { hasOwnProvider } from "./config/provider-name";
-import { resolveEnvValue } from "./config";
+import { resolveProviderApiKey } from "./providers/key-store";
 import { assertProviderDestinationAllowed } from "./lib/destination-policy";
 import { redactSecretString, redactUrlForLog } from "./lib/redact";
 import {
@@ -285,7 +285,7 @@ export function resetCompactionFallbackWarningsForTests(): void {
 }
 
 function usableResolvedApiKey(apiKey: string | undefined): string | undefined {
-  const resolved = resolveEnvValue(apiKey);
+  const resolved = resolveProviderApiKey(apiKey);
   return typeof resolved === "string" && resolved.trim().length > 0 ? resolved : undefined;
 }
 

--- a/src/server/management/oauth-account-routes.ts
+++ b/src/server/management/oauth-account-routes.ts
@@ -536,6 +536,35 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
     clearKeyCooldowns(name); // manual key management resets 429 cooldown state
     return jsonResponse({ ok: true, id: result.id }, 201);
   }
+  // Opt-in OS keychain storage (#1221): move the active key and pool into the OS credential
+  // store (config keeps references), or restore plaintext. Store verifies the keychain before
+  // touching config so an unavailable store refuses instead of half-migrating.
+  if (url.pathname === "/api/providers/keychain" && req.method === "GET") {
+    const name = (url.searchParams.get("name") ?? "").trim();
+    if (!name || !isValidProviderName(name) || !hasOwnProvider(config.providers, name)) return jsonResponse({ error: "unknown provider" }, 404);
+    const { probeProviderKeychain, providerKeyStoreKind } = await import("../../providers/key-store");
+    const probe = probeProviderKeychain();
+    return jsonResponse({
+      name,
+      store: providerKeyStoreKind(config.providers[name]),
+      keychainAvailable: probe.available,
+      ...(probe.available ? {} : { keychainUnavailableReason: probe.reason }),
+    });
+  }
+  if (url.pathname === "/api/providers/keychain" && req.method === "POST") {
+    const body = await readManagementJsonBodyOr(req, {}) as { name?: unknown; action?: unknown };
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    if (!name || !isValidProviderName(name) || !hasOwnProvider(config.providers, name)) return jsonResponse({ error: "unknown provider" }, 404);
+    if (body.action !== "store" && body.action !== "restore") return jsonResponse({ error: "action must be store or restore" }, 400);
+    const { storeProviderKeyInKeychain, restoreProviderKeyFromKeychain, providerKeyStoreKind } = await import("../../providers/key-store");
+    const result = body.action === "store"
+      ? storeProviderKeyInKeychain(config, name)
+      : restoreProviderKeyFromKeychain(config, name);
+    if (!result.ok) return jsonResponse({ error: result.error }, result.status);
+    const { clearProviderQuotaCache } = await import("../../providers/quota");
+    clearProviderQuotaCache();
+    return jsonResponse({ ...result, name, store: providerKeyStoreKind(config.providers[name]) });
+  }
   if (url.pathname === "/api/providers/keys/active" && req.method === "PUT") {
     const body = await readManagementJsonBodyOr(req, {}) as { name?: string; id?: string };
     const name = (body.name ?? "").trim();

--- a/src/server/management/route-registry.ts
+++ b/src/server/management/route-registry.ts
@@ -242,6 +242,8 @@ export const MANAGEMENT_ROUTES: readonly ManagementRoute[] = [
   { method: "GET", path: "/api/oauth/providers", module: "server/management/oauth-account-routes", mutates: false },
   { method: "GET", path: "/api/oauth/status", module: "server/management/oauth-account-routes", mutates: false },
   { method: "GET", path: "/api/providers/keys", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "GET", path: "/api/providers/keychain", module: "server/management/oauth-account-routes", mutates: false },
+  { method: "POST", path: "/api/providers/keychain", module: "server/management/oauth-account-routes", mutates: true },
   { method: "PATCH", path: "/api/keys", module: "server/management/oauth-account-routes", mutates: true },
   { method: "PATCH", path: "/api/oauth/accounts/pool", module: "server/management/oauth-account-routes", mutates: true },
   { method: "POST", path: "/api/keys", module: "server/management/oauth-account-routes", mutates: true },

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -3,8 +3,8 @@ import { bridgeToResponsesSSE, buildResponseJSON, formatErrorResponse, type Resp
 import {
   getConfigPath,
   multiAgentGuidanceEnabled,
-  resolveEnvValue,
 } from "../../config";
+import { resolveProviderApiKey } from "../../providers/key-store";
 import { parseRequest } from "../../responses/parser";
 import { buildCompactV1Output, COMPACT_PROMPT, decodeCompactionSummary, extractCompactUserMessages } from "../../responses/compaction";
 import { FORWARD_HEADERS, sanitizeReasoningInputContent } from "../../adapters/openai-responses";
@@ -401,7 +401,7 @@ async function resolveAlternateCompactContext(args: {
       headers.set("authorization", `Bearer ${override.accessToken}`);
       headers.set("chatgpt-account-id", override.chatgptAccountId);
     }
-    if (provider.apiKey) headers.set("authorization", `Bearer ${resolveEnvValue(provider.apiKey)}`);
+    if (provider.apiKey) headers.set("authorization", `Bearer ${resolveProviderApiKey(provider.apiKey)}`);
     return { authCtx, provider, headers };
   } catch (err) {
     if (err instanceof CodexMainProfileDrainingError) {
@@ -640,7 +640,7 @@ export async function handleResponsesCompact(
       ? CODEX_FORWARD_BASE_URL
       : (compactProvider.baseUrl ?? "").replace(/\/+$/, "");
     if (compactProvider.authMode !== "forward" && compactProvider.apiKey) {
-      headers.set("authorization", `Bearer ${resolveEnvValue(compactProvider.apiKey)}`);
+      headers.set("authorization", `Bearer ${resolveProviderApiKey(compactProvider.apiKey)}`);
     }
     const { reasoning: _reasoning, ...compactBodyRaw } = raw as typeof raw & { reasoning?: unknown };
     // The regular /v1/responses path applies sanitizeReasoningInputContent via the adapter's

--- a/tests/cli-headless-parity.test.ts
+++ b/tests/cli-headless-parity.test.ts
@@ -329,6 +329,20 @@ describe("headless GUI parity CLI", () => {
     expect(clearRuntime.requests[0]?.body).toEqual({ headers: null });
   });
 
+  test("provider keychain status/store/restore drive /api/providers/keychain", async () => {
+    const status = fakeRuntime();
+    expect(await handleProviderRuntimeCommand("keychain", ["relay", "--json"], status.deps)).toBe(0);
+    expect(status.requests[0]).toMatchObject({ path: "/api/providers/keychain?name=relay" });
+
+    const store = fakeRuntime();
+    expect(await handleProviderRuntimeCommand("keychain", ["relay", "store", "--json"], store.deps)).toBe(0);
+    expect(store.requests[0]).toMatchObject({ path: "/api/providers/keychain", method: "POST", body: { name: "relay", action: "store" } });
+
+    const bad = fakeRuntime();
+    expect(await handleProviderRuntimeCommand("keychain", ["relay", "explode"], bad.deps)).toBe(2);
+    expect(bad.requests).toEqual([]);
+  });
+
   test("provider edit --retain-models sends the csv list and - clears it", async () => {
     const runtime = fakeRuntime();
     const code = await handleProviderRuntimeCommand("edit", [

--- a/tests/provider-key-store.test.ts
+++ b/tests/provider-key-store.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, saveConfig } from "../src/config";
+import { maskApiKey } from "../src/providers/api-keys";
+import {
+  PROVIDER_KEYCHAIN_SERVICE,
+  probeProviderKeychain,
+  providerKeyStoreKind,
+  resolveProviderApiKey,
+  restoreProviderKeyFromKeychain,
+  setProviderKeychainEntryFactoryForTests,
+  storeProviderKeyInKeychain,
+  type ProviderKeychainEntry,
+} from "../src/providers/key-store";
+import { routedProviderConfig } from "../src/router";
+import { managementFetch as fetch } from "./helpers/management-auth";
+import { startServer } from "../src/server";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import type { OcxConfig } from "../src/types";
+
+/** In-memory keychain: service/account → secret, with optional fault injection. */
+function fakeKeychain(options: { unavailable?: boolean; readBackMismatch?: boolean } = {}) {
+  const store = new Map<string, string>();
+  const factory = (service: string, account: string): ProviderKeychainEntry => {
+    if (options.unavailable) throw new Error("Secret Service not reachable");
+    const key = `${service}\u0000${account}`;
+    return {
+      getPassword: () => (options.readBackMismatch ? "different" : store.get(key) ?? null),
+      setPassword: value => { store.set(key, value); },
+      deletePassword: () => store.delete(key),
+    };
+  };
+  return { store, factory };
+}
+
+let testDir = "";
+let previousHome: string | undefined;
+let isolated: IsolatedCodexHome | null = null;
+const SECRET = "sk-plain-key-material-1234567890";
+const POOL_SECRET = "sk-second-key-material-0987654321";
+
+function baseConfig(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "relay",
+    providers: {
+      relay: { adapter: "openai-chat", baseUrl: "https://relay.example/v1", apiKey: SECRET },
+    },
+  } as OcxConfig;
+}
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  isolated = installIsolatedCodexHome("ocx-keychain-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-keychain-"));
+  process.env.OPENCODEX_HOME = testDir;
+  saveConfig(baseConfig());
+});
+
+afterEach(() => {
+  setProviderKeychainEntryFactoryForTests(null);
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolated?.restore();
+  isolated = null;
+  if (testDir) rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("provider key resolver (#1221)", () => {
+  test("plain and env values resolve exactly as before", () => {
+    process.env.OCX_TEST_KEY_REF = "from-env";
+    try {
+      expect(resolveProviderApiKey(SECRET)).toBe(SECRET);
+      expect(resolveProviderApiKey("${OCX_TEST_KEY_REF}")).toBe("from-env");
+      expect(resolveProviderApiKey(undefined)).toBeUndefined();
+    } finally {
+      delete process.env.OCX_TEST_KEY_REF;
+    }
+  });
+
+  test("keychain references resolve through the OS entry and fail closed when unreadable", () => {
+    const { store, factory } = fakeKeychain();
+    store.set(`${PROVIDER_KEYCHAIN_SERVICE}\u0000relay`, SECRET);
+    setProviderKeychainEntryFactoryForTests(factory);
+    expect(resolveProviderApiKey("keychain:relay")).toBe(SECRET);
+    // routing clone carries the resolved secret so adapters keep working unchanged
+    expect(routedProviderConfig("relay", { adapter: "openai-chat", baseUrl: "https://relay.example/v1", apiKey: "keychain:relay" }).apiKey).toBe(SECRET);
+
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      setProviderKeychainEntryFactoryForTests(fakeKeychain({ unavailable: true }).factory);
+      expect(resolveProviderApiKey("keychain:relay")).toBeUndefined();
+      expect(resolveProviderApiKey("keychain:relay")).toBeUndefined();
+    } finally {
+      console.warn = original;
+    }
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("no plaintext fallback");
+    expect(warnings[0]).not.toContain(SECRET);
+  });
+
+  test("references are non-secret for masking and store-kind reporting", () => {
+    expect(maskApiKey("keychain:relay")).toBe("keychain:relay");
+    expect(providerKeyStoreKind({ apiKey: "keychain:relay" })).toBe("keychain");
+    expect(providerKeyStoreKind({ apiKey: "${X}" })).toBe("env");
+    expect(providerKeyStoreKind({ apiKey: SECRET })).toBe("file");
+    expect(providerKeyStoreKind({})).toBe("none");
+  });
+});
+
+describe("store / restore", () => {
+  test("store moves the active key and pool into the keychain, config keeps references only", () => {
+    const { store, factory } = fakeKeychain();
+    setProviderKeychainEntryFactoryForTests(factory);
+    const config = loadConfig();
+    config.providers.relay!.apiKeyPool = [
+      { id: "a1", key: SECRET },
+      { id: "b2", key: POOL_SECRET },
+    ];
+    const result = storeProviderKeyInKeychain(config, "relay");
+    expect(result).toEqual({ ok: true, moved: 2 });
+    expect(config.providers.relay!.apiKey).toBe("keychain:relay/a1");
+    expect(config.providers.relay!.apiKeyPool!.map(e => e.key)).toEqual(["keychain:relay/a1", "keychain:relay/b2"]);
+    const onDisk = readFileSync(join(testDir, "config.json"), "utf8");
+    expect(onDisk).not.toContain(SECRET);
+    expect(onDisk).not.toContain(POOL_SECRET);
+    expect(onDisk).toContain("keychain:relay/a1");
+    expect(store.size).toBe(2);
+    // resolves back to the plaintext at request time
+    expect(resolveProviderApiKey(config.providers.relay!.apiKey)).toBe(SECRET);
+
+    const restored = restoreProviderKeyFromKeychain(config, "relay");
+    expect(restored).toEqual({ ok: true, restored: 2 });
+    expect(config.providers.relay!.apiKey).toBe(SECRET);
+    expect(config.providers.relay!.apiKeyPool!.map(e => e.key)).toEqual([SECRET, POOL_SECRET]);
+    expect(store.size).toBe(0);
+  });
+
+  test("store refuses and leaves config untouched when the keychain is unavailable or lies", () => {
+    for (const faulty of [fakeKeychain({ unavailable: true }), fakeKeychain({ readBackMismatch: true })]) {
+      setProviderKeychainEntryFactoryForTests(faulty.factory);
+      const config = loadConfig();
+      const result = storeProviderKeyInKeychain(config, "relay");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.status).toBe(503);
+      expect(config.providers.relay!.apiKey).toBe(SECRET);
+      expect(readFileSync(join(testDir, "config.json"), "utf8")).toContain(SECRET);
+      expect(faulty.store.size).toBe(0);
+    }
+    expect(probeProviderKeychain().available).toBe(false);
+  });
+
+  test("management route: GET reports store kind, POST store/restore round-trips", async () => {
+    const { factory } = fakeKeychain();
+    setProviderKeychainEntryFactoryForTests(factory);
+    const server = startServer(0);
+    try {
+      const before = await fetch(new URL("/api/providers/keychain?name=relay", server.url)).then(r => r.json()) as Record<string, unknown>;
+      expect(before).toMatchObject({ name: "relay", store: "file", keychainAvailable: true });
+
+      const stored = await fetch(new URL("/api/providers/keychain", server.url), {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "relay", action: "store" }),
+      });
+      expect(stored.status).toBe(200);
+      expect(await stored.json()).toMatchObject({ ok: true, store: "keychain", moved: 1 });
+      expect(readFileSync(join(testDir, "config.json"), "utf8")).not.toContain(SECRET);
+
+      const list = await fetch(new URL("/api/providers/keys?name=relay", server.url)).then(r => r.json()) as { keys: Array<{ masked: string }> };
+      expect(list.keys[0]!.masked).toBe("keychain:relay");
+
+      const bad = await fetch(new URL("/api/providers/keychain", server.url), {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "relay", action: "explode" }),
+      });
+      expect(bad.status).toBe(400);
+
+      const restored = await fetch(new URL("/api/providers/keychain", server.url), {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "relay", action: "restore" }),
+      });
+      expect(restored.status).toBe(200);
+      expect(readFileSync(join(testDir, "config.json"), "utf8")).toContain(SECRET);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary

- Opt-in OS keychain storage for provider API keys (#1221), following the maintainer review: funnel every read through one resolver first, opt in per provider, refuse when the keychain is unavailable, and never let backups re-serialize plaintext.
- New `src/providers/key-store.ts`: `resolveProviderApiKey()` is the single synchronous resolver for key material (env reference, `keychain:` reference, or literal). All 24 request-time `resolveEnvValue(x.apiKey)` sites (router, quota, compaction, catalog discovery, OpenAI sidecar, images, lab, OAuth models auth) now go through it; `routedProviderConfig` stays sync because `@napi-rs/keyring` (already a dependency) ships a sync `Entry`.
- `store` moves the active key and every plaintext pool entry into the OS credential store (service `opencodex.provider-api-key.v1`, account `<provider>` or `<provider>/<pool id>`) and rewrites config with references. Every write is verified by read-back before config changes; unavailable keychain or mismatch → 503 and the file is untouched. `restore` reverses it. Pool entries hold references too, so key failover keeps comparing equal strings and persists references, never plaintext.
- At request time a reference that cannot be read yields no credential and one warning per key. There is no plaintext fallback by design; env references are left untouched by `store` and remain the recommended path for headless services (documented).
- Surfaces: `GET /api/providers/keychain?name=` (store kind + keychain availability), `POST /api/providers/keychain {name, action: store|restore}`, `ocx provider keychain <name> [status|store|restore]`. `maskApiKey` shows references verbatim like env references. Plain and env keys behave exactly as before. Dashboard control deferred.
- Docs: providers.md `apiKey` row and a "Storing keys in the OS keychain" section with the when-not-to-opt-in note.

Closes #1221

## Verification

- `bun x tsc --noEmit` clean; `bun run privacy:scan` passed; `bun run skill:surface:check` current.
- `bun test tests/core-lab-boundary.test.ts tests/provider-key-store.test.ts tests/provider-api-keys.test.ts tests/key-failover.test.ts tests/api-keys-routes.test.ts tests/cli-headless-parity.test.ts` → 125 pass / 0 fail. New: resolver parity for plain/env; keychain reference resolves through a mock entry at `routedProviderConfig` and fails closed with one credential-free warning when unavailable; masking/store-kind; store/restore round-trip with config on disk containing references only; store refuses on unavailable keychain and on read-back mismatch leaving config untouched; management GET/POST round-trip and 400 on bad action; CLI verb request shapes. Tests never touch the real OS keychain.
- Full suite runs in CI on this PR (the keyring CI matrix exercises the real napi binding separately).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in OS keychain storage for provider API keys.
  * Added CLI and management API actions to check status, store, and restore keys.
  * Added support for `keychain:<provider>` references in provider configuration.
  * Provider authentication and quota checks now resolve keys from configured keychain references.
  * Added safe validation, verification, rollback, and fail-closed behavior for keychain operations.

* **Documentation**
  * Documented keychain references, supported operations, rotation, validation, and headless-service limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->