### PR TITLE
feat(oauth): generic pool-settings contract for OAuth providers (#695 slice 1)

### DIFF
--- a/devlog/_plan/260902_nonbug_adoption_backlog/120_wp12_oauth_pool_capability.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/120_wp12_oauth_pool_capability.md
@@ -1,0 +1,27 @@
+# wp12 — #695 generic OAuth pool: slice 1 = pool-settings capability contract
+
+Issue #695 (score 69). Reviewer order: (a) per-account Antigravity quota (#1082, landed ef7b3c9cf);
+(b) generalize pool-settings API + CLI through a provider capability contract; (c) selector consumes
+the evidence. Investigation by grok subagent (Fermat); see 121.
+
+## Slice 1 (this cycle): reviewer step (b) only
+- `src/oauth/pool-settings-capability.ts` (new): `poolSettingsCapability(name, provider)` →
+  `"codex" | "anthropic" | "generic" | null`; generic = `isGenericFailoverProvider`.
+- `src/types/provider.ts`: `oauthAccountFailover: { enabled?, strategy?: "quota"|"round-robin"|"fill-first", autoSwitchThreshold?: 0..100 }`.
+- `src/server/management/oauth-account-routes.ts` GET/PUT `/api/oauth/accounts/pool`: admit generic
+  providers; storage `providers.<name>.oauthAccountFailover`; Anthropic path byte-identical.
+- `src/cli/account-extended.ts`: `poolTransportFor` + `cmdAutoSwitch` consult the capability.
+- Docs: providers.md `oauthAccountFailover` section.
+- Stored generic settings are inert in this slice (selector unchanged) and documented as such.
+
+## Deferred (issue stays open with a written slice list)
+Session affinity, classified 401/403 failover, strategy consumption, 95% preemption, stickyLimit,
+selection reasons, cooldown re-probe, GUI.
+
+## Acceptance
+- Codex/Anthropic pool routes and CLI unchanged (existing tests green).
+- GET/PUT for google-antigravity round-trips strategy/autoSwitchThreshold/enabled; validation 400s;
+  api-key provider still 400.
+- CLI `ocx account strategy google-antigravity quota` and `auto-switch google-antigravity 90` send the PUT.
+- tsc, privacy, focused tests.
+

--- a/devlog/_plan/260902_nonbug_adoption_backlog/121_wp12_audit_r1_synthesis.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/121_wp12_audit_r1_synthesis.md
@@ -1,0 +1,4 @@
+# wp12 audit r1 — synthesis
+
+Reviewer: grok-4.6 (Fermat). Verdict near-pass: generic-account-failover is the #2568 reactive rotator; ranking exists (account-quota-rank) but affinity does not; Codex/Anthropic pool storage must not be reused. Slice 1 = capability + persistence + CLI/API only, defaults inert. Adopted whole.
+

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -353,6 +353,8 @@ behaves exactly as before.
 | --- | --- | --- | --- |
 | `oauthAccountFailover.enabled?` | `boolean` | presence-driven | Global override. `false` forces single-account behaviour everywhere; `true` forces rotation on. |
 | `providers.<name>.oauthAccountFailover.enabled?` | `boolean` | inherits | Per-provider override; beats the global setting and beats account presence. |
+| `providers.<name>.oauthAccountFailover.strategy?` | `"quota" \| "round-robin" \| "fill-first"` | — | Declared pool strategy for a generic OAuth provider (#695). Persisted through `ocx account strategy <provider> <name>` or `PUT /api/oauth/accounts/pool`; the generic selector does not act on it yet, so omitted and set behave the same today. |
+| `providers.<name>.oauthAccountFailover.autoSwitchThreshold?` | `number` | — | Declared 0–100 usage percent for a proactive switch on a generic OAuth provider (#695). Set with `ocx account auto-switch <provider> threshold <n>`; inert until the selector consumes it. |
 
 To keep strict single-account behaviour for one provider whose terms you would rather not test:
 
@@ -367,6 +369,14 @@ To keep strict single-account behaviour for one provider whose terms you would r
 ```
 
 That setting survives logging in, adding an account, and reauthenticating.
+
+Generic OAuth providers (Google Antigravity, xAI, Cursor, Kimi, GitHub Copilot, Nous, and any
+other OAuth provider outside the Codex and Anthropic pools) also accept `strategy` and
+`autoSwitchThreshold` on the same key, through `GET`/`PUT /api/oauth/accounts/pool?provider=<name>`
+and the `ocx account strategy` / `ocx account auto-switch` verbs. The response carries
+`"inert": true` while the generic selector ignores those two fields; `stickyLimit` and
+`quotaWindow` are not part of the generic contract. Codex (`/api/codex-auth`) and Anthropic
+(`anthropicAccountPool`) keep their own contracts unchanged.
 
 Deliberately narrower than `anthropicAccountPool`: no session affinity, no quota-ranked
 selection, no probe leases. It answers one question — the account that just returned 429 is

--- a/src/cli/account-extended.ts
+++ b/src/cli/account-extended.ts
@@ -347,9 +347,12 @@ export async function cmdAutoSwitch(args: string[], deps: AccountDeps): Promise<
   const action = args.shift();
   if (!name || !action) return usage();
   const classified = configAndType(deps, name);
-  if ("error" in classified || classified.type !== "codex") {
-    return usage("Error: auto-switch only applies to the openai Codex account pool");
+  // Anthropic keeps its threshold on its own pool contract; generic OAuth providers (#695)
+  // and the Codex pool are accepted here.
+  if ("error" in classified || classified.type === "api-key" || name === "anthropic") {
+    return usage("Error: auto-switch only applies to the openai Codex account pool or a generic OAuth provider pool");
   }
+  const genericPool = classified.type === "oauth";
   let threshold: number | undefined;
   if (action === "on" && args.length === 0) threshold = 80;
   else if (action === "off" && args.length === 0) threshold = 0;
@@ -361,14 +364,19 @@ export async function cmdAutoSwitch(args: string[], deps: AccountDeps): Promise<
   const baseUrl = await resolveBaseUrl(deps);
   if (!baseUrl) return proxyUnreachable();
   if (action === "status") {
-    const response = await apiJson(deps, baseUrl, "GET", "/api/codex-auth/active");
+    const response = await apiJson(
+      deps, baseUrl, "GET",
+      genericPool ? `/api/oauth/accounts/pool?provider=${encodeURIComponent(name)}` : "/api/codex-auth/active",
+    );
     if (response.status === 0) return proxyUnreachable(response.transportError);
-    if (response.status !== 200 || typeof response.json.autoSwitchThreshold !== "number") {
+    if (response.status !== 200 || (!genericPool && typeof response.json.autoSwitchThreshold !== "number")) {
       return apiError(response.json, "failed to read auto-switch status", response.status);
     }
-    threshold = response.json.autoSwitchThreshold;
+    threshold = typeof response.json.autoSwitchThreshold === "number" ? response.json.autoSwitchThreshold : 0;
   } else {
-    const response = await apiJson(deps, baseUrl, "PUT", "/api/codex-auth/auto-switch", { threshold });
+    const response = genericPool
+      ? await apiJson(deps, baseUrl, "PUT", "/api/oauth/accounts/pool", { provider: name, autoSwitchThreshold: threshold })
+      : await apiJson(deps, baseUrl, "PUT", "/api/codex-auth/auto-switch", { threshold });
     if (response.status === 0) return proxyUnreachable(response.transportError);
     if (response.status !== 200) return apiError(response.json, "failed to update auto-switch", response.status);
   }
@@ -846,16 +854,17 @@ function anthropicPoolTransport(provider: string): PoolTransport {
 }
 
 /**
- * The pool-config route supports `anthropic` only and says so with a 400. Any other OAuth
- * provider is refused here with the same wording rather than spending a round-trip to learn it.
+ * Codex and Anthropic keep their own pool transports; every other OAuth provider speaks the
+ * generic pool-settings contract on the same `/api/oauth/accounts/pool` route (#695).
+ * API-key providers have no pool and are refused here without a round-trip.
  */
 function poolTransportFor(
   classified: { type: "codex" | "oauth" | "api-key" },
   name: string,
 ): PoolTransport | string {
   if (classified.type === "codex") return CODEX_POOL_TRANSPORT;
-  if (classified.type === "oauth" && name === "anthropic") return anthropicPoolTransport(name);
-  return `pool settings apply to the openai Codex pool and the anthropic pool, not "${name}"`;
+  if (classified.type === "oauth") return anthropicPoolTransport(name);
+  return `pool settings apply to OAuth account pools, not the API-key provider "${name}"`;
 }
 
 /**

--- a/src/oauth/pool-settings-capability.ts
+++ b/src/oauth/pool-settings-capability.ts
@@ -1,0 +1,55 @@
+import { isGenericFailoverProvider } from "./generic-account-failover";
+import type { OcxProviderConfig } from "../types";
+
+/**
+ * Which pool-settings contract a provider speaks (#695, slice 1).
+ *
+ * `codex` and `anthropic` keep their own routes and storage untouched. `generic` is every
+ * other OAuth provider the generic failover module admits; its settings persist on
+ * `providers.<name>.oauthAccountFailover`. Settings stored for a generic provider are a
+ * declared contract the selector can consume in a later slice; today they change nothing.
+ */
+export type PoolSettingsKind = "codex" | "anthropic" | "generic";
+
+export const GENERIC_POOL_STRATEGIES = ["quota", "round-robin", "fill-first"] as const;
+export type GenericPoolStrategy = typeof GENERIC_POOL_STRATEGIES[number];
+
+export function poolSettingsCapability(name: string, provider: OcxProviderConfig | undefined): PoolSettingsKind | null {
+  if (name === "openai") return "codex";
+  if (name === "anthropic") return "anthropic";
+  if (!provider) return null;
+  return isGenericFailoverProvider(name, provider) ? "generic" : null;
+}
+
+export function parseGenericPoolStrategy(value: unknown): GenericPoolStrategy | null {
+  return typeof value === "string" && (GENERIC_POOL_STRATEGIES as readonly string[]).includes(value)
+    ? value as GenericPoolStrategy
+    : null;
+}
+
+export function parseGenericAutoSwitchThreshold(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 100 ? value : null;
+}
+
+export interface GenericPoolSettingsDto {
+  provider: string;
+  kind: "generic";
+  enabled: boolean | null;
+  strategy: GenericPoolStrategy | null;
+  autoSwitchThreshold: number | null;
+  /** Slice-1 marker: persisted, not yet consumed by the selector. */
+  inert: true;
+}
+
+export function genericPoolSettingsDto(name: string, provider: OcxProviderConfig): GenericPoolSettingsDto {
+  const failover = provider.oauthAccountFailover ?? {};
+  return {
+    provider: name,
+    kind: "generic",
+    enabled: typeof failover.enabled === "boolean" ? failover.enabled : null,
+    strategy: parseGenericPoolStrategy(failover.strategy),
+    autoSwitchThreshold: parseGenericAutoSwitchThreshold(failover.autoSwitchThreshold),
+    inert: true,
+  };
+}
+

--- a/src/server/management/oauth-account-routes.ts
+++ b/src/server/management/oauth-account-routes.ts
@@ -325,7 +325,16 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
   // Opt-in Anthropic OAuth account pool (#294): enable/threshold/strategy + clear cooldown.
   if (url.pathname === "/api/oauth/accounts/pool" && req.method === "GET") {
     const provider = (url.searchParams.get("provider") ?? "").trim().toLowerCase();
-    if (provider !== "anthropic") return jsonResponse({ error: "pool config is only supported for anthropic" }, 400);
+    if (provider !== "anthropic") {
+      // Generic OAuth pool-settings contract (#695 slice 1): persisted per provider, inert until
+      // the selector consumes it. Codex keeps /api/codex-auth; api-key providers have no pool.
+      const { poolSettingsCapability, genericPoolSettingsDto } = await import("../../oauth/pool-settings-capability");
+      const prov = config.providers[provider];
+      if (!provider || !prov || poolSettingsCapability(provider, prov) !== "generic") {
+        return jsonResponse({ error: "pool config is only supported for anthropic and generic OAuth providers" }, 400);
+      }
+      return jsonResponse(genericPoolSettingsDto(provider, prov));
+    }
     const pool = config.anthropicAccountPool ?? {};
     return jsonResponse({
       provider,
@@ -351,7 +360,43 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
       quotaWindow?: unknown;
     };
     const provider = typeof body.provider === "string" ? body.provider.trim().toLowerCase() : "";
-    if (provider !== "anthropic") return jsonResponse({ error: "pool config is only supported for anthropic" }, 400);
+    if (provider !== "anthropic") {
+      const {
+        poolSettingsCapability, genericPoolSettingsDto, parseGenericPoolStrategy, parseGenericAutoSwitchThreshold,
+      } = await import("../../oauth/pool-settings-capability");
+      const prov = config.providers[provider];
+      if (!provider || !prov || poolSettingsCapability(provider, prov) !== "generic") {
+        return jsonResponse({ error: "pool config is only supported for anthropic and generic OAuth providers" }, 400);
+      }
+      if (body.stickyLimit !== undefined || body.quotaWindow !== undefined) {
+        return jsonResponse({ error: "stickyLimit and quotaWindow are not part of the generic pool contract yet" }, 400);
+      }
+      const next = { ...(prov.oauthAccountFailover ?? {}) };
+      if (body.enabled !== undefined) {
+        if (typeof body.enabled !== "boolean") return jsonResponse({ error: "enabled must be a boolean" }, 400);
+        next.enabled = body.enabled;
+      }
+      if (body.strategy !== undefined) {
+        if (body.strategy === null) delete next.strategy;
+        else {
+          const parsed = parseGenericPoolStrategy(body.strategy);
+          if (parsed === null) return jsonResponse({ error: "strategy must be one of: quota, round-robin, fill-first" }, 400);
+          next.strategy = parsed;
+        }
+      }
+      if (body.autoSwitchThreshold !== undefined) {
+        if (body.autoSwitchThreshold === null) delete next.autoSwitchThreshold;
+        else {
+          const parsed = parseGenericAutoSwitchThreshold(body.autoSwitchThreshold);
+          if (parsed === null) return jsonResponse({ error: "autoSwitchThreshold must be an integer 0-100" }, 400);
+          next.autoSwitchThreshold = parsed;
+        }
+      }
+      if (Object.keys(next).length > 0) prov.oauthAccountFailover = next;
+      else delete prov.oauthAccountFailover;
+      saveConfigPreservingClaudeCode(config);
+      return jsonResponse({ ok: true, ...genericPoolSettingsDto(provider, prov) });
+    }
     let enabled = config.anthropicAccountPool?.enabled === true;
     if (body.enabled !== undefined) {
       if (typeof body.enabled !== "boolean") return jsonResponse({ error: "enabled must be a boolean" }, 400);

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -414,6 +414,13 @@ export interface OcxProviderConfig {
    */
   oauthAccountFailover?: {
     enabled?: boolean;
+    /**
+     * Generic OAuth pool selection strategy (#695). Persisted through the pool-settings
+     * contract; the selector does not consume it yet, so omitted keeps today's behavior.
+     */
+    strategy?: "quota" | "round-robin" | "fill-first";
+    /** 0-100 usage percent at which a proactive switch may be considered (#695); inert today. */
+    autoSwitchThreshold?: number;
   };
   /** Allow an explicitly key/oauth provider to run without a credential (for keyless local proxies). */
   keyOptional?: boolean;

--- a/tests/account-pool-management-api.test.ts
+++ b/tests/account-pool-management-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { managementFetch as fetch } from "./helpers/management-auth";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleCodexAuthAPI } from "../src/codex/auth-api";
@@ -432,3 +432,68 @@ describe("Anthropic account pool strategy management API", () => {
     }
   });
 });
+
+describe("generic OAuth pool-settings contract (#695)", () => {
+  let previousHome: string | undefined;
+  let testDir = "";
+  beforeEach(() => {
+    previousHome = process.env.OPENCODEX_HOME;
+    testDir = mkdtempSync(join(tmpdir(), "ocx-pool-generic-"));
+    process.env.OPENCODEX_HOME = testDir;
+    saveConfig({
+      port: 0,
+      hostname: "127.0.0.1",
+      defaultProvider: "google-antigravity",
+      providers: {
+        "google-antigravity": { adapter: "google", baseUrl: "https://daily-cloudcode-pa.googleapis.com", authMode: "oauth" },
+        deepseek: { adapter: "openai-chat", baseUrl: "https://api.deepseek.com/v1", apiKey: "deepseek-key-fixture" },
+      },
+    } as OcxConfig);
+  });
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousHome;
+    if (testDir) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("GET/PUT round-trip for a generic OAuth provider; api-key providers and bad values get 400", async () => {
+    const server = startServer(0);
+    try {
+      const absent = await fetch(new URL("/api/oauth/accounts/pool?provider=google-antigravity", server.url));
+      expect(absent.status).toBe(200);
+      expect(await absent.json()).toEqual({ provider: "google-antigravity", kind: "generic", enabled: null, strategy: null, autoSwitchThreshold: null, inert: true });
+
+      const put = await fetch(new URL("/api/oauth/accounts/pool", server.url), {
+        method: "PUT", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "google-antigravity", strategy: "fill-first", autoSwitchThreshold: 90, enabled: true }),
+      });
+      expect(put.status).toBe(200);
+      expect(await put.json()).toMatchObject({ ok: true, strategy: "fill-first", autoSwitchThreshold: 90, enabled: true, inert: true });
+      const saved = JSON.parse(readFileSync(join(testDir, "config.json"), "utf8"));
+      expect(saved.providers["google-antigravity"].oauthAccountFailover).toEqual({ enabled: true, strategy: "fill-first", autoSwitchThreshold: 90 });
+
+      for (const body of [
+        { provider: "google-antigravity", strategy: "weighted" },
+        { provider: "google-antigravity", autoSwitchThreshold: 101 },
+        { provider: "google-antigravity", stickyLimit: 3 },
+        { provider: "deepseek", strategy: "quota" },
+      ]) {
+        const bad = await fetch(new URL("/api/oauth/accounts/pool", server.url), {
+          method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+        });
+        expect(bad.status).toBe(400);
+      }
+      expect((await fetch(new URL("/api/oauth/accounts/pool?provider=deepseek", server.url))).status).toBe(400);
+
+      const clear = await fetch(new URL("/api/oauth/accounts/pool", server.url), {
+        method: "PUT", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "google-antigravity", strategy: null, autoSwitchThreshold: null }),
+      });
+      expect(clear.status).toBe(200);
+      expect(await clear.json()).toMatchObject({ strategy: null, autoSwitchThreshold: null, enabled: true });
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
+

--- a/tests/cli-account-pool-verbs.test.ts
+++ b/tests/cli-account-pool-verbs.test.ts
@@ -291,7 +291,7 @@ describe("ocx account strategy / sticky on the anthropic pool", () => {
     expect(JSON.parse(out.lines.join("\n"))).toMatchObject({ provider: "openai", strategy: "quota", stickyLimit: 1 });
   });
 
-  test("an OAuth provider without a pool config is refused WITHOUT a round-trip", async () => {
+  test("a provider without an OAuth pool is refused WITHOUT a round-trip", async () => {
     const calls: Captured[] = [];
     const out = capture();
     let code: number;
@@ -308,6 +308,60 @@ describe("ocx account strategy / sticky on the anthropic pool", () => {
     expect(code).not.toBe(0);
     // The route would answer 400; spending the request to learn that is the thing avoided.
     expect(calls).toHaveLength(0);
-    expect(out.errors.join("\n")).toContain("anthropic");
+    expect(out.errors.join("\n")).toContain("pool settings apply to OAuth account pools");
+  });
+});
+
+describe("generic OAuth pool-settings contract (#695)", () => {
+  const { cmdAutoSwitch } = require("../src/cli/account-extended") as typeof import("../src/cli/account-extended");
+  function genericDeps(
+    respond: (captured: Captured) => { status?: number; json: unknown },
+    calls: Captured[],
+    providers: Record<string, unknown> = { "google-antigravity": { authMode: "oauth" } },
+  ): AccountDeps {
+    return {
+      baseUrl: "http://127.0.0.1:10100",
+      loadConfigImpl: () => ({ providers }) as never,
+      fetchImpl: (async (url: string | URL | Request, init?: RequestInit) => {
+        const parsed = new URL(String(url));
+        const captured: Captured = {
+          method: init?.method ?? "GET",
+          path: parsed.pathname + parsed.search,
+          body: init?.body === undefined ? undefined : JSON.parse(String(init.body)),
+        };
+        calls.push(captured);
+        const { status = 200, json } = respond(captured);
+        return new Response(JSON.stringify(json), { status });
+      }) as unknown as typeof fetch,
+    };
+  }
+
+  test("strategy on google-antigravity goes to the shared pool route with the provider key", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      await cmdStrategy(["google-antigravity", "round-robin"], genericDeps(() => ({ json: { ok: true, strategy: "round-robin", stickyLimit: null } }), calls));
+    } finally { out.restore(); }
+    expect(calls[0]).toMatchObject({ method: "PUT", path: "/api/oauth/accounts/pool", body: { provider: "google-antigravity", strategy: "round-robin" } });
+  });
+
+  test("auto-switch on a generic provider writes autoSwitchThreshold through the pool route", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      expect(await cmdAutoSwitch(["google-antigravity", "threshold", "90"], genericDeps(() => ({ json: { ok: true, autoSwitchThreshold: 90 } }), calls))).toBe(0);
+    } finally { out.restore(); }
+    expect(calls[0]).toMatchObject({ method: "PUT", path: "/api/oauth/accounts/pool", body: { provider: "google-antigravity", autoSwitchThreshold: 90 } });
+    expect(out.lines.join("\n")).toContain("threshold 90%");
+  });
+
+  test("api-key providers are still refused before any request", async () => {
+    const calls: Captured[] = [];
+    const out = capture();
+    try {
+      expect(await cmdStrategy(["deepseek", "quota"], genericDeps(() => ({ json: {} }), calls, { deepseek: { apiKey: "x" } }))).not.toBe(0);
+    } finally { out.restore(); }
+    expect(calls).toHaveLength(0);
+    expect(out.errors.join("\n")).toContain("API-key provider");
   });
 });

--- a/tests/cli-account.test.ts
+++ b/tests/cli-account.test.ts
@@ -792,7 +792,7 @@ describe("ocx account CLI (issue #180 matrix)", () => {
     const missingProvider = await run(["auto-switch"]);
 
     expect(wrongProvider.code).toBe(1);
-    expect(wrongProvider.stderr).toContain("auto-switch only applies to the openai Codex account pool");
+    expect(wrongProvider.stderr).toContain("auto-switch only applies to the openai Codex account pool or a generic OAuth provider pool");
     expect(invalidThreshold.code).toBe(1);
     expect(invalidThreshold.stderr).toContain("integer 0-100");
     expect(missingProvider.code).toBe(1);


### PR DESCRIPTION
## Summary

- First slice of #695, exactly the reviewer's step (b): a provider capability contract for pool settings. `src/oauth/pool-settings-capability.ts` classifies a provider as `codex` / `anthropic` / `generic` (generic = every OAuth provider the generic failover module admits) and defines the generic contract: `strategy` (`quota` | `round-robin` | `fill-first`) and `autoSwitchThreshold` (0–100), persisted on `providers.<name>.oauthAccountFailover` next to the existing `enabled`.
- `GET`/`PUT /api/oauth/accounts/pool` now admit generic OAuth providers (Google Antigravity, xAI, Cursor, Kimi, Copilot, Nous, …) instead of hard-rejecting anything but `anthropic`; `null` clears a field; `stickyLimit`/`quotaWindow` are refused for generic providers; api-key providers still get 400. The Anthropic branch is byte-identical and the Codex pool keeps `/api/codex-auth`.
- CLI: `ocx account strategy <provider> <name>` and `ocx account auto-switch <provider> threshold <n>` work for generic providers through the shared route; api-key providers are refused before any request.
- Today's behavior is unchanged: the generic selector does not read the new fields yet. The DTO carries `inert: true` and the docs say so, so an operator who sets a strategy is told it is declared, not active. Step (c) — selector consumption, session affinity, classified 401/403 failover, 95% preemption — is the next slice; the issue stays open with that list.

Refs #695 (issue stays open for the selector slice)

## Verification

- `bun x tsc --noEmit` clean; `bun run privacy:scan` passed.
- `bun test tests/account-pool-management-api.test.ts tests/cli-account-pool-verbs.test.ts tests/cli-account.test.ts tests/generic-oauth-failover.test.ts tests/core-lab-boundary.test.ts` → 184 pass / 0 fail. New: GET/PUT round-trip for google-antigravity with on-disk persistence, 400 for bad strategy/threshold/stickyLimit and for an api-key provider, null clears; CLI strategy and auto-switch request shapes for a generic provider; api-key refusal without a round-trip. Existing Codex/Anthropic assertions untouched except two error-message strings.
- Full suite runs in CI on this PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pool settings for generic OAuth providers, including strategy selection and automatic account-switch thresholds.
  * Added CLI and API support to view and update these settings.
  * Added validation for supported strategies, threshold ranges, and provider eligibility.

* **Documentation**
  * Documented generic OAuth pool configuration, supported values, and current limitations.

* **Bug Fixes**
  * Preserved existing, provider-specific behavior for Codex and Anthropic account pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->