### PR TITLE
docs(readme): shrink the stacked demo gifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,25 @@ ocx start        # proxy + dashboard on localhost:10100
 <table align="center">
   <tr>
     <td align="center">
-      <img src="assets/claude-code-models.gif" alt="Claude Code running a routed model through opencodex — the status bar shows gpt-5.6-luna-medium as the active model" width="840"><br>
+      <img src="assets/claude-code-models.gif" alt="Claude Code running a routed model through opencodex — the status bar shows gpt-5.6-luna-medium as the active model" width="560"><br>
       <sub><b>Claude Code, running any model.</b><br>The picker is stock Claude Code. The brain behind it isn't.</sub>
     </td>
   </tr>
   <tr>
     <td align="center">
-      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/demo.gif" alt="opencodex demo — running a task in the Codex app on a routed non-OpenAI model" width="840"><br>
+      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/demo.gif" alt="opencodex demo — running a task in the Codex app on a routed non-OpenAI model" width="560"><br>
       <sub><b>Codex, running any model.</b><br>Pick a provider and go — same workflow, different brain.</sub>
     </td>
   </tr>
   <tr>
     <td align="center">
-      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/claude-desktop-subagent.gif" alt="Claude Desktop answering as Claude Opus 4.8, then dispatching a GPT-5.6 Sol subagent through opencodex" width="840"><br>
+      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/claude-desktop-subagent.gif" alt="Claude Desktop answering as Claude Opus 4.8, then dispatching a GPT-5.6 Sol subagent through opencodex" width="560"><br>
       <sub><b>Claude Desktop, running any model.</b><br>Opus answers, then hands the task to a GPT-5.6 Sol subagent.</sub>
     </td>
   </tr>
   <tr>
     <td align="center">
-      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/grok-build-subagent.gif" alt="Grok Build running GPT-5.6 Sol through opencodex and calling a Kimi K3 subagent" width="840"><br>
+      <img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/grok-build-subagent.gif" alt="Grok Build running GPT-5.6 Sol through opencodex and calling a Kimi K3 subagent" width="560"><br>
       <sub><b>Grok Build, running any model.</b><br>Sol drives the session and calls a Kimi K3 subagent.</sub>
     </td>
   </tr>


### PR DESCRIPTION
## Summary

Follow-up to #3235. The four README demo GIFs stay one per row with the caption directly beneath each, but render at 560px instead of 840px so the hero section is not dominated by full-width recordings.

## Verification

- Docs-only change to `README.md`; no runtime, test, or build path touched.
- Confirmed the four rows still render uncut at the smaller width.

## Checklist

- [x] Targets `dev`
- [x] Scope limited to README image sizing
- [x] No secrets, tokens, or account identifiers introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reduced the displayed width of four demo GIFs in the README showcase for improved readability and page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->