### PR TITLE
[WRONG BRANCH] release: carry the release.yml permissions fix onto main for v2.40.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,14 @@ jobs:
   bump-dev-version:
     needs: publish
     if: ${{ inputs.dry-run != true }}
+    # A reusable-workflow CALL cannot grant the callee more than the calling job holds,
+    # and GitHub refuses the whole run at startup when the called workflow's own job
+    # declares permissions the caller did not pass down ("startup_failure", runs
+    # 33615174183 / 33615177849 — the first dispatches since #3129 wired this call).
+    # The callee's job declares exactly these two; nothing else in this file gains them.
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/dev-version-bump.yml
     with:
       released-version: v${{ inputs.version }}


### PR DESCRIPTION
## Summary

- Cherry-pick of #3262 (`7ce0ba518`) onto `main`: `release.yml`'s `bump-dev-version` caller job now declares the `contents: write` + `pull-requests: write` that its reusable callee requires. Both v2.40.0 dispatches failed at startup without this; `release.yml` runs from the release branch, so the fix has to be on `main` itself.
- One file, 8 added lines, no code.

## Verification

- `tests/ci-workflows.test.ts` 135 pass on dev; YAML parse confirms the job permissions.
- After merge the v2.40.0 dispatch is re-run against the new `main` tip as `expected-sha`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (n/a).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (#3262).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to support writing repository contents and pull requests during development version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->