### PR TITLE
docs(cursor): dashboard section and read-only surface note

### DIFF
--- a/devlog/_plan/260902_cursor_integrations_tab/030_layer3_docs.md
+++ b/devlog/_plan/260902_cursor_integrations_tab/030_layer3_docs.md
@@ -7,3 +7,24 @@ the Integrations > Cursor tab detects the build, shows the two values with copy 
 the last request seen from Cursor, and never writes Cursor's settings. Update the Cursor
 paragraph in guides/integrations.md to point at the tab. Verifier: cd docs-site && bun run build.
 
+## Stale check (P, after wp3 landed as da5d74b00; amended after audit round 1)
+
+- Guide sections today: Before you start / Configure the gateway / Models and reasoning effort /
+  Verify. "From the dashboard" goes between Configure the gateway and Models and reasoning effort.
+- integrations.md line 62 "Cursor is not on this list" is now wrong. Rewrite it: Cursor has a tab,
+  but it is read-only (not one of the managed switches) — it detects the two builds, shows the
+  gateway values, and reports the last request. Also add a Cursor sentence to "The other four
+  surfaces are not switches" (rename heading count: five) so the read-only surfaces list is complete.
+- Locale copies: `cursor-private-inference.md` has none. `integrations.md` exists in fr, tr, zh-tw
+  (none mention Cursor today). Add the same "not a switch" Cursor sentence to each, in that locale,
+  in the corresponding section (fr ~L66, tr ~L74, zh-tw ~L45), AND rename that section's heading
+  from "four" to "five" in each locale (fr L64, tr L71, zh-tw L43) to match the English change.
+- "From the dashboard" must describe the shipped page exactly: (1) Installed builds — Private
+  Inference vs regular, with the tunnel note when only regular is found; (2) Gateway values — Base
+  URL always has Copy; API Key is a Copy of `opencodex-loopback` only when the bind needs no
+  credential, otherwise the card says to use one of your opencodex API keys and links to the API
+  Keys tab (this reconciles the narrower `OPENCODEX_API_AUTH_TOKEN` row above: any configured API
+  key works); (3) Connection — last `/v1/models` request whose User-Agent starts `Cursor/`; the
+  Refresh model list button in Cursor is what makes it flip from "never seen"; refreshes every 15 s
+  while the tab is open; (4) What Cursor will show — Model / Reasoning / Context table, a prediction;
+  (5) guide link. The tab never writes Cursor's settings, database or keychain.

--- a/devlog/_plan/260902_cursor_integrations_tab/040_publish_stack.md
+++ b/devlog/_plan/260902_cursor_integrations_tab/040_publish_stack.md
@@ -20,7 +20,8 @@ time and recorded in the ledger; the table is the shape, not the evidence.
    reads credential *presence* (`configuredApiAuthToken`, `apiKeys`) to choose `apiKeyMode`. A
    read-only security reviewer checks that no key value is serialized, the route is
    session/admin-gated, the UA recorder is bounded, and detection reads only well-known paths.
-   Its verdict is pasted into PR 1.
+   Its verdict is pasted into PR 1 and is a GATE: `SECURITY: PASS` is required before PR 1
+   merges; on FAIL the findings are fixed, the stack restacked, and the review re-run.
 4. Wait for exact-head CI: `gh pr view --json headRefOid,statusCheckRollup`; every check on
    the exact head must be SUCCESS/NEUTRAL/SKIPPED. Address Codex/CodeRabbit findings that are
    correct; rebut the rest in-thread.
@@ -30,9 +31,10 @@ time and recorded in the ledger; the table is the shape, not the evidence.
    `origin/dev` → `git push --force-with-lease --no-verify` → fresh exact-head CI → admin
    squash-merge. Repeat for PR 3.
 6. Approval: the repository has one active maintainer and the user explicitly authorized admin
