### PR TITLE
feat(cursor): seed claude-fable-5-1 at 1M ahead of the Cursor lineup update

### DIFF
--- a/src/adapters/cursor/catalog.ts
+++ b/src/adapters/cursor/catalog.ts
@@ -106,6 +106,36 @@ export const CURSOR_CAPABILITIES: Record<string, CursorCapability> = {
       thinking: { levels: FULL, order: T },
     },
   },
+  // 260902 preemptive: Claude Fable 5.1 seeded ahead of Cursor's lineup update, mirroring
+  // claude-fable-5 (same 1M window and full effort ladder). Cursor has spelled Claude ids
+  // both Anthropic-style (`claude-opus-4-7`, thinking-then-effort) and version-first
+  // (`claude-4.6-opus`, effort-then-thinking), so all three plausible spellings are seeded;
+  // the live GetUsableModels filter drops whichever the roster does not expose. Collapse to
+  // the one real spelling once it is observed.
+  "claude-fable-5-1": {
+    window: CONTEXT_1M,
+    defaultVariant: "thinking",
+    variants: {
+      regular: { levels: FULL },
+      thinking: { levels: FULL, order: T },
+    },
+  },
+  "claude-fable-5.1": {
+    window: CONTEXT_1M,
+    defaultVariant: "thinking",
+    variants: {
+      regular: { levels: FULL },
+      thinking: { levels: FULL, order: T },
+    },
+  },
+  "claude-5.1-fable": {
+    window: CONTEXT_1M,
+    defaultVariant: "thinking",
+    variants: {
+      regular: { levels: FULL },
+      thinking: { levels: FULL, order: E },
+    },
+  },
   "claude-sonnet-5": {
     window: CONTEXT_1M,
     defaultVariant: "thinking",

--- a/src/adapters/cursor/discovery.ts
+++ b/src/adapters/cursor/discovery.ts
@@ -30,6 +30,8 @@ export function inferCursorContextWindow(modelId: string): number {
   if (id.includes("1m")) return CONTEXT_1M;
   if (id.startsWith("gemini-")) return CONTEXT_1M;
   if (id === "glm-5.3" || id === "glm-5.2") return CONTEXT_1M;
+  // 260902: every Fable is a 1M model; catch live spellings the seed does not carry.
+  if (id.includes("fable")) return CONTEXT_1M;
   if (id.startsWith("gpt-5.6-")) return CONTEXT_1M;
   if (id.startsWith("gpt-5") || id === "gpt-5-codex") return CONTEXT_272K;
   if (id.startsWith("grok-4.5") || id.startsWith("grok-4.6")) return 500_000;
@@ -291,6 +293,11 @@ export const CURSOR_STATIC_MODELS: readonly CursorModelInfo[] = normalizeCursorM
   // quarantined regular wire id for the bare slug).
   { id: "claude-opus-5", contextWindow: CONTEXT_1M, supportsReasoningEffort: true },
   { id: "claude-fable-5", contextWindow: CONTEXT_1M, supportsReasoningEffort: true },
+  // 260902 preemptive: Fable 5.1 seeded ahead of Cursor's lineup update (mirrors fable-5) under
+  // the three spellings Cursor has used for Claude ids; see CURSOR_CAPABILITIES.
+  { id: "claude-fable-5-1", contextWindow: CONTEXT_1M, supportsReasoningEffort: true },
+  { id: "claude-fable-5.1", contextWindow: CONTEXT_1M, supportsReasoningEffort: true },
+  { id: "claude-5.1-fable", contextWindow: CONTEXT_1M, supportsReasoningEffort: true },
 
   { id: "composer-1", contextWindow: CONTEXT_200K },
   { id: "composer-2.5", contextWindow: CONTEXT_200K },

--- a/src/adapters/cursor/effort-map.ts
+++ b/src/adapters/cursor/effort-map.ts
@@ -23,6 +23,11 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   // max is always the top tier (canonical order: low < medium < high < xhigh < max), confirmed
   // against Anthropic's effort ladder docs and Cursor's live model lineup.
   "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
+  // 260902 preemptive: Fable 5.1 seeded ahead of Cursor's lineup update (mirrors fable-5) under
+  // the three spellings Cursor has used for Claude ids.
+  "claude-fable-5-1": ["low", "medium", "high", "xhigh", "max"],
+  "claude-fable-5.1": ["low", "medium", "high", "xhigh", "max"],
+  "claude-5.1-fable": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-7": ["low", "medium", "high", "xhigh", "max"],
   // Opus Fast tiers from the 260822 GetUsableModels dump (devlog .../300): the wire
   // exposes {base-without-fast}-{effort}-fast only; suffix derivation at the bottom of
@@ -49,6 +54,9 @@ const CURSOR_MODEL_EFFORT_TIERS: Record<string, readonly string[]> = {
   "claude-opus-4-7-thinking-fast": ["low", "medium", "high", "xhigh", "max"],
   "claude-sonnet-5-thinking": ["low", "medium", "high", "xhigh", "max"],
   "claude-fable-5-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-fable-5-1-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-fable-5.1-thinking": ["low", "medium", "high", "xhigh", "max"],
+  "claude-5.1-fable-thinking": ["low", "medium", "high", "xhigh", "max"],
   "claude-4.6-opus-thinking": ["high", "max"],
   "claude-4.5-opus-thinking": ["high"],
   "claude-4.6-sonnet-thinking": ["medium"],
@@ -113,6 +121,9 @@ const CURSOR_THINKING_FAMILIES: Readonly<Record<string, { source: string; order:
   "claude-opus-4-7-thinking-fast": { source: "claude-opus-4-7-fast", order: "thinking-then-effort" },
   "claude-sonnet-5-thinking": { source: "claude-sonnet-5", order: "thinking-then-effort" },
   "claude-fable-5-thinking": { source: "claude-fable-5", order: "thinking-then-effort" },
+  "claude-fable-5-1-thinking": { source: "claude-fable-5-1", order: "thinking-then-effort" },
+  "claude-fable-5.1-thinking": { source: "claude-fable-5.1", order: "thinking-then-effort" },
+  "claude-5.1-fable-thinking": { source: "claude-5.1-fable", order: "effort-then-thinking" },
   "claude-4.6-opus-thinking": { source: "claude-4.6-opus", order: "effort-then-thinking" },
   "claude-4.5-opus-thinking": { source: "claude-4.5-opus", order: "effort-then-thinking" },
   "claude-4.6-sonnet-thinking": { source: "claude-4.6-sonnet", order: "effort-then-thinking" },

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -100,6 +100,13 @@ export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
   // bundle collapses anthropic-apikey onto anthropic).
   { provider: "anthropic", modelId: "claude-fable-5-1", cost4: CLAUDE_FABLE_51, source: `anthropic official Claude Fable 5.1 ${ANTHROPIC_PRICING}; cache hit = 0.025x base input`, verifiedAt: "2026-09-02", status: "verified" },
   { provider: "anthropic-apikey", modelId: "claude-fable-5-1", cost4: CLAUDE_FABLE_51, source: `anthropic official Claude Fable 5.1 ${ANTHROPIC_PRICING}; cache hit = 0.025x base input`, verifiedAt: "2026-09-02", status: "verified" },
+  // Cursor seeds Fable 5.1 preemptively under three spellings (adapters/cursor/catalog.ts);
+  // the model-level vendor fallback only searches jawcode metadata, which has no Fable 5.1
+  // row yet, so each Cursor spelling needs its own overlay. Vendor list price, like the
+  // cursor/claude-opus-5 row.
+  { provider: "cursor", modelId: "claude-fable-5-1", cost4: CLAUDE_FABLE_51, source: `anthropic official Claude Fable 5.1 ${ANTHROPIC_PRICING}; cache hit = 0.025x base input; vendor list price applied to the Cursor surface`, verifiedAt: "2026-09-02", status: "verified-derived" },
+  { provider: "cursor", modelId: "claude-fable-5.1", cost4: CLAUDE_FABLE_51, source: `anthropic official Claude Fable 5.1 ${ANTHROPIC_PRICING}; cache hit = 0.025x base input; vendor list price applied to the Cursor surface`, verifiedAt: "2026-09-02", status: "verified-derived" },
+  { provider: "cursor", modelId: "claude-5.1-fable", cost4: CLAUDE_FABLE_51, source: `anthropic official Claude Fable 5.1 ${ANTHROPIC_PRICING}; cache hit = 0.025x base input; vendor list price applied to the Cursor surface`, verifiedAt: "2026-09-02", status: "verified-derived" },
   // claude-opus-5 is exposed by three providers but absent from the jawcode bundle, so
   // cost resolution returned null and the Logs `~$` column rendered an em dash. The
   // model-level vendor fallback only searches jawcode metadata, never overlays, so one

--- a/tests/cursor-discovery.test.ts
+++ b/tests/cursor-discovery.test.ts
@@ -57,6 +57,14 @@ describe("Cursor discovery metadata", () => {
     expect(ids).toContain("glm-5.2");
     expect(ids).toContain("kimi-k2.7-code");
     expect(ids).toContain("kimi-k3");
+    // 260902 preemptive seed: Fable 5.1 registered ahead of Cursor's lineup update, at 1M,
+    // under the three spellings Cursor has used for Claude ids.
+    for (const spelling of ["claude-fable-5-1", "claude-fable-5.1", "claude-5.1-fable"]) {
+      expect(ids).toContain(spelling);
+      expect(cursorModelContextWindows(CURSOR_STATIC_MODELS)[spelling]).toBe(1_000_000);
+    }
+    // Any live Fable spelling the seed does not carry still infers a 1M window.
+    expect(inferCursorContextWindow("claude-fable-6")).toBe(1_000_000);
     // Umbrella merge (devlog 260828): fast duplicate rows folded into bases.
     expect(ids).not.toContain("claude-opus-4-7-fast");
     // 260709 refresh: stale ids dropped from the static seed (cursor.com docs); gpt-5.5-extra

--- a/tests/cursor-effort-suffix.test.ts
+++ b/tests/cursor-effort-suffix.test.ts
@@ -244,6 +244,10 @@ describe("#2569 Cursor explicit-thinking variants", () => {
     ["claude-opus-4-8-thinking-fast", "xhigh", "claude-opus-4-8-thinking-xhigh-fast"],
     ["claude-sonnet-5-thinking", "medium", "claude-sonnet-5-thinking-medium"],
     ["claude-fable-5-thinking", "xhigh", "claude-fable-5-thinking-xhigh"],
+    ["claude-fable-5-1-thinking", "xhigh", "claude-fable-5-1-thinking-xhigh"],
+    ["claude-fable-5.1-thinking", "xhigh", "claude-fable-5.1-thinking-xhigh"],
+    // Version-first spelling follows the 4.x families: marker at the END.
+    ["claude-5.1-fable-thinking", "max", "claude-5.1-fable-max-thinking"],
     // The marker moves to the END for these families.
     ["claude-4.6-opus-thinking", "max", "claude-4.6-opus-max-thinking"],
     ["claude-4.5-opus-thinking", "high", "claude-4.5-opus-high-thinking"],

--- a/tests/usage-cost.test.ts
+++ b/tests/usage-cost.test.ts
@@ -195,6 +195,11 @@ describe("resolveMatchedPrice", () => {
       expect(price?.sourceRef).toContain("0.025x");
     }
     expect(resolveMatchedPrice("anthropic-pb51d9b", "claude-fable-5-1")?.cost4).toEqual(COST4);
+    // Cursor seeds the id preemptively under three spellings and jawcode has no row, so
+    // each carries its own (derived) overlay rather than falling through to null.
+    for (const spelling of ["claude-fable-5-1", "claude-fable-5.1", "claude-5.1-fable"]) {
+      expect(resolveMatchedPrice("cursor", spelling), spelling).toMatchObject({ cost4: COST4, source: "expected", status: "verified-derived" });
+    }
     // The cheaper cache-hit rate must not leak onto Fable 5, which stays at 0.1x.
     expect(resolveMatchedPrice("anthropic", "claude-fable-5")?.cost4.cacheRead).toBe(1);
   });
@@ -292,13 +297,16 @@ describe("resolveMatchedPrice", () => {
     expect(resolveMatchedPrice("openrouter", "anthropic-claude-3.5-sonnet")).toBeNull();
   });
 
-  test("16. shipped overlay membership: 58 keys, including Fable 5.1, Opus 5 and compatibility prices", () => {
-    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(58);
+  test("16. shipped overlay membership: 61 keys, including Fable 5.1, Opus 5 and compatibility prices", () => {
+    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(61);
     expect(EXPECTED_PRICE_OVERLAYS.some(row => row.status === "unverified")).toBe(false);
     const keys = new Set(EXPECTED_PRICE_OVERLAYS.map(row => `${row.provider}/${row.modelId}`));
     for (const expected of [
       "anthropic/claude-fable-5-1",
       "anthropic-apikey/claude-fable-5-1",
+      "cursor/claude-fable-5-1",
+      "cursor/claude-fable-5.1",
+      "cursor/claude-5.1-fable",
       "anthropic/claude-opus-5",
       "cursor/claude-opus-5",
       "kiro/claude-opus-5",


### PR DESCRIPTION
## Summary

Follow-up to #3203. Claude Fable 5.1 is now seeded on the Cursor surface ahead of Cursor's lineup update, at a 1M context window, the same way `glm-5.3` was pre-registered (260814).

- Cursor has spelled Claude ids two ways historically: Anthropic-style (`claude-opus-4-7`, thinking-then-effort suffix order) and version-first (`claude-4.6-opus`, effort-then-thinking). Since Fable 5.1's real Cursor id is not observable yet, all three plausible spellings are seeded so whichever one the live `GetUsableModels` roster exposes is picked up and the rest are dropped by the existing live filter:
  - `claude-fable-5-1` (thinking-then-effort)
  - `claude-fable-5.1` (thinking-then-effort)
  - `claude-5.1-fable` (effort-then-thinking, matching the 4.x version-first families)
- `src/adapters/cursor/catalog.ts`, `discovery.ts`, `effort-map.ts`: each spelling gets a 1M window, the full `low..max` ladder, and an explicit `-thinking` variant; the umbrella resolver, `-1m` ultra marker, and account-availability matching all work for each (smoke-checked).
- `inferCursorContextWindow`: any id containing `fable` now infers 1M, so a live spelling not in the seed still gets the right window (previously the generic `claude` rule gave 200K).
- `src/usage/expected-prices.ts`: `cursor/<spelling>` overlay rows for all three, `verified-derived` at the Anthropic list price ($10 / $50 / $12.50 cache write / $0.25 cache hit), same pattern as `cursor/claude-opus-5`. Without these the `~$` column would be null: the model-level vendor fallback only searches jawcode metadata, which has no Fable 5.1 row yet.
- Collapse to the one real spelling once it is observed in a live roster capture.

## Verification

- `bun test tests/cursor-catalog.test.ts tests/cursor-discovery.test.ts tests/cursor-effort-suffix.test.ts tests/usage-cost.test.ts tests/anthropic-hardening.test.ts tests/provider-registry-parity.test.ts` — 231 pass / 0 fail. The back-compat oracle in `cursor-catalog.test.ts` covers every new id x effort, and new assertions check the three spellings' presence, 1M window, wire ids (`claude-fable-5-1-thinking-xhigh`, `claude-5.1-fable-max-thinking`), `inferCursorContextWindow("claude-fable-6") === 1_000_000`, overlay membership 58 → 61, and `cursor/<spelling>` price resolution.
- `bun -e` smoke: `resolveCursorSelection` / `parseCursorVariantId` / `isCursorModelAvailableForAccount` behave correctly for all three spellings.
- Full local suite and CI intentionally not awaited before merging, per maintainer instruction; the change is catalog data plus tests.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Not needed: Cursor catalog and pricing data only.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (None touched.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Fable 5.1 models in Cursor, including multiple model-name variants.
  * Enabled 1M-token context windows and the full reasoning-effort range.
  * Added support for explicit thinking variants and accurate usage-cost estimates.

* **Bug Fixes**
  * Improved recognition of newly introduced Fable model identifiers, including variants not present in the initial model list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->