### PR TITLE
fix(oauth): honor Kiro reset-aligned cooldown without Retry-After

### DIFF
--- a/src/combos/failover.ts
+++ b/src/combos/failover.ts
@@ -13,6 +13,13 @@ interface TargetCooldown {
 
 const DEFAULT_COOLDOWN_MS = 60_000;
 const MAX_COOLDOWN_MS = 10 * 60_000;
+const IMF_FIXDATE_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/i;
+const RFC850_DATE_RE = /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2}) GMT$/i;
+const ASCTIME_DATE_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d{2}) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/i;
+const HTTP_MONTH_INDEX: Record<string, number> = {
+  jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+  jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+};
 
 /** Map<`${comboId}\0${provider/model}`, TargetCooldown> */
 const targetCooldowns = new Map<string, TargetCooldown>();
@@ -26,22 +33,92 @@ function cooldownMapKey(
   return `${comboId}\0${targetKey(target)}`;
 }
 
+function parseUtcDateParts(
+  year: number,
+  monthName: string,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+): number | undefined {
+  const month = HTTP_MONTH_INDEX[monthName.toLowerCase()];
+  if (month === undefined) return undefined;
+  const timestamp = Date.UTC(year, month, day, hour, minute, second);
+  const parsed = new Date(timestamp);
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month
+    && parsed.getUTCDate() === day
+    && parsed.getUTCHours() === hour
+    && parsed.getUTCMinutes() === minute
+    && parsed.getUTCSeconds() === second
+    ? timestamp
+    : undefined;
+}
+
+function parseHttpDate(value: string, now: number): number | undefined {
+  const imf = IMF_FIXDATE_RE.exec(value);
+  if (imf) {
+    return parseUtcDateParts(
+      Number(imf[3]), imf[2]!, Number(imf[1]),
+      Number(imf[4]), Number(imf[5]), Number(imf[6]),
+    );
+  }
+  const rfc850 = RFC850_DATE_RE.exec(value);
+  if (rfc850) {
+    const current = new Date(now);
+    const currentYear = current.getUTCFullYear();
+    const month = HTTP_MONTH_INDEX[rfc850[2]!.toLowerCase()];
+    if (month === undefined) return undefined;
+    let year = Math.floor(currentYear / 100) * 100 + Number(rfc850[3]);
+    const yearDelta = year - currentYear;
+    const candidateTimeOfYear = Date.UTC(
+      2000, month, Number(rfc850[1]),
+      Number(rfc850[4]), Number(rfc850[5]), Number(rfc850[6]),
+    );
+    const currentTimeOfYear = Date.UTC(
+      2000, current.getUTCMonth(), current.getUTCDate(),
+      current.getUTCHours(), current.getUTCMinutes(), current.getUTCSeconds(),
+      current.getUTCMilliseconds(),
+    );
+    if (yearDelta < -50 || (yearDelta === -50 && candidateTimeOfYear < currentTimeOfYear)) {
+      year += 100;
+    } else if (yearDelta > 50 || (yearDelta === 50 && candidateTimeOfYear > currentTimeOfYear)) {
+      year -= 100;
+    }
+    return parseUtcDateParts(
+      year, rfc850[2]!, Number(rfc850[1]),
+      Number(rfc850[4]), Number(rfc850[5]), Number(rfc850[6]),
+    );
+  }
+  const asctime = ASCTIME_DATE_RE.exec(value);
+  if (!asctime) return undefined;
+  return parseUtcDateParts(
+    Number(asctime[6]), asctime[1]!, Number(asctime[2]),
+    Number(asctime[3]), Number(asctime[4]), Number(asctime[5]),
+  );
+}
+
 export function parseRetryAfterMs(
   value: string | null | undefined,
   now = Date.now(),
+  options?: { preserveImmediate?: boolean },
 ): number | undefined {
   const text = value?.trim();
   if (!text) return undefined;
   if (/^\d+(?:\.\d+)?$/.test(text)) {
     const seconds = Number(text);
-    if (Number.isFinite(seconds) && seconds > 0) {
+    if (
+      Number.isFinite(seconds)
+      && (seconds > 0 || (options?.preserveImmediate && seconds === 0))
+    ) {
       return Math.min(Math.max(Math.ceil(seconds * 1000), 1), MAX_COOLDOWN_MS);
     }
   }
-  const timestamp = Date.parse(text);
-  if (!Number.isFinite(timestamp)) return undefined;
+  const timestamp = parseHttpDate(text, now);
+  if (timestamp === undefined) return undefined;
   const delay = timestamp - now;
-  return delay > 0 ? Math.min(delay, MAX_COOLDOWN_MS) : undefined;
+  if (delay > 0) return Math.min(delay, MAX_COOLDOWN_MS);
+  return options?.preserveImmediate ? 1 : undefined;
 }
 
 export function isComboTargetInCooldown(

--- a/src/oauth/generic-account-failover.ts
+++ b/src/oauth/generic-account-failover.ts
@@ -202,11 +202,11 @@ export function rotateGenericOAuthAccountOn429(
   // A single stored account has nowhere to go; rotating to itself would just replay the 429.
   if (!set || set.accounts.length < 2) return null;
 
-  const parsed = parseRetryAfterMs(retryAfterHeader, now);
+  const parsed = parseRetryAfterMs(retryAfterHeader, now, { preserveImmediate: true });
   // An account whose allowance is provably spent gets a reset-aligned cooldown instead of
   // the default minute: retrying it every 60s until the window rolls over is pure waste.
   // A Retry-After from upstream still wins — it is the server's own instruction.
-  const exhausted = parsed === null ? exhaustedCooldownMs(providerName, failedAccountId, now) : null;
+  const exhausted = parsed === undefined ? exhaustedCooldownMs(providerName, failedAccountId, now) : null;
   const cooldownMs = exhausted ?? Math.min(parsed ?? DEFAULT_COOLDOWN_MS, MAX_COOLDOWN_MS);
   health.set(healthKey(providerName, failedAccountId), {
     cooldownUntil: now + cooldownMs,

--- a/tests/combos.test.ts
+++ b/tests/combos.test.ts
@@ -361,6 +361,7 @@ describe("combo target cooldowns", () => {
     expect(parseRetryAfterMs("120", now)).toBe(120_000);
     expect(parseRetryAfterMs("999999", now)).toBe(600_000);
     expect(parseRetryAfterMs(new Date(now + 90_000).toUTCString(), now)).toBe(90_000);
+    expect(parseRetryAfterMs(new Date(now + 90_000).toUTCString().toLowerCase(), now)).toBe(90_000);
     expect(parseRetryAfterMs(new Date(now + 900_000).toUTCString(), now)).toBe(600_000);
   });
 
@@ -371,6 +372,37 @@ describe("combo target cooldowns", () => {
     expect(parseRetryAfterMs("0", now)).toBeUndefined();
     expect(parseRetryAfterMs("not-a-date", now)).toBeUndefined();
     expect(parseRetryAfterMs(new Date(now - 1_000).toUTCString(), now)).toBeUndefined();
+  });
+
+  test("can preserve valid immediate Retry-After directives", () => {
+    const now = Date.parse("2026-07-18T00:00:00.000Z");
+    const options = { preserveImmediate: true };
+    expect(parseRetryAfterMs("0", now, options)).toBe(1);
+    expect(parseRetryAfterMs(new Date(now - 1_000).toUTCString(), now, options)).toBe(1);
+    expect(parseRetryAfterMs("Sunday, 06-Nov-94 08:49:37 GMT", now, options)).toBe(1);
+    expect(parseRetryAfterMs("Sunday, 06-Nov-50 08:49:37 GMT", now, options)).toBe(600_000);
+    expect(parseRetryAfterMs("Sun Nov  6 08:49:37 1994", now, options)).toBe(1);
+    expect(parseRetryAfterMs("not-a-date", now, options)).toBeUndefined();
+    expect(parseRetryAfterMs("-1", now, options)).toBeUndefined();
+    expect(parseRetryAfterMs("March 1, 2020", now, options)).toBeUndefined();
+    expect(parseRetryAfterMs("Sun Sep 99 99:99:99 2026", now, options)).toBeUndefined();
+    const centuryBoundary = Date.parse("2099-12-31T23:59:00.000Z");
+    expect(parseRetryAfterMs("Friday, 01-Jan-00 00:01:00 GMT", centuryBoundary, options)).toBe(120_000);
+    const fullTimestampBoundary = Date.parse("2026-01-01T00:00:00.000Z");
+    expect(parseRetryAfterMs("Wednesday, 01-Jan-76 00:00:00 GMT", fullTimestampBoundary, options)).toBe(600_000);
+    expect(parseRetryAfterMs("Friday, 31-Dec-76 00:00:00 GMT", fullTimestampBoundary, options)).toBe(1);
+  });
+
+  test("parses asctime Retry-After values as UTC outside the UTC process timezone", () => {
+    const originalTimezone = process.env.TZ;
+    process.env.TZ = "America/Los_Angeles";
+    try {
+      const now = Date.parse("2026-09-06T00:59:00.000Z");
+      expect(parseRetryAfterMs("Sun Sep  6 01:00:00 2026", now)).toBe(60_000);
+    } finally {
+      if (originalTimezone === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTimezone;
+    }
   });
 
   test("expires cooldowns and clears only the requested combo", () => {

--- a/tests/kiro-pool-rank.test.ts
+++ b/tests/kiro-pool-rank.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   clearGenericFailoverHealth,
   forgetGenericFailoverRoster,
+  genericFailoverRetryAfterSeconds,
   preferredInitialAccount,
   rotateGenericOAuthAccountOn429,
 } from "../src/oauth/generic-account-failover";
@@ -146,16 +147,16 @@ describe("pre-dispatch account preference", () => {
   const originalHome = process.env.OPENCODEX_HOME;
   let home: string;
 
-  async function seedAccounts(count: number): Promise<string[]> {
+  async function seedAccounts(count: number, providerName = "xai"): Promise<string[]> {
     for (let i = 0; i < count; i++) {
-      await saveCredential("xai", {
+      await saveCredential(providerName, {
         access: `access-${i}`,
         refresh: `refresh-${i}`,
         expires: Date.now() + 3_600_000,
         accountId: `uuid-${i}`,
       } as never, { addAccount: true });
     }
-    return getAccountSet("xai")?.accounts.map(a => a.id) ?? [];
+    return getAccountSet(providerName)?.accounts.map(a => a.id) ?? [];
   }
 
   test("the account with more headroom is chosen before the first request", async () => {
@@ -229,6 +230,109 @@ describe("pre-dispatch account preference", () => {
       setCachedProviderAccountQuotaForTests("xai", ids[1]!, { monthlyPercent: 1, updatedAt: Date.now() });
       rotateGenericOAuthAccountOn429(config, "xai", ids[1]!, null);
       expect(preferredInitialAccount(config, "xai")).toBeNull();
+    } finally {
+      clearGenericFailoverHealth();
+      clearAccountQuotaCache();
+      if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = originalHome;
+      removeTreeWithRetry(home);
+    }
+  });
+
+  test("an exhausted account without Retry-After stays cooled through its reset window", async () => {
+    home = mkdtempSync(join(tmpdir(), "ocx-predispatch-"));
+    process.env.OPENCODEX_HOME = home;
+    clearGenericFailoverHealth();
+    clearAccountQuotaCache();
+    try {
+      const ids = await seedAccounts(2, "kiro");
+      const now = Date.now();
+      seedExhausted(ids[0]!, now + 60 * 60_000);
+      const kiroConfig = {
+        providers: { kiro: OAUTH_PROVIDER },
+      } as unknown as OcxConfig;
+
+      expect(rotateGenericOAuthAccountOn429(kiroConfig, "kiro", ids[0]!, null, now)).toBe(ids[1]);
+      expect(genericFailoverRetryAfterSeconds("kiro", now)).toBe(60 * 60);
+    } finally {
+      clearGenericFailoverHealth();
+      clearAccountQuotaCache();
+      if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = originalHome;
+      removeTreeWithRetry(home);
+    }
+  });
+
+  test("an unparseable Retry-After uses an exhausted account reset", async () => {
+    home = mkdtempSync(join(tmpdir(), "ocx-predispatch-"));
+    process.env.OPENCODEX_HOME = home;
+    clearGenericFailoverHealth();
+    clearAccountQuotaCache();
+    try {
+      const ids = await seedAccounts(2, "kiro");
+      const now = Date.now();
+      seedExhausted(ids[0]!, now + 60 * 60_000);
+      const kiroConfig = {
+        providers: { kiro: OAUTH_PROVIDER },
+      } as unknown as OcxConfig;
+
+      expect(
+        rotateGenericOAuthAccountOn429(kiroConfig, "kiro", ids[0]!, "not-a-duration", now),
+      ).toBe(ids[1]);
+      expect(genericFailoverRetryAfterSeconds("kiro", now)).toBe(60 * 60);
+    } finally {
+      clearGenericFailoverHealth();
+      clearAccountQuotaCache();
+      if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = originalHome;
+      removeTreeWithRetry(home);
+    }
+  });
+
+  test("valid immediate Retry-After values override an exhausted account reset", async () => {
+    home = mkdtempSync(join(tmpdir(), "ocx-predispatch-"));
+    process.env.OPENCODEX_HOME = home;
+    clearGenericFailoverHealth();
+    clearAccountQuotaCache();
+    try {
+      const ids = await seedAccounts(2, "kiro");
+      const now = Date.now();
+      seedExhausted(ids[0]!, now + 60 * 60_000);
+      const kiroConfig = {
+        providers: { kiro: OAUTH_PROVIDER },
+      } as unknown as OcxConfig;
+
+      for (const retryAfter of ["0", new Date(now - 1_000).toUTCString()]) {
+        clearGenericFailoverHealth();
+        expect(
+          rotateGenericOAuthAccountOn429(kiroConfig, "kiro", ids[0]!, retryAfter, now),
+        ).toBe(ids[1]);
+        expect(genericFailoverRetryAfterSeconds("kiro", now)).toBe(1);
+      }
+    } finally {
+      clearGenericFailoverHealth();
+      clearAccountQuotaCache();
+      if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = originalHome;
+      removeTreeWithRetry(home);
+    }
+  });
+
+  test("a valid Retry-After overrides an exhausted account reset", async () => {
+    home = mkdtempSync(join(tmpdir(), "ocx-predispatch-"));
+    process.env.OPENCODEX_HOME = home;
+    clearGenericFailoverHealth();
+    clearAccountQuotaCache();
+    try {
+      const ids = await seedAccounts(2, "kiro");
+      const now = Date.now();
+      seedExhausted(ids[0]!, now + 60 * 60_000);
+      const kiroConfig = {
+        providers: { kiro: OAUTH_PROVIDER },
+      } as unknown as OcxConfig;
+
+      expect(rotateGenericOAuthAccountOn429(kiroConfig, "kiro", ids[0]!, "120", now)).toBe(ids[1]);
+      expect(genericFailoverRetryAfterSeconds("kiro", now)).toBe(120);
     } finally {
       clearGenericFailoverHealth();
       clearAccountQuotaCache();


### PR DESCRIPTION
## Summary

- Treat missing or malformed `Retry-After` values as the absence of a usable upstream delay.
- Restore the existing reset-aligned cooldown for a Kiro account that is already known to be exhausted.
- Preserve valid immediate, future, and numeric `Retry-After` directives, including case-insensitive HTTP-date tokens, RFC 850's full-timestamp relative-year rule, and UTC asctime parsing.
- Add integration regressions for missing, malformed, immediate, elapsed-date, nonstandard-date, timezone, full-timestamp two-digit-year boundaries, and positive `Retry-After` values.

## Verification

- `bun test tests/kiro-pool-rank.test.ts tests/combos.test.ts` — 72 pass, 0 fail on Bun 1.4.0 after rebasing onto the latest `dev`.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `bun run test:changed` — selected a broad four-worker suite and was stopped after 12 minutes of sustained 3.5 GB worker memory with no assertion output; the exact worker tree was terminated and no residual process remained. The directly affected regression files above are green.
- Independent focused and OAuth-boundary review — no must-fix finding.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No public API, configuration, or UI contract changes, so documentation and release-note edits are not needed. Maintainer security review and sponsorship remain required for the OAuth surface.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account failover when quota limits are reached and `Retry-After` information is missing or invalid.
  - Added support for standard HTTP date formats and immediate retry values, including expired dates.
  - Ensured valid retry delays take precedence over provider cooldown resets.
  - Improved redirection to alternate accounts during Kiro failover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
