### PR TITLE
fix(windows): server.stop drains the config-dir ACL flight; retrying test teardown

### DIFF
--- a/devlog/_plan/260902_windows_ci_release/000_inventory.md
+++ b/devlog/_plan/260902_windows_ci_release/000_inventory.md
@@ -9,11 +9,11 @@ including `main`, so this is a regression in the range 223a0a287..dev, not the r
 
 | # | Signature | Count | Owner (src) | Owner (tests) | Class |
 |---|---|---|---|---|---|
-| A | `EPERM rm tests/.tmp-codex-accounts-test` / `.tmp-codex-auth-api-test` | 49 / 377 | `src/config/paths.ts:31-48` (`hardenConfigDir` → unawaited `hardenSecretDirAsync`), `src/lib/windows-secret-acl.ts:344` (icacls spawn) | `tests/codex-account-store.test.ts:37,44,1231,1238`; `tests/codex-auth-api.test.ts:259,296` | product lifecycle regression (e5d588669) + harness cascade |
+| A | `EPERM rm tests/.tmp-codex-accounts-test` / `.tmp-codex-auth-api-test` | 49 / 377 | `src/config/paths.ts:31-48` (`hardenConfigDir` → unawaited `hardenSecretDirAsync`), `src/lib/windows-secret-acl.ts:345` (icacls spawn) | `tests/codex-account-store.test.ts:37,44,1231,1238`; `tests/codex-auth-api.test.ts:259,296` | product lifecycle regression (e5d588669) + harness cascade |
 | B | `EBUSY rm Temp/ocx-*` after `await server.stop(true)` | ~14 suites | `src/server/index.ts:2294-2315` (`server.stop` never awaits config-dir hardening) | kiro-completion:39, claude-native:28, api-usage:103, vision-e2e:45, oauth-live:57, loopback-listener:109, chat-completions:78, pool-mgmt:178, claude-endpoint:67, oauth-accounts-api:64, server-live:37/61, data-plane-admission:232 | same root as A |
 | C1 | `EPERM fsync` | 3 + 1 child | `src/lib/service-secrets.ts:68` `fsyncRegularFile` opens `"r"`; same in `src/responses/spill-store.ts:387,425` | `tests/service-secrets.test.ts:93,109,130`; `tests/client-connect.test.ts:494` (rotation child) | product portability defect |
 | C2 | icacls `ETIMEDOUT` / access-denied warnings | — | `src/config.ts:2728-2742` | `tests/config.test.ts:2945,2962` inject them | NOT a failure (deliberate test output) |
-| D | `Responses previous_response_id state` / `admission boundary` ~45 cases; one 60 s timeout | ~45 | `src/responses/state.ts:1007,1047` (Windows queues async spill) | `tests/responses-state.test.ts:821+, 1045, 1277, 1328, 3190+` | harness: generic cases assume sync lane; :1277 lacks principal-resolver injection and releases its gate outside `finally`, wedging :1328 |
+| D | `Responses previous_response_id state` / `admission boundary` ~45 cases; one 60 s timeout | ~45 | `src/responses/state.ts:1024-1028,1057-1059` (Windows queues async spill) | `tests/responses-state.test.ts:821+, 1045, 1277, 1328, 3190+` | harness: generic cases assume sync lane; :1277 lacks principal-resolver injection and releases its gate outside `finally`, wedging :1328 |
 | E | `dev version bump rule` ×3 exit 1 | 3 | — | `tests/bump-dev-version.test.ts:15` uses `new URL(..).pathname` (`/D:/a/...`) | harness |
 | F | `config.json JSON Parse error` in ocx-overlay-review | — | — | `tests/user-cost-overlay-coderabbit-regressions.test.ts:89,147` writes `{ not json` on purpose | NOT a failure |
 | G | 20-odd single failures (WS handshake, passthrough, readyz, api/usage, Cockpit import, …) | ~20 | — | see B table | all B teardown or A cascade; no independent defect |
@@ -25,7 +25,7 @@ including `main`, so this is a regression in the range 223a0a287..dev, not the r
       → test/server finishes → rmSync() → EPERM (unlink) / EBUSY (rename)
 
 `server.stop(true)` awaits listeners, background lifecycle and native-main, not this flight.
-A flush exists (`src/config/paths.ts:52`) but is test-only. `tests/codex-account-store.test.ts`
+A flush exists (`src/config/paths.ts:53`) but is test-only. `tests/codex-account-store.test.ts`
 stubs `setIcaclsRunnerForTests` only; the async runner (`setAsyncIcaclsRunnerForTests`) stays real.
 
 ## Roadmap

