### PR TITLE
fix(responses): preserve Spark exec tool identity

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -467,14 +467,18 @@ function normalizeConfiguredReasoningSummaryDelivery(
  * namespace, tool_search, web_search, custom) plus extensions (defer_loading,
  * parallel_tool_calls, tool_search_call/output items). Spark's serving path only
  * supports flat function tools and hosted web_search. This function:
- * - Flattens namespace tools → promotes inner functions to top level
+ * - Flattens routed namespace tools → promotes inner functions to top level
+ * - Preserves Codex's reserved `functions` namespace on the canonical native forward route
  * - Drops unsupported tool types (tool_search, custom)
  * - Strips defer_loading from function tools
  * - Strips namespace from input items
  * - Drops tool_search_call/tool_search_output input items
  * - Sets parallel_tool_calls to false
  */
-function stripSparkCompatibility(body: unknown): unknown {
+function stripSparkCompatibility(
+  body: unknown,
+  preserveBuiltinFunctionsNamespace = false,
+): unknown {
   if (!isPlainObject(body)) return body;
   const model = typeof body.model === "string" ? body.model : "";
   if (!model.includes("codex-spark")) return body;
@@ -487,7 +491,14 @@ function stripSparkCompatibility(body: unknown): unknown {
   if (Array.isArray(tools)) {
     const flattened: unknown[] = [];
     for (const t of tools) {
-      if (isPlainObject(t) && t.type === "namespace") {
+      if (
+        isPlainObject(t)
+        && t.type === "namespace"
+        && preserveBuiltinFunctionsNamespace
+        && t.name === "functions"
+      ) {
+        flattened.push(t);
+      } else if (isPlainObject(t) && t.type === "namespace") {
         changed = true;
         if (Array.isArray(t.tools)) {
           for (const inner of t.tools) flattened.push(inner);
@@ -527,7 +538,14 @@ function stripSparkCompatibility(body: unknown): unknown {
         const innerTools = item.tools as unknown[];
         const filteredInner: unknown[] = [];
         for (const t of innerTools) {
-          if (isPlainObject(t) && t.type === "namespace") {
+          if (
+            isPlainObject(t)
+            && t.type === "namespace"
+            && preserveBuiltinFunctionsNamespace
+            && t.name === "functions"
+          ) {
+            filteredInner.push(t);
+          } else if (isPlainObject(t) && t.type === "namespace") {
             changed = true;
             if (Array.isArray(t.tools)) {
               for (const fn of t.tools) filteredInner.push(fn);
@@ -2233,6 +2251,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
               ),
             ),
           ),
+          isCanonicalOpenAiForwardProvider(provider),
         ),
         isXaiSchemaTarget(provider),
       );

--- a/src/responses/namespace-tool-compat.ts
+++ b/src/responses/namespace-tool-compat.ts
@@ -379,11 +379,12 @@ export function rewriteRoutedNamespaceToolsForUpstream(body: unknown): {
 export function restoreRoutedNamespaceCalls(
   value: unknown,
   aliases: RoutedNamespaceToolAliases,
+  bareCustomToolNames?: ReadonlySet<string>,
 ): { value: unknown; changed: boolean } {
   if (Array.isArray(value)) {
     let changed = false;
     const restored = value.map(entry => {
-      const result = restoreRoutedNamespaceCalls(entry, aliases);
+      const result = restoreRoutedNamespaceCalls(entry, aliases, bareCustomToolNames);
       changed ||= result.changed;
       return result.value;
     });
@@ -394,9 +395,22 @@ export function restoreRoutedNamespaceCalls(
   let changed = false;
   const restored: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    const result = restoreRoutedNamespaceCalls(entry, aliases);
+    const result = restoreRoutedNamespaceCalls(entry, aliases, bareCustomToolNames);
     restored[key] = result.value;
     changed ||= result.changed;
+  }
+
+  if (
+    value.type === "custom_tool_call"
+    && typeof value.name === "string"
+    && value.namespace === value.name
+    && bareCustomToolNames?.has(value.name) === true
+  ) {
+    // Some Responses backends echo a bare custom tool as `{name:"exec", namespace:"exec"}`.
+    // Codex concatenates those fields into `execexec`; remove only the duplicate namespace for a
+    // request-authorized bare custom tool. Genuine same-name namespace tools are excluded upstream.
+    delete restored.namespace;
+    changed = true;
   }
 
   if (
@@ -416,20 +430,22 @@ export function restoreRoutedNamespaceCalls(
 export function restoreRoutedNamespaceCallsInJson(
   text: string,
   aliases: RoutedNamespaceToolAliases,
+  bareCustomToolNames?: ReadonlySet<string>,
 ): string {
-  if (aliases.size === 0) return text;
+  if (aliases.size === 0 && (bareCustomToolNames?.size ?? 0) === 0) return text;
   let payload: unknown;
   try {
     payload = JSON.parse(text);
   } catch {
     return text;
   }
-  const restored = restoreRoutedNamespaceCalls(payload, aliases);
+  const restored = restoreRoutedNamespaceCalls(payload, aliases, bareCustomToolNames);
   return restored.changed ? JSON.stringify(restored.value) : text;
 }
 
 export function createRoutedNamespaceCallRestoreRewrite(
   aliases: RoutedNamespaceToolAliases,
+  bareCustomToolNames?: ReadonlySet<string>,
 ): (payload: string) => string {
-  return payload => restoreRoutedNamespaceCallsInJson(payload, aliases);
+  return payload => restoreRoutedNamespaceCallsInJson(payload, aliases, bareCustomToolNames);
 }

--- a/src/server/responses-undeclared-tool-guard.ts
+++ b/src/server/responses-undeclared-tool-guard.ts
@@ -131,6 +131,58 @@ function addWireToolSpecs(names: Set<string>, specs: unknown): void {
   }
 }
 
+function addBareCustomToolSpecs(
+  names: Set<string>,
+  sameNameNamespaces: Set<string>,
+  specs: unknown,
+): void {
+  if (!Array.isArray(specs)) return;
+  for (const spec of specs) {
+    if (!isPlainObject(spec)) continue;
+    if (spec.type === "custom" && typeof spec.name === "string" && spec.name.length > 0) {
+      names.add(spec.name);
+      continue;
+    }
+    if (spec.type !== "namespace" || !Array.isArray(spec.tools) || typeof spec.name !== "string") {
+      continue;
+    }
+    for (const inner of spec.tools) {
+      if (
+        !isPlainObject(inner)
+        || inner.type !== "custom"
+        || typeof inner.name !== "string"
+        || inner.name.length === 0
+      ) continue;
+      if (spec.name === BUILTIN_FUNCTIONS_NAMESPACE) names.add(inner.name);
+      else if (spec.name === inner.name) sameNameNamespaces.add(inner.name);
+    }
+  }
+}
+
+/**
+ * Bare custom tools declared by this request's readable catalog.
+ *
+ * Callers must first slice away replayed input with `currentTurnWireToolCatalogBody`. A genuine
+ * same-name namespace such as `exec.exec` makes the upstream shape ambiguous and therefore keeps
+ * the namespace fail-closed.
+ */
+export function collectBareCustomToolNames(body: unknown): Set<string> {
+  const names = new Set<string>();
+  const sameNameNamespaces = new Set<string>();
+  if (!isPlainObject(body)) return names;
+  addBareCustomToolSpecs(names, sameNameNamespaces, body.tools);
+  if (Array.isArray(body.input)) {
+    for (const item of body.input) {
+      if (
+        isPlainObject(item)
+        && (item.type === "additional_tools" || item.type === "tool_search_output")
+      ) addBareCustomToolSpecs(names, sameNameNamespaces, item.tools);
+    }
+  }
+  for (const name of sameNameNamespaces) names.delete(name);
+  return names;
+}
+
 /**
  * Tool names the OUTBOUND Responses body actually declared.
  *

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -108,12 +108,15 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
   /** Declared parameter schema per request-visible tool name (#1611 integer repair). */
   toolParameterSchemas: Map<string, Record<string, unknown>>;
   freeformToolNames: Set<string>;
+  /** Bare custom tools whose echoed same-name namespace may be removed on the client response. */
+  bareCustomToolNames: Set<string>;
   toolSearchToolNames: Set<string>;
 } {
   const toolNsMap = new Map<string, { namespace: string; name: string; freeform?: true }>();
   const declaredToolNames = new Set<string>();
   const toolParameterSchemas = new Map<string, Record<string, unknown>>();
   const freeformToolNames = new Set<string>();
+  const bareCustomToolNames = new Set<string>();
   const toolSearchToolNames = new Set<string>();
   const requestedTools = parsed.context.tools ?? [];
   const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice, requestedTools);
@@ -133,6 +136,7 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
     if (t.freeform) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
       freeformToolNames.add(t.name);
+      if (!t.namespace) bareCustomToolNames.add(t.name);
     }
     if (t.toolSearch) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
@@ -162,7 +166,14 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
       toolParameterSchemas.set(t.name, t.parameters);
     }
   }
-  return { toolNsMap, declaredToolNames, toolParameterSchemas, freeformToolNames, toolSearchToolNames };
+  return {
+    toolNsMap,
+    declaredToolNames,
+    toolParameterSchemas,
+    freeformToolNames,
+    bareCustomToolNames,
+    toolSearchToolNames,
+  };
 }
 
 

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -366,6 +366,7 @@ import {
   type RoutedNamespaceToolAliases,
 } from "../../responses/namespace-tool-compat";
 import {
+  collectBareCustomToolNames,
   collectDeclaredNamelessClientCallTypes,
   collectDeclaredWireToolNames,
   collectProviderExecutedCallTypes,
@@ -3659,6 +3660,10 @@ async function handleResponsesInner(
     );
     const clientExplicitWireToolCatalog = hasExplicitWireToolCatalog(clientToolAuthorizationBody);
     const clientDeclaredWireToolNames = collectDeclaredWireToolNames(clientToolAuthorizationBody);
+    const clientBareCustomToolNames = collectBareCustomToolNames(clientToolAuthorizationBody);
+    const authorizedBareCustomToolNames = new Set(
+      [...toolBridgeMaps.bareCustomToolNames].filter(name => clientBareCustomToolNames.has(name)),
+    );
     const clientDeclaredNamelessCallTypes = collectDeclaredNamelessClientCallTypes(
       clientToolAuthorizationBody,
     );
@@ -3748,7 +3753,11 @@ async function handleResponsesInner(
       ),
     );
     const restoreAuthorizedBareNamespaceToolCalls = (value: unknown): unknown =>
-      restoreRoutedNamespaceCalls(value, authorizedBareNamespaceToolAliases).value;
+      restoreRoutedNamespaceCalls(
+        value,
+        authorizedBareNamespaceToolAliases,
+        authorizedBareCustomToolNames,
+      ).value;
     let undeclaredToolGuardActive = false;
     const refreshUndeclaredToolGuard = (builtRequest: AdapterRequest): void => {
       outboundRequestBody = parseOutboundRequestBody(builtRequest.body);
@@ -4644,8 +4653,11 @@ async function handleResponsesInner(
         routedNamespaceToolAliases.size > 0
           ? createRoutedNamespaceCallRestoreRewrite(routedNamespaceToolAliases)
           : undefined,
-        authorizedBareNamespaceToolAliases.size > 0
-          ? createRoutedNamespaceCallRestoreRewrite(authorizedBareNamespaceToolAliases)
+        authorizedBareNamespaceToolAliases.size > 0 || authorizedBareCustomToolNames.size > 0
+          ? createRoutedNamespaceCallRestoreRewrite(
+            authorizedBareNamespaceToolAliases,
+            authorizedBareCustomToolNames,
+          )
           : undefined,
         hasResponsesItemIdRepair(repairConfig)
           ? createResponsesItemIdPayloadRewrite(repairConfig!, translatorBudget)
@@ -4879,6 +4891,7 @@ async function handleResponsesInner(
         const restoredAuthorizedBareNamespace = restoreRoutedNamespaceCallsInJson(
           restoredNamespace,
           authorizedBareNamespaceToolAliases,
+          authorizedBareCustomToolNames,
         );
         const restored = restoreRoutedCustomCallsInJson(
           restoredAuthorizedBareNamespace,

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -1740,6 +1740,52 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.tools.some(t => t.type === "image_generation")).toBe(false);
   });
 
+  test("preserves the builtin functions namespace for canonical Spark forward", () => {
+    const builtinFunctions = {
+      type: "namespace",
+      name: "functions",
+      tools: [
+        {
+          type: "custom",
+          name: "exec",
+          description: "Run shell commands",
+          format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+        },
+        { type: "function", name: "wait", defer_loading: true, parameters: { type: "object" } },
+      ],
+    };
+    const routedNamespace = {
+      type: "namespace",
+      name: "workspace",
+      tools: [{ type: "function", name: "read", defer_loading: true, parameters: { type: "object" } }],
+    };
+    const adapter = createResponsesPassthroughAdapter(provider);
+    const request = adapter.buildRequest({
+      modelId: "gpt-5.3-codex-spark",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "gpt-5.3-codex-spark",
+        input: [{ type: "additional_tools", tools: [builtinFunctions, routedNamespace] }],
+        tools: [builtinFunctions, routedNamespace],
+      },
+    }, { headers: new Headers({ authorization: "Bearer token" }) });
+    const body = JSON.parse(request.body) as {
+      tools: Record<string, unknown>[];
+      input: Array<{ type: string; tools: Record<string, unknown>[] }>;
+    };
+
+    expect(body.tools[0]).toEqual(builtinFunctions);
+    expect(body.input[0]?.tools[0]).toEqual(builtinFunctions);
+    expect(body.tools).toContainEqual({ type: "function", name: "read", parameters: { type: "object" } });
+    expect(body.input[0]?.tools).toContainEqual({
+      type: "function",
+      name: "read",
+      parameters: { type: "object" },
+    });
+  });
+
   test("keeps image_generation hosted tool for supported native slugs", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const request = adapter.buildRequest({

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -729,6 +729,18 @@ describe("empty and absent tool catalogs", () => {
     },
   } as OcxConfig;
 
+  const forwardConfig = {
+    port: 0,
+    defaultProvider: "fixture",
+    providers: {
+      fixture: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+      },
+    },
+  } as OcxConfig;
+
   const call = {
     type: "function_call",
     id: "fc_1",
@@ -748,13 +760,14 @@ describe("empty and absent tool catalogs", () => {
     model = "fixture/deepseek-v4-flash",
     previousResponseId?: string,
     toolChoice?: unknown,
+    requestHeaders?: Record<string, string>,
   ) {
     const savedFetch = globalThis.fetch;
     globalThis.fetch = (async () => upstream()) as typeof fetch;
     try {
       return await handleResponses(new Request("http://localhost/v1/responses", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...requestHeaders },
         body: JSON.stringify({
           model,
           stream,
@@ -788,6 +801,115 @@ describe("empty and absent tool catalogs", () => {
     ].join("\n\n") + "\n\n",
     { headers: { "content-type": "text/event-stream" } },
   );
+
+  test("strips a same-name namespace echoed for a bare Responses Lite custom tool", async () => {
+    const execTool = {
+      type: "namespace",
+      name: "functions",
+      tools: [{
+        type: "custom",
+        name: "exec",
+        description: "Run shell commands",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      }],
+    };
+    const execCall = {
+      type: "custom_tool_call",
+      id: "ctc_exec",
+      call_id: "call_exec",
+      name: "exec",
+      namespace: "exec",
+      input: "pwd",
+      status: "completed",
+    };
+    const upstream = (stream: boolean) => () => stream
+      ? new Response(
+        [
+          frame("response.output_item.added", { output_index: 0, item: execCall }),
+          frame("response.completed", { response: { id: "resp_exec", status: "completed", output: [execCall] } }),
+          "data: [DONE]",
+        ].join("\n\n") + "\n\n",
+        { headers: { "content-type": "text/event-stream" } },
+      )
+      : Response.json({ id: "resp_exec", status: "completed", output: [execCall] });
+
+    const jsonResponse = await post(
+      false,
+      undefined,
+      upstream(false),
+      [execTool],
+      forwardConfig,
+      [],
+      "fixture/gpt-5.3-codex-spark",
+      undefined,
+      undefined,
+      { authorization: "Bearer caller-token" },
+    );
+    expect(jsonResponse.status).toBe(200);
+    const json = await jsonResponse.json() as { output: Array<Record<string, unknown>> };
+    expect(json.output[0]).toMatchObject({ type: "custom_tool_call", name: "exec" });
+    expect(json.output[0]?.namespace).toBeUndefined();
+
+    const sseResponse = await post(
+      true,
+      undefined,
+      upstream(true),
+      [execTool],
+      forwardConfig,
+      [],
+      "fixture/gpt-5.3-codex-spark",
+      undefined,
+      undefined,
+      { authorization: "Bearer caller-token" },
+    );
+    const sseBody = await sseResponse.text();
+    expect(sseBody).toContain('"type":"custom_tool_call"');
+    expect(sseBody).toContain('"name":"exec"');
+    expect(sseBody).not.toContain('"namespace":"exec"');
+  });
+
+  test("preserves a same-name namespace for a genuinely namespaced custom tool", async () => {
+    const namespacedExec = {
+      type: "namespace",
+      name: "exec",
+      tools: [{
+        type: "custom",
+        name: "exec",
+        description: "Run a namespaced command",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      }],
+    };
+    const call = {
+      type: "custom_tool_call",
+      id: "ctc_namespaced_exec",
+      call_id: "call_namespaced_exec",
+      name: "exec",
+      namespace: "exec",
+      input: "status",
+      status: "completed",
+    };
+
+    const response = await post(
+      false,
+      undefined,
+      () => Response.json({ id: "resp_namespaced_exec", status: "completed", output: [call] }),
+      [namespacedExec],
+      forwardConfig,
+      [],
+      "fixture/gpt-5.3-codex-spark",
+      undefined,
+      undefined,
+      { authorization: "Bearer caller-token" },
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json() as { output: Array<Record<string, unknown>> };
+    expect(json.output[0]).toMatchObject({
+      type: "custom_tool_call",
+      name: "exec",
+      namespace: "exec",
+    });
+  });
 
   // A passthrough request may omit `tools` entirely and still receive a tool call the client
   // understands — the Copilot contract in tests/github-copilot-stream-contract.test.ts does
@@ -1091,6 +1213,63 @@ describe("empty and absent tool catalogs", () => {
     expect(response.status).toBe(502);
     const namedBody = await response.json() as { error: { message: string } };
     expect(namedBody.error.message).toContain('undeclared client tool "exec"');
+  });
+
+  test("a replayed bare custom tool cannot dequalify a current namespaced call", async () => {
+    const previousId = "resp_replayed_bare_custom_exec";
+    const historicalExec = {
+      type: "namespace",
+      name: "functions",
+      tools: [{
+        type: "custom",
+        name: "exec",
+        description: "Run shell commands",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      }],
+    };
+    const prime = await post(
+      false,
+      undefined,
+      () => Response.json({ id: previousId, status: "completed", output: [] }),
+      [historicalExec],
+      forwardConfig,
+      [],
+      "fixture/gpt-5.3-codex-spark",
+      undefined,
+      undefined,
+      { authorization: "Bearer caller-token" },
+    );
+    expect(prime.status).toBe(200);
+    await prime.arrayBuffer();
+
+    const response = await post(
+      false,
+      [],
+      () => Response.json({
+        id: "resp_current_deny_all",
+        status: "completed",
+        output: [{
+          type: "custom_tool_call",
+          id: "ctc_current_exec",
+          call_id: "call_current_exec",
+          name: "exec",
+          namespace: "exec",
+          input: "pwd",
+          status: "completed",
+        }],
+      }),
+      undefined,
+      forwardConfig,
+      [],
+      "fixture/gpt-5.3-codex-spark",
+      previousId,
+      undefined,
+      { authorization: "Bearer caller-token" },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { output: Array<Record<string, unknown>> };
+    expect(body.output[0]).toMatchObject({ name: "exec", namespace: "exec" });
   });
 
   test("a replayed nameless catalog cannot authorize a deny-all continuation", async () => {


### PR DESCRIPTION
## Summary

- preserve Codex's reserved `functions` namespace for Spark on the canonical OpenAI forward route while keeping routed namespace flattening unchanged
- normalize an echoed `namespace === name` only for bare custom tools authorized by the current Responses turn
- cover JSON/SSE responses, genuine same-name namespaces, and replay isolation

Closes #3217

## Testing

- `bun run prepush` — 17,221 passed, 14 skipped, 0 failed; typecheck and privacy scan passed
- `bun test tests/responses-undeclared-tool-guard.test.ts tests/namespace-tool-compat.test.ts tests/responses-parser.test.ts tests/openai-responses-passthrough.test.ts` — 277 passed
- sabotage checks confirmed the request rewrite, response normalization, and continuation-boundary tests fail when their pre-fix behavior is restored

## Risk

Low and request-scoped. The request change applies only to the canonical OpenAI Spark forward route's reserved `functions` namespace. The response rewrite applies only to `custom_tool_call` items whose name matches their namespace and whose bare custom declaration is authorized by the current turn. Genuine namespaced tools and historical replay catalogs remain unchanged.

## Checklist

- [x] Change is limited to the reported Responses tool-identity bug
- [x] Tests cover request preservation, JSON/SSE response repair, genuine namespace preservation, and continuation isolation
- [x] Typecheck, canonical tests, and privacy scan pass
- [x] No secrets or credentials are included

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the built-in `functions` namespace on the native forwarding route.
  - Corrected custom tool-call names to prevent duplicated namespaces.
  - Improved handling of tool authorization across current and replayed requests.
  - Preserved genuine namespaced tools while removing synthetic namespace data from bare custom calls.

- **Tests**
  - Added coverage for namespace preservation, tool-call normalization, and replay continuation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->