### PR TITLE
fix(responses): scope the self-named namespace scrub to declared bare tools (carry of #3226)

### DIFF
--- a/src/server/responses-self-named-namespace-scrub.ts
+++ b/src/server/responses-self-named-namespace-scrub.ts
@@ -4,9 +4,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+export interface SelfNamedNamespaceScrubAuthorization {
+  customToolCallNames: ReadonlySet<string>;
+  functionCallNames: ReadonlySet<string>;
+}
+
 function collectBareCustomToolSpecs(
   bareNames: Set<string>,
-  sameNameNamespacedNames: Set<string>,
+  sameNameNamespacedCustomNames: Set<string>,
+  sameNameNamespacedFunctionNames: Set<string>,
   specs: unknown,
 ): void {
   if (!Array.isArray(specs)) return;
@@ -16,48 +22,64 @@ function collectBareCustomToolSpecs(
       const namespace = typeof spec.name === "string" ? spec.name : undefined;
       for (const inner of spec.tools) {
         if (!isPlainObject(inner) || typeof inner.name !== "string") continue;
-        if (
-          (inner.type === "custom" || inner.type === "function")
-          && namespace === inner.name
-        ) sameNameNamespacedNames.add(inner.name);
+        if (namespace === inner.name) {
+          if (inner.type === "custom") sameNameNamespacedCustomNames.add(inner.name);
+          else if (inner.type === "function") sameNameNamespacedFunctionNames.add(inner.name);
+        }
         if (inner.type === "custom" && namespace === "functions") bareNames.add(inner.name);
       }
       continue;
     }
     if (typeof spec.name !== "string") continue;
     const namespace = typeof spec.namespace === "string" ? spec.namespace : undefined;
-    if (
-      (spec.type === "custom" || spec.type === "function")
-      && namespace === spec.name
-    ) sameNameNamespacedNames.add(spec.name);
-    if (spec.type !== "custom") continue;
-    if (!namespace || namespace === "functions") bareNames.add(spec.name);
+    if (namespace === spec.name) {
+      if (spec.type === "custom") sameNameNamespacedCustomNames.add(spec.name);
+      else if (spec.type === "function") sameNameNamespacedFunctionNames.add(spec.name);
+    }
+    if (spec.type === "custom" && (!namespace || namespace === "functions")) bareNames.add(spec.name);
   }
 }
 