--- a/devlog/_plan/260902_windows_ci_release/000_inventory.md
+++ b/devlog/_plan/260902_windows_ci_release/000_inventory.md
@@ -1,0 +1,40 @@
+# 000 — Windows CI failure inventory (windows-latest, workflow_dispatch)
+
+Runs read: 33590540220 (ef68bd1f2, cursor stack), 33584155821 (2cb592174, regaudit),
+33555110133 (af6113a03 = main). Raw logs in `.tmp/win/*.log` (gitignored). Last Windows-green
+dispatch: 33290817128 on 223a0a287 (2026-08-30). Every dispatch since has failed on all branches
+including `main`, so this is a regression in the range 223a0a287..dev, not the runner.
+
+## Signatures → owning file → class
+
+| # | Signature | Count | Owner (src) | Owner (tests) | Class |
+|---|---|---|---|---|---|
+| A | `EPERM rm tests/.tmp-codex-accounts-test` / `.tmp-codex-auth-api-test` | 49 / 377 | `src/config/paths.ts:31-48` (`hardenConfigDir` → unawaited `hardenSecretDirAsync`), `src/lib/windows-secret-acl.ts:344` (icacls spawn) | `tests/codex-account-store.test.ts:37,44,1231,1238`; `tests/codex-auth-api.test.ts:259,296` | product lifecycle regression (e5d588669) + harness cascade |
+| B | `EBUSY rm Temp/ocx-*` after `await server.stop(true)` | ~14 suites | `src/server/index.ts:2294-2315` (`server.stop` never awaits config-dir hardening) | kiro-completion:39, claude-native:28, api-usage:103, vision-e2e:45, oauth-live:57, loopback-listener:109, chat-completions:78, pool-mgmt:178, claude-endpoint:67, oauth-accounts-api:64, server-live:37/61, data-plane-admission:232 | same root as A |
+| C1 | `EPERM fsync` | 3 + 1 child | `src/lib/service-secrets.ts:68` `fsyncRegularFile` opens `"r"`; same in `src/responses/spill-store.ts:387,425` | `tests/service-secrets.test.ts:93,109,130`; `tests/client-connect.test.ts:494` (rotation child) | product portability defect |
+| C2 | icacls `ETIMEDOUT` / access-denied warnings | — | `src/config.ts:2728-2742` | `tests/config.test.ts:2945,2962` inject them | NOT a failure (deliberate test output) |
+| D | `Responses previous_response_id state` / `admission boundary` ~45 cases; one 60 s timeout | ~45 | `src/responses/state.ts:1007,1047` (Windows queues async spill) | `tests/responses-state.test.ts:821+, 1045, 1277, 1328, 3190+` | harness: generic cases assume sync lane; :1277 lacks principal-resolver injection and releases its gate outside `finally`, wedging :1328 |
+| E | `dev version bump rule` ×3 exit 1 | 3 | — | `tests/bump-dev-version.test.ts:15` uses `new URL(..).pathname` (`/D:/a/...`) | harness |
+| F | `config.json JSON Parse error` in ocx-overlay-review | — | — | `tests/user-cost-overlay-coderabbit-regressions.test.ts:89,147` writes `{ not json` on purpose | NOT a failure |
+| G | 20-odd single failures (WS handshake, passthrough, readyz, api/usage, Cockpit import, …) | ~20 | — | see B table | all B teardown or A cascade; no independent defect |
+
+## Mechanism (A/B)
+
+    loadConfig()/account-store/oauth store → hardenConfigDir()
+      → hardenSecretDirAsync() fire-and-forget → icacls.exe holds the dir
+      → test/server finishes → rmSync() → EPERM (unlink) / EBUSY (rename)
+
+`server.stop(true)` awaits listeners, background lifecycle and native-main, not this flight.
+A flush exists (`src/config/paths.ts:52`) but is test-only. `tests/codex-account-store.test.ts`
+stubs `setIcaclsRunnerForTests` only; the async runner (`setAsyncIcaclsRunnerForTests`) stays real.
+
+## Roadmap
+
+- 010 — A/B: production `flushConfigDirHardening(configDir)` awaited in `server.stop`; harness
+  `removeTreeWithRetry` at every cleanup site; async runner stub in account-store test.
+  fuck-powershell case: `env-paths/async-child-holds-dir-after-stop`.
+- 020 — C1 + D + E: `"r+"` fsync handles; responses-state fixture lanes + gate `finally`;
+  `fileURLToPath`. fuck-powershell cases: `env-paths/fsync-readonly-handle-eperm`,
+  `env-paths/file-url-pathname-drive-slash`. Then dispatch CI on an immutable ref → Windows 1-4/4.
+- 030 — regression audit main..dev (parallel reviewers), devlog record.
+- 040 — promote dev → preview → main via `scripts/release.ts`; proof; bump dev.

--- a/devlog/_plan/260902_windows_ci_release/010_async_acl_lifecycle.md
+++ b/devlog/_plan/260902_windows_ci_release/010_async_acl_lifecycle.md
@@ -10,9 +10,12 @@ Branch `codex/win-acl-lifecycle` off origin/dev.
 - `src/server/index.ts` `startServer`: capture the effective config dir before `loadConfig()`;
   in the composite `server.stop` finalizer (~2312) await `flushConfigDirHardening(dir)` after the
   listeners close, before returning.
-- Test: `tests/server-stop-config-hardening.test.ts` — inject a never-settling async icacls runner
-  via `setAsyncIcaclsRunnerForTests` with a controllable promise, start a server, call
-  `stop(true)`, assert it stays pending until the runner settles, then resolves.
+- Test: `tests/server-stop-config-hardening.test.ts` — `setPlatformForTests("win32")` (otherwise
+  `windowsSecretAclApplies()` at `windows-secret-acl.ts:469` is false and no flight starts), inject
+  a controllable async icacls runner via `setAsyncIcaclsRunnerForTests` plus a principal resolver,
+  start a server, call `stop(true)`, assert it stays pending until the runner settles, then
+  resolves. Every seam restore and the gate release live in `finally` so an assertion failure
+  cannot wedge cleanup.
 
 ## tests (harness)
 
@@ -35,5 +38,5 @@ shutdown contract owns every spawned child; retry-on-EPERM only as a harness fal
 
 ## Checks
 
-    bun test tests/server-stop-config-hardening.test.ts tests/codex-account-store.test.ts tests/codex-auth-api.test.ts tests/remove-tree.test.ts
+    bun test tests/server-stop-config-hardening.test.ts tests/codex-account-store.test.ts tests/codex-auth-api.test.ts tests/remove-tree-helper.test.ts
     bun run typecheck

--- a/devlog/_plan/260902_windows_ci_release/010_async_acl_lifecycle.md
+++ b/devlog/_plan/260902_windows_ci_release/010_async_acl_lifecycle.md
@@ -1,0 +1,39 @@
+# 010 — Config-dir ACL hardening must be part of the shutdown contract (signatures A, B, G)
+
+Branch `codex/win-acl-lifecycle` off origin/dev.
+
+## src
+
+- `src/config/paths.ts`: promote the test-only flush to `flushConfigDirHardening(configDir: string): Promise<void>`
+  that awaits the in-flight entry for that exact directory (no-op when none). Keep the existing
+  test helper as a thin wrapper.
+- `src/server/index.ts` `startServer`: capture the effective config dir before `loadConfig()`;
+  in the composite `server.stop` finalizer (~2312) await `flushConfigDirHardening(dir)` after the
+  listeners close, before returning.
+- Test: `tests/server-stop-config-hardening.test.ts` — inject a never-settling async icacls runner
+  via `setAsyncIcaclsRunnerForTests` with a controllable promise, start a server, call
+  `stop(true)`, assert it stays pending until the runner settles, then resolves.
+
+## tests (harness)
+
+Replace recursive `rmSync` with `removeTreeWithRetry` (`tests/helpers/remove-tree.ts`) at:
+codex-account-store:37,44,1231,1238; codex-auth-api:259,296; oauth-status-privacy:33,42;
+server-kiro-completion-e2e:39; claude-native-passthrough:28; api-usage:103; vision-sidecar-e2e:45;
+oauth-login-cli-live-update:57; loopback-listener-integration:109; chat-completions-endpoint:78;
+account-pool-management-api:178; claude-messages-endpoint:67; oauth-accounts-api:64;
+server-live:37,61; data-plane-admission-identity:232.
+
+`tests/codex-account-store.test.ts`: stub AND restore `setAsyncIcaclsRunnerForTests` alongside the
+sync stub; use per-test `mkdtempSync` instead of the fixed repo-local `TEST_DIR` so one failure
+cannot poison the rest of the file.
+
+## fuck-powershell
+
+`cases/env-paths/async-child-holds-dir-after-stop.md`: Symptom = rmSync EPERM/EBUSY right after a
+clean `server.stop()`; Cause = fire-and-forget `icacls.exe` child + mandatory locking; Workaround =
+shutdown contract owns every spawned child; retry-on-EPERM only as a harness fallback.
+
+## Checks
+
+    bun test tests/server-stop-config-hardening.test.ts tests/codex-account-store.test.ts tests/codex-auth-api.test.ts tests/remove-tree.test.ts
+    bun run typecheck

