### PR TITLE
chore(dev): bump to 2.41.0 after the v2.40.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.40.0",
+  "version": "2.41.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

- Move `dev` past the version that just published: **2.40.0 → 2.41.0** (v2.40.0 is a stable release, so dev moves to the next minor). Branch and commit were produced by the `bump-dev-version` job of release run 33617573070 (`scripts/bump-dev-version.ts`); the job could push the branch but its `gh pr create` was refused by the repository setting "Allow GitHub Actions to create and approve pull requests", so this PR is opened by hand from the bot's branch. That setting is repo-level (Settings → Actions → General), not a workflow bug; flipping it makes the next release fully hands-off.

## Verification

- `git diff origin/dev` → `package.json` version line only (1 file, 1 line).
- Release proof: npm `latest=2.40.0` (gitHead 35ff3a462), `preview=2.40.0-preview.20260902` (gitHead 49812c9e8), GitHub releases v2.40.0 / v2.40.0-preview.20260902, tags match branch tips.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (n/a).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (n/a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 2.40.0 to 2.41.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->