### PR TITLE
fix(agents): allow Codexless V2 task recovery

### DIFF
--- a/src/server/responses/agent-task-recovery.ts
+++ b/src/server/responses/agent-task-recovery.ts
@@ -23,6 +23,7 @@ const CODEX_ORIGINATORS = new Set([
   "Codex Desktop",
   "codex_app",
   "codex_work_desktop",
+  "codexless_agent",
 ]);
 const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_TOKEN_ISSUERS = new Set(["https://auth.openai.com", "https://auth.openai.com/"]);

--- a/tests/agent-task-recovery-security.test.ts
+++ b/tests/agent-task-recovery-security.test.ts
@@ -413,4 +413,27 @@ describe("agent task recovery security", () => {
     expect(response.status).toBe(200);
     expect(recoveryOriginator).toBe("codex_work_desktop");
   });
+
+  test("accepts the Codexless originator", async () => {
+    let recoveryOriginator = "";
+    globalThis.fetch = (async (input, init) => {
+      if (String(input).includes("chatgpt.com")) {
+        recoveryOriginator = new Headers(init?.headers).get("originator") ?? "";
+        return new Response(recoverySse("Recover the Codexless child task."), { status: 200 });
+      }
+      return providerResponse();
+    }) as typeof fetch;
+    const headers = codexHeaders();
+    headers.set("originator", "codexless_agent");
+
+    const response = await post(
+      routedConfig(),
+      "xai/grok-4.5",
+      encryptedInput(),
+      headers,
+    );
+
+    expect(response.status).toBe(200);
+    expect(recoveryOriginator).toBe("codexless_agent");
+  });
 });


### PR DESCRIPTION
## Summary

- I hit encrypted V2 subagent tasks failing through Codexless with `unreadable_encrypted_agent_task`.
- I traced it to recovery admission rejecting Codexless's actual app-server originator, `codexless_agent`.
- I added that exact originator to the existing allowlist and added a focused regression test that verifies the recovery request preserves `originator=codexless_agent`.
- The later recovery authentication and security checks are unchanged.

## Verification

- `bun test tests/agent-task-recovery-security.test.ts`: 14 passed, 0 failed
- `bun run typecheck`: passed
- `bun run privacy:scan`: passed
- `git diff --check`: passed
- Broader `test:changed` and full-suite runs reached the repository's 900-second limit with unrelated Windows `icacls`, `EBUSY`, and host-load failures. The relevant recovery security tests passed within those runs.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
  - No docs or release-note change is needed because this admits the existing Codexless app-server originator without changing a documented configuration or contract.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
  - This touches recovery admission and requires explicit maintainer security review. The change does not weaken native JWT validation, account matching, API-key or proxy-secret rejection, bearer/auth checks, loopback checks, envelope checks, or cache protections.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
