### PR TITLE
fix(agents): allow Codexless V2 task recovery (carry of #3229)

### DIFF
--- a/src/server/responses/agent-task-recovery.ts
+++ b/src/server/responses/agent-task-recovery.ts
@@ -23,6 +23,7 @@ const CODEX_ORIGINATORS = new Set([
   "Codex Desktop",
   "codex_app",
   "codex_work_desktop",
+  "codexless_agent",
 ]);
 const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_TOKEN_ISSUERS = new Set(["https://auth.openai.com", "https://auth.openai.com/"]);

--- a/tests/agent-task-recovery-security.test.ts
+++ b/tests/agent-task-recovery-security.test.ts
@@ -413,4 +413,27 @@ describe("agent task recovery security", () => {
     expect(response.status).toBe(200);
     expect(recoveryOriginator).toBe("codex_work_desktop");
   });
+
+  test("accepts the Codexless originator", async () => {
+    let recoveryOriginator = "";
+    globalThis.fetch = (async (input, init) => {
+      if (String(input).includes("chatgpt.com")) {
+        recoveryOriginator = new Headers(init?.headers).get("originator") ?? "";
+        return new Response(recoverySse("Recover the Codexless child task."), { status: 200 });
+      }
+      return providerResponse();
+    }) as typeof fetch;
+    const headers = codexHeaders();
+    headers.set("originator", "codexless_agent");
+
+    const response = await post(
+      routedConfig(),
+      "xai/grok-4.5",
+      encryptedInput(),
+      headers,
+    );
+
+    expect(response.status).toBe(200);
+    expect(recoveryOriginator).toBe("codexless_agent");
+  });
 });


### PR DESCRIPTION
## Summary

Carry of #3229 by @iamnomankazi (`Co-authored-by`; the PR branch was cut from an older `dev` and is not maintainer-pushable, so its two-file diff was re-applied on the current tip).

Codexless's app-server sends `originator=codexless_agent`, which the encrypted V2 recovery admission allowlist (`CODEX_ORIGINATORS`) rejected, so its child tasks failed as `unreadable_encrypted_agent_task`. Admit that originator. The set only gates admission; the OAuth issuer, client id, token, account-id and proxy-secret checks that run after it are unchanged, so no credential boundary is widened. The reviewer confirmed `codexless_agent` is the real identity Codexless sets via app-server `clientInfo.name`.

Supersedes #3229.

## Verification

- `bun test tests/agent-task-recovery-security.test.ts` — 14 pass / 0 fail on the current tip (which includes the #3240 repair). The new case "accepts the Codexless originator" is red without the source line (verified on `1c8278b4d`).
- `bun run typecheck` clean; `bun run privacy:scan` passed. Full suite deferred to CI (maintainer bypass).

## Checklist

- [x] Targets `dev`
- [x] Author credit preserved
- [x] Security-sensitive: admission allowlist only; downstream credential checks untouched
- [x] No GUI / docs-site change