--- a/devlog/_plan/260902_windows_ci_release/020_fsync_spill_bump.md
+++ b/devlog/_plan/260902_windows_ci_release/020_fsync_spill_bump.md
@@ -1,0 +1,37 @@
+# 020 — fsync handles, responses-state fixtures, bump CLI path (signatures C1, D, E) + Windows dispatch
+
+Branch `codex/win-fsync-fixtures` on top of 010.
+
+## C1 — read-only fsync (product)
+
+- `src/lib/service-secrets.ts:68` `fsyncRegularFile`: `openSync(path, "r+")`.
+- `src/responses/spill-store.ts:387,425`: the copied destination reopened for fsync uses `"r+"`.
+- Existing contract test `tests/codex-transition-state-adoption.test.ts:73` already documents the
+  Windows rule; add one assertion in `tests/service-secrets.test.ts` that the handle mode is
+  writable (spy `openSync`).
+
+## D — responses-state fixtures (harness)
+
+- Generic spill/admission describe blocks: fixture platform `"linux"` so they exercise the sync
+  lane; `spill-store.ts::harden` must consult `windowsSecretAclApplies()` consistently.
+- Dedicated Windows cases stay `"win32"` and `await flushPendingResponseSpillsForTests()` before
+  settled-state assertions.
+- `tests/responses-state.test.ts:1277`: inject sync+async principal runners like
+  `tests/helpers/responses-state-never-settling-acl-child.ts:17`; move `release()` into a
+  `finally` that covers every await after gate creation (this is what wedged :1328 for 60 s).
+
+## E — bump CLI (harness)
+
+`tests/bump-dev-version.test.ts:15`: `fileURLToPath(new URL(...))`, spawn `process.execPath`,
+include stderr in the failure message, and make the malformed case assert the specific stderr.
+
+## fuck-powershell
+
+- `cases/env-paths/fsync-readonly-handle-eperm.md`
+- `cases/env-paths/file-url-pathname-drive-slash.md`
+
+## Gate
+
+Push both branches, open PRs, then `gh workflow run ci.yml --ref codex/win-dispatch-<sha>` on an
+immutable ref of the stacked head. Required: windows 1/4..4/4 SUCCESS. Iterate on failures from
+the exact-head logs; never loosen an assertion.

--- a/devlog/_plan/260902_windows_ci_release/020_fsync_spill_bump.md
+++ b/devlog/_plan/260902_windows_ci_release/020_fsync_spill_bump.md
@@ -17,7 +17,7 @@ Branch `codex/win-fsync-fixtures` on top of 010.
 - Dedicated Windows cases stay `"win32"` and `await flushPendingResponseSpillsForTests()` before
   settled-state assertions.
 - `tests/responses-state.test.ts:1277`: inject sync+async principal runners like
-  `tests/helpers/responses-state-never-settling-acl-child.ts:17`; move `release()` into a
+  `tests/helpers/responses-state-never-settling-acl-child.ts:44`; move `release()` into a
   `finally` that covers every await after gate creation (this is what wedged :1328 for 60 s).
 
 ## E — bump CLI (harness)

--- a/devlog/_plan/260902_windows_ci_release/030_regression_audit.md
+++ b/devlog/_plan/260902_windows_ci_release/030_regression_audit.md
@@ -1,0 +1,6 @@
+# 030 — Regression audit main..dev
+
+After 010/020 land: `git log --oneline origin/main..origin/dev`, split into 4 lanes (src first half,
+src second half, tests-only + gui, security boundary per MAINTAINERS.md) and dispatch read-only
+sol/high reviewers in parallel. Each returns VERDICT + per-commit user-impact notes. Record
+verbatim tails in `031_verdicts.md`. Any medium+ finding becomes a fix cycle before 040.

--- a/devlog/_plan/260902_windows_ci_release/040_promote_and_bump.md
+++ b/devlog/_plan/260902_windows_ci_release/040_promote_and_bump.md
@@ -1,0 +1,11 @@
+# 040 — Promote and bump
+
+Preconditions: dispatch CI green on the dev tip incl. Windows; service-lifecycle.yml green on the
+same SHA; regression audit recorded. Read `scripts/release.ts` before running (it accepts only
+main/preview and pushes even without --publish). Use a dedicated clean worktree with root + gui
+`bun install`. Promote dev → preview (prerelease) → main (stable) per the helper; if a gate fails
+after the bump push, rerun once then manual `release.yml` with `expected-sha`.
+
+Proof: `npm view @bitkyc08/opencodex dist-tags --json` + `gitHead`, `gh release view`,
+`git ls-remote` for preview/main tips. Then `scripts/bump-dev-version.ts` for the next minor on
+dev via PR, admin merge, is-ancestor proof.

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -49,7 +49,21 @@ export function hardenConfigDir(): void {
   }
 }
 
