### PR TITLE
perf(logs): poll request history incrementally

### DIFF
--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -26,6 +26,7 @@ import {
   sanitizeLogEntryRouteDecision,
   validCachedRouteDecision,
 } from "./log-route-decision";
+import { mergeLogDelta, parseLogPollResponse } from "./log-poll";
 
 function logsCacheKey(apiBase: string): string {
   return `ocx.logs.list.v1:${apiBase}`;
@@ -379,6 +380,11 @@ export default function Logs({ apiBase }: { apiBase: string }) {
   const logRetryRef = useRef<{ key: string; failures: number; nextAttemptAt: number; error: unknown }>(
     { key: resourceKey, failures: 0, nextAttemptAt: 0, error: null },
   );
+  const logPollRef = useRef<{
+    key: string;
+    cursor: string | null;
+    rows: LogEntry[];
+  }>({ key: resourceKey, cursor: null, rows: cachedLogs ?? [] });
   const localeTag = LOCALES.find(l => l.code === locale)?.htmlLang;
   // The proxy's own zone, so timestamps read the same as the server's logs rather than being
   // silently shifted into the viewer's zone (#725). Fetched once: it cannot change while the
@@ -433,15 +439,40 @@ export default function Logs({ apiBase }: { apiBase: string }) {
       logRetryRef.current = retry;
     }
     if (retry.failures > 0 && Date.now() < retry.nextAttemptAt) throw retry.error;
+
+    let pollState = logPollRef.current;
+    if (pollState.key !== resourceKey) {
+      pollState = { key: resourceKey, cursor: null, rows: readSessionListCache(resourceKey) ?? [] };
+      logPollRef.current = pollState;
+    }
+
+    const currentCursor = pollState.cursor;
+    const url = currentCursor
+      ? `${apiBase}/api/logs?limit=2000&cursor=${encodeURIComponent(currentCursor)}`
+      : `${apiBase}/api/logs?limit=2000`;
+
     try {
-      const res = await fetch(`${apiBase}/api/logs?limit=2000`, { signal });
+      const res = await fetch(url, { signal });
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`.trim());
-      const body = await res.json() as LogEntry[] | { logs?: LogEntry[] };
-      const raw = Array.isArray(body) ? body : (body.logs ?? []);
-      const next = raw.map(sanitizeLogEntryRouteDecision);
+      const body = await res.json();
+      const parsed = parseLogPollResponse<LogEntry>(body);
+      const sanitizedIncoming = parsed.rows.map(sanitizeLogEntryRouteDecision);
+
+      let nextRows: LogEntry[];
+      if (currentCursor && parsed.cursorCapable && !parsed.reset) {
+        nextRows = mergeLogDelta(pollState.rows, sanitizedIncoming, 2000);
+      } else {
+        nextRows = sanitizedIncoming;
+      }
+
+      logPollRef.current = {
+        key: resourceKey,
+        cursor: parsed.cursor,
+        rows: nextRows,
+      };
       logRetryRef.current = { key: resourceKey, failures: 0, nextAttemptAt: 0, error: null };
-      writeSessionListCache(resourceKey, next);
-      return next;
+      writeSessionListCache(resourceKey, nextRows);
+      return nextRows;
     } catch (error) {
       if (signal.aborted) throw error;
       const normalized = error ?? new Error("log request failed");
@@ -473,6 +504,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
   const fetchLogs = logsResource.refresh;
   const retryLogs = useCallback(() => {
     logRetryRef.current = { key: resourceKey, failures: 0, nextAttemptAt: 0, error: null };
+    logPollRef.current = { key: resourceKey, cursor: null, rows: logPollRef.current.rows };
     fetchLogs({ forceLoading: true });
   }, [fetchLogs, resourceKey]);
 

--- a/gui/src/pages/log-poll.ts
+++ b/gui/src/pages/log-poll.ts
@@ -1,0 +1,54 @@
+export interface ParsedLogPollResponse<T> {
+  rows: T[];
+  cursor: string | null;
+  reset: boolean;
+  cursorCapable: boolean;
+}
+
+export function parseLogPollResponse<T>(body: unknown): ParsedLogPollResponse<T> {
+  if (Array.isArray(body)) {
+    return {
+      rows: body as T[],
+      cursor: null,
+      reset: false,
+      cursorCapable: false,
+    };
+  }
+  if (typeof body === "object" && body !== null) {
+    const candidate = body as { logs?: unknown; cursor?: unknown; reset?: unknown };
+    const rows = Array.isArray(candidate.logs) ? (candidate.logs as T[]) : [];
+    const cursor = typeof candidate.cursor === "string" && candidate.cursor.trim() ? candidate.cursor.trim() : null;
+    const reset = candidate.reset === true;
+    const cursorCapable = cursor !== null || reset || Object.hasOwn(candidate, "cursor") || Object.hasOwn(candidate, "reset");
+    return {
+      rows,
+      cursor,
+      reset,
+      cursorCapable,
+    };
+  }
+  return {
+    rows: [],
+    cursor: null,
+    reset: false,
+    cursorCapable: false,
+  };
+}
+
+export function mergeLogDelta<T extends { requestId?: string }>(
+  previous: readonly T[],
+  incoming: readonly T[],
+  cap = 2000,
+): T[] {
+  if (incoming.length === 0) {
+    return previous.length > cap ? previous.slice(previous.length - cap) : [...previous];
+  }
+  const incomingIds = new Set(
+    incoming
+      .map(row => row.requestId)
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
+  );
+  const filteredPrev = previous.filter(row => !row.requestId || !incomingIds.has(row.requestId));
+  const merged = [...filteredPrev, ...incoming];
+  return merged.length > cap ? merged.slice(merged.length - cap) : merged;
+}

--- a/gui/tests/log-poll.test.ts
+++ b/gui/tests/log-poll.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { mergeLogDelta, parseLogPollResponse } from "../src/pages/log-poll";
+
+describe("log-poll helpers", () => {
+  test("merge appends delta rows, replaces duplicate ids, and keeps newest cap", () => {
+    expect(mergeLogDelta(
+      [{ requestId: "a", value: 1 }, { requestId: "b", value: 1 }],
+      [{ requestId: "b", value: 2 }, { requestId: "c", value: 1 }],
+      2,
+    )).toEqual([{ requestId: "b", value: 2 }, { requestId: "c", value: 1 }]);
+  });
+
+  test("merge preserves all rows when under cap and no duplicates", () => {
+    expect(mergeLogDelta(
+      [{ requestId: "a", value: 1 }],
+      [{ requestId: "b", value: 2 }],
+      10,
+    )).toEqual([{ requestId: "a", value: 1 }, { requestId: "b", value: 2 }]);
+  });
+
+  test("merge returns previous capped rows when incoming is empty", () => {
+    expect(mergeLogDelta(
+      [{ requestId: "a", value: 1 }, { requestId: "b", value: 2 }],
+      [],
+      2,
+    )).toEqual([{ requestId: "a", value: 1 }, { requestId: "b", value: 2 }]);
+  });
+
+  test("legacy array and object bodies are full snapshots", () => {
+    expect(parseLogPollResponse([{ requestId: "a" }])).toEqual({
+      rows: [{ requestId: "a" }],
+      cursor: null,
+      reset: false,
+      cursorCapable: false,
+    });
+    expect(parseLogPollResponse({ logs: [{ requestId: "a" }] })).toEqual({
+      rows: [{ requestId: "a" }],
+      cursor: null,
+      reset: false,
+      cursorCapable: false,
+    });
+  });
+
+  test("cursor response preserves reset metadata and cursorCapable flag", () => {
+    expect(parseLogPollResponse({ logs: [], cursor: "opaque", reset: true })).toEqual({
+      rows: [],
+      cursor: "opaque",
+      reset: true,
+      cursorCapable: true,
+    });
+    expect(parseLogPollResponse({ logs: [{ requestId: "x" }], cursor: "c-1", reset: false })).toEqual({
+      rows: [{ requestId: "x" }],
+      cursor: "c-1",
+      reset: false,
+      cursorCapable: true,
+    });
+  });
+
+  test("malformed response returns empty rows and cursorCapable false", () => {
+    expect(parseLogPollResponse(null)).toEqual({
+      rows: [],
+      cursor: null,
+      reset: false,
+      cursorCapable: false,
+    });
+    expect(parseLogPollResponse("string")).toEqual({
+      rows: [],
+      cursor: null,
+      reset: false,
+      cursorCapable: false,
+    });
+  });
+});

--- a/gui/tests/logs-auto-refresh.test.tsx
+++ b/gui/tests/logs-auto-refresh.test.tsx
@@ -540,3 +540,80 @@ test("Logs: an intercepted helper row is badged and filterable", async () => {
 
   await act(async () => { root.unmount(); });
 });
+
+test("Logs: incremental cursor delta polling, delta append, empty delta, reset, and legacy fallback", async () => {
+  const calls: string[] = [];
+  let pollStep = 0;
+
+  globalThis.fetch = (async (input) => {
+    const url = String(input);
+    calls.push(url);
+    if (!url.includes("/api/logs")) return new Response(null, { status: 404 });
+
+    if (pollStep === 0) {
+      // Step 0: Initial fetch -> returns initial log and cursor
+      return jsonResponse({ logs: [sampleLog], cursor: "cursor-0", reset: false });
+    }
+    if (pollStep === 1) {
+      // Step 1: Empty delta -> cursor unchanged, keep existing rows
+      return jsonResponse({ logs: [], cursor: "cursor-0", reset: false });
+    }
+    if (pollStep === 2) {
+      // Step 2: Delta with new row -> append updatedLog
+      return jsonResponse({ logs: [updatedLog], cursor: "cursor-1", reset: false });
+    }
+    if (pollStep === 3) {
+      // Step 3: Eviction / reset: true -> replaces list
+      const resetLog = { ...sampleLog, requestId: "req-reset", model: "gpt-reset" };
+      return jsonResponse({ logs: [resetLog], cursor: "cursor-reset", reset: true });
+    }
+    if (pollStep === 4) {
+      // Step 4: Legacy server returns array without cursor
+      const legacyLog = { ...sampleLog, requestId: "req-legacy", model: "gpt-legacy" };
+      return jsonResponse([legacyLog]);
+    }
+    // Step 5: Next poll after legacy response must be full request without cursor
+    return jsonResponse([sampleLog]);
+  }) as typeof fetch;
+
+  const { root, container } = await mountLogs();
+
+  await flushMicrotasks();
+  expectTableLoaded(container, "gpt-test");
+  const logCalls = () => calls.filter(u => u.includes("/api/logs"));
+  expect(logCalls()[0]).toBe("http://localhost/api/logs?limit=2000");
+
+  // Advance to Step 1 (Empty delta)
+  pollStep = 1;
+  await advanceSilentRefresh(2000);
+  expect(logCalls().at(-1)).toContain("cursor=cursor-0");
+  expectTableLoaded(container, "gpt-test");
+
+  // Advance to Step 2 (Delta with updatedLog)
+  pollStep = 2;
+  await advanceSilentRefresh(2000);
+  expect(logCalls().at(-1)).toContain("cursor=cursor-0");
+  expectTableLoaded(container, "gpt-test");
+  expect(container.textContent).toContain("gpt-updated");
+
+  // Advance to Step 3 (Reset replaces whole list)
+  pollStep = 3;
+  await advanceSilentRefresh(2000);
+  expect(logCalls().at(-1)).toContain("cursor=cursor-1");
+  expectTableLoaded(container, "gpt-reset");
+  expect(container.textContent).not.toContain("gpt-updated");
+
+  // Advance to Step 4 (Legacy server response)
+  pollStep = 4;
+  await advanceSilentRefresh(2000);
+  expect(logCalls().at(-1)).toContain("cursor=cursor-reset");
+  expectTableLoaded(container, "gpt-legacy");
+
+  // Advance to Step 5 (Next poll after legacy response has no cursor)
+  pollStep = 5;
+  await advanceSilentRefresh(2000);
+  expect(logCalls().at(-1)).toBe("http://localhost/api/logs?limit=2000");
+  expectTableLoaded(container, "gpt-test");
+
+  await act(async () => { root.unmount(); });
+});

--- a/src/server/management/logs-usage-routes.ts
+++ b/src/server/management/logs-usage-routes.ts
@@ -68,6 +68,7 @@ import {
 import type { OcxClaudeCodeConfig, OcxConfig, OcxCustomModel, OcxProviderConfig } from "../../types";
 import { drainAndShutdown } from "../lifecycle";
 import { filterRequestLogs, filteredRequestLogCount, getRequestLogEntries, type RequestLogEntry } from "../request-log";
+import { decodeRequestLogCursor, encodeRequestLogCursor, sliceRequestLogsAfterCursor } from "../request-log-cursor";
 import { estimateComboCost, estimateRequestCost, normalizeCostTokens, tokensPerSecond } from "../../usage/cost";
 import { userCostOverlayVersion } from "../../usage/user-cost-overlays";
 import type { PersistedUsageAttempt } from "../../usage/log";
@@ -133,12 +134,23 @@ export async function handleLogsUsageRoutes(ctx: ManagementContext): Promise<Res
 
   if (url.pathname === "/api/logs" && req.method === "GET") {
     const all = getRequestLogEntries();
+    const rawCursor = url.searchParams.get("cursor");
+    const decoded = rawCursor === null ? null : decodeRequestLogCursor(rawCursor);
+    if (rawCursor !== null && decoded === null) {
+      return jsonResponse({ error: { code: "invalid_cursor", message: "invalid cursor" } }, 400, req, config);
+    }
+    const delta = decoded
+      ? sliceRequestLogsAfterCursor(all, decoded)
+      : { entries: all, reset: false };
     const total = filteredRequestLogCount(all, url.searchParams);
-    const logs = filterRequestLogs(all, url.searchParams);
+    const logs = filterRequestLogs(delta.entries, url.searchParams);
+    const newest = all.at(-1);
     return jsonResponse({
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       total,
       logs: logs.map(requestLogDto),
+      ...(newest ? { cursor: encodeRequestLogCursor(newest) } : {}),
+      reset: delta.reset,
     });
   }
 

--- a/src/server/request-log-cursor.ts
+++ b/src/server/request-log-cursor.ts
@@ -1,0 +1,58 @@
+import type { RequestLogEntry } from "./request-log";
+
+export interface RequestLogCursor {
+  timestamp: number;
+  requestId: string;
+}
+
+interface SerializedCursorV1 {
+  v: 1;
+  t: number;
+  id: string;
+}
+
+export function encodeRequestLogCursor(
+  entry: Pick<RequestLogEntry, "timestamp" | "requestId">,
+): string {
+  const payload: SerializedCursorV1 = {
+    v: 1,
+    t: entry.timestamp,
+    id: entry.requestId,
+  };
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+export function decodeRequestLogCursor(raw: string): RequestLogCursor | null {
+  if (typeof raw !== "string" || !raw || raw.length > 512) return null;
+  try {
+    const json = Buffer.from(raw, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    if (parsed.v !== 1) return null;
+    if (typeof parsed.t !== "number" || !Number.isFinite(parsed.t) || parsed.t < 0) return null;
+    if (typeof parsed.id !== "string" || parsed.id.length === 0 || parsed.id.length > 256) return null;
+    return { timestamp: parsed.t, requestId: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+export function sliceRequestLogsAfterCursor(
+  logs: readonly RequestLogEntry[],
+  cursor: RequestLogCursor,
+): { entries: RequestLogEntry[]; reset: boolean } {
+  if (logs.length === 0) return { entries: [], reset: true };
+  // Search from the end towards the beginning since recent cursors are near the end
+  let matchIndex = -1;
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const entry = logs[i];
+    if (entry && entry.timestamp === cursor.timestamp && entry.requestId === cursor.requestId) {
+      matchIndex = i;
+      break;
+    }
+  }
+  if (matchIndex === -1) {
+    return { entries: [...logs], reset: true };
+  }
+  return { entries: logs.slice(matchIndex + 1), reset: false };
+}

--- a/tests/management-api-logs-metrics.test.ts
+++ b/tests/management-api-logs-metrics.test.ts
@@ -57,6 +57,68 @@ function baseEntry(overrides: Partial<RequestLogEntry>): RequestLogEntry {
 }
 
 describe("GET /api/logs display metrics", () => {
+  test("supports cursor delta polling, empty delta, eviction reset, and invalid cursor rejection", async () => {
+    addRequestLog(baseEntry({ requestId: "req-1", timestamp: 1000, provider: "anthropic" }));
+    addRequestLog(baseEntry({ requestId: "req-2", timestamp: 2000, provider: "anthropic" }));
+
+    // Initial request returns the full window, an opaque cursor, and reset: false
+    const initUrl = new URL("http://localhost/api/logs");
+    const initRes = await handleManagementAPI(new Request(initUrl), initUrl, config);
+    expect(initRes?.status).toBe(200);
+    const initBody = await initRes!.json() as { logs: Array<{ requestId: string }>; cursor?: string; reset?: boolean; total: number };
+    expect(initBody.logs.map(r => r.requestId)).toEqual(["req-1", "req-2"]);
+    expect(typeof initBody.cursor).toBe("string");
+    expect(initBody.reset).toBe(false);
+    expect(initBody.total).toBe(2);
+
+    const cursor1 = initBody.cursor!;
+
+    // Empty delta when no new logs have been added
+    const pollUrl = new URL(`http://localhost/api/logs?cursor=${encodeURIComponent(cursor1)}`);
+    const pollRes = await handleManagementAPI(new Request(pollUrl), pollUrl, config);
+    expect(pollRes?.status).toBe(200);
+    const pollBody = await pollRes!.json() as { logs: Array<{ requestId: string }>; cursor?: string; reset?: boolean; total: number };
+    expect(pollBody.logs).toEqual([]);
+    expect(pollBody.cursor).toBe(cursor1);
+    expect(pollBody.reset).toBe(false);
+    expect(pollBody.total).toBe(2);
+
+    // Live cursor returns only new entries
+    addRequestLog(baseEntry({ requestId: "req-3", timestamp: 3000, provider: "anthropic" }));
+    const pollRes2 = await handleManagementAPI(new Request(pollUrl), pollUrl, config);
+    expect(pollRes2?.status).toBe(200);
+    const pollBody2 = await pollRes2!.json() as { logs: Array<{ requestId: string }>; cursor?: string; reset?: boolean; total: number };
+    expect(pollBody2.logs.map(r => r.requestId)).toEqual(["req-3"]);
+    expect(pollBody2.cursor).not.toBe(cursor1);
+    expect(pollBody2.reset).toBe(false);
+    expect(pollBody2.total).toBe(3);
+
+    // Filtered delta advances the raw cursor even if 0 matching rows in delta
+    const filterUrl = new URL(`http://localhost/api/logs?provider=openai&cursor=${encodeURIComponent(cursor1)}`);
+    const filterRes = await handleManagementAPI(new Request(filterUrl), filterUrl, config);
+    expect(filterRes?.status).toBe(200);
+    const filterBody = await filterRes!.json() as { logs: Array<{ requestId: string }>; cursor?: string; reset?: boolean; total: number };
+    expect(filterBody.logs).toEqual([]);
+    expect(filterBody.cursor).toBe(pollBody2.cursor);
+    expect(filterBody.total).toBe(0);
+
+    // Stale/evicted cursor returns full window with reset: true
+    const fakeCursor = Buffer.from(JSON.stringify({ v: 1, t: 999, id: "evicted-req" })).toString("base64url");
+    const staleUrl = new URL(`http://localhost/api/logs?cursor=${fakeCursor}`);
+    const staleRes = await handleManagementAPI(new Request(staleUrl), staleUrl, config);
+    expect(staleRes?.status).toBe(200);
+    const staleBody = await staleRes!.json() as { logs: Array<{ requestId: string }>; cursor?: string; reset?: boolean; total: number };
+    expect(staleBody.logs.map(r => r.requestId)).toEqual(["req-1", "req-2", "req-3"]);
+    expect(staleBody.reset).toBe(true);
+
+    // Malformed cursor fails closed with 400
+    const badUrl = new URL("http://localhost/api/logs?cursor=not-valid-cursor");
+    const badRes = await handleManagementAPI(new Request(badUrl), badUrl, config);
+    expect(badRes?.status).toBe(400);
+    const badBody = await badRes!.json();
+    expect(badBody).toEqual({ error: { code: "invalid_cursor", message: "invalid cursor" } });
+  });
+
   test("reports filtered total before limit pagination", async () => {
     addRequestLog(baseEntry({ requestId: "ok-a", provider: "anthropic", status: 200 }));
     addRequestLog(baseEntry({ requestId: "ok-b", provider: "anthropic", status: 200 }));

--- a/tests/request-log-cursor.test.ts
+++ b/tests/request-log-cursor.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decodeRequestLogCursor,
+  encodeRequestLogCursor,
+  sliceRequestLogsAfterCursor,
+} from "../src/server/request-log-cursor";
+import type { RequestLogEntry } from "../src/server/request-log";
+
+function makeEntry(requestId: string, timestamp: number): RequestLogEntry {
+  return {
+    requestId,
+    timestamp,
+    model: "test-model",
+    provider: "test-provider",
+    status: 200,
+    durationMs: 100,
+    usageStatus: "reported",
+  };
+}
+
+describe("request-log cursor", () => {
+  test("round-trips timestamp and request id", () => {
+    const encoded = encodeRequestLogCursor({ timestamp: 1700000000000, requestId: "req-2" });
+    expect(decodeRequestLogCursor(encoded)).toEqual({ timestamp: 1700000000000, requestId: "req-2" });
+  });
+
+  test("rejects malformed, empty, and type-confused payloads", () => {
+    expect(decodeRequestLogCursor("")).toBeNull();
+    expect(decodeRequestLogCursor("not-base64-json")).toBeNull();
+    expect(decodeRequestLogCursor("!!!")).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify({ t: "1", id: 2 })).toString("base64url"))).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify({ v: 2, t: 1, id: "req" })).toString("base64url"))).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify({ v: 1, t: -1, id: "req" })).toString("base64url"))).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify({ v: 1, t: Number.NaN, id: "req" })).toString("base64url"))).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify({ v: 1, t: 1, id: "" })).toString("base64url"))).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify({ v: 1, t: 1, id: "a".repeat(300) })).toString("base64url"))).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify([1, 2, 3])).toString("base64url"))).toBeNull();
+    expect(decodeRequestLogCursor(Buffer.from(JSON.stringify(null)).toString("base64url"))).toBeNull();
+  });
+
+  test("ring slice returns only rows after a live cursor", () => {
+    const rows = [makeEntry("req-1", 1), makeEntry("req-2", 2), makeEntry("req-3", 3)];
+    expect(sliceRequestLogsAfterCursor(rows, { timestamp: 2, requestId: "req-2" })).toEqual({
+      entries: [rows[2]],
+      reset: false,
+    });
+  });
+
+  test("ring slice returns empty entries when cursor matches the newest item", () => {
+    const rows = [makeEntry("req-1", 1), makeEntry("req-2", 2), makeEntry("req-3", 3)];
+    expect(sliceRequestLogsAfterCursor(rows, { timestamp: 3, requestId: "req-3" })).toEqual({
+      entries: [],
+      reset: false,
+    });
+  });
+
+  test("ring slice requests a reset when the cursor was evicted or not found", () => {
+    const rows = [makeEntry("req-3", 3), makeEntry("req-4", 4)];
+    expect(sliceRequestLogsAfterCursor(rows, { timestamp: 2, requestId: "req-2" })).toEqual({
+      entries: rows,
+      reset: true,
+    });
+  });
+
+  test("ring slice handles empty logs array with reset", () => {
+    expect(sliceRequestLogsAfterCursor([], { timestamp: 1, requestId: "req-1" })).toEqual({
+      entries: [],
+      reset: true,
+    });
+  });
+});


