### PR TITLE
feat(cursor): expose -fast identities to clients without a Fast toggle

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -210,6 +210,35 @@ contract; existing configurations see these migration deltas:
 
 Explicit capability `false` and Responses caller-tier forwarding retain their existing contracts.
 
+### Cursor Fast (`cursor-variant`)
+
+Cursor has no `service_tier` field. Its fast product is a different **model variant** —
+`claude-opus-5-thinking-high-fast`, or a `{id:"fast",value:"true"}` request parameter for
+Grok — so the Cursor entry declares `fastWire.kind: "cursor-variant"` and the request
+builder resolves the variant instead of setting a request field.
+
+Only the bases that actually declare a fast variant advertise Fast: `claude-opus-4-7`,
+`claude-opus-4-8`, `claude-opus-5`, `grok-4.5`, `grok-4.6`. Every other Cursor row publishes
+`supportsServiceTier: false`, so Codex shows no toggle rather than a dead one.
+
+A base whose umbrella row routes thinking upgrades to its **thinking-fast** variant, not to
+the plain fast sibling — that sibling is a different product with a shorter effort ladder,
+and for `claude-opus-5` its regular family is quarantined upstream.
+
+`fastMode` behaves differently per surface, because only Codex has a Fast toggle of its own:
+
+| Surface | `fastMode: true` |
+|---|---|
+| Codex | rows stay umbrella rows; the app's Fast toggle selects the variant |
+| Claude Code (`?ids=cli`) | lists the fast identity, e.g. `claude-ocx-cursor--claude-opus-5-thinking-fast` |
+| OpenAI `/v1/models` | lists `cursor/claude-opus-5-thinking-fast` |
+| Claude Desktop (3P) | unchanged — its aliases are hashed from the model name |
+| Dashboard `/api/models` | row ids unchanged; they are the enable/disable keys |
+
+Requests are promoted either way: with `fastMode: true`, picking the umbrella id still
+resolves to the fast variant, so a client whose saved config predates the switch does not
+need to rediscover. Every legacy variant id keeps routing unchanged.
+
 ### xAI Priority Processing
 
 The built-in `xai` preset advertises and injects Fast only when its effective transport uses

--- a/src/adapters/cursor/catalog.ts
+++ b/src/adapters/cursor/catalog.ts
@@ -469,6 +469,27 @@ export function cursorFastCapableBases(): string[] {
     .map(([baseId]) => baseId);
 }
 