-/** Test-only: settle optional config-directory hardening without exposing it to production callers. */
+/**
+ * Settle the optional hardening flight for one config directory.
+ *
+ * The flight spawns `icacls.exe`, which holds the directory open until it exits. Windows file
+ * locking is mandatory, so anything that removes or renames that directory after a "clean"
+ * shutdown — a test fixture teardown, an uninstaller, a home move — gets EPERM/EBUSY unless the
+ * process that started the child also waits for it. `server.stop` calls this so the shutdown
+ * contract owns every child it started. No-op when nothing is in flight.
+ */
+export async function flushConfigDirHardening(dir: string = getConfigDir()): Promise<void> {
+  const flight = configDirHardeningFlights.get(dir);
+  if (flight) await flight;
+}
+
+/** Test-only: settle every in-flight config-directory harden regardless of directory. */
 export async function flushConfigDirHardeningForTests(): Promise<void> {
   await Promise.all([...configDirHardeningFlights.values()]);
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ import {
   websocketsEnabled,
 } from "../config";
 import { grokDefaultReasoningEffort } from "../grok/effort";
+import { flushConfigDirHardening } from "../config/paths";
 import { reconcileOAuthProviders } from "../oauth";
 import { withCatalogWriteSerialization } from "../codex/catalog-write-serialization";
 import { invalidateCodexModelsCacheWithPermit } from "../codex/catalog/sync";
@@ -638,6 +639,9 @@ export function warnAgentTaskRecoveryStartup(config: {
 
 export function startServer(port?: number, deps: StartServerDeps = {}): Server<WsData> {
   const localAttestationSecret = deps.localAttestationSecret ?? createLocalAttestationSecret();
+  // Captured before loadConfig() starts the optional ACL flight so stop() drains the same dir
+  // even if OPENCODEX_HOME changes underneath a long-lived process.
+  const startupConfigDir = getConfigDir();
   const config = runModelRenameStartupMigration(runAlibabaRegionStartupMigration(runOpenAiTierStartupMigration(loadConfig())));
   warnAgentTaskRecoveryStartup(config);
   setLiveStateStoreConfig(config);
@@ -2312,6 +2316,9 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         async () => {
           await backgroundLifecycle.release();
           await releaseNativeMainStartupLifecycle(server);
+          // icacls.exe from hardenConfigDir() holds the config dir open; a caller that removes
+          // the dir right after stop() resolves would hit EPERM/EBUSY on Windows otherwise.
+          await flushConfigDirHardening(startupConfigDir);
         },
       );
     },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2314,11 +2314,16 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
           },
         ],
         async () => {
-          await backgroundLifecycle.release();
-          await releaseNativeMainStartupLifecycle(server);
-          // icacls.exe from hardenConfigDir() holds the config dir open; a caller that removes
-          // the dir right after stop() resolves would hit EPERM/EBUSY on Windows otherwise.
-          await flushConfigDirHardening(startupConfigDir);
+          try {
+            await backgroundLifecycle.release();
+            await releaseNativeMainStartupLifecycle(server);
+          } finally {
+            // icacls.exe from hardenConfigDir() holds the config dir open; a caller that
+            // removes the dir right after stop() settles would hit EPERM/EBUSY on Windows
+            // otherwise. Runs even when an earlier release rejected — that rejection still
+            // propagates, but not before the child is drained.
+            await flushConfigDirHardening(startupConfigDir);
+          }
         },
       );
     },

