### PR TITLE
fix(ci): declare the provider keychain capability and refresh the Cursor seed count

### DIFF
--- a/skills/ocx/references/01_management_surface.md
+++ b/skills/ocx/references/01_management_surface.md
@@ -358,6 +358,24 @@ JSON mode: `payload`.
 - Requires transient authority on stdin; the credential is never persisted or echoed.
 - A rotation left pending by a crash is resumed here — startup and status stop rather than guess which key generation is live.
 
+### `ocx provider keychain`
+
+Move a provider's API key into the OS keychain, restore it, or report where it lives.
+
+| Method | Route |
+|---|---|
+| GET | `/api/providers/keychain` |
+| POST | `/api/providers/keychain` |
+
+| Flag | Value | Meaning |
+|---|---|---|
+| `--json` | boolean | Emit the keychain status or result as JSON. |
+
+JSON mode: `payload`.
+
+- `store` verifies every keychain write by read-back before config.json is rewritten with keychain: references; an unavailable keychain refuses with 503 and leaves the file untouched.
+- Headless services usually have no unlocked keychain session; prefer ${ENV_VAR} references there.
+
 ### `ocx account pause`
 
 Stop routing new requests to one account in the Codex pool.
@@ -568,6 +586,6 @@ JSON mode: `payload`.
 
 ## Counts
 
-- declared capabilities: 31
-- of those, state-changing: 12
+- declared capabilities: 32
+- of those, state-changing: 13
 - head-resolved invocations: 2

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -154,6 +154,21 @@ export const CAPABILITIES: readonly Capability[] = [
     details: ["Reads local config; drives no management API route."],
   },
   {
+    command: ["provider", "keychain"],
+    summary: "Move a provider's API key into the OS keychain, restore it, or report where it lives.",
+    routes: [
+      { method: "GET", path: "/api/providers/keychain" },
+      { method: "POST", path: "/api/providers/keychain" },
+    ],
+    flags: [{ name: "--json", value: "boolean", summary: "Emit the keychain status or result as JSON." }],
+    mutates: true,
+    json: "payload",
+    details: [
+      "`store` verifies every keychain write by read-back before config.json is rewritten with keychain: references; an unavailable keychain refuses with 503 and leaves the file untouched.",
+      "Headless services usually have no unlocked keychain session; prefer ${ENV_VAR} references there.",
+    ],
+  },
+  {
     command: ["account", "list"],
     summary: "Codex OAuth accounts with pool priority and pause state.",
     routes: [{ method: "GET", path: "/api/codex-auth/accounts" }],

--- a/tests/cursor-umbrella-rows.test.ts
+++ b/tests/cursor-umbrella-rows.test.ts
@@ -35,9 +35,10 @@ describe("cursor umbrella picker rows (devlog 260828_cursor_umbrella_catalog)", 
   });
 
   test("row count shrank from the 69-row legacy seed", () => {
-    // 4 router + 47 base rows. Legacy carried 69 (13 thinking + 5 fast
+    // 4 router + 50 base rows. Legacy carried 69 (13 thinking + 5 fast
     // duplicates + kimi-k3-1m folded away; quarantined opus-5 base returned).
-    expect(CURSOR_STATIC_MODELS.length).toBe(51);
+    // #3211 pre-seeded Claude Fable 5.1 under three spellings (+3).
+    expect(CURSOR_STATIC_MODELS.length).toBe(54);
   });
 
   test("umbrella rows and seed efforts agree for every cataloged base", () => {


### PR DESCRIPTION
## Summary

- Repairs two Linux failures on `dev` observed on run 33554406490 (`ef7b3c9cf`), neither a runtime bug:
  - `GET`/`POST /api/providers/keychain` (#3210) landed without a capability entry, so the route-parity test failed. Added `provider keychain` to `src/cli/capabilities.ts` and regenerated the skill surface map.
  - #3211 pre-seeded Claude Fable 5.1 under three spellings, so the Cursor umbrella row count is 54 rather than 51; the test comment and expectation now say why.
- The remaining Linux reds on that run (`Responses previous_response_id state` shutdown-fallback ACL x2) do not map to any batch commit's files and pass locally; tracked separately.

## Verification

- `bun x tsc --noEmit` clean; `bun run privacy:scan` passed; `bun run skill:surface` regenerated.
- `bun test tests/cli-capabilities.test.ts tests/cursor-umbrella-rows.test.ts tests/skill-ocx.test.ts tests/provider-registry-parity.test.ts` -> 78 pass / 0 fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `provider keychain` capability.
  - Providers’ API keys can now be moved to the operating system keychain, restored to configuration, or checked for their current location.
  - Added JSON output support for keychain operations.

- **Documentation**
  - Updated capability listings and counts to include provider keychain management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->