-   merge for this stack; the merge command documents the owner bypass in the PR thread the way
-   prior admin landings did (#3230/#3231). Admin covers approval only; CI, privacy scan, the
-   security lane and reviewer threads remain required evidence.
+   merge for this stack. `gh pr merge --admin` posts nothing, so before each merge run
+   `gh pr comment <n> --body` stating the user-authorized owner bypass, the exact head SHA
+   merged, the CI rollup result, and (for PR 1) the security verdict. Admin covers approval
+   only; CI, privacy scan, the security lane and reviewer threads remain required evidence.
 7. Proof: `git fetch origin dev && git merge-base --is-ancestor <mergeSha> FETCH_HEAD` x3.
 8. Move the devlog unit to `_fin` in a follow-up if the maintainer wants; not part of this PR.
 

--- a/devlog/_plan/260902_cursor_integrations_tab/040_publish_stack.md
+++ b/devlog/_plan/260902_cursor_integrations_tab/040_publish_stack.md
@@ -1,26 +1,41 @@
 # 040 — Publish the stack and land it bottom-up
 
-Stack (rebased onto origin/dev 8fb4e6e79):
+Stack (rebased onto origin/dev 8fb4e6e79). Heads are resolved with `git rev-parse` at push
+time and recorded in the ledger; the table is the shape, not the evidence.
 
-| PR | Branch | Head | Base |
-|---|---|---|---|
-| 1 | codex/cursor-integration-status | ef68bd1f2 | dev |
-| 2 | codex/cursor-integration-tab | 598f24f57 | codex/cursor-integration-status |
-| 3 | codex/cursor-integration-docs | e848b12ee | codex/cursor-integration-tab |
+| PR | Branch | Base |
+|---|---|---|
+| 1 | codex/cursor-integration-status | dev |
+| 2 | codex/cursor-integration-tab | codex/cursor-integration-status |
+| 3 | codex/cursor-integration-docs | codex/cursor-integration-tab |
 
 ## Steps
 
 1. `git push --no-verify -u origin <branch>` for all three (push approved; local suite forbidden).
-2. `gh pr create` with the repository template (Summary / Verification / Checklist), a stack map
-   in each body, and the two PNGs from `assets/` embedded in PR 2 (body mentions gui).
-3. Wait for exact-head CI: `gh pr view --json headRefOid,statusCheckRollup`; every check on
+2. `gh pr create --base <base>` in order 1 → 2 → 3 with the repository template (Summary /
+   Verification / Checklist) and a stack map in each body. PR 2 mentions gui, so its body embeds
+   the two PNGs as `![alt](https://raw.githubusercontent.com/<owner>/<repo>/<commit>/...)` pinned
+   to the commit that carries them (a bare link does not satisfy pr-quality.cjs).
+3. Security lane (MAINTAINERS.md: credential handling needs explicit review): the status route
+   reads credential *presence* (`configuredApiAuthToken`, `apiKeys`) to choose `apiKeyMode`. A
+   read-only security reviewer checks that no key value is serialized, the route is
+   session/admin-gated, the UA recorder is bounded, and detection reads only well-known paths.
+   Its verdict is pasted into PR 1.
+4. Wait for exact-head CI: `gh pr view --json headRefOid,statusCheckRollup`; every check on
    the exact head must be SUCCESS/NEUTRAL/SKIPPED. Address Codex/CodeRabbit findings that are
    correct; rebut the rest in-thread.
-4. Admin squash-merge PR 1. Retarget PR 2 to dev, wait for CI on its head, merge. Same for PR 3.
-5. Proof: `git fetch origin dev && git merge-base --is-ancestor <mergeSha> FETCH_HEAD` x3.
-6. Move the devlog unit to `_fin` in a follow-up if the maintainer wants; not part of this PR.
+5. Land bottom-up. `ci.yml` runs on `pull_request: {}` default types, which do not include the
+   base-change `edited` event, so a retarget alone reruns nothing. For each child after its
+   parent squashes: `gh pr edit --base dev` → rebase the child's unique commits onto the new
+   `origin/dev` → `git push --force-with-lease --no-verify` → fresh exact-head CI → admin
+   squash-merge. Repeat for PR 3.
+6. Approval: the repository has one active maintainer and the user explicitly authorized admin
+   merge for this stack; the merge command documents the owner bypass in the PR thread the way
+   prior admin landings did (#3230/#3231). Admin covers approval only; CI, privacy scan, the
+   security lane and reviewer threads remain required evidence.
+7. Proof: `git fetch origin dev && git merge-base --is-ancestor <mergeSha> FETCH_HEAD` x3.
+8. Move the devlog unit to `_fin` in a follow-up if the maintainer wants; not part of this PR.
 
 ## Constraints
 
-Never touch the 10100 service. No `bun run test` locally. Admin bypass covers approval only —
-CI, privacy scan and reviewer threads are still required evidence.
+Never touch the 10100 service. No `bun run test` locally.

--- a/devlog/_plan/260902_cursor_integrations_tab/040_publish_stack.md
+++ b/devlog/_plan/260902_cursor_integrations_tab/040_publish_stack.md
@@ -1,0 +1,26 @@
+# 040 — Publish the stack and land it bottom-up
+
+Stack (rebased onto origin/dev 8fb4e6e79):
+
+| PR | Branch | Head | Base |
+|---|---|---|---|
+| 1 | codex/cursor-integration-status | ef68bd1f2 | dev |
+| 2 | codex/cursor-integration-tab | 598f24f57 | codex/cursor-integration-status |
+| 3 | codex/cursor-integration-docs | e848b12ee | codex/cursor-integration-tab |
+
+## Steps
+
+1. `git push --no-verify -u origin <branch>` for all three (push approved; local suite forbidden).
+2. `gh pr create` with the repository template (Summary / Verification / Checklist), a stack map
+   in each body, and the two PNGs from `assets/` embedded in PR 2 (body mentions gui).
+3. Wait for exact-head CI: `gh pr view --json headRefOid,statusCheckRollup`; every check on
+   the exact head must be SUCCESS/NEUTRAL/SKIPPED. Address Codex/CodeRabbit findings that are
+   correct; rebut the rest in-thread.
+4. Admin squash-merge PR 1. Retarget PR 2 to dev, wait for CI on its head, merge. Same for PR 3.
+5. Proof: `git fetch origin dev && git merge-base --is-ancestor <mergeSha> FETCH_HEAD` x3.
+6. Move the devlog unit to `_fin` in a follow-up if the maintainer wants; not part of this PR.
+
+## Constraints
+
+Never touch the 10100 service. No `bun run test` locally. Admin bypass covers approval only —
+CI, privacy scan and reviewer threads are still required evidence.

--- a/docs-site/src/content/docs/fr/guides/integrations.md
+++ b/docs-site/src/content/docs/fr/guides/integrations.md
@@ -61,14 +61,16 @@ opencodex lit ces variables dans son propre environnement. Si votre passerelle u
 dossier personnel déplacé, lancez opencodex avec les mêmes variables ; sinon, il suivra correctement une
 autre installation.
 
-## Les quatre autres surfaces ne sont pas des commutateurs
+## Les cinq autres surfaces ne sont pas des commutateurs
 
 **Clés API** gère les propres identifiants d'opencodex et n'est donc pas un client. **Codex CLI** est relié
 par le service du proxy lui-même : démarrer opencodex applique ce routage et l'arrêter restaure le routage
 natif ; aucun fichier ne doit donc être activé ou désactivé séparément. **Claude** conserve son propre
 indicateur d'activation et le flux **Enregistrer/Appliquer** de Desktop, tandis que **Grok Build** conserve
 sa barrière « sélectionner, puis appliquer » pour les modèles. Ces règles sont antérieures à cette
-fonctionnalité et restent inchangées.
+fonctionnalité et restent inchangées. **Cursor** n'écrit absolument rien : son onglet affiche la détection,
+les valeurs de la passerelle et la dernière requête observée, et tout le reste se passe dans Cursor Private
+Inference.
 
 ## Restauration
 

--- a/docs-site/src/content/docs/guides/cursor-private-inference.md
+++ b/docs-site/src/content/docs/guides/cursor-private-inference.md
@@ -76,22 +76,25 @@ read-only toward Cursor: it never writes Cursor's settings database, keychain en
 bundle, so there is no switch to flip. What it does is hand you the values and show you whether
 they took.
 
-- **Installed builds.** Whether Cursor Private Inference and regular Cursor are present, with
-  the path and version. If only regular Cursor is found, the tab says so and links back here:
+- **Installed builds.** Whether Cursor Private Inference (with its path and version) and
+  regular Cursor (path only) are present. If only regular Cursor is found, the tab says so and links back here:
   regular Cursor routes custom endpoints through Cursor's servers, so a loopback proxy is
   unreachable without a public tunnel.
-- **Gateway values.** The Base URL for the port the dashboard itself reached, with a Copy
-  button. The API Key row depends on the bind: when it needs no credential the row is
+- **Gateway values.** The Base URL on the proxy's own listening port (from its runtime record,
+  so a reverse-proxied dashboard still shows the port Cursor on this machine can reach), with a
+  Copy button. The API Key row depends on the bind: when it needs no credential the row is
   `opencodex-loopback` with Copy; when API auth is on, or any opencodex API key is configured,
   the row tells you to use one of your own keys and links to the API Keys tab. Any configured
   key works, not only `OPENCODEX_API_AUTH_TOKEN`.
-- **Connection.** The last `/v1/models` request whose User-Agent starts with `Cursor/`, with
-  the time and the version. It reads "never seen" until Cursor calls the proxy; pressing
+- **Connection.** The last `/v1/models` request whose User-Agent is exactly `Cursor/<version>`
+  (the header Cursor's local-agent runtime sends), with the time and the version. It reads
+  "never seen" until Cursor calls the proxy; pressing
   **Refresh model list** in Cursor is what makes it flip. The card refreshes every 15 seconds
   while the tab is open.
-- **What Cursor will show.** A Model / Reasoning / Context table for the models on the raw
-  list, following the same rules as the next section. It is a prediction: Cursor picks the
-  Reasoning ladder from its own table.
+- **What Cursor will show.** A Model / Reasoning / Context table for the models opencodex
+  advertises (disabled models and provider allowlists apply, the same as the raw list),
+  following the rules in the next section. It is a prediction: Cursor picks the Reasoning
+  ladder from its own table.
 
 ## Models and reasoning effort
 

--- a/docs-site/src/content/docs/guides/cursor-private-inference.md
+++ b/docs-site/src/content/docs/guides/cursor-private-inference.md
@@ -69,6 +69,30 @@ its own; the variable has to be in the environment of whatever launches the app.
 The build exists for macOS (arm64, x64, universal), Windows (x64, arm64) and Linux (x64,
 arm64). Configuration is identical across them.
 
+## From the dashboard
+
+The opencodex dashboard has a **Cursor** tab under Integrations (`/#integrations/cursor`). It is
+read-only toward Cursor: it never writes Cursor's settings database, keychain entry, or app
+bundle, so there is no switch to flip. What it does is hand you the values and show you whether
+they took.
+
+- **Installed builds.** Whether Cursor Private Inference and regular Cursor are present, with
+  the path and version. If only regular Cursor is found, the tab says so and links back here:
+  regular Cursor routes custom endpoints through Cursor's servers, so a loopback proxy is
+  unreachable without a public tunnel.
+- **Gateway values.** The Base URL for the port the dashboard itself reached, with a Copy
+  button. The API Key row depends on the bind: when it needs no credential the row is
+  `opencodex-loopback` with Copy; when API auth is on, or any opencodex API key is configured,
+  the row tells you to use one of your own keys and links to the API Keys tab. Any configured
+  key works, not only `OPENCODEX_API_AUTH_TOKEN`.
+- **Connection.** The last `/v1/models` request whose User-Agent starts with `Cursor/`, with
+  the time and the version. It reads "never seen" until Cursor calls the proxy; pressing
+  **Refresh model list** in Cursor is what makes it flip. The card refreshes every 15 seconds
+  while the tab is open.
+- **What Cursor will show.** A Model / Reasoning / Context table for the models on the raw
+  list, following the same rules as the next section. It is a prediction: Cursor picks the
+  Reasoning ladder from its own table.
+
 ## Models and reasoning effort
 
 The picker is opencodex's raw `/v1/models` list. Two things decide whether a model row gets

--- a/docs-site/src/content/docs/guides/integrations.md
+++ b/docs-site/src/content/docs/guides/integrations.md
@@ -59,9 +59,11 @@ One caveat specific to Aside: the running app rewrites `models.json` itself, so
 fully quit and reopen Aside after applying, the same way Claude Desktop needs a
 restart. Aside's block is loopback-only and never carries a real credential.
 
-Cursor is not on this list. Regular Cursor calls custom endpoints from its own backend, so a
-loopback proxy is unreachable without a public tunnel, and Cursor's separate local-agent build
-is configured inside Cursor rather than from this tab. See
+Cursor has a tab but is not one of these switches. Regular Cursor calls custom endpoints from
+its own backend, so a loopback proxy is unreachable without a public tunnel, and Cursor's
+separate Private Inference build is configured inside Cursor. The **Cursor** tab is read-only:
+it detects which build is installed, shows the Base URL and API Key to paste into Cursor, and
+reports the last request Cursor made to the proxy. See
 [Cursor Private Inference](/guides/cursor-private-inference/).
 
 Paths honor each client's own environment override where it has one. For OMP,
@@ -92,13 +94,15 @@ opencodex reads these from its own environment. If your gateway runs with a prof
 or a relocated home, start opencodex with the same variables set, or it will
 correctly follow a different installation.
 
-## The other four surfaces are not switches
+## The other five surfaces are not switches
 
 **API Keys** manages opencodex's own credentials and is not a client at all. **Codex
 CLI** is wired by the proxy service itself — starting opencodex applies it, stopping it
 restores native routing — so there is nothing to toggle per-file. **Claude** keeps its
 own enable flag and Desktop's Save/Apply flow, and **Grok Build** keeps its
 select-then-apply model fence. Those semantics predate this feature and are unchanged.
+**Cursor** writes nothing at all: its tab shows detection, the gateway values, and the last
+request seen, and the rest happens inside Cursor Private Inference.
 
 ## Rollback
 

--- a/docs-site/src/content/docs/tr/guides/integrations.md
+++ b/docs-site/src/content/docs/tr/guides/integrations.md
@@ -68,7 +68,7 @@ opencodex bunları kendi ortamından okur. Ağ geçidiniz bir profil veya taşı
 bir ev dizini ile çalışıyorsa, opencodex'i aynı değişkenler ayarlanmış olarak
 başlatın; aksi takdirde doğru şekilde farklı bir kurulumu takip eder.
 
-## Diğer dört yüzey anahtar değildir
+## Diğer beş yüzey anahtar değildir
 
 **API Anahtarları (API Keys)** opencodex'in kendi kimlik bilgilerini yönetir ve
 hiçbir şekilde bir istemci değildir. **Codex CLI**, proxy servisinin kendisi
@@ -76,7 +76,9 @@ tarafından bağlanır — opencodex'i başlatmak uygular, durdurmak yerel
 yönlendirmeyi geri yükler — bu nedenle dosya başına değiştirilecek bir şey
 yoktur. **Claude** kendi etkinleştirme bayrağını ve Desktop'ın Kaydet/Uygula
 akışını korur; **Grok Build** ise seç ve uygula model çitini korur. Bu
-anlambilimler bu özellikten öncedir ve değişmemiştir.
+anlambilimler bu özellikten öncedir ve değişmemiştir. **Cursor** hiçbir şey
+yazmaz: sekmesi algılama durumunu, ağ geçidi değerlerini ve görülen son isteği
+gösterir; geri kalanı Cursor Private Inference içinde gerçekleşir.
 
 ## Geri Alma (Rollback)
 

--- a/docs-site/src/content/docs/zh-tw/guides/integrations.md
+++ b/docs-site/src/content/docs/zh-tw/guides/integrations.md
@@ -40,9 +40,9 @@ OpenClaw 有數個環境變數，各自負責不同的工作。`OPENCLAW_CONFIG_
 
 opencodex 從自己的環境讀取這些變數。如果你的 gateway 以 profile 或搬移過的家目錄執行，請以相同的變數啟動 opencodex，否則它會正確地遵循另一個安裝。
 
-## 其他四個介面不是開關
+## 其他五個介面不是開關
 
-**API Keys** 管理 opencodex 自己的憑證，根本不是客戶端。**Codex CLI** 由 proxy 服務本身連接——啟動 opencodex 即套用，停止即回復原生路由——所以沒有什麼需要逐檔切換。**Claude** 保留自己的啟用旗標與 Desktop 的 Save/Apply 流程，**Grok Build** 保留其先選後套用的模型圍欄（model fence）。那些語意早於這項功能，且維持不變。
+**API Keys** 管理 opencodex 自己的憑證，根本不是客戶端。**Codex CLI** 由 proxy 服務本身連接——啟動 opencodex 即套用，停止即回復原生路由——所以沒有什麼需要逐檔切換。**Claude** 保留自己的啟用旗標與 Desktop 的 Save/Apply 流程，**Grok Build** 保留其先選後套用的模型圍欄（model fence）。那些語意早於這項功能，且維持不變。**Cursor** 完全不會寫入任何內容：其分頁會顯示偵測結果、gateway 值，以及最近一次看到的請求，其餘則在 Cursor Private Inference 內部進行。
 
 ## 回復（Rollback）
 


### PR DESCRIPTION
## Summary

- Cursor Private Inference guide gains a **From the dashboard** section describing the four cards exactly as shipped (regular Cursor path-only, Base URL from the runtime port record, API Key branch on credential mode, User-Agent exactly `Cursor/<version>`, prediction table following catalog visibility).
- The integrations guide no longer says Cursor "is not on this list": it names the read-only tab and the "not switches" section grows to five surfaces in en/fr/tr/zh-tw.
- Devlog unit for the stack (research, audits, decade docs, publish plan).

## Stack

| PR | Branch | Base |
|---|---|---|
| 1 | `codex/cursor-integration-status` | `dev` |
| 2 | `codex/cursor-integration-tab` | `codex/cursor-integration-status` |
| 3 (this) | `codex/cursor-integration-docs` | `codex/cursor-integration-tab` |

Lands bottom-up; each child is retargeted to `dev` and restacked after its parent merges. Plan: `devlog/_plan/260902_cursor_integrations_tab/`.

## Verification

- `cd docs-site && bun run build` — 417 pages, Complete.
- `bun run privacy:scan` green.
- Read-only docs reviewer checked every factual claim against the shipped route and page; its first round found a real route defect, fixed in PR 1 (`filterCatalogVisibleModels`), then PASS.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (none in this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using the read-only Cursor tab in Integrations.
  - Documented detected Cursor builds, gateway values, copy actions, connection details, and the latest observed request.
  - Clarified that the tab does not change Cursor settings.
  - Updated integration documentation in English, French, Turkish, and Traditional Chinese to include Cursor among the five non-switch surfaces.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->