--- a/tests/account-pool-management-api.test.ts
+++ b/tests/account-pool-management-api.test.ts
@@ -8,6 +8,7 @@ import { saveConfig } from "../src/config";
 import { startServer } from "../src/server";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
 function makeCodexConfig(overrides: Partial<OcxConfig> = {}): OcxConfig {
   return {
@@ -175,7 +176,7 @@ describe("Anthropic account pool strategy management API", () => {
     else process.env.OPENCODEX_HOME = previousHome;
     isolatedCodexHome?.restore();
     isolatedCodexHome = null;
-    if (testDir) rmSync(testDir, { recursive: true, force: true });
+    if (testDir) removeTreeWithRetry(testDir);
   });
 
   test("GET /api/oauth/accounts/pool surfaces strategy defaults", async () => {
@@ -496,4 +497,3 @@ describe("generic OAuth pool-settings contract (#695)", () => {
     }
   });
 });
-

--- a/tests/api-usage.test.ts
+++ b/tests/api-usage.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { managementFetch as fetch } from "./helpers/management-auth";
-import { appendFileSync, closeSync, mkdirSync, mkdtempSync, openSync, rmSync, writeFileSync, writeSync } from "node:fs";
+import { appendFileSync, closeSync, mkdirSync, mkdtempSync, openSync, writeFileSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
@@ -9,6 +9,7 @@ import type { OcxConfig } from "../src/types";
 import { refreshUserCostOverlays, resetPreservedDiskOnlyProvidersForTests, userCostOverlayVersion } from "../src/usage/user-cost-overlays";
 import { stopUserCostOverlayReconciler } from "../src/usage/user-cost-overlay-reconciler";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 import { resetUsageReadCacheForTests, setManagementUsageMaxEntriesForTests, usageReadCacheStatsForTests } from "../src/usage/log";
 import * as usageLogModule from "../src/usage/log";
 import { getUsageSummaryCacheEntry, resetUsageSummaryCacheForTests } from "../src/server/management/usage-summary-cache";
@@ -100,7 +101,7 @@ afterEach(() => {
   else process.env.OPENCODEX_HOME = previousHome;
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
-  if (testDir) rmSync(testDir, { recursive: true, force: true });
+  if (testDir) removeTreeWithRetry(testDir);
 });
 
 describe("GET /api/usage", () => {

--- a/tests/chat-completions-endpoint.test.ts
+++ b/tests/chat-completions-endpoint.test.ts
@@ -1,6 +1,6 @@
 import { waitForNativeMainStartupGate } from "../src/codex/native-profile-startup";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
@@ -8,6 +8,7 @@ import { startServer } from "../src/server";
 import { ownedServiceHomeInspection } from "./helpers/owned-service-home-inspection";
 import type { OcxConfig, OcxProviderConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 import { chatCompletionsToResponsesBody, ChatCompletionsRequestError } from "../src/chat/inbound";
 import { chatCompletionsUsage } from "../src/chat/outbound";
 import { parseRequest } from "../src/responses/parser";
@@ -75,7 +76,7 @@ afterEach(() => {
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
   globalThis.fetch = originalFetch;
-  if (testDir) rmSync(testDir, { recursive: true, force: true });
+  if (testDir) removeTreeWithRetry(testDir);
 });
 
 function mockChatUpstream() {

--- a/tests/claude-messages-endpoint.test.ts
+++ b/tests/claude-messages-endpoint.test.ts
@@ -25,6 +25,7 @@ import {
 import { estimateTokens } from "../src/lib/token-estimate";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 import { SERVER_BUDGET_MS } from "./helpers/test-budget";
 import { createTestTranslatorBudget } from "./helpers/translator-budget";
 import {
@@ -64,7 +65,7 @@ afterEach(() => {
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
   globalThis.fetch = originalFetch;
-  if (testDir) rmSync(testDir, { recursive: true, force: true });
+  if (testDir) removeTreeWithRetry(testDir);
 });
 
 function mockChatUpstream() {

--- a/tests/claude-native-passthrough.test.ts
+++ b/tests/claude-native-passthrough.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { managementFetch as fetch } from "./helpers/management-auth";
 import { logsFromApiBody } from "./helpers/logs-api";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
 import { startServer } from "../src/server";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
 let testDir = "";
 let previousHome: string | undefined;
@@ -25,7 +26,7 @@ afterEach(() => {
   else process.env.OPENCODEX_HOME = previousHome;
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
-  if (testDir) rmSync(testDir, { recursive: true, force: true });
+  if (testDir) removeTreeWithRetry(testDir);
 });
 
 interface Captured { path: string; headers: Headers; body: any }

--- a/tests/codex-account-store.test.ts
+++ b/tests/codex-account-store.test.ts
@@ -1,11 +1,40 @@
 import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, rmSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
+import { flushConfigDirHardeningForTests } from "../src/config/paths";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
-const TEST_DIR = join(import.meta.dir, ".tmp-codex-accounts-test");
-const ACCOUNTS_PATH = join(TEST_DIR, "codex-accounts.json");
+/**
+ * Per-test scratch home. A fixed repo-local directory meant that ONE failed teardown (Windows
+ * EPERM while icacls.exe still held the dir) poisoned every later case in the file: 49 of the
+ * 49 errors in run 33590540220 were before/after hooks failing on the same path.
+ */
+let TEST_DIR = "";
+let ACCOUNTS_PATH = "";
+
+const ICACLS_OK = { success: true, exitCode: 0, timedOut: false, stdout: "" };
+
+function installScratchHome(): void {
+  // These exercises cover credential-store contention, not Windows ACL behavior. Stub BOTH
+  // runners: hardenConfigDir() uses the async one, so a sync-only stub still spawned icacls.
+  setIcaclsRunnerForTests(() => ICACLS_OK);
+  setAsyncIcaclsRunnerForTests(async () => ICACLS_OK);
+  TEST_DIR = mkdtempSync(join(tmpdir(), "ocx-codex-accounts-"));
+  ACCOUNTS_PATH = join(TEST_DIR, "codex-accounts.json");
+  process.env.OPENCODEX_HOME = TEST_DIR;
+}
+
+async function removeScratchHome(): Promise<void> {
+  await flushConfigDirHardeningForTests();
+  setIcaclsRunnerForTests(null);
+  setAsyncIcaclsRunnerForTests(null);
+  delete process.env.OPENCODEX_HOME;
+  if (TEST_DIR) removeTreeWithRetry(TEST_DIR);
+  TEST_DIR = "";
+}
 
 function refreshGrantFingerprint(refreshToken: string): string {
   return createHash("sha256").update(`codex-refresh-grant:${refreshToken}`).digest("hex");
@@ -28,21 +57,8 @@ function planJwt(plan: string, accountId = "acct-plan-flight"): string {
 }
 
 describe("codex-account-store CRUD", () => {
-  beforeEach(() => {
-    // These exercises cover credential-store contention, not Windows ACL behavior.
-    // Avoid spawning icacls for every fixture write; its lingering handle makes
-    // the fixed fixture directory flaky under `bun test --isolate` on Windows.
-    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "" }));
-    process.env.OPENCODEX_HOME = TEST_DIR;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-    mkdirSync(TEST_DIR, { recursive: true });
-  });
-
-  afterEach(() => {
-    setIcaclsRunnerForTests(null);
-    delete process.env.OPENCODEX_HOME;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-  });
+  beforeEach(() => { installScratchHome(); });
+  afterEach(async () => { await removeScratchHome(); });
 
   test("save and load credential round-trip", async () => {
     const { saveCodexAccountCredential, getCodexAccountCredential } = await import("../src/codex/account-store");
@@ -1225,18 +1241,8 @@ describe("codex-account-store CRUD", () => {
 });
 
 describe("shared refresh flight plan reconciliation (#2892 gap 2 follow-up)", () => {
-  beforeEach(() => {
-    setIcaclsRunnerForTests(() => ({ success: true, exitCode: 0, timedOut: false, stdout: "" }));
-    process.env.OPENCODEX_HOME = TEST_DIR;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-    mkdirSync(TEST_DIR, { recursive: true });
-  });
-
-  afterEach(() => {
-    setIcaclsRunnerForTests(null);
-    delete process.env.OPENCODEX_HOME;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-  });
+  beforeEach(() => { installScratchHome(); });
+  afterEach(async () => { await removeScratchHome(); });
 
   test("an aborted owner still reconciles the refreshed plan for the shared flight", async () => {
     // The flight deliberately outlives the caller that opened it, so plan reconciliation

--- a/tests/codex-auth-api.test.ts
+++ b/tests/codex-auth-api.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { ServerWebSocket } from "bun";
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   acquireNativeMainProfileDrain,
@@ -71,10 +72,14 @@ import {
   resolveFirstUsableOpenAiSidecar,
 } from "../src/providers/openai-sidecar";
 import { BOUNDED_BODY_MAX_BYTES } from "../src/lib/bounded-body";
+import { flushConfigDirHardeningForTests } from "../src/config/paths";
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
-const TEST_DIR = join(import.meta.dir, ".tmp-codex-auth-api-test");
-const TEST_CODEX_HOME = join(TEST_DIR, "codex");
+let TEST_DIR = "";
+let TEST_CODEX_HOME = "";
 const MANUAL_IMPORT_ENV = "OPENCODEX_ENABLE_UNVERIFIED_CODEX_IMPORT";
+const ICACLS_OK = { success: true, exitCode: 0, timedOut: false, stdout: "" };
 let previousOpencodexHome: string | undefined;
 let previousCodexHome: string | undefined;
 let previousManualImportEnv: string | undefined;
@@ -256,7 +261,10 @@ beforeEach(() => {
   previousCodexHome = process.env.CODEX_HOME;
   previousManualImportEnv = process.env[MANUAL_IMPORT_ENV];
   previousFetch = globalThis.fetch;
-  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  setIcaclsRunnerForTests(() => ICACLS_OK);
+  setAsyncIcaclsRunnerForTests(async () => ICACLS_OK);
+  TEST_DIR = mkdtempSync(join(tmpdir(), "ocx-codex-auth-api-"));
+  TEST_CODEX_HOME = join(TEST_DIR, "codex");
   mkdirSync(TEST_CODEX_HOME, { recursive: true });
   process.env.OPENCODEX_HOME = TEST_DIR;
   process.env.CODEX_HOME = TEST_CODEX_HOME;
@@ -274,7 +282,7 @@ beforeEach(() => {
   resetJwtPlanNotesForTests();
 });
 
-afterEach(() => {
+afterEach(async () => {
   resetLifecycleDrainStateForTests();
   setPersistedConfigMutationBeforeCommitForTests(null);
   clearAccountNeedsReauth("__main__");
@@ -293,7 +301,12 @@ afterEach(() => {
   else process.env.CODEX_HOME = previousCodexHome;
   if (previousManualImportEnv === undefined) delete process.env[MANUAL_IMPORT_ENV];
   else process.env[MANUAL_IMPORT_ENV] = previousManualImportEnv;
-  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  await flushConfigDirHardeningForTests();
+  setIcaclsRunnerForTests(null);
+  setAsyncIcaclsRunnerForTests(null);
+  if (TEST_DIR) removeTreeWithRetry(TEST_DIR);
+  TEST_DIR = "";
+  TEST_CODEX_HOME = "";
 });
 
 describe("codex-auth API", () => {

--- a/tests/data-plane-admission-identity.test.ts
+++ b/tests/data-plane-admission-identity.test.ts
@@ -8,13 +8,14 @@ import {
   resolveDataPlaneAdmissionSecret,
   resolveResponsesApiAuth,
 } from "../src/server/auth-cors";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
 import { startServer } from "../src/server";
 import { buildResponsesWsData } from "../src/server/ws-bridge";
 import type { OcxConfig } from "../src/types";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
 // The admission path already knew WHICH key matched and threw it away. These
 // tests pin two things at once: the id now survives, and no admission decision
@@ -229,7 +230,7 @@ describe("the Responses WebSocket handshake", () => {
       else process.env.OPENCODEX_ADMIN_AUTH_TOKEN = previousAdminToken;
       if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
       else process.env.OPENCODEX_HOME = previousHome;
-      rmSync(home, { recursive: true, force: true });
+      removeTreeWithRetry(home);
     }
   });
 

--- a/tests/loopback-listener-integration.test.ts
+++ b/tests/loopback-listener-integration.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../src/server/ports";
 import type { OcxConfig } from "../src/types";
 import { SERVER_BUDGET_MS } from "./helpers/test-budget";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
 const previousApiToken = process.env.OPENCODEX_API_AUTH_TOKEN;
 const previousAdminToken = process.env.OPENCODEX_ADMIN_AUTH_TOKEN;
@@ -106,7 +107,7 @@ afterEach(() => {
   else process.env.OPENCODEX_ADMIN_AUTH_TOKEN = previousAdminToken;
   if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
   else process.env.OPENCODEX_HOME = previousHome;
-  if (testDir && existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  if (testDir && existsSync(testDir)) removeTreeWithRetry(testDir);
   testDir = "";
 });
 

--- a/tests/oauth-accounts-api.test.ts
+++ b/tests/oauth-accounts-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { managementFetch as fetch } from "./helpers/management-auth";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
@@ -9,6 +9,7 @@ import { gatherRoutedModels as gatherRoutedModelsDirect } from "../src/codex/cat
 import { clearModelCache, getStaleCached, setCached } from "../src/codex/model-cache";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 import { withStubbedProviderFetch } from "./helpers/catalog-provider-fetch";
 import { getAccountSet } from "../src/oauth/store";
 import { ACCOUNT_IMPORT_DEADLINE_MS, ACCOUNT_IMPORT_MAX_BYTES, ACCOUNT_IMPORT_MAX_REQUEST_BYTES } from "../src/oauth/account-import/types";
@@ -61,7 +62,7 @@ afterEach(() => {
   else process.env.OPENCODEX_HOME = previousHome;
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
-  if (testDir) rmSync(testDir, { recursive: true, force: true });
+  if (testDir) removeTreeWithRetry(testDir);
 });
 
 describe("multiauth accounts API", () => {

--- a/tests/oauth-login-cli-live-update.test.ts
+++ b/tests/oauth-login-cli-live-update.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { managementFetch as fetch } from "./helpers/management-auth";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig, saveConfig, writePid, writeRuntimePort } from "../src/config";
@@ -14,6 +14,7 @@ import { startServer } from "../src/server";
 import { createLocalAttestationSecret } from "../src/lib/local-management-attestation";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
 /**
  * Regression: CLI OAuth login used to POST the bare OAuth preset into a running proxy.
@@ -54,7 +55,7 @@ afterEach(() => {
   else process.env.OPENCODEX_HOME = previousHome;
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
-  if (testDir) rmSync(testDir, { recursive: true, force: true });
+  if (testDir) removeTreeWithRetry(testDir);
 });
 
 describe("CLI OAuth live-update credential preservation", () => {

--- a/tests/oauth-status-privacy.test.ts
+++ b/tests/oauth-status-privacy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   clearLoginState,
@@ -20,26 +21,35 @@ import { handleManagementAPI } from "../src/server/management-api";
 import { handleResponses } from "../src/server/responses";
 import type { OcxConfig } from "../src/types";
 import { ManagementRequest } from "./helpers/management-auth";
+import { flushConfigDirHardeningForTests } from "../src/config/paths";
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../src/lib/windows-secret-acl";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
-const TEST_DIR = join(import.meta.dir, `.tmp-oauth-status-privacy-test-${process.pid}`);
+let TEST_DIR = "";
 const PUBLIC_OAUTH_ERROR = "OAuth authentication failed. Check the OpenCodex account status and retry.";
 const PUBLIC_ERROR_CANARY = "C:\\Users\\Alice\\.opencodex\\auth.json.ocx-tmp \\\\server\\share\\auth.json /home/alice/.opencodex/auth.json";
+const ICACLS_OK = { success: true, exitCode: 0, timedOut: false, stdout: "" };
 let previousOpencodexHome: string | undefined;
 
 describe("OAuth status privacy", () => {
   beforeEach(() => {
     clearLoginState("xai");
     previousOpencodexHome = process.env.OPENCODEX_HOME;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-    mkdirSync(TEST_DIR, { recursive: true });
+    setIcaclsRunnerForTests(() => ICACLS_OK);
+    setAsyncIcaclsRunnerForTests(async () => ICACLS_OK);
+    TEST_DIR = mkdtempSync(join(tmpdir(), "ocx-oauth-status-privacy-"));
     process.env.OPENCODEX_HOME = TEST_DIR;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     clearLoginState("xai");
     if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
     else process.env.OPENCODEX_HOME = previousOpencodexHome;
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    await flushConfigDirHardeningForTests();
+    setIcaclsRunnerForTests(null);
+    setAsyncIcaclsRunnerForTests(null);
+    if (TEST_DIR) removeTreeWithRetry(TEST_DIR);
+    TEST_DIR = "";
   });
 
   test("getLoginStatus returns a masked provider email", async () => {

--- a/tests/server-kiro-completion-e2e.test.ts
+++ b/tests/server-kiro-completion-e2e.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { KIRO_COMPLETION_TOOL_NAME } from "../src/adapters/kiro-constants";
@@ -9,6 +9,7 @@ import { startServer } from "../src/server";
 import { clearRequestLogsForTests, getRequestLogEntries } from "../src/server/request-log";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
 const enc = new TextEncoder();
 const originalFetch = globalThis.fetch;
@@ -36,7 +37,7 @@ afterEach(() => {
   else process.env.KIRO_REGION = previousRegion;
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
-  rmSync(testDir, { recursive: true, force: true });
+  removeTreeWithRetry(testDir);
 });
 
 function eventFrame(eventType: string, payload: Record<string, unknown>): Uint8Array {

--- a/tests/server-live.test.ts
+++ b/tests/server-live.test.ts
@@ -3,7 +3,7 @@
  * so the proxy must relay it to an OpenAI upstream instead of the /v1/* JSON-404 guard.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { saveCodexAccountCredential } from "../src/codex/account-store";
 import { clearAccountNeedsReauth, clearAccountQuota } from "../src/codex/auth-api";
@@ -25,6 +25,7 @@ import { beginShutdownDrain, isDraining, resetLifecycleDrainStateForTests } from
 import type { OcxConfig } from "../src/types";
 import { fakeChatGptJwt } from "./helpers/fake-chatgpt-jwt";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 
 const previousApiToken = process.env.OPENCODEX_API_AUTH_TOKEN;
 const previousOpencodexHome = process.env.OPENCODEX_HOME;
@@ -34,7 +35,7 @@ let isolatedCodexHome: IsolatedCodexHome | null = null;
 const DIRECT_CHATGPT_TOKEN = fakeChatGptJwt({ chatgpt_account_id: "acct-123" });
 
 beforeEach(() => {
-  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
   mkdirSync(TEST_DIR, { recursive: true });
   process.env.OPENCODEX_HOME = TEST_DIR;
   delete process.env.OPENCODEX_API_AUTH_TOKEN;
@@ -58,7 +59,7 @@ afterEach(() => {
   clearThreadAccountMap();
   clearAccountNeedsReauth("pool-a");
   clearAccountQuota();
-  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
 });
 
 interface CapturedRequest {

--- a/tests/server-stop-config-hardening.test.ts
+++ b/tests/server-stop-config-hardening.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { saveConfig } from "../src/config";
 import { flushConfigDirHardening, flushConfigDirHardeningForTests, hardenConfigDir } from "../src/config/paths";
 import * as windowsAcl from "../src/lib/windows-secret-acl";
+import * as nativeStartup from "../src/codex/native-profile-startup";
 import { startServer } from "../src/server";
 import type { OcxConfig } from "../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
@@ -86,6 +87,41 @@ test("server.stop(true) resolves promptly when no flight is in progress", async 
   const t0 = Date.now();
   await server.stop(true);
   expect(Date.now() - t0).toBeLessThan(2_000);
+});
+
+test("a rejected native-lifecycle release still drains the ACL flight before stop() settles", async () => {
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  let release!: () => void;
+  const pending = new Promise<void>(resolve => { release = resolve; });
+  let flightSettled = false;
+  const aclSpy = spyOn(windowsAcl, "hardenSecretDirAsync").mockImplementation(async () => {
+    await pending;
+    flightSettled = true;
+    return { ok: true };
+  });
+  const releaseSpy = spyOn(nativeStartup, "releaseNativeMainStartupLifecycle").mockImplementation(async () => {
+    throw new Error("native release exploded");
+  });
+  let server: ReturnType<typeof startServer> | null = null;
+  try {
+    server = startServer(0);
+    let settled: "pending" | "rejected" | "resolved" = "pending";
+    const stopping = server.stop(true).then(() => { settled = "resolved"; }, () => { settled = "rejected"; });
+    await new Promise(resolve => setTimeout(resolve, 60));
+    // The release already threw, but stop() must not settle until the flight is drained.
+    expect(settled).toBe("pending");
+    expect(flightSettled).toBe(false);
+    release();
+    await stopping;
+    expect(flightSettled).toBe(true);
+    expect(settled).toBe("rejected");
+    server = null;
+  } finally {
+    release();
+    releaseSpy.mockRestore();
+    aclSpy.mockRestore();
+    if (server) await server.stop(true).catch(() => undefined);
+  }
 });
 
 test("flushConfigDirHardening scopes to one directory and is a no-op for a stranger", async () => {

--- a/tests/server-stop-config-hardening.test.ts
+++ b/tests/server-stop-config-hardening.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../src/config";
+import { flushConfigDirHardening, flushConfigDirHardeningForTests, hardenConfigDir } from "../src/config/paths";
+import * as windowsAcl from "../src/lib/windows-secret-acl";
+import { startServer } from "../src/server";
+import type { OcxConfig } from "../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
+
+/**
+ * On Windows, `hardenConfigDir()` starts an `icacls.exe` child that holds the config directory
+ * open until it exits. `server.stop(true)` used to resolve without waiting for it, so a caller
+ * that removed the directory right after a "clean" shutdown got EPERM/EBUSY (mandatory file
+ * locking). Every Windows CI shard since e5d588669 failed on exactly that: the fixture teardown
+ * of the account-store, auth-api and every live-server suite. The contract now: stop() settles
+ * the flight the process itself started.
+ */
+
+let testDir = "";
+let previousHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+const originalPlatform = process.platform;
+
+function config(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "kimi",
+    providers: { kimi: { adapter: "openai-chat", baseUrl: "https://kimi.test/v1", liveModels: false, models: ["k3"] } },
+  };
+}
+
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-stop-harden-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-stop-harden-"));
+  process.env.OPENCODEX_HOME = testDir;
+  saveConfig(config());
+});
+
+afterEach(async () => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  await flushConfigDirHardeningForTests();
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  if (testDir) removeTreeWithRetry(testDir);
+});
+
+test("server.stop(true) waits for the config-dir ACL flight the startup loadConfig started", async () => {
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  let release!: () => void;
+  const pending = new Promise<void>(resolve => { release = resolve; });
+  let started = 0;
+  const spy = spyOn(windowsAcl, "hardenSecretDirAsync").mockImplementation(async () => {
+    started += 1;
+    await pending;
+    return { ok: true };
+  });
+  let server: ReturnType<typeof startServer> | null = null;
+  try {
+    server = startServer(0);
+    expect(started).toBe(1);
+    let stopped = false;
+    const stopping = server.stop(true).then(() => { stopped = true; });
+    await new Promise(resolve => setTimeout(resolve, 60));
+    // Listeners are closed by now; the only thing keeping stop() open is the ACL child.
+    expect(stopped).toBe(false);
+    release();
+    await stopping;
+    expect(stopped).toBe(true);
+    server = null;
+  } finally {
+    release();
+    if (server) await server.stop(true);
+    spy.mockRestore();
+  }
+});
+
+test("server.stop(true) resolves promptly when no flight is in progress", async () => {
+  const server = startServer(0);
+  const t0 = Date.now();
+  await server.stop(true);
+  expect(Date.now() - t0).toBeLessThan(2_000);
+});
+
+test("flushConfigDirHardening scopes to one directory and is a no-op for a stranger", async () => {
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  let release!: () => void;
+  const pending = new Promise<void>(resolve => { release = resolve; });
+  const spy = spyOn(windowsAcl, "hardenSecretDirAsync").mockImplementation(async () => { await pending; return { ok: true }; });
+  try {
+    hardenConfigDir();
+    let settled = false;
+    const own = flushConfigDirHardening(testDir).then(() => { settled = true; });
+    await flushConfigDirHardening(join(testDir, "not-a-flight"));
+    expect(settled).toBe(false);
+    release();
+    await own;
+    expect(settled).toBe(true);
+  } finally {
+    release();
+    spy.mockRestore();
+  }
+});

--- a/tests/vision-sidecar-e2e.test.ts
+++ b/tests/vision-sidecar-e2e.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { saveConfig } from "../src/config";
@@ -9,6 +9,7 @@ import type { OcxConfig } from "../src/types";
 import { parseRequest } from "../src/responses/parser";
 import { resetVisionDescriptionCache, stripImagesInPlace } from "../src/vision";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "./helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
 import { fakeChatGptJwt } from "./helpers/fake-chatgpt-jwt";
 
 // Issue #88: text-only input models (DeepSeek, ...) get "eyes" — the vision sidecar describes
@@ -42,7 +43,7 @@ afterEach(() => {
   else process.env.OPENCODEX_HOME = previousHome;
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
-  if (testDir) rmSync(testDir, { recursive: true, force: true });
+  if (testDir) removeTreeWithRetry(testDir);
 });
 
 const PNG_DATA_URL = "data:image/png;base64,aGVsbG8taW1hZ2UtYnl0ZXM=";


### PR DESCRIPTION
## Summary

- `server.stop()` now drains the config-directory ACL harden it started. Since e5d588669 `hardenConfigDir()` spawns `icacls.exe` as a fire-and-forget flight; the child holds the directory open, Windows locking is mandatory, and anything that removed the directory after a "clean" stop got EPERM/EBUSY. That is what turned every Windows CI shard red on every branch (incl. `main`) since 2026-08-30. `flushConfigDirHardening(dir)` is a production function scoped to one directory; `startServer` captures its dir before `loadConfig` and the composite `stop()` awaits it in a `finally` so an earlier release rejection still drains the child.
- Harness: account-store / auth-api / oauth-status move to per-test scratch homes and stub BOTH icacls runners (the sync-only stub no longer covered `hardenConfigDir`); 14 live-server suites remove their scratch home via `removeTreeWithRetry`.
- fuck-powershell case `async-child-holds-dir-after-stop` (lidge-jun/fuck-powershell 56e1801) records the landmine.

Plan: `devlog/_plan/260902_windows_ci_release/{000,010,011}`.

## Stack

| PR | Branch | Base |
|---|---|---|
| 1 (this) | `codex/win-acl-lifecycle` | `dev` |
| 2 | `codex/win-fsync-fixtures` | `codex/win-acl-lifecycle` |

## Verification

- `tests/server-stop-config-hardening.test.ts` (4): stop() pending until the held flight settles; rejected native release still drains and propagates its own error; both driven red before the fix.
- Focused: server-stop-config-hardening, codex-account-store (43), codex-auth-api (194), 14 live-server suites — all green; `bun run typecheck`, `bun run privacy:scan` green.
- Windows dispatch evidence lives on PR 2's head (stack tip): windows 1/4, 2/4, 3/4 SUCCESS on runs 33597649234 / 33601508392 / 33605723635 / 33610501053; 4/4 progressed from a 25-min ceiling to individual timing fixes.
- Two read-only reviewer rounds (P2: flush skipped on rejected finalizer → fixed).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (devlog unit).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (no credential path changed; ACL hardening stays fail-closed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows shutdown handling so configuration-directory security operations complete before cleanup finishes.
  - Reduced intermittent `EPERM` and `EBUSY` errors when removing configuration or temporary directories after stopping the application.
  - Ensured cleanup still completes when other shutdown tasks encounter errors.

- **Tests**
  - Added coverage for Windows shutdown synchronization and configuration-directory cleanup.
  - Improved temporary-directory isolation and teardown reliability across automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->