### PR TITLE
fix(subagents): let encrypted-task recovery run before the synthesized native chain

### DIFF
--- a/src/codex/subagent-model-fallback.ts
+++ b/src/codex/subagent-model-fallback.ts
@@ -614,7 +614,15 @@ export function applySubagentModelFallback(
     : resolvedFallbackChain;
   // Native-only encrypted V2 tasks need a readable ChatGPT backend even when the
   // operator configured no fallback chain. Keep ordinary routed spawns unchanged.
+  //
+  // Not when encrypted-task recovery is enabled: that operator chose to decrypt the
+  // assignment and stay on the routed model. The synthesized chain would reroute the
+  // spawn to native in this first pass, before recovery runs, and recovery's own
+  // caller-auth / proxy-secret / token-validity gates would never execute
+  // (tests/agent-task-recovery-security.test.ts went 13/13 -> 2/13 when #3239 landed
+  // without this guard). A configured chain keeps its existing precedence.
   const fallbackChain = configuredFallbackChain === null && nativeFallbackOnly
+    && config.agentTaskRecovery?.enabled !== true
     ? normalizedChain(parsed.modelId, config, [], DEFAULT_SUBAGENT_MODELS)
     : configuredFallbackChain;
   if (!fallbackChain) return null;

--- a/tests/subagent-model-fallback.test.ts
+++ b/tests/subagent-model-fallback.test.ts
@@ -1079,6 +1079,33 @@ describe("subagent model fallback chain", () => {
     expect(parsed.modelId).toBe("gpt-5.5");
   });
 
+  test("the synthesized native chain yields to enabled encrypted-task recovery", () => {
+    // With recovery on, the first fallback pass must leave the routed spawn alone so
+    // recoverEncryptedAgentTask runs (and its security gates fire); rerouting here
+    // would bypass them.
+    const config = cfg({
+      subagentModelFallback: undefined,
+      defaultProvider: "xai",
+      agentTaskRecovery: { enabled: true },
+    });
+    const parsed = {
+      modelId: "xai/grok-4.5",
+      options: {},
+      context: { messages: [] },
+      _rawBody: { model: "xai/grok-4.5" },
+    };
+    const result = applySubagentModelFallback(
+      parsed as never,
+      new Headers({ "x-openai-subagent": "collab_spawn" }),
+      config,
+      "pool-a",
+      Date.now(),
+      true,
+    );
+    expect(result).toBeNull();
+    expect(parsed.modelId).toBe("xai/grok-4.5");
+  });
+
   test("applySubagentModelFallback is a no-op for main turns", () => {
     updateAccountQuota("pool-a", 95);
     const parsed = {


### PR DESCRIPTION
## Summary

Trailing-CI repair for #3239 (`744d12d02`). That change synthesized a `DEFAULT_SUBAGENT_MODELS` chain for an unreadable encrypted spawn when no fallback chain is configured. The chain fires in the **first** fallback pass, before `recoverEncryptedAgentTask`, so with `agentTaskRecovery.enabled` the spawn was rerouted to native `gpt-5.5` and recovery was skipped — together with the caller-auth, proxy-secret and token-validity gates recovery enforces. `tests/agent-task-recovery-security.test.ts` went 13/13 → 2/13 on `dev` (bisected: green at `1c8278b4d`, red at `744d12d02`).

Fix: synthesize the chain only when recovery is not enabled. An operator who enabled recovery chose to decrypt and stay routed; a configured chain keeps its precedence either way; #3239's own case (recovery off, no chain) still gets `gpt-5.5`.

## Verification

- `bun test tests/subagent-model-fallback.test.ts tests/agent-task-recovery-security.test.ts` — 74 pass / 0 fail. New unit case "the synthesized native chain yields to enabled encrypted-task recovery" is red without the guard; the 13 recovery security cases are 2/13 without it.
- `bun run typecheck` clean; `bun run privacy:scan` passed. Full suite deferred to CI (maintainer bypass).

## Checklist

- [x] Targets `dev`
- [x] Regression test next to the existing fallback tests; security file restored
- [x] No GUI / docs-site change

