### PR TITLE
fix(cli): stop a sibling start from persisting its port into config.port

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -149,7 +149,10 @@ function startArgv(port?: number): string[] {
   return selfLaunchArgv(args);
 }
 
-async function chooseListenPort(requestedPort?: number): Promise<number> {
+async function chooseListenPort(
+  requestedPort?: number,
+  options: { sibling?: boolean } = {},
+): Promise<number> {
   const config = loadConfig();
   const preferred = requestedPort ?? config.port ?? 10100;
   const hardPin = requestedPort !== undefined && requestedPort > 0;
@@ -197,7 +200,7 @@ async function chooseListenPort(requestedPort?: number): Promise<number> {
     if (preferred > 0 && selected !== preferred) {
       console.log(`⚠️  Port ${preferred} is busy; starting opencodex on ${selected}.`);
     }
-    if (shouldPersistSelectedPort(config.port, selected, preferred)) {
+    if (shouldPersistSelectedPort(config.port, selected, preferred, options)) {
       config.port = selected;
       saveConfig(config);
     }
@@ -253,6 +256,7 @@ async function handleStart(options: { block?: boolean } = {}) {
   // shutdown then left no runtime record for discovery at all. `handleEnsure`
   // already passes this; `handleStart` is the path that did not.
   const owner = await findProxyOwnerBeforeJournalRecovery({ probeConfiguredPort: true });
+  let siblingStart = false;
   if (owner.live) {
     // Rationale and the full decision table live on `decideStartWithLiveOwner`.
     const decision = decideStartWithLiveOwner({
@@ -276,6 +280,10 @@ async function handleStart(options: { block?: boolean } = {}) {
     // Sibling path. Honest about the side effects it shares with any start in this home:
     // the new instance takes over this home's ocx.pid / runtime-port.json while it runs,
     // and re-points this home's Codex config at the new port when injection applies.
+    // What it must NOT do is persist its port into config.port: the configured-port
+    // proxy is still the owner of this home, and a later `ocx service` reads config.port
+    // to bake the service (observed: a probe on 10198 left the service pinned there).
+    siblingStart = true;
     console.warn(
       `Proxy already running on port ${owner.live.port}; starting a second instance on requested port ${requestedPort}. `
       + `The new instance takes over this home's pid/runtime records and Codex config while it runs.`,
@@ -304,7 +312,7 @@ async function handleStart(options: { block?: boolean } = {}) {
   // Port selection is check-then-bind: a concurrent `ocx start`/`ensure` can win the port
   // between the probe and Bun.serve. Soft starts may re-pick; hard-pinned `--port` retries
   // the same port only (never hop — that was the remaining PR #152 gap).
-  let port = await chooseListenPort(requestedPort);
+  let port = await chooseListenPort(requestedPort, { sibling: siblingStart });
   const { drainAndShutdown, isRecyclingForExit, startServer } = await import("../server");
   // One private readiness gate for this startServer invocation, captured by the
   // listener's closure. handleStart owns it and transitions it after the
@@ -334,7 +342,7 @@ async function handleStart(options: { block?: boolean } = {}) {
         continue;
       }
       console.log(`⚠️  Port ${port} was taken while starting; picking another...`);
-      port = await chooseListenPort(requestedPort);
+      port = await chooseListenPort(requestedPort, { sibling: siblingStart });
     }
   }
   // A single request's streaming error must never crash the daemon serving every

--- a/src/server/ports.ts
+++ b/src/server/ports.ts
@@ -151,6 +151,13 @@ export function shouldPersistSelectedPort(
   configPort: number | undefined,
   selectedPort: number,
   preferredPort: number,
+  options: { sibling?: boolean } = {},
 ): boolean {
+  // A sibling start (`--port X` beside a live proxy on the configured port) is a
+  // second instance, not a new home for this config. Persisting its port rewrote
+  // config.port under the still-running configured-port proxy, and the next
+  // `ocx service` install then baked the sibling's port into the service and
+  // re-pointed every client at a listener that no longer existed.
+  if (options.sibling) return false;
   return selectedPort === preferredPort && configPort !== selectedPort;
 }

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -252,6 +252,19 @@ describe("start probes the configured port before shadowing it (source-level)", 
     expect(cliSource).not.toContain("explicitSiblingPort");
   });
 
+  test("a sibling start carries its flag into every chooseListenPort call", () => {
+    // The sibling instance must not persist its explicit port into config.port: the
+    // configured-port proxy still owns this home, and `ocx service` bakes config.port.
+    // Both call sites (initial pick and the EADDRINUSE re-pick) have to pass the flag,
+    // or the re-pick path silently regains the old behavior.
+    const calls = cliSource.match(/await chooseListenPort(([^)]*))/g) ?? [];
+    expect(calls.length).toBe(2);
+    for (const call of calls) {
+      expect(call).toContain("sibling: siblingStart");
+    }
+    expect(cliSource).toContain("siblingStart = true;");
+  });
+
   test("the probe option still gates on an explicit true", () => {
     // A truthy-but-not-true default would silently probe for callers that pass
     // nothing, which is a different behavior than the one asserted above.

--- a/tests/ports.test.ts
+++ b/tests/ports.test.ts
@@ -62,6 +62,15 @@ describe("port selection", () => {
     expect(shouldPersistSelectedPort(10100, 10100, 10100)).toBe(false);
   });
 
+  test("a sibling start never persists its explicit port over the configured one", () => {
+    // `ocx start --port 10198` beside a live proxy on 10100: the sibling gets its port,
+    // but config.port stays 10100 so the next `ocx service` install is not re-pinned.
+    expect(shouldPersistSelectedPort(10100, 10198, 10198, { sibling: true })).toBe(false);
+    // The same arguments without the sibling flag are the ordinary first-start persist.
+    expect(shouldPersistSelectedPort(10100, 10198, 10198)).toBe(true);
+    expect(shouldPersistSelectedPort(10100, 10198, 10198, { sibling: false })).toBe(true);
+  });
+
   test("waitForPortAvailable resolves once a busy port is released", async () => {
     const { server, port } = await listen();
     expect(await isPortAvailable(port)).toBe(false);


### PR DESCRIPTION
## Summary

- #3188 opened the sibling path: `ocx start --port X` beside a live proxy on the configured port starts a second instance instead of refusing. That instance goes through `chooseListenPort` with `X` as its hard-pinned preference, so `shouldPersistSelectedPort(config.port, X, X)` is true and **`config.port` is rewritten to `X` under the still-running configured-port proxy**.
- Observed on the maintainer dogfooding host: a probe session ran `start --port 10198` a few times against the real home, exited, and left `config.port=10198` behind. The next `ocx stop` + `ocx service` read `config.port`, baked `--port 10198` into the launchd plist, and re-pointed Codex `openai_base_url` at 10198 — the service silently moved off 10100 with no start on 10198 in sight.
- A sibling is a second instance, not a new home for this config, so it must never persist its port. `handleStart` now records the sibling decision and passes `{ sibling: true }` into both `chooseListenPort` call sites (initial pick and the EADDRINUSE re-pick); `shouldPersistSelectedPort` returns false for it. The ordinary first-start persist and the fallback-port non-persist are unchanged.

## Verification

- `bun run typecheck`
- `bun test tests/ports.test.ts tests/cli-dispatch.test.ts tests/update-notify.test.ts` — 66 pass / 0 fail
  - new: `shouldPersistSelectedPort` sibling case (`(10100, 10198, 10198, { sibling: true })` → false; same args without the flag → true)
  - new: source pin that both `chooseListenPort` call sites in `handleStart` carry `sibling: siblingStart`, so the re-pick path cannot silently regain the old behavior
- Live recovery on the affected host: `ocx config set port 10100` + `ocx service` → plist `--port 10100`, `/healthz` on 10100, `openai_base_url` back on 10100.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing doc describes the sibling persist; the warn text already says the sibling only takes over runtime records.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No auth/credential path touched.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy startup when launching a second instance alongside an existing proxy.
  * Prevented the secondary instance’s selected port from replacing the configured port used by the primary proxy.
  * Preserved expected port selection behavior during startup retries.

* **Tests**
  * Added coverage for sibling proxy startup and port persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->