### PR TITLE
docs(readme): stack the four demo gifs one per row

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,26 @@ ocx start        # proxy + dashboard on localhost:10100
 
 <table align="center">
   <tr>
-    <td width="50%" align="center">
-      <img src="assets/claude-code-models.gif" alt="Claude Code running a routed model through opencodex — the status bar shows gpt-5.6-luna-medium as the active model" width="410"><br>
+    <td align="center">
+      <img src="assets/claude-code-models.gif" alt="Claude Code running a routed model through opencodex — the status bar shows gpt-5.6-luna-medium as the active model" width="840"><br>
       <sub><b>Claude Code, running any model.</b><br>The picker is stock Claude Code. The brain behind it isn't.</sub>
     </td>
-    <td width="50%" align="center">
-      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/demo.gif" alt="opencodex demo — running a task in the Codex app on a routed non-OpenAI model" width="410"><br>
+  </tr>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/demo.gif" alt="opencodex demo — running a task in the Codex app on a routed non-OpenAI model" width="840"><br>
       <sub><b>Codex, running any model.</b><br>Pick a provider and go — same workflow, different brain.</sub>
     </td>
   </tr>
   <tr>
-    <td width="50%" align="center">
-      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/claude-desktop-subagent.gif" alt="Claude Desktop answering as Claude Opus 4.8, then dispatching a GPT-5.6 Sol subagent through opencodex" width="410"><br>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/claude-desktop-subagent.gif" alt="Claude Desktop answering as Claude Opus 4.8, then dispatching a GPT-5.6 Sol subagent through opencodex" width="840"><br>
       <sub><b>Claude Desktop, running any model.</b><br>Opus answers, then hands the task to a GPT-5.6 Sol subagent.</sub>
     </td>
-    <td width="50%" align="center">
-      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/grok-build-subagent.gif" alt="Grok Build running GPT-5.6 Sol through opencodex and calling a Kimi K3 subagent" width="410"><br>
+  </tr>
+  <tr>
+    <td align="center">
+      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/grok-build-subagent.gif" alt="Grok Build running GPT-5.6 Sol through opencodex and calling a Kimi K3 subagent" width="840"><br>
       <sub><b>Grok Build, running any model.</b><br>Sol drives the session and calls a Kimi K3 subagent.</sub>
     </td>
   </tr>


### PR DESCRIPTION
## Summary

The README hero table laid out the four demo GIFs as a 2x2 grid at 410px each, which clipped the recordings at GitHub's rendered column width. This stacks them one per row at full width (840px) so every GIF renders uncut. Captions and alt text are unchanged.

## Verification

- Docs-only change to `README.md`; no runtime, test, or build path touched.
- Checked the rendered README preview shows the four rows without horizontal clipping.

## Checklist

- [x] Targets `dev`
- [x] Scope limited to README layout
- [x] No secrets, tokens, or account identifiers introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured the README demo showcase into a single-column layout.
  * Enlarged demo images for improved visibility.
  * Updated the Grok Build demo caption punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->