+/**
+ * The id to LIST for a base when the global fast switch is on, for clients that have no
+ * Fast toggle of their own. Undefined when the base has no fast dimension, so a caller
+ * cannot advertise an id that would not route.
+ *
+ * Composed from the base's defaultVariant rather than a bare `-fast` suffix. Measured: for a
+ * thinking-default base, `claude-opus-5-fast` parses back as the REGULAR-fast sibling and
+ * resolves to `claude-opus-5-high-fast` — a shorter ladder, in the quarantined regular
+ * family, and a different wire from what the Codex toggle sends. The mirror case is equally
+ * wrong: grok has no thinkingFast spec, so `grok-4.6-thinking-fast` would fall back to the
+ * regular spec and emit a bare `grok-4.6` with no effort and no fast marker at all.
+ */
+export function cursorFastIdFor(baseId: string): string | undefined {
+  const capability = CURSOR_CAPABILITIES[baseId];
+  if (!capability) return undefined;
+  const kind = upgradeToFast(baseId, capability.defaultVariant);
+  if (kind === "thinkingFast") return `${baseId}-thinking-fast`;
+  if (kind === "fast") return `${baseId}-fast`;
+  return undefined;
+}
+
 function normalizeRequestedEffort(reasoning: string | undefined): string | undefined {
   const normalized = reasoning?.toLowerCase();
   return normalized === "ultra" ? "max" : normalized;

--- a/src/claude/model-info.ts
+++ b/src/claude/model-info.ts
@@ -17,6 +17,7 @@
  */
 import { catalogModelEfforts, nativeEffortClamp, nativeOpenAiContextWindow, nativeOpenAiMaxInputTokens, type CatalogModel, type NativeContextLimitsInput } from "../codex/catalog";
 import { claudeCodeAlias, claudeCodeNativeAlias } from "./alias";
+import { cursorFastIdFor } from "../adapters/cursor/catalog";
 import { desktop3pAlias } from "./desktop-3p";
 import { AUTO_CONTEXT_OFF, type AutoContextMode } from "./context-windows";
 
@@ -109,6 +110,7 @@ export function buildAnthropicModelInfos(
   idStyle: AnthropicIdStyle = "desktop3p",
   aliasForRoute: (provider: string, modelId: string) => string = desktop3pAlias,
   nativeContextCap?: NativeContextLimitsInput,
+  fastMode?: boolean,
 ): AnthropicModelInfo[] {
   const out: AnthropicModelInfo[] = [];
   const seen = new Set<string>();
@@ -151,7 +153,16 @@ export function buildAnthropicModelInfos(
     push1mVariant(info, nativeWindow, nativeMaxInput);
   }
   for (const m of routedModels) {
-    const id = idStyle === "readable" ? claudeCodeAlias(m.provider, m.id) : aliasForRoute(m.provider, m.id);
+    // Global Fast has no toggle on this surface, so the fast identity is what gets listed —
+    // a client here can only pick a listed id. Limited to the readable CLI style: Desktop 3P
+    // ids are hashed from the model name, so rewriting them would strand a saved selection.
+    const fastModelId = fastMode === true && m.provider === "cursor" && idStyle === "readable"
+      ? cursorFastIdFor(m.id)
+      : undefined;
+    const listedModelId = fastModelId ?? m.id;
+    const id = idStyle === "readable"
+      ? claudeCodeAlias(m.provider, listedModelId)
+      : aliasForRoute(m.provider, m.id);
     if (seen.has(id)) continue;
     seen.add(id);
     const ladder = Array.isArray(m.reasoningEfforts) ? m.reasoningEfforts : [];
@@ -164,7 +175,7 @@ export function buildAnthropicModelInfos(
         ? Math.min(m.maxInputTokens, m.contextWindow)
         : m.maxInputTokens)
       : undefined;
-    const info = modelInfo(id, `${m.id} (${m.provider})`, ladder, imageInput, routedMaxInput ?? m.contextWindow);
+    const info = modelInfo(id, `${listedModelId} (${m.provider})`, ladder, imageInput, routedMaxInput ?? m.contextWindow);
     out.push(info);
     // Anthropic passthrough guard (audit 021 #3): never auto-widen canonical claude
     // routes — only a genuine >=1M window earns the variant row there.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1528,6 +1528,15 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
               inputModalities: nativeInputModalities(metadataId),
             }),
           });
+        // Resolved once per request, not per model: the global fast switch offers the fast
+        // identity to clients that have no Fast toggle of their own. Null when the switch is
+        // off, so the row mapper does no work and loads no adapter module.
+        const cursorFastIdForListing = config.fastMode === true
+          ? await (async () => {
+            const { cursorFastIdFor } = await import("../adapters/cursor/catalog");
+            return (modelId: string, provider = "cursor") => provider === "cursor" ? cursorFastIdFor(modelId) : undefined;
+          })()
+          : null;
         // Selector-active discovery follows the same complete supported set as the Codex catalog
         // for both bare and qualified rows. Without selectors, the live catalog continues to own
         // bare availability.
@@ -1555,9 +1564,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             // Same rule as the anthropic branch: with the global fast switch on, a client
             // that has no Fast toggle is offered the fast identity directly. An operator
             // alias is an explicit decision and still wins.
