### PR TITLE
fix: use configured subagent roster for encrypted fallback

### DIFF
--- a/src/codex/subagent-model-fallback.ts
+++ b/src/codex/subagent-model-fallback.ts
@@ -606,9 +606,17 @@ export function applySubagentModelFallback(
   resolvedFallbackChain?: readonly string[] | null,
 ): { from?: string; to?: string; skipped?: string[] } | null {
   if (!isThreadSpawnRequest(headers)) return null;
-  const fallbackChain = resolvedFallbackChain === undefined
+  const configuredFallbackChain = resolvedFallbackChain === undefined
     ? resolveSubagentFallbackChain(parsed, config)
     : resolvedFallbackChain;
+  // Encrypted V2 fallback is opt-in through the configured subagent roster. Do not
+  // synthesize native candidates when the roster is unset; that would silently
+  // spend a native credential for an operator who never configured this path.
+  const fallbackChain = configuredFallbackChain === null
+    && nativeFallbackOnly
+    && config.subagentModels !== undefined
+    ? normalizedChain(parsed.modelId, config, [], config.subagentModels)
+    : configuredFallbackChain;
   if (!fallbackChain) return null;
   const selection = selectAvailableSubagentModel(
     parsed.modelId,

--- a/tests/subagent-model-fallback.test.ts
+++ b/tests/subagent-model-fallback.test.ts
@@ -1026,6 +1026,46 @@ describe("subagent model fallback chain", () => {
     expect((parsed._rawBody as { model?: string }).model).toBe("alibaba-token-plan/qwen3.8-max");
   });
 
+  test("native-only encrypted fallback uses the configured subagent roster", () => {
+    const parsed = {
+      modelId: "xai/grok-4.5",
+      options: {},
+      context: { messages: [] },
+      _rawBody: { model: "xai/grok-4.5" },
+    };
+    const result = applySubagentModelFallback(
+      parsed as never,
+      new Headers({ "x-openai-subagent": "collab_spawn" }),
+      cfg({
+        subagentModelFallback: undefined,
+        subagentModels: ["gpt-5.6-sol", "gpt-5.5"],
+      }),
+      "pool-a",
+      Date.now(),
+      true,
+    );
+    expect(result?.to).toBe("gpt-5.6-sol");
+    expect(parsed.modelId).toBe("gpt-5.6-sol");
+  });
+
+  test("native-only encrypted fallback stays disabled when the roster is unset", () => {
+    const parsed = {
+      modelId: "xai/grok-4.5",
+      options: {},
+      context: { messages: [] },
+      _rawBody: { model: "xai/grok-4.5" },
+    };
+    expect(applySubagentModelFallback(
+      parsed as never,
+      new Headers({ "x-openai-subagent": "collab_spawn" }),
+      cfg({ subagentModelFallback: undefined }),
+      "pool-a",
+      Date.now(),
+      true,
+    )).toBeNull();
+    expect(parsed.modelId).toBe("xai/grok-4.5");
+  });
+
   test("applySubagentModelFallback is a no-op for main turns", () => {
     updateAccountQuota("pool-a", 95);
     const parsed = {


### PR DESCRIPTION
## Summary

- Use the configured `subagentModels` roster when encrypted V2 sub-agent tasks require native-only fallback.
- Keep the fallback disabled when no sub-agent roster is configured, avoiding implicit native credential use.

## Verification

- `bun run typecheck`
- `git diff --check`
- Focused Bun test attempted, but the Windows test process did not complete in this environment; no assertion failures were reported.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback handling for encrypted subagent requests when a configured model roster is available.
  * Requests now use the first configured fallback model when no explicit fallback chain is set.
  * Requests remain unchanged when no fallback models are configured.

* **Tests**
  * Added coverage for configured and unconfigured native-only fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->