### PR TITLE
fix(release): pass the bump job's permissions through the reusable-workflow call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,14 @@ jobs:
   bump-dev-version:
     needs: publish
     if: ${{ inputs.dry-run != true }}
+    # A reusable-workflow CALL cannot grant the callee more than the calling job holds,
+    # and GitHub refuses the whole run at startup when the called workflow's own job
+    # declares permissions the caller did not pass down ("startup_failure", runs
+    # 33615174183 / 33615177849 — the first dispatches since #3129 wired this call).
+    # The callee's job declares exactly these two; nothing else in this file gains them.
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/dev-version-bump.yml
     with:
       released-version: v${{ inputs.version }}


### PR DESCRIPTION
## Summary

- `release.yml`'s `bump-dev-version` job calls `dev-version-bump.yml` (#3129) whose job declares `contents: write` + `pull-requests: write`. A reusable-workflow call cannot grant more than the calling job holds, and GitHub refuses the run at startup when it would need to — both v2.40.0 dispatches (33615174183, 33615177849) ended in `startup_failure` before any job ran. #3129 was never exercised by a live dispatch until now.
- The caller job now declares exactly those two permissions. No other job in `release.yml` changes; `validate-dispatch`/`publish` keep their own scopes.

## Verification

- `bun test tests/ci-workflows.test.ts` 135 pass; YAML parse shows `bump-dev-version.permissions == {contents: write, pull-requests: write}`.
- Security boundary: this is a GitHub Actions change. It grants the caller job the same two scopes the callee already declared under #3129's review; the bump branch is unprotected and `Protect dev` still requires a PR, so this token still cannot land on `dev`.
- Will be cherry-picked to `main` and `preview` (release.yml runs from those refs) and the v2.40.0 dispatches re-run.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (n/a).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to support required repository and pull request operations.
  * No other release workflow behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->