### PR TITLE
revert(subagents): drop the synthesized native chain for encrypted spawns (#3239, #3240)

### DIFF
--- a/src/codex/subagent-model-fallback.ts
+++ b/src/codex/subagent-model-fallback.ts
@@ -7,7 +7,7 @@
  */
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { DEFAULT_SUBAGENT_MODELS, hasOwnProvider } from "../config";
+import { hasOwnProvider } from "../config";
 import { isRateLimitOrQuotaFailureMessage } from "../lib/errors";
 import type { OcxParsedRequest, OcxConfig } from "../types";
 import { slugsEquivalent } from "../providers/slug-codec";
@@ -609,14 +609,9 @@ export function applySubagentModelFallback(
   resolvedFallbackChain?: readonly string[] | null,
 ): { from?: string; to?: string; skipped?: string[] } | null {
   if (!isThreadSpawnRequest(headers)) return null;
-  const configuredFallbackChain = resolvedFallbackChain === undefined
+  const fallbackChain = resolvedFallbackChain === undefined
     ? resolveSubagentFallbackChain(parsed, config)
     : resolvedFallbackChain;
-  // Native-only encrypted V2 tasks need a readable ChatGPT backend even when the
-  // operator configured no fallback chain. Keep ordinary routed spawns unchanged.
-  const fallbackChain = configuredFallbackChain === null && nativeFallbackOnly
-    ? normalizedChain(parsed.modelId, config, [], DEFAULT_SUBAGENT_MODELS)
-    : configuredFallbackChain;
   if (!fallbackChain) return null;
   const selection = selectAvailableSubagentModel(
     parsed.modelId,

--- a/src/codex/subagent-model-fallback.ts
+++ b/src/codex/subagent-model-fallback.ts
@@ -614,15 +614,7 @@ export function applySubagentModelFallback(
     : resolvedFallbackChain;
   // Native-only encrypted V2 tasks need a readable ChatGPT backend even when the
   // operator configured no fallback chain. Keep ordinary routed spawns unchanged.
-  //
-  // Not when encrypted-task recovery is enabled: that operator chose to decrypt the
-  // assignment and stay on the routed model. The synthesized chain would reroute the
-  // spawn to native in this first pass, before recovery runs, and recovery's own
-  // caller-auth / proxy-secret / token-validity gates would never execute
-  // (tests/agent-task-recovery-security.test.ts went 13/13 -> 2/13 when #3239 landed
-  // without this guard). A configured chain keeps its existing precedence.
   const fallbackChain = configuredFallbackChain === null && nativeFallbackOnly
-    && config.agentTaskRecovery?.enabled !== true
     ? normalizedChain(parsed.modelId, config, [], DEFAULT_SUBAGENT_MODELS)
     : configuredFallbackChain;
   if (!fallbackChain) return null;

--- a/tests/subagent-model-fallback.test.ts
+++ b/tests/subagent-model-fallback.test.ts
@@ -1056,29 +1056,6 @@ describe("subagent model fallback chain", () => {
     expect((parsed._rawBody as { model?: string }).model).toBe("alibaba-token-plan/qwen3.8-max");
   });
 
-  test("encrypted routed spawn gets an automatic native fallback when none is configured", () => {
-    const config = cfg({
-      subagentModelFallback: undefined,
-      defaultProvider: "xai",
-    });
-    const parsed = {
-      modelId: "xai/grok-4.5",
-      options: {},
-      context: { messages: [] },
-      _rawBody: { model: "xai/grok-4.5" },
-    };
-    const result = applySubagentModelFallback(
-      parsed as never,
-      new Headers({ "x-openai-subagent": "collab_spawn" }),
-      config,
-      "pool-a",
-      Date.now(),
-      true,
-    );
-    expect(result?.to).toBe("gpt-5.5");
-    expect(parsed.modelId).toBe("gpt-5.5");
-  });
-
   test("applySubagentModelFallback is a no-op for main turns", () => {
     updateAccountQuota("pool-a", 95);
     const parsed = {

--- a/tests/subagent-model-fallback.test.ts
+++ b/tests/subagent-model-fallback.test.ts
@@ -1079,33 +1079,6 @@ describe("subagent model fallback chain", () => {
     expect(parsed.modelId).toBe("gpt-5.5");
   });
 
-  test("the synthesized native chain yields to enabled encrypted-task recovery", () => {
-    // With recovery on, the first fallback pass must leave the routed spawn alone so
-    // recoverEncryptedAgentTask runs (and its security gates fire); rerouting here
-    // would bypass them.
-    const config = cfg({
-      subagentModelFallback: undefined,
-      defaultProvider: "xai",
-      agentTaskRecovery: { enabled: true },
-    });
-    const parsed = {
-      modelId: "xai/grok-4.5",
-      options: {},
-      context: { messages: [] },
-      _rawBody: { model: "xai/grok-4.5" },
-    };
-    const result = applySubagentModelFallback(
-      parsed as never,
-      new Headers({ "x-openai-subagent": "collab_spawn" }),
-      config,
-      "pool-a",
-      Date.now(),
-      true,
-    );
-    expect(result).toBeNull();
-    expect(parsed.modelId).toBe("xai/grok-4.5");
-  });
-
   test("applySubagentModelFallback is a no-op for main turns", () => {
     updateAccountQuota("pool-a", 95);
     const parsed = {


### PR DESCRIPTION
## Summary

Reverts #3239 (`744d12d02`) and its follow-up #3240 (`7f00d0eee`).

#3239 synthesized a `DEFAULT_SUBAGENT_MODELS` chain for an unreadable encrypted spawn when no chain is configured. That silently reroutes a routed sub-agent to the native ChatGPT backend — spending a stored ChatGPT credential the operator never opted into for that model. `tests/agent-task-recovery.test.ts` pins the opposite contract: with recovery absent or disabled, an encrypted spawn on a routed model fails fast with a byte-identical 400 `unreadable_encrypted_agent_task` and **zero** upstream fetches. On the exact `dev` tip (`b54508c8c`, dispatch run 33581824312) that case fails 400→502, and the file was 19/19 at `1c8278b4d`, 7/19 at `744d12d02`, 18/19 after #3240.

#3240 restored the recovery-enabled path but could not restore the recovery-off contract without removing the feature, so both go. The reporter's case (#3228) needs an opt-in — either a configured `subagentModelFallback` chain, or `agentTaskRecovery.enabled` — and that is the documented behaviour, not a bug. Recorded in the devlog for #3228's author.

## Verification

- `bun test tests/agent-task-recovery.test.ts tests/agent-task-recovery-security.test.ts tests/subagent-model-fallback.test.ts` — 92 pass / 0 fail after the revert (19+14+59; the two tests added by #3239/#3240 are removed with their code).
- `bun run typecheck` clean; `bun run privacy:scan` passed. Full suite deferred to CI (maintainer bypass).

## Checklist

- [x] Targets `dev`
- [x] Pure revert, no other changes
- [x] No GUI / docs-site change

