### PR TITLE
fix(subagents): auto-fallback encrypted V2 spawns to native Codex (carry of #3228)

### DIFF
--- a/src/codex/subagent-model-fallback.ts
+++ b/src/codex/subagent-model-fallback.ts
@@ -7,7 +7,7 @@
  */
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { hasOwnProvider } from "../config";
+import { DEFAULT_SUBAGENT_MODELS, hasOwnProvider } from "../config";
 import { isRateLimitOrQuotaFailureMessage } from "../lib/errors";
 import type { OcxParsedRequest, OcxConfig } from "../types";
 import { slugsEquivalent } from "../providers/slug-codec";
@@ -609,9 +609,14 @@ export function applySubagentModelFallback(
   resolvedFallbackChain?: readonly string[] | null,
 ): { from?: string; to?: string; skipped?: string[] } | null {
   if (!isThreadSpawnRequest(headers)) return null;
-  const fallbackChain = resolvedFallbackChain === undefined
+  const configuredFallbackChain = resolvedFallbackChain === undefined
     ? resolveSubagentFallbackChain(parsed, config)
     : resolvedFallbackChain;
+  // Native-only encrypted V2 tasks need a readable ChatGPT backend even when the
+  // operator configured no fallback chain. Keep ordinary routed spawns unchanged.
+  const fallbackChain = configuredFallbackChain === null && nativeFallbackOnly
+    ? normalizedChain(parsed.modelId, config, [], DEFAULT_SUBAGENT_MODELS)
+    : configuredFallbackChain;
   if (!fallbackChain) return null;
   const selection = selectAvailableSubagentModel(
     parsed.modelId,

--- a/tests/subagent-model-fallback.test.ts
+++ b/tests/subagent-model-fallback.test.ts
@@ -1056,6 +1056,29 @@ describe("subagent model fallback chain", () => {
     expect((parsed._rawBody as { model?: string }).model).toBe("alibaba-token-plan/qwen3.8-max");
   });
 
+  test("encrypted routed spawn gets an automatic native fallback when none is configured", () => {
+    const config = cfg({
+      subagentModelFallback: undefined,
+      defaultProvider: "xai",
+    });
+    const parsed = {
+      modelId: "xai/grok-4.5",
+      options: {},
+      context: { messages: [] },
+      _rawBody: { model: "xai/grok-4.5" },
+    };
+    const result = applySubagentModelFallback(
+      parsed as never,
+      new Headers({ "x-openai-subagent": "collab_spawn" }),
+      config,
+      "pool-a",
+      Date.now(),
+      true,
+    );
+    expect(result?.to).toBe("gpt-5.5");
+    expect(parsed.modelId).toBe("gpt-5.5");
+  });
+
   test("applySubagentModelFallback is a no-op for main turns", () => {
     updateAccountQuota("pool-a", 95);
     const parsed = {


### PR DESCRIPTION
## Summary

Carry of the source fix from #3228 by @x3M3x (`Co-authored-by` credit; the PR also bundled an unrelated GUI fallback-chain editor which is left for its own feature PR with a screenshot).

An encrypted V2 worker payload needs the native ChatGPT backend, but `applySubagentModelFallback` only consulted a fallback chain the operator configured. With no chain, a routed sub-agent model reached the encrypted-task guard and failed with `unreadable_encrypted_agent_task`. When `nativeFallbackOnly` is set and no chain exists, the chain is now built from `DEFAULT_SUBAGENT_MODELS`; `selectAvailableSubagentModel` still drops every non-forward candidate and `isSubagentModelUnavailable` still honours disabled models, quota, and health. Ordinary routed spawns are unchanged.

Supersedes the source half of #3228.

## Verification

- `bun test tests/subagent-model-fallback.test.ts` — 60 pass / 0 fail; the new case "encrypted routed spawn gets an automatic native fallback when none is configured" fails without the source change.
- Reviewer confirmed `nativeFallbackOnly` is only set for unreadable encrypted payloads (`core.ts`) and the gate `configuredFallbackChain === null && nativeFallbackOnly` leaves non-encrypted spawns untouched.
- `bun run typecheck` clean; `bun run privacy:scan` passed. Full suite deferred to CI (maintainer bypass).

## Checklist

- [x] Targets `dev`
- [x] Author credit preserved
- [x] Focused regression next to the existing fallback tests
- [x] No GUI change in this PR; no docs-site change