-/** Bare custom tools both declared by this turn and authorized by its tool_choice. */
-export function collectAuthorizedBareCustomToolNames(
+/** Bare custom tools authorized by this turn, scoped to each response call type. */
+export function collectSelfNamedNamespaceScrubAuthorization(
   body: unknown,
-  authorizedFreeformToolNames: ReadonlySet<string>,
-): Set<string> {
+  authorizedBareCustomToolNames: ReadonlySet<string>,
+): SelfNamedNamespaceScrubAuthorization {
   const bareNames = new Set<string>();
-  const sameNameNamespacedNames = new Set<string>();
-  if (!isPlainObject(body)) return bareNames;
-  collectBareCustomToolSpecs(bareNames, sameNameNamespacedNames, body.tools);
-  if (Array.isArray(body.input)) {
-    for (const item of body.input) {
-      if (
-        isPlainObject(item)
-        && (item.type === "additional_tools" || item.type === "tool_search_output")
-      ) collectBareCustomToolSpecs(bareNames, sameNameNamespacedNames, item.tools);
+  const sameNameNamespacedCustomNames = new Set<string>();
+  const sameNameNamespacedFunctionNames = new Set<string>();
+  if (isPlainObject(body)) {
+    collectBareCustomToolSpecs(
+      bareNames,
+      sameNameNamespacedCustomNames,
+      sameNameNamespacedFunctionNames,
+      body.tools,
+    );
+    if (Array.isArray(body.input)) {
+      for (const item of body.input) {
+        if (
+          isPlainObject(item)
+          && (item.type === "additional_tools" || item.type === "tool_search_output")
+        ) {
+          collectBareCustomToolSpecs(
+            bareNames,
+            sameNameNamespacedCustomNames,
+            sameNameNamespacedFunctionNames,
+            item.tools,
+          );
+        }
+      }
     }
   }
-  return new Set(
-    [...bareNames].filter(name => (
-      authorizedFreeformToolNames.has(name)
-      && !sameNameNamespacedNames.has(name)
-    )),
-  );
+  const authorizedNames = [...bareNames].filter(name => authorizedBareCustomToolNames.has(name));
+  return {
+    customToolCallNames: new Set(
+      authorizedNames.filter(name => !sameNameNamespacedCustomNames.has(name)),
+    ),
+    functionCallNames: new Set(
+      authorizedNames.filter(name => !sameNameNamespacedFunctionNames.has(name)),
+    ),
+  };
 }
 
 /**
@@ -74,12 +96,12 @@ export function collectAuthorizedBareCustomToolNames(
  */
 export function scrubSelfNamedToolCallNamespace(
   value: unknown,
-  authorizedBareCustomToolNames: ReadonlySet<string>,
+  authorization: SelfNamedNamespaceScrubAuthorization,
 ): { value: unknown; changed: boolean } {
   if (Array.isArray(value)) {
     let changed = false;
     const out = value.map(entry => {
-      const result = scrubSelfNamedToolCallNamespace(entry, authorizedBareCustomToolNames);
+      const result = scrubSelfNamedToolCallNamespace(entry, authorization);
       changed ||= result.changed;
       return result.value;
     });
@@ -89,16 +111,21 @@ export function scrubSelfNamedToolCallNamespace(
   let changed = false;
   const out: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    const result = scrubSelfNamedToolCallNamespace(entry, authorizedBareCustomToolNames);
+    const result = scrubSelfNamedToolCallNamespace(entry, authorization);
     out[key] = result.value;
     changed ||= result.changed;
   }
+  const authorizedNames = value.type === "custom_tool_call"
+    ? authorization.customToolCallNames
+    : value.type === "function_call"
+      ? authorization.functionCallNames
+      : undefined;
   if (
-    (value.type === "custom_tool_call" || value.type === "function_call")
+    authorizedNames
     && typeof value.name === "string"
     && value.name.length > 0
     && value.namespace === value.name
-    && authorizedBareCustomToolNames.has(value.name)
+    && authorizedNames.has(value.name)
   ) {
     delete out.namespace;
     changed = true;
@@ -108,7 +135,7 @@ export function scrubSelfNamedToolCallNamespace(
 
 export function scrubSelfNamedToolCallNamespaceInJson(
   text: string,
-  authorizedBareCustomToolNames: ReadonlySet<string>,
+  authorization: SelfNamedNamespaceScrubAuthorization,
 ): string {
   if (!text.includes("\"namespace\"")) return text;
   let payload: unknown;
@@ -117,13 +144,13 @@ export function scrubSelfNamedToolCallNamespaceInJson(
   } catch {
     return text;
   }
-  const result = scrubSelfNamedToolCallNamespace(payload, authorizedBareCustomToolNames);
+  const result = scrubSelfNamedToolCallNamespace(payload, authorization);
   return result.changed ? JSON.stringify(result.value) : text;
 }
 
 export function createSelfNamedToolCallNamespaceScrubRewrite(
-  authorizedBareCustomToolNames: ReadonlySet<string>,
+  authorization: SelfNamedNamespaceScrubAuthorization,
 ): SsePayloadRewrite {
-  return payload => scrubSelfNamedToolCallNamespaceInJson(payload, authorizedBareCustomToolNames);
+  return payload => scrubSelfNamedToolCallNamespaceInJson(payload, authorization);
 }
 

--- a/src/server/responses-self-named-namespace-scrub.ts
+++ b/src/server/responses-self-named-namespace-scrub.ts
@@ -15,16 +15,23 @@ function collectBareCustomToolSpecs(
     if (spec.type === "namespace" && Array.isArray(spec.tools)) {
       const namespace = typeof spec.name === "string" ? spec.name : undefined;
       for (const inner of spec.tools) {
-        if (!isPlainObject(inner) || inner.type !== "custom" || typeof inner.name !== "string") continue;
-        if (namespace === "functions") bareNames.add(inner.name);
-        else if (namespace === inner.name) sameNameNamespacedNames.add(inner.name);
+        if (!isPlainObject(inner) || typeof inner.name !== "string") continue;
+        if (
+          (inner.type === "custom" || inner.type === "function")
+          && namespace === inner.name
+        ) sameNameNamespacedNames.add(inner.name);
+        if (inner.type === "custom" && namespace === "functions") bareNames.add(inner.name);
       }
       continue;
     }
-    if (spec.type !== "custom" || typeof spec.name !== "string") continue;
+    if (typeof spec.name !== "string") continue;
     const namespace = typeof spec.namespace === "string" ? spec.namespace : undefined;
+    if (
+      (spec.type === "custom" || spec.type === "function")
+      && namespace === spec.name
+    ) sameNameNamespacedNames.add(spec.name);
+    if (spec.type !== "custom") continue;
     if (!namespace || namespace === "functions") bareNames.add(spec.name);
-    else if (namespace === spec.name) sameNameNamespacedNames.add(spec.name);
   }
 }
 
@@ -45,10 +52,12 @@ export function collectAuthorizedBareCustomToolNames(
       ) collectBareCustomToolSpecs(bareNames, sameNameNamespacedNames, item.tools);
     }
   }
-  for (const name of bareNames) {
-    if (!authorizedFreeformToolNames.has(name) || sameNameNamespacedNames.has(name)) bareNames.delete(name);
-  }
-  return bareNames;
+  return new Set(
+    [...bareNames].filter(name => (
+      authorizedFreeformToolNames.has(name)
+      && !sameNameNamespacedNames.has(name)
+    )),
+  );
 }
 
 /**

--- a/src/server/responses-self-named-namespace-scrub.ts
+++ b/src/server/responses-self-named-namespace-scrub.ts
@@ -9,8 +9,9 @@ export interface SelfNamedNamespaceScrubAuthorization {
   functionCallNames: ReadonlySet<string>;
 }
 
-function collectBareCustomToolSpecs(
-  bareNames: Set<string>,
+function collectBareToolSpecs(
+  bareCustomNames: Set<string>,
+  bareFunctionNames: Set<string>,
   sameNameNamespacedCustomNames: Set<string>,
   sameNameNamespacedFunctionNames: Set<string>,
   specs: unknown,
@@ -22,21 +23,27 @@ function collectBareCustomToolSpecs(
       const namespace = typeof spec.name === "string" ? spec.name : undefined;
       for (const inner of spec.tools) {
         if (!isPlainObject(inner) || typeof inner.name !== "string") continue;
-        if (namespace === inner.name) {
+        if (namespace !== "functions" && namespace === inner.name) {
           if (inner.type === "custom") sameNameNamespacedCustomNames.add(inner.name);
           else if (inner.type === "function") sameNameNamespacedFunctionNames.add(inner.name);
         }
-        if (inner.type === "custom" && namespace === "functions") bareNames.add(inner.name);
+        if (namespace === "functions") {
+          if (inner.type === "custom") bareCustomNames.add(inner.name);
+          else if (inner.type === "function") bareFunctionNames.add(inner.name);
+        }
       }
       continue;
     }
     if (typeof spec.name !== "string") continue;
     const namespace = typeof spec.namespace === "string" ? spec.namespace : undefined;
-    if (namespace === spec.name) {
+    if (namespace !== "functions" && namespace === spec.name) {
       if (spec.type === "custom") sameNameNamespacedCustomNames.add(spec.name);
       else if (spec.type === "function") sameNameNamespacedFunctionNames.add(spec.name);
     }
-    if (spec.type === "custom" && (!namespace || namespace === "functions")) bareNames.add(spec.name);
+    if (!namespace || namespace === "functions") {
+      if (spec.type === "custom") bareCustomNames.add(spec.name);
+      else if (spec.type === "function") bareFunctionNames.add(spec.name);
+    }
   }
 }
 
@@ -44,13 +51,16 @@ function collectBareCustomToolSpecs(
 export function collectSelfNamedNamespaceScrubAuthorization(
   body: unknown,
   authorizedBareCustomToolNames: ReadonlySet<string>,
+  authorizedBareFunctionToolNames: ReadonlySet<string>,
 ): SelfNamedNamespaceScrubAuthorization {
-  const bareNames = new Set<string>();
+  const bareCustomNames = new Set<string>();
+  const bareFunctionNames = new Set<string>();
   const sameNameNamespacedCustomNames = new Set<string>();
   const sameNameNamespacedFunctionNames = new Set<string>();
   if (isPlainObject(body)) {
-    collectBareCustomToolSpecs(
-      bareNames,
+    collectBareToolSpecs(
+      bareCustomNames,
+      bareFunctionNames,
       sameNameNamespacedCustomNames,
       sameNameNamespacedFunctionNames,
       body.tools,
@@ -61,8 +71,9 @@ export function collectSelfNamedNamespaceScrubAuthorization(
           isPlainObject(item)
           && (item.type === "additional_tools" || item.type === "tool_search_output")
         ) {
-          collectBareCustomToolSpecs(
-            bareNames,
+          collectBareToolSpecs(
+            bareCustomNames,
+            bareFunctionNames,
             sameNameNamespacedCustomNames,
             sameNameNamespacedFunctionNames,
             item.tools,
@@ -71,13 +82,18 @@ export function collectSelfNamedNamespaceScrubAuthorization(
       }
     }
   }
-  const authorizedNames = [...bareNames].filter(name => authorizedBareCustomToolNames.has(name));
+  const authorizedCustomNames = [...bareCustomNames]
+    .filter(name => authorizedBareCustomToolNames.has(name));
+  const authorizedFunctionNames = new Set([
+    ...authorizedCustomNames,
+    ...[...bareFunctionNames].filter(name => authorizedBareFunctionToolNames.has(name)),
+  ]);
   return {
     customToolCallNames: new Set(
-      authorizedNames.filter(name => !sameNameNamespacedCustomNames.has(name)),
+      authorizedCustomNames.filter(name => !sameNameNamespacedCustomNames.has(name)),
     ),
     functionCallNames: new Set(
-      authorizedNames.filter(name => !sameNameNamespacedFunctionNames.has(name)),
+      [...authorizedFunctionNames].filter(name => !sameNameNamespacedFunctionNames.has(name)),
     ),
   };
 }

--- a/src/server/responses-self-named-namespace-scrub.ts
+++ b/src/server/responses-self-named-namespace-scrub.ts
@@ -4,6 +4,53 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function collectBareCustomToolSpecs(
+  bareNames: Set<string>,
+  sameNameNamespacedNames: Set<string>,
+  specs: unknown,
+): void {
+  if (!Array.isArray(specs)) return;
+  for (const spec of specs) {
+    if (!isPlainObject(spec)) continue;
+    if (spec.type === "namespace" && Array.isArray(spec.tools)) {
+      const namespace = typeof spec.name === "string" ? spec.name : undefined;
+      for (const inner of spec.tools) {
+        if (!isPlainObject(inner) || inner.type !== "custom" || typeof inner.name !== "string") continue;
+        if (namespace === "functions") bareNames.add(inner.name);
+        else if (namespace === inner.name) sameNameNamespacedNames.add(inner.name);
+      }
+      continue;
+    }
+    if (spec.type !== "custom" || typeof spec.name !== "string") continue;
+    const namespace = typeof spec.namespace === "string" ? spec.namespace : undefined;
+    if (!namespace || namespace === "functions") bareNames.add(spec.name);
+    else if (namespace === spec.name) sameNameNamespacedNames.add(spec.name);
+  }
+}
+
+/** Bare custom tools both declared by this turn and authorized by its tool_choice. */
+export function collectAuthorizedBareCustomToolNames(
+  body: unknown,
+  authorizedFreeformToolNames: ReadonlySet<string>,
+): Set<string> {
+  const bareNames = new Set<string>();
+  const sameNameNamespacedNames = new Set<string>();
+  if (!isPlainObject(body)) return bareNames;
+  collectBareCustomToolSpecs(bareNames, sameNameNamespacedNames, body.tools);
+  if (Array.isArray(body.input)) {
+    for (const item of body.input) {
+      if (
+        isPlainObject(item)
+        && (item.type === "additional_tools" || item.type === "tool_search_output")
+      ) collectBareCustomToolSpecs(bareNames, sameNameNamespacedNames, item.tools);
+    }
+  }
+  for (const name of bareNames) {
+    if (!authorizedFreeformToolNames.has(name) || sameNameNamespacedNames.has(name)) bareNames.delete(name);
+  }
+  return bareNames;
+}
+
 /**
  * Drop a tool-call `namespace` that merely repeats the call's own `name` (#3217).
  *
@@ -11,15 +58,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * `None | "" | "functions"` as the default namespace; anything else is concatenated into a flat
  * name before routing. A backend answer of `{ name: "exec", namespace: "exec" }` therefore
  * becomes `execexec`, which no client tool matches, and Codex re-issues the same call forever.
- * That shape is never a legitimate identity — an MCP namespace is a server name, not the tool —
- * so it is safe to scrub without consulting the declared catalog. The adapter fix that stops
- * provoking the answer lives in `stripSparkCompatibility`; this is the belt to that suspender.
+ * The malformed Spark shape is scrubbed only when the current turn authorized a bare custom tool
+ * with that name. A genuine namespaced tool may intentionally use the same namespace and name.
+ * The adapter fix that stops provoking the answer lives in `stripSparkCompatibility`; this is the
+ * belt to that suspender.
  */
-export function scrubSelfNamedToolCallNamespace(value: unknown): { value: unknown; changed: boolean } {
+export function scrubSelfNamedToolCallNamespace(
+  value: unknown,
+  authorizedBareCustomToolNames: ReadonlySet<string>,
+): { value: unknown; changed: boolean } {
   if (Array.isArray(value)) {
     let changed = false;
     const out = value.map(entry => {
-      const result = scrubSelfNamedToolCallNamespace(entry);
+      const result = scrubSelfNamedToolCallNamespace(entry, authorizedBareCustomToolNames);
       changed ||= result.changed;
       return result.value;
     });
@@ -29,7 +80,7 @@ export function scrubSelfNamedToolCallNamespace(value: unknown): { value: unknow
   let changed = false;
   const out: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    const result = scrubSelfNamedToolCallNamespace(entry);
+    const result = scrubSelfNamedToolCallNamespace(entry, authorizedBareCustomToolNames);
     out[key] = result.value;
     changed ||= result.changed;
   }
@@ -38,6 +89,7 @@ export function scrubSelfNamedToolCallNamespace(value: unknown): { value: unknow
     && typeof value.name === "string"
     && value.name.length > 0
     && value.namespace === value.name
+    && authorizedBareCustomToolNames.has(value.name)
   ) {
     delete out.namespace;
     changed = true;
@@ -45,7 +97,10 @@ export function scrubSelfNamedToolCallNamespace(value: unknown): { value: unknow
   return changed ? { value: out, changed: true } : { value, changed: false };
 }
 
-export function scrubSelfNamedToolCallNamespaceInJson(text: string): string {
+export function scrubSelfNamedToolCallNamespaceInJson(
+  text: string,
+  authorizedBareCustomToolNames: ReadonlySet<string>,
+): string {
   if (!text.includes("\"namespace\"")) return text;
   let payload: unknown;
   try {
@@ -53,11 +108,13 @@ export function scrubSelfNamedToolCallNamespaceInJson(text: string): string {
   } catch {
     return text;
   }
-  const result = scrubSelfNamedToolCallNamespace(payload);
+  const result = scrubSelfNamedToolCallNamespace(payload, authorizedBareCustomToolNames);
   return result.changed ? JSON.stringify(result.value) : text;
 }
 
-export function createSelfNamedToolCallNamespaceScrubRewrite(): SsePayloadRewrite {
-  return payload => scrubSelfNamedToolCallNamespaceInJson(payload);
+export function createSelfNamedToolCallNamespaceScrubRewrite(
+  authorizedBareCustomToolNames: ReadonlySet<string>,
+): SsePayloadRewrite {
+  return payload => scrubSelfNamedToolCallNamespaceInJson(payload, authorizedBareCustomToolNames);
 }
 

--- a/src/server/responses-self-named-namespace-scrub.ts
+++ b/src/server/responses-self-named-namespace-scrub.ts
@@ -34,15 +34,25 @@ function collectBareToolSpecs(
       }
       continue;
     }
-    if (typeof spec.name !== "string") continue;
+    // `buildTools` (parser.ts) also accepts the Chat-shaped `{ type: "function", function: { name } }`
+    // declaration, and the undeclared-tool guard authorizes it the same way. Reading only
+    // `spec.name` here left such a function out of the raw-body set, so the intersection dropped
+    // it and a self-named echo for it reached Codex again.
+    const nestedFunction = spec.type === "function" && isPlainObject(spec.function) ? spec.function : undefined;
+    const name = typeof spec.name === "string" && spec.name.length > 0
+      ? spec.name
+      : typeof nestedFunction?.name === "string" && nestedFunction.name.length > 0
+        ? nestedFunction.name
+        : undefined;
+    if (!name) continue;
     const namespace = typeof spec.namespace === "string" ? spec.namespace : undefined;
-    if (namespace !== "functions" && namespace === spec.name) {
-      if (spec.type === "custom") sameNameNamespacedCustomNames.add(spec.name);
-      else if (spec.type === "function") sameNameNamespacedFunctionNames.add(spec.name);
+    if (namespace !== "functions" && namespace === name) {
+      if (spec.type === "custom") sameNameNamespacedCustomNames.add(name);
+      else if (spec.type === "function") sameNameNamespacedFunctionNames.add(name);
     }
     if (!namespace || namespace === "functions") {
-      if (spec.type === "custom") bareCustomNames.add(spec.name);
-      else if (spec.type === "function") bareFunctionNames.add(spec.name);
+      if (spec.type === "custom") bareCustomNames.add(name);
+      else if (spec.type === "function") bareFunctionNames.add(name);
     }
   }
 }
@@ -169,4 +179,3 @@ export function createSelfNamedToolCallNamespaceScrubRewrite(
 ): SsePayloadRewrite {
   return payload => scrubSelfNamedToolCallNamespaceInJson(payload, authorization);
 }
-

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -108,12 +108,14 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
   /** Declared parameter schema per request-visible tool name (#1611 integer repair). */
   toolParameterSchemas: Map<string, Record<string, unknown>>;
   freeformToolNames: Set<string>;
+  bareCustomToolNames: Set<string>;
   toolSearchToolNames: Set<string>;
 } {
   const toolNsMap = new Map<string, { namespace: string; name: string; freeform?: true }>();
   const declaredToolNames = new Set<string>();
   const toolParameterSchemas = new Map<string, Record<string, unknown>>();
   const freeformToolNames = new Set<string>();
+  const bareCustomToolNames = new Set<string>();
   const toolSearchToolNames = new Set<string>();
   const requestedTools = parsed.context.tools ?? [];
   const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice, requestedTools);
@@ -133,6 +135,10 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
     if (t.freeform) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
       freeformToolNames.add(t.name);
+      if (!t.namespace || t.namespace === "functions") {
+        budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
+        bareCustomToolNames.add(t.name);
+      }
     }
     if (t.toolSearch) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
@@ -162,7 +168,14 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
       toolParameterSchemas.set(t.name, t.parameters);
     }
   }
-  return { toolNsMap, declaredToolNames, toolParameterSchemas, freeformToolNames, toolSearchToolNames };
+  return {
+    toolNsMap,
+    declaredToolNames,
+    toolParameterSchemas,
+    freeformToolNames,
+    bareCustomToolNames,
+    toolSearchToolNames,
+  };
 }
 
 

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -109,6 +109,7 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
   toolParameterSchemas: Map<string, Record<string, unknown>>;
   freeformToolNames: Set<string>;
   bareCustomToolNames: Set<string>;
+  bareFunctionToolNames: Set<string>;
   toolSearchToolNames: Set<string>;
 } {
   const toolNsMap = new Map<string, { namespace: string; name: string; freeform?: true }>();
@@ -116,6 +117,7 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
   const toolParameterSchemas = new Map<string, Record<string, unknown>>();
   const freeformToolNames = new Set<string>();
   const bareCustomToolNames = new Set<string>();
+  const bareFunctionToolNames = new Set<string>();
   const toolSearchToolNames = new Set<string>();
   const requestedTools = parsed.context.tools ?? [];
   const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice, requestedTools);
@@ -139,6 +141,15 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
         budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
         bareCustomToolNames.add(t.name);
       }
+    } else if (
+      !t.toolSearch
+      && !t.webSearch
+      && !t.imageGeneration
+      && !t.videoGeneration
+      && (!t.namespace || t.namespace === "functions")
+    ) {
+      budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
+      bareFunctionToolNames.add(t.name);
     }
     if (t.toolSearch) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });
@@ -174,6 +185,7 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
     toolParameterSchemas,
     freeformToolNames,
     bareCustomToolNames,
+    bareFunctionToolNames,
     toolSearchToolNames,
   };
 }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -3665,6 +3665,7 @@ async function handleResponsesInner(
     const selfNamedNamespaceScrubAuthorization = collectSelfNamedNamespaceScrubAuthorization(
       clientToolAuthorizationBody,
       toolBridgeMaps.bareCustomToolNames,
+      toolBridgeMaps.bareFunctionToolNames,
     );
     const clientExplicitWireToolCatalog = hasExplicitWireToolCatalog(clientToolAuthorizationBody);
     const clientDeclaredWireToolNames = collectDeclaredWireToolNames(clientToolAuthorizationBody);

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -327,7 +327,7 @@ import {
 } from "../responses-image-gen-repair";
 import { createResponsesModelPayloadRewrite, rewriteResponsesModelJson } from "../responses-model-rewrite";
 import {
-  collectAuthorizedBareCustomToolNames,
+  collectSelfNamedNamespaceScrubAuthorization,
   createSelfNamedToolCallNamespaceScrubRewrite,
   scrubSelfNamedToolCallNamespaceInJson,
 } from "../responses-self-named-namespace-scrub";
@@ -3662,9 +3662,9 @@ async function handleResponsesInner(
       parsed._rawBody,
       replayedInputPrefixLength,
     );
-    const selfNamedNamespaceScrubToolNames = collectAuthorizedBareCustomToolNames(
+    const selfNamedNamespaceScrubAuthorization = collectSelfNamedNamespaceScrubAuthorization(
       clientToolAuthorizationBody,
-      toolBridgeMaps.freeformToolNames,
+      toolBridgeMaps.bareCustomToolNames,
     );
     const clientExplicitWireToolCatalog = hasExplicitWireToolCatalog(clientToolAuthorizationBody);
     const clientDeclaredWireToolNames = collectDeclaredWireToolNames(clientToolAuthorizationBody);
@@ -4651,7 +4651,7 @@ async function handleResponsesInner(
       const payloadRewrites = [
         createImageGenCallRestoreRewrite(imageGenCallAliases),
         // #3217: a call whose namespace repeats its own name is unroutable in codex-rs.
-        createSelfNamedToolCallNamespaceScrubRewrite(selfNamedNamespaceScrubToolNames),
+        createSelfNamedToolCallNamespaceScrubRewrite(selfNamedNamespaceScrubAuthorization),
         routedNamespaceToolAliases.size > 0
           ? createRoutedNamespaceCallRestoreRewrite(routedNamespaceToolAliases)
           : undefined,
@@ -4886,7 +4886,7 @@ async function handleResponsesInner(
         const restoredNamespace = restoreRoutedNamespaceCallsInJson(
           scrubSelfNamedToolCallNamespaceInJson(
             restoreImageGenCallsInJson(text, imageGenCallAliases),
-            selfNamedNamespaceScrubToolNames,
+            selfNamedNamespaceScrubAuthorization,
           ),
           routedNamespaceToolAliases,
         );

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -327,6 +327,7 @@ import {
 } from "../responses-image-gen-repair";
 import { createResponsesModelPayloadRewrite, rewriteResponsesModelJson } from "../responses-model-rewrite";
 import {
+  collectAuthorizedBareCustomToolNames,
   createSelfNamedToolCallNamespaceScrubRewrite,
   scrubSelfNamedToolCallNamespaceInJson,
 } from "../responses-self-named-namespace-scrub";
@@ -3661,6 +3662,10 @@ async function handleResponsesInner(
       parsed._rawBody,
       replayedInputPrefixLength,
     );
+    const selfNamedNamespaceScrubToolNames = collectAuthorizedBareCustomToolNames(
+      clientToolAuthorizationBody,
+      toolBridgeMaps.freeformToolNames,
+    );
     const clientExplicitWireToolCatalog = hasExplicitWireToolCatalog(clientToolAuthorizationBody);
     const clientDeclaredWireToolNames = collectDeclaredWireToolNames(clientToolAuthorizationBody);
     const clientDeclaredNamelessCallTypes = collectDeclaredNamelessClientCallTypes(
@@ -4646,7 +4651,7 @@ async function handleResponsesInner(
       const payloadRewrites = [
         createImageGenCallRestoreRewrite(imageGenCallAliases),
         // #3217: a call whose namespace repeats its own name is unroutable in codex-rs.
-        createSelfNamedToolCallNamespaceScrubRewrite(),
+        createSelfNamedToolCallNamespaceScrubRewrite(selfNamedNamespaceScrubToolNames),
         routedNamespaceToolAliases.size > 0
           ? createRoutedNamespaceCallRestoreRewrite(routedNamespaceToolAliases)
           : undefined,
@@ -4879,7 +4884,10 @@ async function handleResponsesInner(
       inspectResponseLogJson(logCtx, text);
       const clientJson = (() => {
         const restoredNamespace = restoreRoutedNamespaceCallsInJson(
-          scrubSelfNamedToolCallNamespaceInJson(restoreImageGenCallsInJson(text, imageGenCallAliases)),
+          scrubSelfNamedToolCallNamespaceInJson(
+            restoreImageGenCallsInJson(text, imageGenCallAliases),
+            selfNamedNamespaceScrubToolNames,
+          ),
           routedNamespaceToolAliases,
         );
         const restoredAuthorizedBareNamespace = restoreRoutedNamespaceCallsInJson(

--- a/tests/responses-self-named-namespace-scrub.test.ts
+++ b/tests/responses-self-named-namespace-scrub.test.ts
@@ -123,6 +123,46 @@ test("a self-named namespace declared by the current turn is preserved", async (
   expect(text).toContain('\"name\":\"exec\",\"namespace\":\"exec\"');
 });
 
+test("the reserved functions namespace does not create a same-name collision", async () => {
+  const call = { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "functions", namespace: "functions", input: "pwd", status: "completed" };
+  globalThis.fetch = (async () => new Response(sseFrom([call]), {
+    status: 200, headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+  const body = {
+    ...requestBody,
+    input: [
+      {
+        type: "additional_tools",
+        role: "developer",
+        tools: [{
+          type: "namespace",
+          name: "functions",
+          tools: [{ type: "custom", name: "functions", description: "shell" }],
+        }],
+      },
+      requestBody.input[1],
+    ],
+  };
+
+  const res = await handleResponses(request(body), forwardConfig(), { model: "", provider: "" });
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  expect(text).not.toContain('\"namespace\":\"functions\"');
+});
+
+test("a self-named namespace on a passthrough bare function_call is scrubbed", async () => {
+  const call = { type: "function_call", id: "fc_1", call_id: "call_1", name: "wait", namespace: "wait", arguments: "{}", status: "completed" };
+  globalThis.fetch = (async () => new Response(sseFrom([call]), {
+    status: 200, headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+
+  const res = await handleResponses(request(), forwardConfig(), { model: "", provider: "" });
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  expect(text).toContain('\"type\":\"function_call\"');
+  expect(text).not.toContain('\"namespace\":\"wait\"');
+});
+
 test("tool_choice for a namespaced custom tool cannot authorize a colliding bare scrub", async () => {
   const call = { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", namespace: "exec", input: "pwd", status: "completed" };
   globalThis.fetch = (async () => new Response(sseFrom([call]), {

--- a/tests/responses-self-named-namespace-scrub.test.ts
+++ b/tests/responses-self-named-namespace-scrub.test.ts
@@ -118,6 +118,41 @@ test("a self-named namespace declared by the current turn is preserved", async (
   expect(text).toContain('\"name\":\"exec\",\"namespace\":\"exec\"');
 });
 
+test("a namespaced function wins over a colliding bare custom tool", async () => {
+  const call = { type: "function_call", id: "fc_1", call_id: "call_1", name: "exec", namespace: "exec", arguments: "{}", status: "completed" };
+  globalThis.fetch = (async () => new Response(sseFrom([call]), {
+    status: 200, headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+  const body = {
+    ...requestBody,
+    input: [
+      {
+        type: "additional_tools",
+        role: "developer",
+        tools: [
+          {
+            type: "namespace",
+            name: "functions",
+            tools: [{ type: "custom", name: "exec", description: "shell" }],
+          },
+          {
+            type: "namespace",
+            name: "exec",
+            tools: [{ type: "function", name: "exec", parameters: { type: "object", properties: {} } }],
+          },
+        ],
+      },
+      requestBody.input[1],
+    ],
+  };
+
+  const res = await handleResponses(request(body), forwardConfig(), { model: "", provider: "" });
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  expect(text).toContain('\"type\":\"function_call\"');
+  expect(text).toContain('\"name\":\"exec\",\"namespace\":\"exec\"');
+});
+
 test("a genuine MCP namespace on a passthrough call is left alone", async () => {
   const call = { type: "function_call", id: "fc_1", call_id: "call_1", name: "search", namespace: "mcp__docs", arguments: "{}", status: "completed" };
   globalThis.fetch = (async () => new Response(sseFrom([call]), {

--- a/tests/responses-self-named-namespace-scrub.test.ts
+++ b/tests/responses-self-named-namespace-scrub.test.ts
@@ -69,6 +69,11 @@ function request(body: Record<string, unknown> = requestBody): Request {
   });
 }
 
+function scrubAuthorization(names: string[]) {
+  const authorizedNames = new Set(names);
+  return { customToolCallNames: authorizedNames, functionCallNames: authorizedNames };
+}
+
 test("a self-named namespace on a passthrough custom_tool_call is scrubbed before the client (#3217)", async () => {
   const call = { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", namespace: "exec", input: "pwd", status: "completed" };
   globalThis.fetch = (async () => new Response(sseFrom([call]), {
@@ -118,7 +123,42 @@ test("a self-named namespace declared by the current turn is preserved", async (
   expect(text).toContain('\"name\":\"exec\",\"namespace\":\"exec\"');
 });
 
-test("a namespaced function wins over a colliding bare custom tool", async () => {
+test("tool_choice for a namespaced custom tool cannot authorize a colliding bare scrub", async () => {
+  const call = { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", namespace: "exec", input: "pwd", status: "completed" };
+  globalThis.fetch = (async () => new Response(sseFrom([call]), {
+    status: 200, headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+  const body = {
+    ...requestBody,
+    tool_choice: { type: "custom", name: "remote__exec" },
+    input: [
+      {
+        type: "additional_tools",
+        role: "developer",
+        tools: [
+          {
+            type: "namespace",
+            name: "functions",
+            tools: [{ type: "custom", name: "exec", description: "local shell" }],
+          },
+          {
+            type: "namespace",
+            name: "remote",
+            tools: [{ type: "custom", name: "exec", description: "remote shell" }],
+          },
+        ],
+      },
+      requestBody.input[1],
+    ],
+  };
+
+  const res = await handleResponses(request(body), forwardConfig(), { model: "", provider: "" });
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  expect(text).toContain('\"name\":\"exec\",\"namespace\":\"exec\"');
+});
+
+test("mixed custom and function collisions are scoped to the response item type", async () => {
   const call = { type: "function_call", id: "fc_1", call_id: "call_1", name: "exec", namespace: "exec", arguments: "{}", status: "completed" };
   globalThis.fetch = (async () => new Response(sseFrom([call]), {
     status: 200, headers: { "content-type": "text/event-stream" },
@@ -151,6 +191,16 @@ test("a namespaced function wins over a colliding bare custom tool", async () =>
   const text = await res.text();
   expect(text).toContain('\"type\":\"function_call\"');
   expect(text).toContain('\"name\":\"exec\",\"namespace\":\"exec\"');
+
+  const bareCall = { type: "custom_tool_call", id: "ctc_1", call_id: "call_2", name: "exec", namespace: "exec", input: "pwd", status: "completed" };
+  globalThis.fetch = (async () => new Response(sseFrom([bareCall]), {
+    status: 200, headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+  const bareRes = await handleResponses(request(body), forwardConfig(), { model: "", provider: "" });
+  expect(bareRes.status).toBe(200);
+  const bareText = await bareRes.text();
+  expect(bareText).toContain('\"type\":\"custom_tool_call\"');
+  expect(bareText).not.toContain('\"namespace\":\"exec\"');
 });
 
 test("a genuine MCP namespace on a passthrough call is left alone", async () => {
@@ -184,11 +234,11 @@ test("the bounded JSON (stream:false) passthrough path scrubs the same shape (#3
 
 test("scrub is recursive, shape-preserving, and a no-op on clean payloads", () => {
   const clean = { type: "response.completed", response: { output: [{ type: "custom_tool_call", name: "exec", input: "" }] } };
-  expect(scrubSelfNamedToolCallNamespace(clean, new Set(["exec"]))).toEqual({ value: clean, changed: false });
+  expect(scrubSelfNamedToolCallNamespace(clean, scrubAuthorization(["exec"]))).toEqual({ value: clean, changed: false });
   const dirty = { response: { output: [{ type: "function_call", name: "wait", namespace: "wait", arguments: "{}" }, { type: "message" }] } };
-  const result = scrubSelfNamedToolCallNamespace(dirty, new Set(["wait"]));
+  const result = scrubSelfNamedToolCallNamespace(dirty, scrubAuthorization(["wait"]));
   expect(result.changed).toBe(true);
   expect(result.value).toEqual({ response: { output: [{ type: "function_call", name: "wait", arguments: "{}" }, { type: "message" }] } });
   // An empty name never matches: a namespace equal to "" is not the self-named shape.
-  expect(scrubSelfNamedToolCallNamespace({ type: "custom_tool_call", name: "", namespace: "" }, new Set()).changed).toBe(false);
+  expect(scrubSelfNamedToolCallNamespace({ type: "custom_tool_call", name: "", namespace: "" }, scrubAuthorization([])).changed).toBe(false);
 });

--- a/tests/responses-self-named-namespace-scrub.test.ts
+++ b/tests/responses-self-named-namespace-scrub.test.ts
@@ -61,11 +61,11 @@ function sseFrom(items: Array<Record<string, unknown>>): string {
   return events.map(e => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`).join("");
 }
 
-function request(): Request {
+function request(body: Record<string, unknown> = requestBody): Request {
   return new Request("http://localhost/v1/responses", {
     method: "POST",
     headers: { "content-type": "application/json", authorization: "Bearer test", "chatgpt-account-id": "acct" },
-    body: JSON.stringify(requestBody),
+    body: JSON.stringify(body),
   });
 }
 
@@ -89,6 +89,33 @@ test("a self-named namespace on a passthrough custom_tool_call is scrubbed befor
     expect(item.name).toBe("exec");
     expect("namespace" in item).toBe(false);
   }
+});
+
+test("a self-named namespace declared by the current turn is preserved", async () => {
+  const call = { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", namespace: "exec", input: "pwd", status: "completed" };
+  globalThis.fetch = (async () => new Response(sseFrom([call]), {
+    status: 200, headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+  const body = {
+    ...requestBody,
+    input: [
+      {
+        type: "additional_tools",
+        role: "developer",
+        tools: [{
+          type: "namespace",
+          name: "exec",
+          tools: [{ type: "custom", name: "exec", description: "shell" }],
+        }],
+      },
+      requestBody.input[1],
+    ],
+  };
+
+  const res = await handleResponses(request(body), forwardConfig(), { model: "", provider: "" });
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  expect(text).toContain('\"name\":\"exec\",\"namespace\":\"exec\"');
 });
 
 test("a genuine MCP namespace on a passthrough call is left alone", async () => {
@@ -122,11 +149,11 @@ test("the bounded JSON (stream:false) passthrough path scrubs the same shape (#3
 
 test("scrub is recursive, shape-preserving, and a no-op on clean payloads", () => {
   const clean = { type: "response.completed", response: { output: [{ type: "custom_tool_call", name: "exec", input: "" }] } };
-  expect(scrubSelfNamedToolCallNamespace(clean)).toEqual({ value: clean, changed: false });
+  expect(scrubSelfNamedToolCallNamespace(clean, new Set(["exec"]))).toEqual({ value: clean, changed: false });
   const dirty = { response: { output: [{ type: "function_call", name: "wait", namespace: "wait", arguments: "{}" }, { type: "message" }] } };
-  const result = scrubSelfNamedToolCallNamespace(dirty);
+  const result = scrubSelfNamedToolCallNamespace(dirty, new Set(["wait"]));
   expect(result.changed).toBe(true);
   expect(result.value).toEqual({ response: { output: [{ type: "function_call", name: "wait", arguments: "{}" }, { type: "message" }] } });
   // An empty name never matches: a namespace equal to "" is not the self-named shape.
-  expect(scrubSelfNamedToolCallNamespace({ type: "custom_tool_call", name: "", namespace: "" }).changed).toBe(false);
+  expect(scrubSelfNamedToolCallNamespace({ type: "custom_tool_call", name: "", namespace: "" }, new Set()).changed).toBe(false);
 });

--- a/tests/responses-self-named-namespace-scrub.test.ts
+++ b/tests/responses-self-named-namespace-scrub.test.ts
@@ -163,6 +163,29 @@ test("a self-named namespace on a passthrough bare function_call is scrubbed", a
   expect(text).not.toContain('\"namespace\":\"wait\"');
 });
 
+test("a Chat-shaped function declaration still authorizes the bare function scrub", async () => {
+  // `buildTools` accepts `{ type: "function", function: { name } }` and the undeclared-tool guard
+  // authorizes it, so the scrub's raw-body collector has to read the nested name too; otherwise
+  // the intersection drops the tool and a self-named echo for it loops Codex again.
+  const chatShaped = {
+    ...requestBody,
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "wait" }] },
+    ],
+    tools: [{ type: "function", function: { name: "wait", parameters: { type: "object", properties: {} } } }],
+  };
+  const call = { type: "function_call", id: "fc_1", call_id: "call_1", name: "wait", namespace: "wait", arguments: "{}", status: "completed" };
+  globalThis.fetch = (async () => new Response(sseFrom([call]), {
+    status: 200, headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+
+  const res = await handleResponses(request(chatShaped), forwardConfig(), { model: "", provider: "" });
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  expect(text).toContain('"type":"function_call"');
+  expect(text).not.toContain('"namespace":"wait"');
+});
+
 test("tool_choice for a namespaced custom tool cannot authorize a colliding bare scrub", async () => {
   const call = { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "exec", namespace: "exec", input: "pwd", status: "completed" };
   globalThis.fetch = (async () => new Response(sseFrom([call]), {


### PR DESCRIPTION
## Summary

Carry of #3226 by @alex-jordan547 (four commits cherry-picked with author credit) plus one maintainer commit.

#3226 scopes the #3217 self-named-namespace scrub (landed in #3224) to bare custom / bare function tools the current turn actually declared, so a genuine same-name namespaced tool (`namespace: "exec"` holding `name: "exec"`, which codex-rs routes by structured `ToolName`) is no longer damaged. Authorization is built from `tools`, `additional_tools`, and `tool_search_output`, threaded through `buildToolBridgeMaps`, honours `tool_choice`, and applies to both the SSE and bounded-JSON passthrough paths.

Review found one hole: `collectBareToolSpecs` read only `spec.name`, so a Chat-shaped `{ type: "function", function: { name } }` declaration — which `buildTools` accepts and the undeclared-tool guard authorizes — never entered the raw-body set; the intersection dropped it and a self-named echo for that function would loop Codex again. The maintainer commit mirrors `addWireToolName` and reads the nested name, with a regression that is red without it.

Supersedes #3226 (landed via maintainer).

## Verification

- `bun test tests/responses-self-named-namespace-scrub.test.ts tests/responses-undeclared-tool-guard.test.ts tests/openai-responses-passthrough.test.ts` — 202 pass / 0 fail. New case "a Chat-shaped function declaration still authorizes the bare function scrub" fails without the collector change.
- `bun run typecheck` clean; `bun run privacy:scan` passed.
- Full suite deferred to CI (maintainer bypass, tracked after merge).

## Checklist

- [x] Targets `dev`
- [x] Author credit preserved on the carried commits
- [x] Focused regression next to the existing scrub tests
- [x] No GUI change; no docs-site change (internal hardening of a bugfix)
- [x] No new logging of request bodies or identifiers