### PR DESCRIPTION
<!-- four-track-landing-status:start -->
### Delivered — superseded by merged work

Verified in `dev` at `5759d9ea2f1e7281cdc01eb9628f2e0a123fb59c`: [#3800](https://github.com/lidge-jun/opencodex/pull/3800) (`57211f43d4`).

Original contribution: **perf(logs): poll request history incrementally**, by @chilung-cgu.

Incremental request-history polling, extended to preserve changed requests and reset behavior.

The original PR is closed as superseded; its contribution remains credited in the landed history.

Attribution strengthened by [#3811](https://github.com/lidge-jun/opencodex/pull/3811), merged as `cf9f662190c4c6770697c45c870941509cc98f9c`. See [CREDITS.md](https://github.com/lidge-jun/opencodex/blob/dev/CREDITS.md#2026-09-07-follow-up-four-track-source-to-landing-attribution) for the source-to-landing attribution record.
<!-- four-track-landing-status:end -->

## Summary

Replace 2,000-row full snapshot polling on `GET /api/logs` with a backward-compatible opaque cursor delta protocol:

- **Server-side Delta Slicing**: `GET /api/logs?cursor=<opaque>` decodes a safe base64url cursor (`{ v: 1, t: timestamp, id: requestId }`), matches against the in-memory log ring, and returns only entries appended since the cursor along with additive metadata (`cursor`, `reset: boolean`).
- **Self-Healing Recovery**: If a cursor is evicted (due to high traffic or proxy restart), the server returns the full window with `reset: true` so the client transparently resets without losing data.
- **Fail-Closed Validation**: Malformed or type-confused cursor parameters return HTTP 400 `invalid_cursor`.
- **Client Delta Merge**: GUI `Logs.tsx` requests incremental deltas after the initial full fetch, merging new rows by `requestId` up to the 2,000-row cap, while falling back cleanly to full snapshots when talking to older servers.

## Verification

### Automated Test Gates
- **Focused Backend Tests**:
  ```bash
  bun test tests/request-log-cursor.test.ts tests/management-api-logs-metrics.test.ts tests/request-log.test.ts
  # Result: 76 pass, 0 fail (343 expect() calls)
  ```
- **Focused GUI Tests**:
  ```bash
  cd gui && bun test tests/log-poll.test.ts tests/logs-auto-refresh.test.tsx tests/client-resource-poll.test.tsx tests/visibility-poll.test.ts
  # Result: 38 pass, 0 fail (159 expect() calls)
  ```
- **Typecheck & Privacy Scan**:
  ```bash
  bun run typecheck
  bun run privacy:scan
  # Result: TypeScript clean, Privacy scan passed
  ```
- **GUI Lint & Build**:
  ```bash
  cd gui && bun run lint && bun run build
  # Result: oxlint clean, Vite production bundle built successfully
  ```
- **Import-Connected Test Suite**:
  ```bash
  bun run test:changed
  # Result: 2999 pass, 0 fail across 167 files (22225 expect() calls)
  ```
- **Core-Lab Boundary & Repo Hygiene**:
  ```bash
  bun test tests/core-lab-boundary.test.ts tests/repo-hygiene.test.ts
  # Result: 29 pass, 0 fail
  ```
- **Full GUI Test Suite**:
  ```bash
  cd gui && bun test tests
  # Result: 1235 pass, 0 fail across 200 files (10637 expect() calls)
  ```

### UI Verification
Visual layout, controls, filters, auto-refresh toggles, and detail dialogs remain bit-for-bit identical; network payload on background polling drops from ~7.3 MB per tick (full 2,000 DTOs) to < 1 KB (empty or incremental delta).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
