### PR TITLE
fix(combo): fail over zero-output transport incompletes (carry of #3227)

### DIFF
--- a/src/server/responses/combo-stream-preflight.ts
+++ b/src/server/responses/combo-stream-preflight.ts
@@ -24,6 +24,24 @@ const TERMINAL_EVENTS = new Set([
   "response.incomplete",
 ]);
 
+const RETRYABLE_ZERO_OUTPUT_INCOMPLETE_REASONS = new Set([
+  "adapter_eof",
+  "missing_terminal_event",
+  "upstream_stall_timeout",
+]);
+
+function retryableZeroOutputTerminal(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const event = payload as {
+    type?: unknown;
+    response?: { incomplete_details?: { reason?: unknown } };
+  };
+  if (event.type === "response.failed") return true;
+  if (event.type !== "response.incomplete") return false;
+  const reason = event.response?.incomplete_details?.reason;
+  return typeof reason === "string" && RETRYABLE_ZERO_OUTPUT_INCOMPLETE_REASONS.has(reason);
+}
+
 /**
  * Decide when replaying the request on another combo target would risk duplicating
  * client-visible output or a tool-side effect. Unknown event types commit the child
@@ -128,14 +146,14 @@ export async function preflightComboStreamResponse(
   let bufferedBytes = 0;
   let outputCommitted = false;
   let terminalStatus: ResponsesTerminalStatus | undefined;
-  let failedPayload: Record<string, unknown> | undefined;
+  let retryableTerminalPayload: Record<string, unknown> | undefined;
   const inspector = createSseInspector({
     logCtx,
     onParsedPayload: payload => {
       if (comboStreamPayloadCommitsOutput(payload)) outputCommitted = true;
       if (!payload || typeof payload !== "object" || Array.isArray(payload)) return;
-      if ((payload as { type?: unknown }).type === "response.failed") {
-        failedPayload = payload as Record<string, unknown>;
+      if (retryableZeroOutputTerminal(payload)) {
+        retryableTerminalPayload = payload as Record<string, unknown>;
       }
     },
     onTerminal: status => { terminalStatus = status; },
@@ -162,9 +180,10 @@ export async function preflightComboStreamResponse(
         inspector.feed(retained);
       }
 
-      if (terminalStatus === "failed" && !outputCommitted && failedPayload) {
-        await reader.cancel("retrying zero-output combo stream failure").catch(() => undefined);
-        return { kind: "failed", response: failedTerminalResponse(response, failedPayload, logCtx) };
+      if ((terminalStatus === "failed" || terminalStatus === "incomplete")
+        && !outputCommitted && retryableTerminalPayload) {
+        await reader.cancel("retrying zero-output combo stream terminal").catch(() => undefined);
+        return { kind: "failed", response: failedTerminalResponse(response, retryableTerminalPayload, logCtx) };
       }
       if (next.done || terminalStatus !== undefined || outputCommitted
         || bufferedBytes >= COMBO_STREAM_PREFLIGHT_MAX_BYTES

--- a/tests/combo-stream-preflight.test.ts
+++ b/tests/combo-stream-preflight.test.ts
@@ -18,6 +18,7 @@ describe("combo stream preflight", () => {
     expect(comboStreamPayloadCommitsOutput({ type: "response.created" })).toBe(false);
     expect(comboStreamPayloadCommitsOutput({ type: "response.heartbeat" })).toBe(false);
     expect(comboStreamPayloadCommitsOutput({ type: "response.failed" })).toBe(false);
+    expect(comboStreamPayloadCommitsOutput({ type: "response.incomplete" })).toBe(false);
     expect(comboStreamPayloadCommitsOutput({ type: "response.output_text.delta", delta: "x" })).toBe(true);
     expect(comboStreamPayloadCommitsOutput({ type: "response.output_item.added", item: { type: "function_call" } })).toBe(true);
     expect(comboStreamPayloadCommitsOutput({ type: "provider.future_event" })).toBe(true);
@@ -47,6 +48,72 @@ describe("combo stream preflight", () => {
       response: { usage: { input_tokens: 7, output_tokens: 0 } },
     });
     expect(JSON.stringify(body)).not.toContain("provider_trace_id");
+  });
+
+  test("converts zero-output transport incompletes into retryable HTTP failures", async () => {
+    const cases = [
+      ["adapter_eof", "Upstream stream ended unexpectedly without a terminal event"],
+      ["missing_terminal_event", "Upstream incomplete"],
+      ["upstream_stall_timeout", "Upstream stalled"],
+    ] as const;
+    for (const [reason, message] of cases) {
+      const result = await preflightComboStreamResponse(sse(
+        { type: "response.created", response: { id: "r1", status: "in_progress" } },
+        {
+          type: "response.incomplete",
+          response: {
+            id: "r1",
+            status: "incomplete",
+            incomplete_details: { reason },
+            usage: { input_tokens: 11, output_tokens: 0, total_tokens: 11 },
+          },
+        },
+      ), { model: "m1", provider: "a" });
+
+      expect(result.kind).toBe("failed");
+      expect(result.response.status).toBe(502);
+      const body = await result.response.json();
+      expect(body.error).toMatchObject({ type: "upstream_error", code: "upstream_server_error" });
+      expect(body.error.message).toContain(message);
+      expect(body.response.usage).toMatchObject({ input_tokens: 11, output_tokens: 0 });
+    }
+  });
+
+  test("does not replay semantic incompletes that another provider cannot safely repair", async () => {
+    const source = sse(
+      { type: "response.created", response: { id: "r1", status: "in_progress" } },
+      {
+        type: "response.incomplete",
+        response: {
+          id: "r1",
+          status: "incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+        },
+      },
+    );
+    const expected = await source.clone().text();
+    const result = await preflightComboStreamResponse(source, { model: "m1", provider: "a" });
+    expect(result.kind).toBe("accepted");
+    expect(await result.response.text()).toBe(expected);
+  });
+
+  test("does not replay transport incompletes after output commits the target", async () => {
+    const source = sse(
+      { type: "response.created", response: { id: "r1", status: "in_progress" } },
+      { type: "response.output_text.delta", delta: "visible" },
+      {
+        type: "response.incomplete",
+        response: {
+          id: "r1",
+          status: "incomplete",
+          incomplete_details: { reason: "adapter_eof" },
+        },
+      },
+    );
+    const expected = await source.clone().text();
+    const result = await preflightComboStreamResponse(source, { model: "m1", provider: "a" });
+    expect(result.kind).toBe("accepted");
+    expect(await result.response.text()).toBe(expected);
   });
 
   test("replays buffered bytes unchanged after output commits the target", async () => {

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -204,6 +204,13 @@ function chatStream(text: string): Response {
   return new Response(frames, { headers: { "content-type": "text/event-stream" } });
 }
 
+function chatTruncatedZeroOutputStream(): Response {
+  const frames = [
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: null }] })}\n\n`,
+  ].join("");
+  return new Response(frames, { headers: { "content-type": "text/event-stream" } });
+}
+
 function chatErrorStream(message: string, prefix?: string): Response {
   const frames = [
     ...(prefix
@@ -478,6 +485,41 @@ describe("server combo failover 030 activation matrix", () => {
     const response = await postLogged(config, { stream: true });
     expect(response.status).toBe(200);
     expect(JSON.stringify(await collectSse(response))).toContain("stream backup");
+    expect(hits).toEqual(["a", "b"]);
+
+    const { log, usage } = await latestAttemptReceipts(config);
+    for (const receipt of [log, usage]) {
+      expect(receipt).toMatchObject({
+        provider: "combo",
+        model: "combo/free",
+        resolvedModel: "m2",
+        attempts: [
+          { ordinal: 1, provider: "a", model: "m1", status: 502 },
+          { ordinal: 2, provider: "b", model: "m2", status: 200 },
+        ],
+      });
+      expect(receipt.attempts[0]).not.toHaveProperty("firstOutputMs");
+    }
+  });
+
+  test("zero-output adapter EOF hops to the next combo target", async () => {
+    const hits: string[] = [];
+    const a = serve(() => {
+      hits.push("a");
+      return chatTruncatedZeroOutputStream();
+    });
+    const b = serve(() => {
+      hits.push("b");
+      return chatStream("stream backup after adapter eof");
+    });
+    const config = comboConfig({
+      a: provider("openai-chat", baseUrl(a), "key-a"),
+      b: provider("openai-chat", baseUrl(b), "key-b"),
+    });
+
+    const response = await postLogged(config, { stream: true });
+    expect(response.status).toBe(200);
+    expect(JSON.stringify(await collectSse(response))).toContain("stream backup after adapter eof");
     expect(hits).toEqual(["a", "b"]);
 
     const { log, usage } = await latestAttemptReceipts(config);


### PR DESCRIPTION
## Summary

Carry of #3227 by @RHODIZSECURITY (commit cherry-picked onto current `dev` with author credit; the contributor branch is not pushable by maintainers).

Combo stream preflight only treated `response.failed` as a retryable zero-output terminal. An upstream answering HTTP 200 with a stream that ends as `response.incomplete` for a proxy-minted transport reason (`adapter_eof`, `missing_terminal_event`, `upstream_stall_timeout`) was accepted, so a combo with healthy backups never advanced. Those three reasons now count as retryable when no output has committed; semantic incompletes (`max_output_tokens`, `content_filter`) and any incomplete after output commit stay accepted. The failed attempt is recorded as a 502 in log/usage receipts, same as a zero-output `response.failed`.

Supersedes #3227 (landed via maintainer).

## Verification

- `bun test tests/combo-stream-preflight.test.ts tests/server-combo-failover-e2e.test.ts` — 88 pass / 0 fail on the PR head and again after rebase onto `dev`. New unit cases: transport incomplete → retryable; semantic incomplete → accepted; transport incomplete after commit → accepted. New e2e: A ends `adapter_eof` before output, B wins, receipts assert 502 → 200.
- Reviewer confirmed the three reasons are minted proxy-side (`bridge.ts`, `relay.ts`, `responses-terminal-repair.ts`), not upstream semantics.
- `bun run typecheck` clean; `bun run privacy:scan` passed. Full suite deferred to CI (maintainer bypass).

## Checklist

- [x] Targets `dev`
- [x] Author credit preserved
- [x] Focused regression tests next to the existing combo preflight tests
- [x] No GUI change; no docs-site change (failover contract unchanged for users)

