### PR TITLE
docs(cursor): closeout verification on the landed dev

### DIFF
--- a/devlog/_plan/260902_cursor_unified_identity/040_residuals.md
+++ b/devlog/_plan/260902_cursor_unified_identity/040_residuals.md
@@ -99,3 +99,19 @@ Each child was re-stacked by CHERRY-PICKING its unique commits onto the landed p
 by rebasing. A parent squash absorbs the child's content under a different commit id, so a
 plain rebase conflicts against work that is already in the base - the hazard the stacked-PR
 rules warn about, observed here on #3225.
+
+### Closeout verification (landed dev `21416a7af`)
+
+```
+git merge-base --is-ancestor 7aa64bb0b FETCH_HEAD   -> OK   (#3222)
+git merge-base --is-ancestor 83838e7fa FETCH_HEAD   -> OK   (#3225)
+git merge-base --is-ancestor 8d2dd6639 FETCH_HEAD   -> OK   (#3233)
+git merge-base --is-ancestor 21416a7af FETCH_HEAD   -> OK   (#3243, this record)
+
+bun run typecheck                                    exit 0
+bun test (11 files: cursor-*, fastwire-policy, claude-*, codex-catalog,
+          agent-task-recovery)                       662 pass / 0 fail
+```
+
+No PR from this unit is left open. Remote branch deletion is refused by the repository
+ruleset, which is expected protection and does not affect the landings.


### PR DESCRIPTION
## Summary

Adds the closeout verification block to the landing record merged in #3243: the four squash commits proven as ancestors of the landed `dev`, and the landed tree verified green for every surface the Cursor identity work touched.

## Verification

```
git merge-base --is-ancestor 7aa64bb0b / 83838e7fa / 8d2dd6639 / 21416a7af  -> all OK
bun run typecheck                                                           exit 0
bun test (11 files: cursor-*, fastwire-policy, claude-*, codex-catalog,
          agent-task-recovery)                                              662 pass / 0 fail
```

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development log details covering an observed task-recovery issue during landing.
  * Documented the merged change stack, re-stacking notes, and closeout verification results.
  * Recorded successful ancestry checks, tests, and type checks for the landed changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->