-            const fastModelId = config.fastMode === true && m.provider === "cursor"
-              ? (await import("../adapters/cursor/catalog")).cursorFastIdFor(m.id)
-              : undefined;
+            const fastModelId = cursorFastIdForListing?.(m.id, m.provider);
             const publicId = m.alias ?? `${m.provider}/${fastModelId ?? m.id}`;
             const isCombo = m.provider === "combo" && exactComboSlugs.has(publicId);
             const provider = config.providers[m.provider];

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1432,7 +1432,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             : idsParam === "desktop"
               ? "desktop3p" as const
               : (/^claude-code\//i.test(req.headers.get("user-agent") ?? "") ? "readable" as const : "desktop3p" as const);
-          const data = buildAnthropicModelInfos(desktopNativeSlugs, goOrdered, resolveAutoContext(config.claudeCode), idStyle, activeDesktop3pAlias, nativeContextLimits(config));
+          const data = buildAnthropicModelInfos(desktopNativeSlugs, goOrdered, resolveAutoContext(config.claudeCode), idStyle, activeDesktop3pAlias, nativeContextLimits(config), config.fastMode);
           return jsonResponse({ data }, 200, req, policy);
         }
         if (url.searchParams.has("client_version")) {
@@ -1552,7 +1552,13 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
           ...visibleNatives.map(id => nativeModelRow(id)),
           ...visibleAccountNatives.map(({ id, metadataId }) => nativeModelRow(id, metadataId)),
           ...await Promise.all(uniqueCatalogModelsForRawPublicList(goOrdered).map(async m => {
-            const publicId = m.alias ?? `${m.provider}/${m.id}`;
+            // Same rule as the anthropic branch: with the global fast switch on, a client
+            // that has no Fast toggle is offered the fast identity directly. An operator
+            // alias is an explicit decision and still wins.
+            const fastModelId = config.fastMode === true && m.provider === "cursor"
+              ? (await import("../adapters/cursor/catalog")).cursorFastIdFor(m.id)
+              : undefined;
+            const publicId = m.alias ?? `${m.provider}/${fastModelId ?? m.id}`;
             const isCombo = m.provider === "combo" && exactComboSlugs.has(publicId);
             const provider = config.providers[m.provider];
             const effective = provider

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -1041,6 +1041,11 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
       ...models.filter(m => !isDisabled(m.provider, m.id)).map(m => `${m.provider}/${m.id}`),
     ];
     const aliases: { id: string; display_name: string }[] = [];
+    // Resolved once, not per model: with the global fast switch on, Claude Code discovers the
+    // fast identity, so the dashboard must list the same id rather than the umbrella one.
+    const cursorFastIdFor = config.fastMode === true
+      ? (await import("../../adapters/cursor/catalog")).cursorFastIdFor
+      : undefined;
     for (const slug of listCatalogNativeSlugs()) {
       // Readable CLI-surface alias with hash fallback (devlog 050 / audit 051 #2) —
       // the same shared helper the /v1/models ?ids=cli path uses.
@@ -1048,12 +1053,7 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     }
     for (const m of models) {
       if (isDisabled(m.provider, m.id)) continue;
-      // Match what Claude Code will actually discover: with the global fast switch on,
-      // /v1/models lists the fast identity for a fast-capable cursor base, so the
-      // dashboard must show the same id rather than the umbrella one.
-      const listedId = config.fastMode === true && m.provider === "cursor"
-        ? (await import("../../adapters/cursor/catalog")).cursorFastIdFor(m.id) ?? m.id
-        : m.id;
+      const listedId = (m.provider === "cursor" ? cursorFastIdFor?.(m.id) : undefined) ?? m.id;
       aliases.push({ id: claudeCodeAlias(m.provider, listedId), display_name: `${listedId} (${m.provider})` });
     }
     const contextWindows = buildClaudeContextWindows([...visibleNativeSlugs(config)], models, nativeContextLimits(config));

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -1048,7 +1048,13 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     }
     for (const m of models) {
       if (isDisabled(m.provider, m.id)) continue;
-      aliases.push({ id: claudeCodeAlias(m.provider, m.id), display_name: `${m.id} (${m.provider})` });
+      // Match what Claude Code will actually discover: with the global fast switch on,
+      // /v1/models lists the fast identity for a fast-capable cursor base, so the
+      // dashboard must show the same id rather than the umbrella one.
+      const listedId = config.fastMode === true && m.provider === "cursor"
+        ? (await import("../../adapters/cursor/catalog")).cursorFastIdFor(m.id) ?? m.id
+        : m.id;
+      aliases.push({ id: claudeCodeAlias(m.provider, listedId), display_name: `${listedId} (${m.provider})` });
     }
     const contextWindows = buildClaudeContextWindows([...visibleNativeSlugs(config)], models, nativeContextLimits(config));
     const webSearchOverride = config.claudeCode?.webSearchSidecar;

--- a/tests/cursor-fast-listing.test.ts
+++ b/tests/cursor-fast-listing.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { cursorFastCapableBases, cursorFastIdFor, resolveCursorSelection } from "../src/adapters/cursor/catalog";
+import { buildAnthropicModelInfos } from "../src/claude/model-info";
+import { AUTO_CONTEXT_OFF } from "../src/claude/context-windows";
+import { desktop3pAlias } from "../src/claude/desktop-3p";
+import { providerConfigSeed } from "../src/providers/derive";
+import { getProviderRegistryEntry } from "../src/providers/registry";
+import { decideTier } from "../src/providers/fastwire";
+import { fastPolicyForModel } from "../src/providers/service-tier";
+import type { CatalogModel } from "../src/codex/catalog";
+
+function cursorModel(id: string, contextWindow = 1_000_000): CatalogModel {
+  return { provider: "cursor", id, contextWindow, reasoningEfforts: ["low", "high"] } as CatalogModel;
+}
+
+const listIds = (models: CatalogModel[], fastMode?: boolean) =>
+  buildAnthropicModelInfos([], models, AUTO_CONTEXT_OFF, "readable", desktop3pAlias, undefined, fastMode)
+    .map(info => info.id);
+
+/**
+ * Codex has a Fast toggle, so its rows stay umbrella rows. Claude Code and other
+ * OpenAI-compatible clients have none — they can only pick a listed id — so the global
+ * switch offers them the fast identity directly
+ * (devlog 260902_cursor_unified_identity/030).
+ */
+describe("global fast switch lists -fast identities outside Codex", () => {
+  test("the listed id and the Codex toggle converge on the same wire", () => {
+    // The guard against the whole point of the feature: two surfaces, one behaviour.
+    // A bare -fast suffix would NOT satisfy this for a thinking-default base.
+    for (const base of cursorFastCapableBases()) {
+      const listed = cursorFastIdFor(base);
+      expect(listed).toBeDefined();
+      expect(resolveCursorSelection(listed!, "max").wireId)
+        .toBe(resolveCursorSelection(base, "max", undefined, { fast: true }).wireId);
+    }
+  });
+
+  test("a thinking-default base lists its thinking-fast id, a regular-default base its fast id", () => {
+    expect(cursorFastIdFor("claude-opus-5")).toBe("claude-opus-5-thinking-fast");
+    expect(cursorFastIdFor("grok-4.6")).toBe("grok-4.6-fast");
+  });
+
+  test("a base with no fast variant yields no fast id at all", () => {
+    for (const base of ["kimi-k3", "gpt-5.6-sol", "glm-5.3", "gemini-3.7-flash"]) {
+      expect(cursorFastIdFor(base)).toBeUndefined();
+    }
+  });
+
+  test("Claude Code discovery lists the umbrella id with the switch off", () => {
+    expect(listIds([cursorModel("claude-opus-5")], false))
+      .toContain("claude-ocx-cursor--claude-opus-5");
+    expect(listIds([cursorModel("claude-opus-5")], undefined))
+      .toContain("claude-ocx-cursor--claude-opus-5");
+  });
+
+  test("Claude Code discovery lists the fast identity with the switch on", () => {
+    expect(listIds([cursorModel("claude-opus-5")], true))
+      .toContain("claude-ocx-cursor--claude-opus-5-thinking-fast");
+    expect(listIds([cursorModel("grok-4.6", 500_000)], true))
+      .toContain("claude-ocx-cursor--grok-4.6-fast");
+  });
+
+  test("the switch leaves a base without a fast variant alone", () => {
+    expect(listIds([cursorModel("kimi-k3")], true)).toContain("claude-ocx-cursor--kimi-k3");
+  });
+
+  test("Desktop 3P hashed aliases are untouched by the switch", () => {
+    // Hashes are written into Desktop's config; rewriting them would strand a saved pick.
+    const off = buildAnthropicModelInfos([], [cursorModel("claude-opus-5")], AUTO_CONTEXT_OFF, "desktop3p", desktop3pAlias, undefined, false);
+    const on = buildAnthropicModelInfos([], [cursorModel("claude-opus-5")], AUTO_CONTEXT_OFF, "desktop3p", desktop3pAlias, undefined, true);
+    expect(on.map(i => i.id)).toEqual(off.map(i => i.id));
+  });
+
+  test("fastMode alone promotes an umbrella request, with no caller service_tier", () => {
+    // The persisted-config case: a client still naming the umbrella id must go fast too.
+    const config = providerConfigSeed(getProviderRegistryEntry("cursor")!);
+    const decide = (id: string, fastMode?: boolean) =>
+      decideTier(fastPolicyForModel(config, id, "cursor"), fastMode, undefined);
+
+    expect(decide("claude-opus-5", true)).toEqual({ kind: "set", value: "fast" });
+    expect(decide("grok-4.6", true)).toEqual({ kind: "set", value: "fast" });
+    expect(decide("kimi-k3", true)).toEqual({ kind: "drop" });
+    // And the switch off must not promote.
+    expect(decide("claude-opus-5", false)).toEqual({ kind: "drop" });
+  });
+});


### PR DESCRIPTION
## Summary

Codex has a Fast toggle, so its rows stay umbrella rows and the toggle picks the dimension (#3225). Claude Code and other OpenAI-compatible clients have none — they can only pick a listed id — so with `fastMode` on they are offered the fast identity directly.

| Surface | `fastMode: true` |
|---|---|
| Codex | unchanged umbrella rows; the app's Fast toggle selects the variant |
| Claude Code (`?ids=cli`) | `claude-ocx-cursor--claude-opus-5-thinking-fast` |
| OpenAI `/v1/models` | `cursor/claude-opus-5-thinking-fast` |
| Claude Desktop (3P) | unchanged — aliases are hashed from the model name |
| Dashboard `/api/models` | row ids unchanged — they are the enable/disable keys |

**The listed id is composed from the base's `defaultVariant`, not a bare `-fast` suffix.** That was a real defect in the first draft of this plan, caught in review and confirmed by measurement:

```
claude-opus-5-fast          -> kind=fast          -> claude-opus-5-high-fast
                                                     (clamped, and in the quarantined regular family)
claude-opus-5-thinking-fast -> kind=thinkingFast  -> claude-opus-5-thinking-max-fast   <- what the toggle sends
grok-4.6-thinking-fast      -> kind=thinkingFast  -> grok-4.6   <- no effort, no fast marker: grok has no
                                                                   thinkingFast spec, so it falls back
```

Either fixed suffix is wrong for half the table, so it has to be per base. A test asserts the two surfaces converge: for every fast-capable base, the listed id and the toggled umbrella id resolve to the same wire.

**Request-time promotion needed no new code.** `fastMode` already produces a `{kind:"set"}` tier decision on a fast-capable route with no caller `service_tier`, and every non-Codex inbound path replays through `handleResponses`, so #3225's builder already promotes a client whose saved config still names the umbrella id. The fallback this plan originally called for would have been an unreachable branch.

Third of three stacked PRs, on top of #3225. Plan and audit: [030_wp4_global_fast_switch.md](devlog/_plan/260902_cursor_unified_identity/030_wp4_global_fast_switch.md).

## Verification

```
bun test tests/cursor-fast-listing.test.ts tests/cursor-fast-tier.test.ts \
         tests/claude-model-info.test.ts tests/claude-models-discovery.test.ts \
         tests/claude-management-api.test.ts tests/cursor-catalog.test.ts \
         tests/cursor-umbrella-rows.test.ts tests/cursor-display-names.test.ts \
         tests/fastwire-policy.test.ts tests/codex-catalog.test.ts
                                  643 pass / 0 fail across 10 files
bun run typecheck                 exit 0
bun run privacy:scan              passed
```

The listing tests include the negative cases that keep the rewrite scoped: a base with no fast variant is listed unchanged, and Desktop 3P ids are byte-identical with the switch on and off.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Cursor Fast variants through the global Fast Mode setting.
  - Cursor models now automatically use their Fast or Thinking Fast counterpart when available.
  - Model discovery and aliases consistently display Fast identities across supported surfaces.
  - Requests can be promoted to Fast Mode without requiring an explicit service-tier value.
  - Models without Fast variants and Desktop 3P hashed aliases remain unchanged.

- **Documentation**
  - Added configuration guidance for declaring and using Cursor Fast variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->