### PR TITLE
feat(cursor): read-only Private Inference status route for the dashboard

### DIFF
--- a/skills/ocx/references/01_management_surface.md
+++ b/skills/ocx/references/01_management_surface.md
@@ -548,7 +548,7 @@ JSON mode: `payload`.
 
 ### `ocx integration native`
 
-Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations, and read the Cursor Private Inference status.
+Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations, and read the Cursor status (which builds are installed, gateway values, last request seen).
 
 | Method | Route |
 |---|---|

--- a/skills/ocx/references/01_management_surface.md
+++ b/skills/ocx/references/01_management_surface.md
@@ -548,7 +548,7 @@ JSON mode: `payload`.
 
 ### `ocx integration native`
 
-Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations.
+Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations, and read the Cursor Private Inference status.
 
 | Method | Route |
 |---|---|
@@ -557,6 +557,7 @@ Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations.
 | PUT | `/api/native-integrations/claude-desktop` |
 | PUT | `/api/native-integrations/codex` |
 | PUT | `/api/native-integrations/grok` |
+| GET | `/api/native-integrations/cursor` |
 
 | Flag | Value | Meaning |
 |---|---|---|

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -498,13 +498,14 @@ export const CAPABILITIES: readonly Capability[] = [
   },
   {
     command: ["integration", "native"],
-    summary: "Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations.",
+    summary: "Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations, and read the Cursor Private Inference status.",
     routes: [
       { method: "GET", path: "/api/native-integrations" },
       { method: "PUT", path: "/api/native-integrations/claude" },
       { method: "PUT", path: "/api/native-integrations/claude-desktop" },
       { method: "PUT", path: "/api/native-integrations/codex" },
       { method: "PUT", path: "/api/native-integrations/grok" },
+      { method: "GET", path: "/api/native-integrations/cursor" },
     ],
     flags: [{ name: "--json", value: "boolean", summary: "Emit the client rows or toggle result as JSON." }],
     mutates: true,

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -498,7 +498,7 @@ export const CAPABILITIES: readonly Capability[] = [
   },
   {
     command: ["integration", "native"],
-    summary: "Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations, and read the Cursor Private Inference status.",
+    summary: "Show or toggle the native Claude, Claude Desktop, Codex, and Grok integrations, and read the Cursor status (which builds are installed, gateway values, last request seen).",
     routes: [
       { method: "GET", path: "/api/native-integrations" },
       { method: "PUT", path: "/api/native-integrations/claude" },

--- a/src/integrations/cursor-detect.ts
+++ b/src/integrations/cursor-detect.ts
@@ -1,0 +1,133 @@
+/**
+ * Detect Cursor desktop installs and tell the two builds apart.
+ *
+ * Cursor ships a second desktop distribution, "Cursor Private Inference", whose agent loop
+ * runs locally and calls an OpenAI-compatible gateway the user configures. That build can
+ * reach opencodex on loopback. Regular Cursor cannot: its backend calls the custom base URL
+ * and rejects private addresses. The two share a bundle id, data folder and URL scheme, so
+ * the only reliable discriminator is `nameLong` in the app's `product.json`.
+ *
+ * Detection is read-only and injectable: the proxy never writes anything into a Cursor
+ * install, its state database, or its keychain entries (the T20 exclusion in
+ * devlog/_plan/260822_senpi_cursor_transfer/090), and the tests run against a temp tree.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { posix, win32 } from "node:path";
+
+export type CursorBuild = "private-inference" | "regular";
+
+export interface CursorInstall {
+  build: CursorBuild;
+  /** The install root (the .app bundle, install directory, or AppImage extraction root). */
+  path: string;
+  version: string | null;
+}
+
+export interface CursorDetectDeps {
+  platform: string;
+  homedir: string;
+  env: Record<string, string | undefined>;
+  readText(path: string): string | null;
+  listDir(path: string): string[];
+}
+
+export function realCursorDetectDeps(): CursorDetectDeps {
+  return {
+    platform: process.platform,
+    homedir: homedir(),
+    env: process.env,
+    readText: path => {
+      try {
+        return existsSync(path) ? readFileSync(path, "utf-8") : null;
+      } catch {
+        return null;
+      }
+    },
+    listDir: path => {
+      try {
+        return readdirSync(path);
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+const PRIVATE_INFERENCE_NAME = "Cursor Private Inference";
+const REGULAR_NAME = "Cursor";
+
+/**
+ * Candidate `product.json` paths per platform, each paired with the install root it
+ * belongs to. Only well-known locations; a custom install path is the user's to name.
+ */
+export function cursorProductJsonCandidates(deps: CursorDetectDeps): Array<{ root: string; productJson: string }> {
+  const out: Array<{ root: string; productJson: string }> = [];
+  // Join with the target platform's separator so the candidate list is stable in tests
+  // that describe another OS from this one.
+  const { join } = deps.platform === "win32" ? win32 : posix;
+  if (deps.platform === "darwin") {
+    for (const dir of ["/Applications", join(deps.homedir, "Applications")]) {
+      for (const entry of deps.listDir(dir)) {
+        if (!/^Cursor.*\.app$/i.test(entry)) continue;
+        const root = join(dir, entry);
+        out.push({ root, productJson: join(root, "Contents", "Resources", "app", "product.json") });
+      }
+    }
+    return out;
+  }
+  if (deps.platform === "win32") {
+    const bases = [
+      deps.env.LOCALAPPDATA ? join(deps.env.LOCALAPPDATA, "Programs") : null,
+      deps.env.ProgramFiles ?? null,
+    ].filter((value): value is string => value !== null);
+    for (const dir of bases) {
+      for (const entry of deps.listDir(dir)) {
+        if (!/^cursor/i.test(entry)) continue;
+        const root = join(dir, entry);
+        out.push({ root, productJson: join(root, "resources", "app", "product.json") });
+      }
+    }
+    return out;
+  }
+  // Linux: AppImages carry product.json only once extracted, so this covers the tarball /
+  // package layouts and stays best-effort.
+  for (const dir of ["/opt", join(deps.homedir, ".local", "share")]) {
+    for (const entry of deps.listDir(dir)) {
+      if (!/^cursor/i.test(entry)) continue;
+      const root = join(dir, entry);
+      out.push({ root, productJson: join(root, "resources", "app", "product.json") });
+    }
+  }
+  return out;
+}
+
+function classify(productJson: string): { build: CursorBuild; version: string | null } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(productJson);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const record = parsed as { nameLong?: unknown; version?: unknown };
+  const version = typeof record.version === "string" ? record.version : null;
+  if (record.nameLong === PRIVATE_INFERENCE_NAME) return { build: "private-inference", version };
+  if (record.nameLong === REGULAR_NAME) return { build: "regular", version };
+  return null;
+}
+
+export function detectCursorInstalls(deps: CursorDetectDeps = realCursorDetectDeps()): CursorInstall[] {
+  const found: CursorInstall[] = [];
+  const seen = new Set<string>();
+  for (const candidate of cursorProductJsonCandidates(deps)) {
+    if (seen.has(candidate.root)) continue;
+    const text = deps.readText(candidate.productJson);
+    if (text === null) continue;
+    const classified = classify(text);
+    if (!classified) continue;
+    seen.add(candidate.root);
+    found.push({ build: classified.build, path: candidate.root, version: classified.version });
+  }
+  return found;
+}

--- a/src/integrations/cursor-seen.ts
+++ b/src/integrations/cursor-seen.ts
@@ -1,0 +1,31 @@
+/**
+ * Remember the last time a Cursor client asked this proxy for its model list.
+ *
+ * The Integrations page cannot read Cursor's own settings (and must not write them), so
+ * "is Cursor pointed at me?" is answered from our side: Cursor's local-agent runtime sends
+ * `User-Agent: Cursor/<version>` on `GET /v1/models`. Only that header value and a
+ * timestamp are kept, in memory, so a proxy restart forgets it and the card says so.
+ */
+// Attacker-controlled header: accept only the shape Cursor sends and keep it short.
+const CURSOR_USER_AGENT = /^Cursor\/[\w.+-]{1,40}$/;
+
+export interface CursorSeen {
+  at: number;
+  userAgent: string;
+}
+
+let last: CursorSeen | null = null;
+
+export function recordCursorSeen(headers: Headers, now = Date.now()): void {
+  const userAgent = headers.get("user-agent")?.trim() ?? "";
+  if (!CURSOR_USER_AGENT.test(userAgent)) return;
+  last = { at: now, userAgent };
+}
+
+export function cursorLastSeen(): CursorSeen | null {
+  return last ? { ...last } : null;
+}
+
+export function resetCursorSeenForTests(): void {
+  last = null;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -225,6 +225,7 @@ import {
 import { detectInstall } from "../update/index";
 import { readyProtocolMetadata } from "../remote/protocol";
 import { modelCapabilityFields } from "./models-capabilities";
+import { recordCursorSeen } from "../integrations/cursor-seen";
 
 export const MAX_WS_FRAME_BYTES = 50 * 1024 * 1024;
 const WEBSOCKET_IDLE_TIMEOUT_SECONDS = 0;
@@ -1327,6 +1328,9 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         if (!isAllowedRequestOrigin(req, policy)) {
           return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, policy);
         }
+        // The Integrations page reports whether a Cursor client has reached this proxy; the
+        // recorder keeps only a bounded User-Agent value and a timestamp, in memory.
+        recordCursorSeen(req.headers);
         let goModels;
         let modelEntitlements;
         try {

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -72,6 +72,7 @@ import { handleSidebarRoutes } from "./management/sidebar-routes";
 import { handleCodexPromptRoutes } from "./management/codex-prompt-routes";
 import { handleIntegrationRoutes } from "./management/integration-routes";
 import { handleNativeIntegrationRoutes } from "./management/native-integration-routes";
+import { handleCursorIntegrationRoutes } from "./management/cursor-integration-routes";
 import type { ManagementContext } from "./management/context";
 import type { ManagementPrincipal, ManagementSessionControl } from "./management-auth";
 export type { ManagementApiDeps } from "./management/context";
@@ -234,6 +235,7 @@ export async function handleManagementAPI(
     ??     (await handleModelRoutes(ctx))
     ??     (await handleIntegrationRoutes(ctx))
     ??     (await handleNativeIntegrationRoutes(ctx))
+    ??     (await handleCursorIntegrationRoutes(ctx))
     ??     (await handleAgentSettingsRoutes(ctx))
     ??     (await handleCodexPromptRoutes(ctx))
     ??     (await handleOauthAccountRoutes(ctx))

--- a/src/server/management/cursor-integration-routes.ts
+++ b/src/server/management/cursor-integration-routes.ts
@@ -9,7 +9,7 @@
  * started — plus which active models will show Cursor's Reasoning and Context controls.
  */
 import { readRuntimePort } from "../../config/process-state";
-import { nativeContextLimits, nativeOpenAiContextTier, uniqueCatalogModelsForRawPublicList, visibleNativeSlugs } from "../../codex/catalog";
+import { filterCatalogVisibleModels, nativeContextLimits, nativeOpenAiContextTier, uniqueCatalogModelsForRawPublicList, visibleNativeSlugs } from "../../codex/catalog";
 import { cursorLastSeen, type CursorSeen } from "../../integrations/cursor-seen";
 import { detectCursorInstalls, type CursorInstall } from "../../integrations/cursor-detect";
 import { configuredApiAuthToken, isApiAuthRequired, jsonResponse } from "../auth-cors";
@@ -55,7 +55,9 @@ export async function buildCursorIntegrationStatus(
   const apiKeyMode = isApiAuthRequired(config) || credentialConfigured ? "credential" : "placeholder";
 
   const limits = nativeContextLimits(config);
-  const goModels = await fetchAllModels(config);
+  // Same visibility rules as the raw /v1/models list Cursor will read: disabled models and
+  // provider allowlists drop out here too, or the prediction shows rows Cursor never gets.
+  const goModels = filterCatalogVisibleModels(await fetchAllModels(config), config);
   const ids = [
     ...visibleNativeSlugs(config),
     ...uniqueCatalogModelsForRawPublicList(goModels).map(model => model.alias ?? `${model.provider}/${model.id}`),

--- a/src/server/management/cursor-integration-routes.ts
+++ b/src/server/management/cursor-integration-routes.ts
@@ -1,0 +1,96 @@
+/**
+ * Read-only status for the Cursor integration card.
+ *
+ * Cursor Private Inference is configured inside Cursor (Settings > Models > Gateway), not by
+ * this proxy: its settings live in a SQLite database the running app rewrites and its API key
+ * in the OS keychain, both out of bounds for opencodex. So this route only answers the three
+ * questions the dashboard needs — which Cursor builds are installed, what to paste into the
+ * gateway form, and whether a Cursor client has actually called `/v1/models` since the proxy
+ * started — plus which active models will show Cursor's Reasoning and Context controls.
+ */
+import { readRuntimePort } from "../../config/process-state";
+import { nativeContextLimits, nativeOpenAiContextTier, uniqueCatalogModelsForRawPublicList, visibleNativeSlugs } from "../../codex/catalog";
+import { cursorLastSeen, type CursorSeen } from "../../integrations/cursor-seen";
+import { detectCursorInstalls, type CursorInstall } from "../../integrations/cursor-detect";
+import { configuredApiAuthToken, isApiAuthRequired, jsonResponse } from "../auth-cors";
+import { fetchAllModels } from "../management-api";
+import { cursorEffortFamily } from "../models-capabilities";
+import type { ManagementContext } from "./context";
+
+export const CURSOR_GATEWAY_PLACEHOLDER_KEY = "opencodex-loopback";
+export const CURSOR_GUIDE_URL = "https://lidge-jun.github.io/opencodex/guides/cursor-private-inference/";
+
+export interface CursorIntegrationStatus {
+  privateInference: { installed: boolean; path: string | null; version: string | null };
+  regularCursor: { installed: boolean; path: string | null };
+  gateway: { baseUrl: string; apiKeyMode: "credential" | "placeholder"; placeholder: string };
+  lastSeen: CursorSeen | null;
+  models: Array<{
+    id: string;
+    reasoning: string[] | null;
+    context: { defaultWindow: number; longWindow: number } | null;
+  }>;
+  guideUrl: string;
+}
+
+function pick(installs: CursorInstall[], build: CursorInstall["build"]): CursorInstall | undefined {
+  return installs.find(install => install.build === build);
+}
+
+export async function buildCursorIntegrationStatus(
+  ctx: Pick<ManagementContext, "config" | "deps"> & { url?: URL },
+  installs: CursorInstall[] = detectCursorInstalls(),
+): Promise<CursorIntegrationStatus> {
+  const { config, deps } = ctx;
+  const privateInference = pick(installs, "private-inference");
+  const regular = pick(installs, "regular");
+  const runtime = (deps.readRuntimePort ?? readRuntimePort)(process.pid);
+  // The port the browser reached is the one Cursor on the same machine will reach too; the
+  // runtime record and config.port are fallbacks for a request that carries no port.
+  const port = runtime?.port ?? (Number(ctx.url?.port) || config.port);
+  // Describes the public bind. A second unauthenticated loopback listener may exist, but the
+  // value a user pastes into Cursor must work against the bind they will actually reach.
+  const credentialConfigured = !!configuredApiAuthToken(config)
+    || (config.apiKeys ?? []).some(entry => !!entry.key.trim());
+  const apiKeyMode = isApiAuthRequired(config) || credentialConfigured ? "credential" : "placeholder";
+
+  const limits = nativeContextLimits(config);
+  const goModels = await fetchAllModels(config);
+  const ids = [
+    ...visibleNativeSlugs(config),
+    ...uniqueCatalogModelsForRawPublicList(goModels).map(model => model.alias ?? `${model.provider}/${model.id}`),
+  ];
+  const models = ids.map(id => {
+    const tier = nativeOpenAiContextTier(id, limits);
+    return {
+      id,
+      reasoning: cursorEffortFamily(id),
+      context: tier ? { defaultWindow: tier.defaultWindow, longWindow: tier.longWindow } : null,
+    };
+  });
+
+  return {
+    privateInference: {
+      installed: privateInference !== undefined,
+      path: privateInference?.path ?? null,
+      version: privateInference?.version ?? null,
+    },
+    regularCursor: { installed: regular !== undefined, path: regular?.path ?? null },
+    gateway: {
+      baseUrl: `http://127.0.0.1:${port}/v1`,
+      apiKeyMode,
+      placeholder: CURSOR_GATEWAY_PLACEHOLDER_KEY,
+    },
+    lastSeen: cursorLastSeen(),
+    models,
+    guideUrl: CURSOR_GUIDE_URL,
+  };
+}
+
+export async function handleCursorIntegrationRoutes(ctx: ManagementContext): Promise<Response | null> {
+  const { req, url } = ctx;
+  if (url.pathname === "/api/native-integrations/cursor" && req.method === "GET") {
+    return jsonResponse(await buildCursorIntegrationStatus(ctx));
+  }
+  return null;
+}

--- a/src/server/management/route-registry.ts
+++ b/src/server/management/route-registry.ts
@@ -230,6 +230,8 @@ export const MANAGEMENT_ROUTES: readonly ManagementRoute[] = [
   { method: "PUT", path: "/api/native-integrations/claude-desktop", module: "server/management/native-integration-routes", mutates: true },
   { method: "PUT", path: "/api/native-integrations/codex", module: "server/management/native-integration-routes", mutates: true },
   { method: "PUT", path: "/api/native-integrations/grok", module: "server/management/native-integration-routes", mutates: true },
+  // server/management/cursor-integration-routes
+  { method: "GET", path: "/api/native-integrations/cursor", module: "server/management/cursor-integration-routes", mutates: false },
   // server/management/oauth-account-routes
   { method: "DELETE", path: "/api/keys", module: "server/management/oauth-account-routes", mutates: true },
   { method: "DELETE", path: "/api/keys/rotate", module: "server/management/oauth-account-routes", mutates: true },

--- a/src/server/models-capabilities.ts
+++ b/src/server/models-capabilities.ts
@@ -19,6 +19,41 @@ export const OPENCODEX_MODEL_API_TYPES: readonly string[] = Object.freeze(["chat
 
 export const OPENAI_FAMILY_API_TYPES: ReadonlySet<string> = new Set(["chat_completions", "responses", "openai_chat", "openai_responses"]);
 
+/**
+ * The reasoning-effort ladder Cursor's local-agent runtime attaches to a model, keyed by the
+ * model id after its last `/`. Cursor decides this from its own table rather than from the
+ * gateway's `reasoning_effort` list, so the dashboard can only PREDICT it; the values here
+ * mirror that table (read from the 3.18.25 bundle) and carry no Cursor behavior of their own.
+ * Null means Cursor shows no Reasoning control for the id. Distinct from
+ * `src/adapters/cursor/effort-map.ts`, which maps opencodex efforts onto Cursor's *backend*
+ * tiers for the outbound provider; this is what Cursor's *local* picker renders.
+ */
+const CURSOR_EFFORT_FAMILIES: ReadonlyArray<{ test: RegExp; ladder: readonly string[] }> = [
+  { test: /^gpt-5[.-]6-(?:luna|sol|terra)$/u, ladder: ["low", "medium", "high", "xhigh"] },
+  { test: /^gpt-5(?:\.\d+)?$/u, ladder: ["low", "medium", "high", "xhigh"] },
+  { test: /^claude-opus-5$/u, ladder: ["low", "medium", "high", "xhigh", "max"] },
+  { test: /^claude-opus-4[-.](?:7|8)$/u, ladder: ["low", "medium", "high", "xhigh", "max"] },
+  { test: /^claude-sonnet-5$/u, ladder: ["low", "medium", "high", "xhigh", "max"] },
+  { test: /^claude-opus-4[-.](?:5|6)$/u, ladder: ["low", "medium", "high", "max"] },
+  { test: /^claude-sonnet-4[-.]6$/u, ladder: ["low", "medium", "high", "max"] },
+  { test: /^grok-4[.-](?:3|5|6)(?:-(?:batch|build|nocomp))?$/u, ladder: ["minimal", "low", "medium", "high", "xhigh"] },
+  { test: /^grok-build-latest$/u, ladder: ["minimal", "low", "medium", "high", "xhigh"] },
+  { test: /^gemini-3\.[1-9].*flash-lite/u, ladder: [] },
+  { test: /^gemini-/u, ladder: ["minimal", "low", "medium", "high"] },
+];
+
+export function cursorEffortFamily(modelId: string): string[] | null {
+  let id = modelId.trim().toLowerCase();
+  const slash = id.lastIndexOf("/");
+  if (slash !== -1) id = id.slice(slash + 1);
+  const at = id.indexOf("@");
+  if (at !== -1) id = id.slice(0, at);
+  for (const family of CURSOR_EFFORT_FAMILIES) {
+    if (family.test.test(id)) return family.ladder.length > 0 ? [...family.ladder] : null;
+  }
+  return null;
+}
+
 export interface ModelCapabilityInput {
   reasoningEfforts?: readonly string[];
   contextWindow?: number;

--- a/tests/cursor-integration-status.test.ts
+++ b/tests/cursor-integration-status.test.ts
@@ -187,4 +187,21 @@ describe("GET /api/native-integrations/cursor", () => {
       await server.stop(true);
     }
   });
+
+  test("a disabled model leaves the prediction the same way it leaves /v1/models", async () => {
+    seedCodexModelEntitlementsForTests("main", ["gpt-5.6-sol"]);
+    saveConfig({ ...statusConfig(), disabledModels: ["kimi/k3"] });
+    const server = startServer(0);
+    try {
+      const adminToken = readFileSync(join(testHome, "admin-api-token"), "utf8").trim();
+      const status = await fetch(new URL("/api/native-integrations/cursor", server.url), { headers: { "x-opencodex-api-key": adminToken } });
+      const body = await status.json() as { models: Array<{ id: string }> };
+      expect(body.models.some(model => model.id === "kimi/k3")).toBe(false);
+      const raw = await fetch(new URL("/v1/models", server.url), { headers: { "user-agent": "Cursor/3.18.25" } });
+      const list = await raw.json() as { data: Array<{ id: string }> };
+      expect(list.data.some(model => model.id === "kimi/k3")).toBe(false);
+    } finally {
+      await server.stop(true);
+    }
+  });
 });

--- a/tests/cursor-integration-status.test.ts
+++ b/tests/cursor-integration-status.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import {
+  resetCodexModelEntitlementCacheForTests,
+  seedCodexModelEntitlementsForTests,
+} from "../src/codex/model-entitlements";
+import { cursorProductJsonCandidates, detectCursorInstalls, type CursorDetectDeps } from "../src/integrations/cursor-detect";
+import { cursorLastSeen, recordCursorSeen, resetCursorSeenForTests } from "../src/integrations/cursor-seen";
+import { cursorEffortFamily } from "../src/server/models-capabilities";
+import { startServer } from "../src/server";
+import type { OcxConfig } from "../src/types";
+import { SERVER_BUDGET_MS } from "./helpers/test-budget";
+
+setDefaultTimeout(SERVER_BUDGET_MS);
+
+function fakeDeps(platform: string, tree: Record<string, string | string[]>, env: Record<string, string> = {}): CursorDetectDeps {
+  return {
+    platform,
+    homedir: "/home/u",
+    env,
+    readText: path => {
+      const value = tree[path];
+      return typeof value === "string" ? value : null;
+    },
+    listDir: path => {
+      const value = tree[path];
+      return Array.isArray(value) ? value : [];
+    },
+  };
+}
+
+describe("detectCursorInstalls", () => {
+  test("tells Private Inference apart from regular Cursor by product.json nameLong on macOS", () => {
+    const deps = fakeDeps("darwin", {
+      "/Applications": ["Cursor.app", "Cursor Private Inference.app", "Xcode.app"],
+      "/Applications/Cursor.app/Contents/Resources/app/product.json": JSON.stringify({ nameLong: "Cursor", version: "3.18.9" }),
+      "/Applications/Cursor Private Inference.app/Contents/Resources/app/product.json": JSON.stringify({ nameLong: "Cursor Private Inference", version: "3.18.25" }),
+    });
+    expect(detectCursorInstalls(deps)).toEqual([
+      { build: "regular", path: "/Applications/Cursor.app", version: "3.18.9" },
+      { build: "private-inference", path: "/Applications/Cursor Private Inference.app", version: "3.18.25" },
+    ]);
+  });
+
+  test("looks under LOCALAPPDATA/Programs on Windows and skips malformed product.json", () => {
+    const deps = fakeDeps("win32", {
+      "C:\\Users\\u\\AppData\\Local\\Programs": ["cursor", "cursor-private-inference"],
+      "C:\\Users\\u\\AppData\\Local\\Programs\\cursor\\resources\\app\\product.json": "{not json",
+      "C:\\Users\\u\\AppData\\Local\\Programs\\cursor-private-inference\\resources\\app\\product.json": JSON.stringify({ nameLong: "Cursor Private Inference" }),
+    }, { LOCALAPPDATA: "C:\\Users\\u\\AppData\\Local" });
+    const candidates = cursorProductJsonCandidates(deps);
+    expect(candidates.length).toBe(2);
+    const installs = detectCursorInstalls(deps);
+    expect(installs.map(install => install.build)).toEqual(["private-inference"]);
+    expect(installs[0].version).toBeNull();
+  });
+
+  test("finds nothing when no candidate directory exists", () => {
+    expect(detectCursorInstalls(fakeDeps("linux", {}))).toEqual([]);
+  });
+});
+
+describe("cursor last-seen recorder", () => {
+  beforeEach(() => resetCursorSeenForTests());
+  afterEach(() => resetCursorSeenForTests());
+
+  test("records only a Cursor user agent, bounded and validated", () => {
+    recordCursorSeen(new Headers({ "user-agent": "curl/8.7.1" }), 1000);
+    expect(cursorLastSeen()).toBeNull();
+    recordCursorSeen(new Headers({ "user-agent": "Cursor/3.18.25" }), 2000);
+    expect(cursorLastSeen()).toEqual({ at: 2000, userAgent: "Cursor/3.18.25" });
+    // A padded or oversized value is not the shape Cursor sends and is ignored.
+    recordCursorSeen(new Headers({ "user-agent": `Cursor/${"x".repeat(60)}` }), 3000);
+    recordCursorSeen(new Headers({ "user-agent": "Cursor/3.18.25 <script>" }), 4000);
+    expect(cursorLastSeen()?.at).toBe(2000);
+  });
+});
+
+describe("cursorEffortFamily", () => {
+  test("mirrors Cursor's local picker table and strips provider prefixes", () => {
+    expect(cursorEffortFamily("gpt-5.6-sol")).toEqual(["low", "medium", "high", "xhigh"]);
+    expect(cursorEffortFamily("anthropic/claude-opus-5")).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(cursorEffortFamily("xai/grok-4.6")).toEqual(["minimal", "low", "medium", "high", "xhigh"]);
+    expect(cursorEffortFamily("cursor/gemini-3.7-flash")).toEqual(["minimal", "low", "medium", "high"]);
+    expect(cursorEffortFamily("anthropic/claude-fable-5-1")).toBeNull();
+    expect(cursorEffortFamily("kimi/k3")).toBeNull();
+  });
+});
+
+const previousHome = process.env.OPENCODEX_HOME;
+let testHome = "";
+
+function statusConfig(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "kimi",
+    providers: {
+      kimi: {
+        adapter: "openai-chat",
+        baseUrl: "https://kimi.test/v1",
+        liveModels: false,
+        models: ["k3"],
+      },
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        liveModels: false,
+      },
+    },
+  };
+}
+
+describe("GET /api/native-integrations/cursor", () => {
+  beforeEach(() => {
+    testHome = mkdtempSync(join(tmpdir(), "ocx-cursor-status-"));
+    process.env.OPENCODEX_HOME = testHome;
+    resetCursorSeenForTests();
+  });
+
+  afterEach(() => {
+    resetCodexModelEntitlementCacheForTests();
+    resetCursorSeenForTests();
+    if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousHome;
+    if (testHome) rmSync(testHome, { recursive: true, force: true });
+    testHome = "";
+  });
+
+  test("reports gateway values, model expectations, and a last-seen Cursor request", async () => {
+    seedCodexModelEntitlementsForTests("main", ["gpt-5.6-sol"]);
+    saveConfig(statusConfig());
+    const server = startServer(0);
+    try {
+      const adminToken = readFileSync(join(testHome, "admin-api-token"), "utf8").trim();
+      const headers = { "x-opencodex-api-key": adminToken };
+
+      const before = await fetch(new URL("/api/native-integrations/cursor", server.url), { headers });
+      expect(before.status).toBe(200);
+      const first = await before.json() as {
+        gateway: { baseUrl: string; apiKeyMode: string; placeholder: string };
+        lastSeen: unknown;
+        models: Array<{ id: string; reasoning: string[] | null; context: { defaultWindow: number; longWindow: number } | null }>;
+        privateInference: { installed: boolean };
+        guideUrl: string;
+      };
+      expect(first.gateway.baseUrl).toBe(`http://127.0.0.1:${server.port}/v1`);
+      expect(first.gateway.apiKeyMode).toBe("placeholder");
+      expect(first.gateway.placeholder).toBe("opencodex-loopback");
+      expect(first.lastSeen).toBeNull();
+      expect(typeof first.privateInference.installed).toBe("boolean");
+      expect(first.guideUrl).toContain("cursor-private-inference");
+      const k3 = first.models.find(model => model.id === "kimi/k3");
+      expect(k3).toEqual({ id: "kimi/k3", reasoning: null, context: null });
+      const sol = first.models.find(model => model.id === "gpt-5.6-sol");
+      expect(sol).toEqual({
+        id: "gpt-5.6-sol",
+        reasoning: ["low", "medium", "high", "xhigh"],
+        context: { defaultWindow: 272000, longWindow: 922000 },
+      });
+
+      const discovery = await fetch(new URL("/v1/models", server.url), { headers: { "user-agent": "Cursor/3.18.25" } });
+      expect(discovery.status).toBe(200);
+      const after = await fetch(new URL("/api/native-integrations/cursor", server.url), { headers });
+      const second = await after.json() as { lastSeen: { at: number; userAgent: string } | null };
+      expect(second.lastSeen?.userAgent).toBe("Cursor/3.18.25");
+      expect(typeof second.lastSeen?.at).toBe("number");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("reports credential mode when an API key is configured", async () => {
+    const config = statusConfig();
+    config.apiKeys = [{ id: "k1", name: "test", key: "ocx_test_key_value_1234567890", createdAt: new Date(0).toISOString() }];
+    saveConfig(config);
+    const server = startServer(0);
+    try {
+      const adminToken = readFileSync(join(testHome, "admin-api-token"), "utf8").trim();
+      const res = await fetch(new URL("/api/native-integrations/cursor", server.url), { headers: { "x-opencodex-api-key": adminToken } });
+      const body = await res.json() as { gateway: { apiKeyMode: string } };
+      expect(body.gateway.apiKeyMode).toBe("credential");
+    } finally {
+      await server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a read-only management route `GET /api/native-integrations/cursor` for the upcoming dashboard Cursor tab. It reports which Cursor builds are installed (Cursor Private Inference vs regular Cursor, told apart by `product.json` `nameLong` under well-known install paths per OS), the two gateway values Cursor's own form wants (Base URL on the proxy's runtime port; API Key mode `credential` or the constant placeholder `opencodex-loopback` — never a key value), the last `/v1/models` request whose User-Agent was exactly `Cursor/<version>` (memory-only, bounded), and a Model / Reasoning / Context prediction table filtered by the same catalog visibility rules as the raw list.
- The route never writes to Cursor's settings database, keychain, or app bundle.
- Follow-up fix in the same PR: the prediction table applies `filterCatalogVisibleModels`, so a model disabled in opencodex leaves the prediction the same way it leaves `/v1/models`.

## Stack

| PR | Branch | Base |
|---|---|---|
| 1 (this) | `codex/cursor-integration-status` | `dev` |
| 2 | `codex/cursor-integration-tab` | `codex/cursor-integration-status` |
| 3 | `codex/cursor-integration-docs` | `codex/cursor-integration-tab` |

Lands bottom-up; each child is retargeted to `dev` and restacked after its parent merges. Plan: `devlog/_plan/260902_cursor_integrations_tab/`.

## Verification

- `bun test tests/cursor-integration-status.test.ts` — 8 pass (detection per OS, UA recorder bounds, effort family, status shape, credential mode, disabled-model parity; the parity test was driven red before the fix).
- `bun run typecheck`, `bun run privacy:scan` green.
- Read-only security lane on the credential-presence check (verdict posted in this thread before merge).
- Exact-head CI on this PR is the gate; no full local suite was run.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (docs land in PR 3 of the stack).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cursor integration status endpoint showing detected installations, versions, Private Inference availability, gateway settings, authentication mode, available models, and recent Cursor activity.
  * Added cross-platform detection for Cursor desktop installations.
  * Added Cursor-specific model reasoning-effort information.
* **Documentation**
  * Updated native integration documentation to describe Cursor status reporting and its API route.
* **Tests**
  * Added coverage for installation detection, activity tracking, model mappings, and integration status responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->