### PR TITLE
devlog: wp14 carry record and wp15 disposition

### DIFF
--- a/devlog/_plan/260902_nonbug_adoption_backlog/150_wp15_plaintext_v2_disposition.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/150_wp15_plaintext_v2_disposition.md
@@ -12,3 +12,6 @@ keyed off undocumented upstream behavior, no exact-head green, reviewer blockers
 smaller slice would not close the issue. Estimated honest merge path 8–12h with a maintainer-owned
 rebase and security pass; not this batch.
 
+## Executed
+PR #2496 closed 2026-09-02 with the rationale above; #2495 commented with reopen conditions
+(maintainer-owned rebase, exact-head green run, security pass on plaintext retention).

--- a/devlog/_plan/260902_nonbug_adoption_backlog/151_wp15_audit_r1_synthesis.md
+++ b/devlog/_plan/260902_nonbug_adoption_backlog/151_wp15_audit_r1_synthesis.md
@@ -1,0 +1,6 @@
+# wp15 audit r1 — synthesis
+
+James (grok-4.6): PR #2496 head e4b88af4f is a +2729/18-file protocol rewrite keyed off undocumented
+ChatGPT/Codex behavior; exact-head CI never ran (fork approval), last executed suite red on two
+PR-specific assertions; CHANGES_REQUESTED not re-reviewed; a smaller slice would not close #2495.
+Verdict: close the PR with rationale, keep the issue open with reopen conditions. Adopted.


### PR DESCRIPTION
## Summary

- Planning records for the non-bug adoption backlog: wp14 (#2816 carry of #2817, landed as #3216) and wp15 (#2495 / PR #2496 disposition: PR closed with rationale, issue kept open). `devlog/` only; nothing in the build, typecheck, or test path reads it.

## Verification

- `bun test tests/repo-hygiene.test.ts` -> 12 pass. Docs-only.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
