### PR TITLE
fix(gui): stop the log panel from jittering as rows scroll in

### DIFF
--- a/devlog/_plan/260903_bug_drawdown_bcda/000_plan.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/000_plan.md
@@ -1,0 +1,86 @@
+# 000 — bug_drawdown_bcda: Plan
+
+> DIFFLEVEL-ROADMAP-01: write this doc to full diff-level precision (exact paths,
+> NEW/MODIFY/DELETE, before/after diffs) BEFORE P -> A. An empty scaffold does not
+> satisfy the rule; the A-phase reviewer FAILS outline-only phase docs.
+
+## Objective
+
+Drive every open `bug`-labelled pull request and `bug`-labelled issue in
+lidge-jun/opencodex to a terminal state on `dev`: squash-merged, closed with
+evidence, or explicitly recorded as blocked. The campaign runs as a chain of
+PABCD work-phases in the managed worktree
+`/Users/jun/.codex/worktrees/bcda/opencodex`, with parallel `gpt-5.6-sol`
+(effort high) read-only investigators feeding each phase's plan.
+
+### Evidence base (captured 2026-09-03, live `gh`)
+
+Open bug-labelled PRs:
+
+| PR | Title | Draft | Mergeable | Head | CI at capture |
+|----|-------|-------|-----------|------|----------------|
+| #3254 | fix(chat): share transient retry budget across native recovery legs | no | MERGEABLE / UNSTABLE | `49858a2d` | every check SUCCESS (31 checks, CodeRabbit neutral) |
+| #3256 | fix(oauth): honor Kiro reset-aligned cooldown without Retry-After | no | MERGEABLE / BLOCKED | `821462f9` | `enforce-target` FAIL `unsponsored_surface`, `hygiene` FAIL |
+| #3246 | fix(responses): bridge write_stdin through exec | yes | MERGEABLE / BLOCKED | `db96ae50` | `enforce-target` CANCELLED, hygiene SUCCESS |
+| #3270 | fix(usage): aggregate complete ledger incrementally | yes | MERGEABLE / BLOCKED | `f5aaf120` | `enforce-target` FAIL x2 + CANCELLED |
+
+Open bug-labelled issues: #3280 (GUI full-config PUT rejected after providers
+JSON save), #3279 (GUI 401 flap on `/api/*` while health is OK), #3245 (macOS
+Codex 0.152.0 stream disconnects, `upstream-tracking`), #3152 (dashboard log
+panel jitter), #3141 (aggressive `responses-state.json` disk writes), #1527
+(Cursor adapter large-context collapse).
+
+## Loop-spec
+
+- Loop archetype: verifier-defined (spec-satisfaction repair). Each phase's
+  verifier is the exact-head GitHub check rollup plus a focused local test.
+- Write scope: `src/`, `gui/`, `tests/`, `docs-site/`, `devlog/_plan`,
+  `devlog/_fin` in this worktree only. Branches carry the `codex/` prefix and
+  target `dev` through a pull request.
+- Out of scope: releases, tag pushes, promotion to `main`/`preview`, `go/`,
+  unrelated dependency bumps, credential-spending actions, and any
+  pre-disclosure security note inside a tracked directory.
+- User-imposed constraints: never run the repository-wide suite (no bare
+  `bun test`, no `bun run test`); push with `--no-verify`; merge with
+  `gh pr merge --squash --admin`; close linked issues manually after the change
+  lands on `dev`.
+- Bounds: for phases that produce a diff, exact-head CI is the verification
+  signal, backed by a focused local test. For phases that terminate as
+  NEEDS_HUMAN (wp6, wp9) neither exists: there is no PR head and no executable
+  RED assertion, and manufacturing one would encode a guess. Their verification
+  is the posted analysis — ruled-out causes with file:line citations plus the
+  exact capture the reporter must supply.
+
+## Work-phase map (one phase = one full PABCD cycle)
+
+| WP | Doc | Slice | Depends on |
+|----|-----|-------|------------|
+| wp0 | `000_plan.md` | This roadmap; locks the phase map | — |
+| wp1 | `010_phase1.md` | PR #3254 — land the green approved fix | wp0 |
+| wp2 | `020_phase2.md` | PR #3256 — clear `unsponsored_surface`, then land | wp0 |
+| wp3 | `030_phase3.md` | PR #3246 — repair, mark ready, land | wp0 |
+| wp4 | `040_phase4.md` | PR #3270 — repair, mark ready, land | wp0 |
+| wp5 | `050_phase5.md` | Issue #3280 — GUI full-config PUT rejection | wp0 |
+| wp6 | `060_phase6.md` | Issue #3279 — dashboard 401 flap | wp0 |
+| wp7 | `070_phase7.md` | Issue #3141 — `responses-state.json` write storm | wp0 |
+| wp8 | `080_phase8.md` | Issue #3152 — log panel jitter | wp0 |
+| wp9 | `090_phase9.md` | Issues #3245 and #1527 — disposition with evidence | wp0 |
+
+## Accept criteria
+
+Mirrored into the goalplan `criteria[]` as `c-1` through `c-11`. Terminal state
+is outcome-dependent, not uniformly a merge:
+
+- MERGED items (wp1-wp4, and any issue whose fix lands): the squash-merge sha
+  must be an ancestor of `origin/dev`, proved by `git fetch origin dev` plus
+  `git merge-base --is-ancestor`; the full exact-head check rollup must have
+  been inspected rather than `gh pr checks --required` being empty; and any
+  linked issue must be closed with a comment naming the merge commit.
+- NEEDS_HUMAN items (wp6 for #3279, wp9 for #3245 and #1527): no merge sha
+  exists and none is required. The evidence is the posted analysis — the
+  ruled-out causes with file:line citations, and the exact capture the reporter
+  must supply. These are terminal despite having no diff.
+- BLOCKED / UNSAFE items: terminal on a recorded blocker naming the specific
+  gate, dependency, or unreviewed security surface.
+
+A remembered green is never evidence for any of these.

--- a/devlog/_plan/260903_bug_drawdown_bcda/010_phase1.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/010_phase1.md
@@ -1,0 +1,73 @@
+# 010 — Phase 1 (wp1): PR #3254 — native chat transient send budget
+
+## Item
+
+`fix(chat): share transient retry budget across native recovery legs`, head
+`49858a2df56d4c0aa0043d6483d50bf865c58918`, author luvs01, labels `bug` +
+`review-ready`, reviewDecision APPROVED, 174 additions / 5 deletions across 2 files.
+
+## Phase class: ADOPTION, not authoring
+
+This phase writes no source. The unit of work is a merge decision on a diff a
+contributor already wrote and CI already exercised, so DIFFLEVEL-ROADMAP-01 is
+satisfied by naming the exact incoming hunks rather than authoring new ones. The
+"before" is `origin/dev` at `529639a57`; the "after" is that tree plus the diff
+below, transcribed from `gh pr diff 3254`.
+
+## MODIFY / NEW / DELETE map (incoming diff, verbatim)
+
+MODIFY `src/server/chat-native.ts`, three hunks:
+
+1. `@@ -204,12 +204,24 @@` in `handleNativeChatCompletions` — BEFORE: `send()`
+   recomputed `const transientPolicy = transientRetryPolicyFor(activeProvider)` on
+   every call. AFTER: the policy is captured once per inbound request as
+   `requestTransientPolicy`, with `transientSendsUsed`, `remainingTransientSends()`
+   returning `Math.max(0, attempts - used)` (or `Number.POSITIVE_INFINITY` with no
+   policy), and `transientSendAvailable()`. `send()` throws
+   "native Chat transient send budget exhausted before recovery dispatch" when the
+   remainder reaches zero.
+2. `@@ -232,7 +244,12 @@` — BEFORE:
+   `...(transientPolicy ? { attempts: transientPolicy.attempts } : {})`. AFTER:
+   `attempts: remaining` plus
+   `onSendsConsumed: (sends) => { transientSendsUsed += Math.max(0, sends); }`.
+3. `@@ -245,7 +262,12 @@` with `@@ -263,6 +285,10 @@` — BEFORE the 429 loop read
+   `response.status === 429 && retryPolicy && retries < retryPolicy.attempts`.
+   AFTER `&& transientSendAvailable()` is appended, and the rotation branch keeps
+   the failed key's cooldown bookkeeping while preserving the terminal 429 once
+   the request has spent its final send.
+
+MODIFY `tests/chat-completions-endpoint.test.ts` — the only other file in the
+diff. BEFORE: the native-chat suite covered the 429 rotation path without
+constraining how many upstream sends a single inbound request could produce, so
+a rotation that reset the ceiling passed unnoticed. AFTER: a case drives one
+inbound request through a 429 plus a key rotation against a provider configured
+with a transient policy, counts upstream sends across BOTH legs, and asserts the
+total never exceeds the policy's `attempts`, plus that the terminal 429 is
+preserved once the budget is spent.
+
+## TESTS — the assertion that is RED before the fix
+
+Contract that fails on `529639a57` without hunk 3: given a transient policy of N
+attempts, a request whose upstream returns 429 and whose key then rotates issues
+MORE than N upstream sends, because the pre-fix loop is bounded by
+`retryPolicy.attempts` alone and rotation mints a fresh ceiling. The PR's
+regression counts sends across the rotation boundary and fails on the pre-fix
+tree. It is the contributor's test; this phase confirms CI executed it rather
+than re-authoring it.
+
+The exact-head rollup is the binding verifier. Captured 2026-09-03 on
+`49858a2d`: 31 checks, all SUCCESS or SKIPPED (`test 1..4/4`, `macos`, `gates`,
+`storage policy`, `api usage`, `keyring ubuntu/windows/macos`, `npm-global` x3,
+`hygiene`, `react-doctor`, `enforce-target` x4, `ci`), CodeRabbit neutral.
+`mergeStateStatus: UNSTABLE` reflects that neutral status, not a failure.
+
+## Verification (C)
+
+```
+gh pr view 3254 --json headRefOid,statusCheckRollup
+gh pr merge 3254 --squash --admin
+git fetch origin dev && git merge-base --is-ancestor <merge-sha> FETCH_HEAD
+```
+
+Terminal outcome: DONE when the squash sha is an ancestor of `origin/dev`.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/020_phase2.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/020_phase2.md
@@ -1,0 +1,95 @@
+# 020 — Phase 2 (wp2): PR #3256 — Kiro reset-aligned cooldown
+
+## Item
+
+`fix(oauth): honor Kiro reset-aligned cooldown without Retry-After`, head
+`821462f9a3f887ba2c913b7a7ca62cb624498a19`, base `origin/dev` at `529639a57`,
+labels `bug`, `maintainer-sponsored`, `review-ready`.
+
+## Phase class: ADOPTION on a restricted surface
+
+No source is authored here. Per-file incoming change map (from
+`gh pr view 3256 --json files`, 222 additions / 9 deletions):
+
+| File | Role in this diff |
+|------|-------------------|
+| `src/combos/failover.ts` | the exported `parseRetryAfterMs()` shared HTTP-date parser |
+| `src/oauth/generic-account-failover.ts` | the cooldown-selection call site |
+| `tests/combos.test.ts` | parser regressions |
+| `tests/kiro-pool-rank.test.ts` | failover-ranking regressions |
+
+## Actual pre-fix behavior (corrected)
+
+The first draft of this doc claimed an absent header caused a zero-delay retry.
+That is wrong, and the correction matters because it changes what the fix is
+for. Reading the current tree:
+
+- `src/combos/failover.ts:29-45` — `parseRetryAfterMs()` returns `undefined` for an
+  empty, unparseable, or already-elapsed value; it returns a clamped millisecond
+  delay otherwise.
+- `src/oauth/generic-account-failover.ts:205-211` — `const parsed = parseRetryAfterMs(...)`,
+  then the exhausted-account branch is taken only when `parsed === null`, and
+  `cooldownMs = exhausted ?? Math.min(parsed ?? DEFAULT_COOLDOWN_MS, MAX_COOLDOWN_MS)`.
+
+So on the pre-fix tree an unusable header yields `undefined`, not `null`. The
+`parsed === null` test never fires, `exhaustedCooldownMs()` is never consulted, and
+the account falls back to `DEFAULT_COOLDOWN_MS` — sixty seconds, not zero. The
+defect is therefore a wasted 60-second retry cycle against an account whose
+allowance is provably spent until its window rolls over, exactly what the
+comment at `:206-208` says the code intends to avoid. The fix makes the absent /
+malformed case reach the reset-aligned cooldown instead of the default minute.
+
+## TESTS — the assertion that is RED before the fix
+
+In `tests/kiro-pool-rank.test.ts`: an exhausted Kiro account 429s with a missing
+or malformed `Retry-After`. Assert the recorded `cooldownUntil` equals the
+reset-aligned deadline from `exhaustedCooldownMs()`. On the pre-fix tree it
+equals `now + DEFAULT_COOLDOWN_MS` (60 s) instead, so the assertion fails.
+In `tests/combos.test.ts`: the parser cases — case-insensitive HTTP-date tokens,
+the RFC 850 relative-year rule, UTC asctime, and elapsed dates — fail on the
+pre-fix parser. Author-reported post-fix run: 72 pass across both files.
+
+## Security review — explicit, not inferred
+
+`MAINTAINERS.md` requires explicit security review for OAuth surfaces;
+`.github/scripts/pr-sponsored-surface.cjs:24-27` restricts the `src/oauth/` prefix
+and `assessSponsoredSurface()` at `:78` clears the CI code when the
+`maintainer-sponsored` label is present. The label clears the gate; it is not
+the review. The review:
+
+- Blast radius, corrected and widened: this diff substantially rewrites the
+  EXPORTED `parseRetryAfterMs()` in `src/combos/failover.ts`, which is also the
+  parser behind combo-target cooldowns (`coolComboTarget()` at `failover.ts:62`).
+  A parser change is therefore not confined to Kiro account ranking — it moves
+  combo cooldown timing too. `tests/combos.test.ts` is the regression surface
+  that must cover that second consumer, and it is in the diff.
+- Direction of the shared-parser change, mode by mode: the rewritten parser is
+  NARROWER, not broader. It implements the three HTTP-date grammars explicitly
+  (`src/combos/failover.ts:41`) and rejects non-HTTP strings the prior bare
+  `Date.parse` happened to accept, while gaining an opt-in `preserveImmediate`
+  mode.
+  In the DEFAULT mode — the one `coolComboTarget()` uses — an elapsed or
+  unparseable date still yields `undefined`, so combo cooldown timing keeps its
+  existing fallback semantics. In the OAuth call site's mode, a valid but
+  already-elapsed date is converted to a 1 ms delay rather than discarded,
+  which is what lets an explicit "retry now" instruction survive instead of
+  being replaced by a 60-second default. Both modes keep the `MAX_COOLDOWN_MS`
+  clamp. These are timing changes, not authorization changes, and the two modes
+  must not be conflated: only the OAuth path takes the immediate branch.
+- Credential handling: unchanged. Nothing here reads, writes, logs, or
+  serializes a token, refresh credential, or account identifier.
+- Workflow and release surfaces: untouched.
+- Conclusion: accepted. Admin merge bypasses the approval requirement only; the
+  green exact-head rollup, the combo-parser regressions, and this review are the
+  non-bypassable evidence.
+
+## Verification (C)
+
+```
+gh pr checks 3256                # full rollup, never --required alone
+gh pr merge 3256 --squash --admin
+git fetch origin dev && git merge-base --is-ancestor <merge-sha> FETCH_HEAD
+```
+
+If the gate is red on the current head, the outcome is BLOCKED, not merged.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/030_phase3.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/030_phase3.md
@@ -1,0 +1,68 @@
+# 030 — Phase 3 (wp3): PR #3246 — bridge write_stdin through exec
+
+## Item
+
+`fix(responses): bridge write_stdin through exec`, head
+`db96ae50d787df10dc5e3c5767776bfa8fb7d115`, base `8fb4e6e797d4e0d44425a0167b399fa573c3226d`, 162 additions /
+15 deletions across 6 files, label `bug`.
+
+## Phase class: ADOPTION, gate-blocked
+
+Per-file incoming change map (`gh pr view 3246 --json files`):
+
+| File | +/- | Role |
+|------|-----|------|
+| `src/responses/code-mode-helper-compat.ts` | +4 / -1 | the bridge itself |
+| `src/types/tools.ts` | +12 / -9 | tool declaration typing |
+| `tests/legacy-shell-compat.test.ts` | +22 / -0 | new coverage |
+| `tests/bridge-legacy-shell-normalization.test.ts` | +19 / -3 | normalization |
+| `tests/responses-custom-tool-repair.test.ts` | +68 / -0 | repair path |
+| `tests/responses-undeclared-tool-guard.test.ts` | +37 / -2 | the guard boundary |
+
+Four of six files are tests: 146 of the 162 added lines are coverage, and the
+production delta is 16 lines across two files. Per the PR description the bridge
+is request-scoped and fail-closed — it activates only for an exact bare `exec`
+declaration, preserves an explicitly declared `write_stdin`, and refuses unknown
+or namespaced tools — so the exec surface is not widened.
+
+## Gate analysis and the draft question
+
+`resolve-pr`, `label`, `hygiene` passed; `enforce-target` failed while the PR sat
+in draft with three of four readiness boxes unticked, so the full matrix never
+ran on `db96ae50`.
+
+`AGENTS.md:303` is precise about what that checklist is: the local-CI box is an
+author attestation the gate never disproves, because fork contributors cannot
+start repository CI — a maintainer has to. The other three boxes are the
+author's own to tick, and when all four are ticked the gate itself marks the PR
+ready. So a maintainer marking it ready EARLY is a deliberate override of the
+contributor flow, not a step the policy prescribes.
+
+The justification for doing it here is narrow: this campaign's acceptance
+requires exact-head CI evidence, and no such evidence can exist while the PR
+stays in draft with the matrix unrun. Marking ready starts the matrix a fork
+author cannot start. The override buys evidence, nothing else — the merge
+decision still rests entirely on the resulting green rollup, and a red matrix
+ends the phase as BLOCKED regardless of the checklist.
+
+## TESTS — the assertion that is RED before the fix
+
+The PR reports a red-first run of four expected failures. The concrete
+pre-fix behavior: a model emitting `write_stdin` against a bare `exec` declaration
+is rejected by the undeclared-tool guard
+(`tests/responses-undeclared-tool-guard.test.ts`) instead of being bridged onto
+`exec`, and the normalization path leaves the call unmapped
+(`tests/bridge-legacy-shell-normalization.test.ts`). Post-fix those four files
+report 120 pass / 0 fail. Only those focused files may run locally.
+
+## Verification (C)
+
+```
+gh pr ready 3246
+gh pr view 3246 --json headRefOid,statusCheckRollup
+gh pr merge 3246 --squash --admin
+git fetch origin dev && git merge-base --is-ancestor <merge-sha> FETCH_HEAD
+```
+
+Terminal outcome: DONE on merge, or BLOCKED naming the exact failing gate.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/040_phase4.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/040_phase4.md
@@ -1,0 +1,71 @@
+# 040 — Phase 4 (wp4): PR #3270 — incremental usage ledger aggregation
+
+## Item
+
+`fix(usage): aggregate complete ledger incrementally`, head
+`f5aaf12071043bb1adaaf75217d62b53145d74ef`, base `ee24bab40004f4e3698636cba64f5bb6d18438fd`, 3535 additions /
+1287 deletions across 21 files, label `bug` (+ `gui-screenshot-waived`, see below).
+
+## Phase class: ADOPTION of a large diff
+
+Per-file incoming change map, grouped:
+
+New modules — `src/usage/ledger-scanner.ts` (+448), 
+`src/server/management/usage-aggregate-cache.ts` (+464).
+Rewritten core — `src/usage/summary.ts` (+915 / -655),
+`src/server/management/api-key-usage.ts` (+97 / -43),
+`src/server/management/logs-usage-routes.ts` (+64 / -87).
+Wiring — `src/config.ts` (+3/-1), `src/types/config.ts` (+4/-1),
+`src/lib/app-owned-memory-stores.ts` (+27/-8),
+`src/server/management/usage-summary-cache.ts` (+4), `src/usage/log.ts` (+1/-1).
+GUI — `gui/src/pages/use-dashboard-data.ts` (+1/-1) and
+`gui/tests/dashboard-contracts.test.ts` (+1/-1): a single dashboard refresh
+constant, nothing visual.
+Docs — `docs-site/src/content/docs/reference/management-api.md` (+20/-1),
+`structure/05_gui-and-management-api.md` (+33/-12).
+Tests — `tests/usage-ledger-scanner.test.ts` (+498),
+`tests/usage-summary.test.ts` (+311), `tests/usage-aggregate-cache.test.ts` (+301),
+`tests/api-usage.test.ts` (+202/-473), `tests/api-key-attribution.test.ts` (+135/-3),
+plus two-line touches to `tests/memory-watchdog.test.ts` and
+`tests/settings-stream-mode.test.ts`. 1447 added test lines.
+
+## Gate analysis
+
+`enforce-target` failed with `PR quality gate failed: missing UI screenshot` (run
+33660610072). The gate triggers on any `gui/` path, but the entire GUI delta here
+is one refresh-interval constant and its contract test — there is no UI change to
+screenshot. This is the false positive that `gui-screenshot-waived` exists for. Its
+authority is the enforcement workflow itself: `GUI_SCREENSHOT_WAIVER_LABEL` is
+declared at `.github/workflows/enforce-pr-target.yml:259`, matched against the
+PR labels at `:678`, and removes the screenshot failure from `failures` at
+`:727-730`. `AGENTS.md` does not mention the label; the workflow is the only
+authority, and PR #2805 carries the same label as precedent. The label was
+applied rather than demanding a screenshot of a one-constant change.
+
+## TESTS — the assertion that is RED before the fix (corrected)
+
+The earlier draft claimed incremental-equals-full-recompute as the red
+assertion. That is not red: the pre-fix implementation recomputes wholesale, so
+it satisfies that equality trivially. The actual defect, per the PR title and
+CodeRabbit's summary, is COMPLETENESS — the pre-fix aggregation is bounded by
+read and row limits, so earlier history is silently omitted from usage reports.
+
+The red assertion is therefore: build a ledger larger than the pre-fix read/row
+bound, request the usage summary, and assert the reported totals include the
+oldest rows. On the pre-fix tree the early rows are missing and the totals come
+back short. `tests/usage-ledger-scanner.test.ts` and `tests/usage-summary.test.ts`
+are the files carrying that case; `tests/api-key-attribution.test.ts` carries the
+per-key equivalent. Locally, only those files may be run.
+
+## Verification (C)
+
+```
+gh pr view 3270 --json headRefOid,statusCheckRollup
+gh run view <run-id> --log-failed      # when any check is red
+git fetch origin dev && git merge-base --is-ancestor <merge-sha> FETCH_HEAD
+```
+
+Merge requires the green exact-head matrix AND a read confirming the new scanner
+still reads a ledger written by the old aggregator. Otherwise the outcome is
+BLOCKED or NEEDS_HUMAN with the concrete reason.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/050_phase5.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/050_phase5.md
@@ -1,0 +1,79 @@
+# 050 — Phase 5 (wp5): Issue #3280 — GUI full-config PUT rejection
+
+## Finding (gpt-5.6-sol investigator, high effort)
+
+VERDICT FIXABLE_NOW, confidence high, credential-surface risk YES.
+
+`gui/src/hooks/useJsonConfigEditor.ts:27-39` serializes the redacted config DTO
+and submits `PUT /api/config`. The server deliberately rejects every such
+request at `src/server/management/config-routes.ts:248-253`, reinforced by
+`src/server/management/route-registry.ts:165`. Fanning out to per-provider
+POST/PATCH/DELETE is unsafe: each operation persists independently
+(`src/server/management/provider-routes.ts:652-655`, `779-781`, `1101-1138`),
+which allows partial saves and loss of fields absent from the public DTO.
+
+## MODIFY / NEW / DELETE map
+
+- MODIFY `src/server/auth-cors.ts` — typed provider-editor DTO plus a single
+  public-field projection, so a redacted or derived field can never become write
+  authority.
+- MODIFY `src/server/management/provider-routes.ts` — NEW atomic
+  `PUT /api/providers` taking `{ baseline, next }`; compare `baseline` against
+  the latest public projection, merge `next` into freshly read persisted
+  providers while preserving API keys, pools, headers and credentials, validate
+  every provider/default/deletion, then commit once through
+  `mutatePersistedConfig` and reconcile caches/accounts/catalog a single time.
+- MODIFY `src/server/management/route-registry.ts` — register the new route;
+  keep the `/api/config` 405 exactly as is.
+- MODIFY `gui/src/hooks/useJsonConfigEditor.ts` — expose only
+  `{ defaultProvider, providers }`, send one `{ baseline, next }` request, and
+  keep parse failures distinct from network/server failures.
+
+## TESTS
+
+- NEW `tests/provider-config-batch-management.test.ts` — the PUT updates several
+  providers in one commit, preserves masked credentials and private fields,
+  returns 400 with zero persisted change when any row is invalid, and 409 on a
+  stale baseline.
+- NEW `gui/tests/use-json-config-editor.test.tsx` — Save issues exactly one
+  `PUT /api/providers` carrying baseline and next, never `PUT /api/config`, never
+  a POST/PATCH/DELETE fan-out, and refreshes only after success.
+
+Both are red on current HEAD.
+
+## Verification (C)
+
+```
+bun test tests/provider-config-batch-management.test.ts
+bun test gui/tests/use-json-config-editor.test.tsx
+bun run typecheck
+```
+
+The credential-preservation assertion is the load-bearing one: the endpoint must
+never persist `hasApiKey`/`hasHeaders` or any other derived marker.
+
+
+## Security review checkpoint (required before merge)
+
+This phase creates a NEW write endpoint that must preserve secrets the caller
+never sees. `MAINTAINERS.md` requires explicit security review for credential
+surfaces, and a green CI run is not that review. Record all of the following in
+the PR description before requesting merge:
+
+- Threat model: the GUI holds only the redacted public projection. A naive
+  round-trip therefore writes `hasApiKey: true` back over a real `apiKey`. The
+  `{ baseline, next }` shape exists so the server, which alone holds the secret,
+  performs the merge.
+- Non-authority invariant: no field originating from the public projection may
+  become write authority. `hasApiKey`, `hasHeaders`, and every other derived
+  marker must be rejected, not persisted.
+- Atomicity invariant: one `mutatePersistedConfig` commit. A partial save on this
+  surface can strand a provider without its credential.
+- Concurrency invariant: a stale `baseline` returns 409 rather than overwriting a
+  concurrent edit.
+- Unchanged: the `/api/config` 405 stays exactly as is. This phase does not
+  re-enable full-config PUT.
+
+Merge is blocked until this block is filled in on the PR. If review concludes the
+merge semantics cannot be made safe, the outcome is UNSAFE, not merged.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/060_phase6.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/060_phase6.md
@@ -1,0 +1,56 @@
+# 060 — Phase 6 (wp6): Issue #3279 — dashboard 401 flap
+
+## Finding (gpt-5.6-sol investigator, high effort)
+
+VERDICT NEEDS_REPRO, confidence medium, auth-surface risk YES.
+
+No intermittent invalidation mechanism could be established. An unexpired
+session 401s only when absent/evicted or when its exact server-origin,
+browser-origin, or CSRF binding fails (`src/server/gui-session.ts:417`);
+loopback sessions otherwise expire deterministically after five minutes
+(`src/server/gui-session.ts:62`, `:428`). Management auth state initializes once
+per server process, so admin-token rotation is not involved
+(`src/server/index.ts:653`). The GUI installs its auth wrapper before React
+renders and its 401 recovery is single-flight (`gui/src/App.tsx:42`,
+`gui/src/api.ts:247`, `:299`). The reported "online then offline" may be cached
+health followed by the first failed authenticated poll
+(`gui/src/pages/use-dashboard-data.ts:97`, `:220`, `:307`).
+
+PR #3080 is NOT the same fix: it persists a 12-hour opaque session for remote
+dashboards, is draft and conflicting, does not change the injected loopback
+session path, and cannot survive a proxy restart.
+
+## MODIFY / NEW / DELETE map
+
+None. Making a production change here without the trace would mean weakening
+loopback-origin equality on a guess, on an authentication surface.
+
+## Action
+
+Comment on #3279 requesting the exact failing request URL, the session meta
+origins, whether the Authorization header was present, and the immediate
+`GET /opencodex-session` result. The issue already carries `needs-info`.
+
+Terminal outcome: NEEDS_HUMAN — reproduction requires the reporter's browser and
+machine.
+
+
+## TESTS — what would be RED, once the trace exists
+
+No test can be written yet, and that is the finding rather than an omission: the
+report supplies no constructible failing sequence, and the existing suite already
+covers deterministic expiry and concurrent refresh. When the reporter supplies
+the trace, the RED assertion is:
+
+- `tests/server-management-auth.test.ts` — replay the captured Host/Origin/header
+  request against a session that is still valid, and assert
+  `GET /api/system/health` returns 200. This must fail on the then-current HEAD
+  before any production change.
+- `gui/tests/api-auth-memory.test.ts` — replay the first-401 →
+  `/opencodex-session` → parallel-retry sequence and assert exactly one
+  bootstrap, no admin-token prompt, and 200 for both health and providers.
+
+Writing either test against a guess would encode the guess. That is why this
+phase's terminal outcome is NEEDS_HUMAN rather than a speculative patch on an
+authentication surface.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/070_phase7.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/070_phase7.md
@@ -1,0 +1,45 @@
+# 070 — Phase 7 (wp7): Issue #3141 — responses-state.json write storm
+
+## Finding (gpt-5.6-sol investigator, high effort)
+
+VERDICT FIXABLE_NOW, confidence high, no auth/release risk.
+
+Every eligible completed response mutates the continuation cache and calls
+`schedulePersist()` (`src/responses/state.ts:2182-2232`). A process-level timer
+coalesces triggers every 2–30 s depending on snapshot size
+(`src/responses/state.ts:1562-1573`) and byte-identical snapshots are skipped
+(`:1521-1530`). Under concurrent completions, though, the revision changes
+during async disk I/O, so the loop at `src/responses/state.ts:1479-1536`
+performs up to four immediate full atomic rewrites per background tick. The
+current tests codify that: four background writes and eight shutdown writes at
+`tests/responses-state.test.ts:2204-2240`.
+
+## MODIFY / NEW / DELETE map
+
+- MODIFY `src/responses/state.ts` — parameterize `writeBoundedSnapshot()` with an
+  attempt limit; pass `1` for ordinary background persistence and, when the
+  snapshot is unstable, keep the existing delayed `schedulePersistAt(path, true)`
+  follow-up instead of rewriting immediately. Retain bounded retry only for
+  graceful shutdown after request draining. Leave the byte-identity check and
+  `atomicWriteFileAsync()` untouched.
+- MODIFY `tests/responses-state.test.ts` — update the background-churn
+  expectation from four attempts to one plus a pending follow-up.
+- MODIFY `docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md` —
+  document the one-rewrite-per-background-cadence guarantee.
+
+## TESTS
+
+`tests/responses-state.test.ts`, case "background revision churn schedules
+exactly one follow-up pass": assert `attempts === 1` with a pending follow-up
+timer. Red on current HEAD, where the observed contract is `attempts === 4`.
+
+## Verification (C)
+
+```
+bun test tests/responses-state.test.ts -t 'background revision churn'
+bun run typecheck
+```
+
+Accepted tradeoff: crash-recovery state may lag by one extra debounce interval
+under sustained traffic.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/080_phase8.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/080_phase8.md
@@ -1,0 +1,65 @@
+# 080 — Phase 8 (wp8): Issue #3152 — dashboard log panel jitter
+
+## Finding (gpt-5.6-sol investigator, high effort)
+
+VERDICT FIXABLE_NOW, confidence medium, no auth/release risk.
+
+`gui/src/pages/Logs.tsx:521-533` virtualizes dynamically measured rows with a
+44px estimate while the multiline cells at `:746-826` are far taller. The table
+stays on automatic layout with no fixed column schema
+(`gui/src/styles.css:1992-1995`), so every changed mounted-row subset
+recalculates intrinsic column widths; model wrapping (`gui/src/styles.css:1985`)
+then changes row heights and feeds another virtualizer measurement
+(`gui/src/pages/Logs.tsx:741-744`). Native scroll anchoring and the 2 s refresh
+(`:458-468`) amplify it rather than cause it.
+
+PR #3250 replaces only the polling at `gui/src/pages/Logs.tsx:429-456` with delta
+merging. It touches neither table geometry nor virtualization, so it does not
+fix or supersede #3152 — but it will need a small same-file rebase.
+
+## MODIFY / NEW / DELETE map
+
+- MODIFY `gui/src/pages/Logs.tsx` — add a ten-column `<colgroup>` before
+  `<thead>`; change `estimateSize` 44 → 92; supply `getItemKey` from
+  `requestId` with a timestamp/model/provider fallback so measurements survive
+  prepends.
+- MODIFY `gui/src/styles.css` — `table.logs-table { table-layout: fixed; }`, ten
+  explicit `<col>` widths (12/9/7/8/15/9/13/8/11/8 %), and `overflow-anchor: none`
+  plus `scrollbar-gutter: stable` on `.logs-table-wrap`.
+
+## TESTS
+
+- `gui/tests/viewport-scroll-caps.test.ts` — effective `table-layout` is
+  `fixed`, all ten width declarations exist and total 100 %, and
+  `.logs-table-wrap` carries `overflow-anchor: none` + `scrollbar-gutter: stable`.
+  The `table-layout` assertion is red on HEAD.
+- `gui/tests/logs-auto-refresh.test.tsx` — the rendered table contains the
+  ordered ten-column `<colgroup>`.
+
+## RED-before-fix status of each assertion
+
+- `table-layout: fixed` on `table.logs-table` — RED on HEAD. `gui/src/styles.css`
+  currently leaves the table on automatic layout, so the computed value is
+  `auto`.
+- The ten `<col>` width declarations totalling 100% — RED on HEAD. No
+  `<colgroup>` exists in `gui/src/pages/Logs.tsx`, so there is nothing to sum.
+- `overflow-anchor: none` and `scrollbar-gutter: stable` on `.logs-table-wrap` —
+  RED on HEAD; neither declaration is present.
+- The ordered ten-column `<colgroup>` in the rendered table
+  (`gui/tests/logs-auto-refresh.test.tsx`) — RED on HEAD for the same reason.
+
+All four are red by absence, which is a legitimate red so long as the assertion
+is written and observed failing BEFORE the fix lands, not asserted afterwards.
+
+## Verification (C)
+
+```
+bun test gui/tests/viewport-scroll-caps.test.ts
+bun test gui/tests/logs-auto-refresh.test.tsx
+bun run lint:gui
+```
+
+Both focused GUI test files must be run — the `<colgroup>` render assertion lives
+in the second one. A `gui`-labelled PR also requires a screenshot in the
+description per `enforce-target`.
+

--- a/devlog/_plan/260903_bug_drawdown_bcda/090_phase9.md
+++ b/devlog/_plan/260903_bug_drawdown_bcda/090_phase9.md
@@ -1,0 +1,66 @@
+# 090 — Phase 9 (wp9): Issues #3245 and #1527 — evidence-backed disposition
+
+Two items that investigation shows cannot be fixed from this machine. Each gets
+a recorded disposition rather than a speculative patch.
+
+## Issue #3245 — macOS Codex 0.152.0 stream disconnect
+
+VERDICT NEEDS_REPRO / upstream. OpenCodex returns 426 by design when WebSockets
+are disabled (`src/server/index.ts:1107-1126`), and its Responses data plane
+only begins on the subsequent POST (`:1755-1787`). The reporter's probe shows no
+POST and no usage-log entry, so SSE relay, terminal repair, timeout, and
+outbound connection reuse were never reached
+(`src/server/responses/core.ts:4657-4675`, `src/lib/upstream-retry.ts:294-311`).
+Codex itself routes 426 to HTTP and already tests for the resulting POST. The
+control test `tests/server-auth.test.ts:1384-1422` asserts 426 followed by HTTP
+200 and predates v2.39.0.
+
+Action: no OpenCodex diff. Comment with this trace, keep `upstream-tracking`,
+and ask for a 0.152.1+ re-run recording `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`,
+and the localhost probe.
+
+## Issue #1527 — Cursor adapter large-context collapse
+
+VERDICT NEEDS_REPRO, confidence high. The original full-history and overflow
+defects are already fixed: checkpoints are reused and final replay envelopes are
+bounded (`src/adapters/cursor/request-builder.ts:438`,
+`src/adapters/cursor/protobuf-request.ts:1580`); rate limits are explicitly
+non-retryable and post-terminal aborts no longer reclassify completed turns
+(`src/adapters/cursor/transport-retry.ts:20`,
+`src/adapters/cursor/live-transport.ts:716`). `max_output_tokens` is not lowered
+— it has no wire field at all (`src/adapters/cursor/types.ts:12`,
+`src/adapters/cursor/gen/agent_pb.ts:2736`). The only live candidate is cold
+full replay after a missing/expired checkpoint, which needs a failing turn's
+`continuationMode`, `rootBytes`, and direct-client cache evidence.
+
+Action: no diff. Comment with the ruled-out causes and the exact capture needed
+(matched direct-vs-proxy run on one account, redacted `run-request` fields).
+
+## Verification (C)
+
+Both are terminal as NEEDS_HUMAN with the analysis posted to the issue. No merge
+proof applies; the evidence is the comment plus the file:line trace above.
+
+
+## TESTS — why no RED assertion exists for either item
+
+Both items are NEEDS_REPRO, so there is no honest failing unit test to write, and
+manufacturing one would encode a guess as a contract. What each needs first:
+
+- #3245: the control test `tests/server-auth.test.ts:1384-1422` already asserts
+  426 followed by HTTP 200 and it PASSES on HEAD, which is precisely why the
+  OpenCodex side is exonerated. A red test would have to live upstream in
+  `codex-rs/core/tests/suite/websocket_fallback.rs`, asserting
+  `websocket_attempts == 1 && http_attempts == 1` under the reporter's proxy
+  environment; the reported failure is `http_attempts == 0`.
+- #1527: the first artifact is a secret-free matched probe under `.tmp/` whose
+  failure condition is that direct Cursor completes the workload without 429
+  while OpenCodex returns 429 or fails the same completion rubric. Only after
+  that isolates a cause does a red assertion become writable —
+  `tests/cursor-request-builder.test.ts` asserting
+  `continuationMode === "checkpoint"` with retained `checkpointBytes`, or
+  `tests/cursor-blob.test.ts` asserting a captured direct wire parameter decodes.
+
+Writing either assertion before its evidence exists is the failure mode this
+campaign is supposed to avoid.
+

--- a/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
+++ b/docs-site/src/content/docs/troubleshooting/disk-usage-temp-files.md
@@ -63,6 +63,12 @@ still owner-only. A fresh process rewrites an identical snapshot once, and a fil
 whose contents or permissions changed underneath the proxy is rewritten through the
 hardening path rather than left alone.
 
+Each ordinary background cadence performs at most one full atomic rewrite. If the
+continuation cache changes while that write is in progress, opencodex schedules one
+follow-up on the normal delayed cadence instead of rewriting the whole snapshot again
+immediately. Graceful shutdown keeps its bounded retry behavior after in-flight
+requests have drained so the final snapshot can catch up before the process exits.
+
 Together these keep the write rate roughly flat as the cache grows, instead of
 re-serializing and replacing the whole file every two seconds.
 

--- a/gui/src/pages/Logs.tsx
+++ b/gui/src/pages/Logs.tsx
@@ -523,8 +523,12 @@ export default function Logs({ apiBase }: { apiBase: string }) {
   const rowVirtualizer = useVirtualizer({
     count: filteredLogs.length,
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => 44,
+    estimateSize: () => 92,
     overscan: 15,
+    getItemKey: index => {
+      const log = filteredLogs[filteredLogs.length - 1 - index]!;
+      return log.requestId ?? `${log.timestamp}:${log.model}:${log.provider}`;
+    },
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
   const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
@@ -713,6 +717,18 @@ export default function Logs({ apiBase }: { apiBase: string }) {
         <>
         <div ref={scrollContainerRef} className="tbl-wrap logs-table-wrap">
           <table className="tbl logs-table">
+            <colgroup>
+              <col className="logs-col-time" />
+              <col className="logs-col-tokens" />
+              <col className="logs-col-rate" />
+              <col className="logs-col-cost" />
+              <col className="logs-col-model" />
+              <col className="logs-col-effort" />
+              <col className="logs-col-provider" />
+              <col className="logs-col-status" />
+              <col className="logs-col-request" />
+              <col className="logs-col-duration" />
+            </colgroup>
             <thead>
              <tr>
                <th>{t("logs.col.time")}</th>
@@ -739,7 +755,7 @@ export default function Logs({ apiBase }: { apiBase: string }) {
                 const when = formatLogDateParts(log.timestamp, localeTag, serverTimeZone);
                 return (
                <tr
-                 key={log.requestId ?? `${log.timestamp}-${virtualRow.index}`}
+                 key={virtualRow.key}
                  data-index={virtualRow.index}
                  ref={rowVirtualizer.measureElement}
                >

--- a/gui/src/styles.css
+++ b/gui/src/styles.css
@@ -1992,7 +1992,18 @@ dialog.modal-overlay::backdrop {
 table.logs-table {
   width: 100%;
   min-width: 1100px;
+  table-layout: fixed;
 }
+.logs-table col.logs-col-time { width: 12%; }
+.logs-table col.logs-col-tokens { width: 9%; }
+.logs-table col.logs-col-rate { width: 7%; }
+.logs-table col.logs-col-cost { width: 8%; }
+.logs-table col.logs-col-model { width: 15%; }
+.logs-table col.logs-col-effort { width: 9%; }
+.logs-table col.logs-col-provider { width: 13%; }
+.logs-table col.logs-col-status { width: 8%; }
+.logs-table col.logs-col-request { width: 11%; }
+.logs-table col.logs-col-duration { width: 8%; }
 .log-col-rate { min-width: 7ch; white-space: nowrap; }
 .log-col-cost { min-width: 10ch; white-space: nowrap; }
 .log-status-cell { display: inline-flex; flex-direction: column; align-items: flex-start; gap: var(--space-0-5); min-width: 7ch; line-height: var(--leading-tight); }
@@ -2050,6 +2061,8 @@ table.logs-table {
 
 .logs-table-wrap {
   overflow-y: auto;
+  overflow-anchor: none;
+  scrollbar-gutter: stable;
   /* `dvh`, not `vh`: static `vh` resolves against the LARGE viewport, so on mobile the
      cap is computed for a viewport taller than the one the user can see and the last rows
      sit under the browser chrome. The rest of the shell already moved to `100dvh`

--- a/gui/tests/logs-auto-refresh.test.tsx
+++ b/gui/tests/logs-auto-refresh.test.tsx
@@ -162,6 +162,33 @@ function expectTableLoaded(container: HTMLElement, model: string): void {
   expect(container.textContent).toContain(model);
 }
 
+test("Logs: renders the ordered ten-column layout schema", async () => {
+  globalThis.fetch = (async (input) => {
+    if (!String(input).includes("/api/logs")) return new Response(null, { status: 404 });
+    return jsonResponse([sampleLog]);
+  }) as typeof fetch;
+
+  const { root, container } = await mountLogs();
+  await flushMicrotasks();
+
+  const colgroup = container.querySelector(".logs-table > colgroup");
+  expect(colgroup).not.toBeNull();
+  expect([...colgroup!.children].map(column => column.className)).toEqual([
+    "logs-col-time",
+    "logs-col-tokens",
+    "logs-col-rate",
+    "logs-col-cost",
+    "logs-col-model",
+    "logs-col-effort",
+    "logs-col-provider",
+    "logs-col-status",
+    "logs-col-request",
+    "logs-col-duration",
+  ]);
+
+  await act(async () => { root.unmount(); });
+});
+
 test("Logs: initial failure shows error; silent failure keeps it; retry then recovers", async () => {
   const calls: string[] = [];
   let mode: "fail" | "ok" = "fail";

--- a/gui/tests/viewport-scroll-caps.test.ts
+++ b/gui/tests/viewport-scroll-caps.test.ts
@@ -32,6 +32,35 @@ test("the log table caps its scroll height against the dynamic viewport", async 
   expect(wrap).not.toMatch(/max-height:\s*calc\(\s*100vh\s*-/);
 });
 
+test("the virtualized log table keeps a fixed ten-column layout", async () => {
+  const css = withoutComments(await Bun.file(cssUrl).text());
+  const columns = [
+    ["time", 12],
+    ["tokens", 9],
+    ["rate", 7],
+    ["cost", 8],
+    ["model", 15],
+    ["effort", 9],
+    ["provider", 13],
+    ["status", 8],
+    ["request", 11],
+    ["duration", 8],
+  ] as const;
+
+  expect(effectiveDeclaration(css, "table.logs-table", "table-layout")).toBe("fixed");
+
+  const widths = columns.map(([column, expectedWidth]) => {
+    const width = effectiveDeclaration(css, `.logs-table col.logs-col-${column}`, "width");
+    expect(width).toBe(`${expectedWidth}%`);
+    return Number(width.slice(0, -1));
+  });
+  expect(widths).toHaveLength(10);
+  expect(widths.reduce((total, width) => total + width, 0)).toBe(100);
+
+  expect(effectiveDeclaration(css, ".logs-table-wrap", "overflow-anchor")).toBe("none");
+  expect(effectiveDeclaration(css, ".logs-table-wrap", "scrollbar-gutter")).toBe("stable");
+});
+
 test("the toast width cap outranks the later .notice rule", async () => {
   const css = withoutComments(await Bun.file(cssUrl).text());
 

--- a/src/responses/state.ts
+++ b/src/responses/state.ts
@@ -1469,14 +1469,14 @@ function ensureLoaded(): void {
 
 type SnapshotWriteOutcome = "stable" | "unstable" | "failed";
 
-async function writeBoundedSnapshot(path: string): Promise<SnapshotWriteOutcome> {
+async function writeBoundedSnapshot(path: string, attemptLimit: number): Promise<SnapshotWriteOutcome> {
   // Serialize writers so concurrent flush + debounce cannot race on temps / ACL (#612).
   const previous = persistGate;
   let release!: () => void;
   persistGate = new Promise<void>(resolve => { release = resolve; });
   await previous;
   try {
-    for (let attempt = 0; attempt < MAX_SNAPSHOT_REWRITE_ATTEMPTS; attempt += 1) {
+    for (let attempt = 0; attempt < attemptLimit; attempt += 1) {
       const revision = stateRevision;
       const entries: Array<[string, unknown]> = [];
       let total = 0;
@@ -1579,12 +1579,13 @@ async function persistNow(path: string, awaitFollowUp = false): Promise<void> {
     persistTimer = null;
   }
   pendingPersistPath = null;
-  let outcome = await writeBoundedSnapshot(path);
+  const attemptLimit = awaitFollowUp ? MAX_SNAPSHOT_REWRITE_ATTEMPTS : 1;
+  let outcome = await writeBoundedSnapshot(path, attemptLimit);
   if (outcome === "unstable" && awaitFollowUp) {
     if (persistTimer) clearTimeout(persistTimer);
     persistTimer = null;
     pendingPersistPath = null;
-    outcome = await writeBoundedSnapshot(path);
+    outcome = await writeBoundedSnapshot(path, attemptLimit);
   }
   if (outcome === "stable") drainPendingSpillUnlinks();
   else if (outcome === "unstable" && !awaitFollowUp) schedulePersistAt(path, true);

--- a/tests/responses-state.test.ts
+++ b/tests/responses-state.test.ts
@@ -2236,7 +2236,7 @@ describe("Responses previous_response_id state", () => {
 
     await runPendingResponseStatePersistForTests();
 
-    expect(attempts).toBe(4);
+    expect(attempts).toBe(1);
     expect(responseStatePersistPendingForTests()).toBe(true);
     setResponseStatePersistAttemptHookForTests(null);
     await runPendingResponseStatePersistForTests();


### PR DESCRIPTION
## Summary

- The virtualized log table now uses `table-layout: fixed` with an explicit ten-column `<colgroup>`, so column widths no longer depend on which rows happen to be mounted.
- `estimateSize` moves from 44px to the observed mean row height, and `getItemKey` keys measurements to the request rather than the row index, so a prepend does not shift them.
- `.logs-table-wrap` disables scroll anchoring and reserves the scrollbar gutter.

Root cause: rows were measured dynamically from a 44px estimate while the multiline cells are roughly twice that, on a table left in automatic layout. Every changed mounted-row subset recomputed intrinsic column widths, model wrapping then changed row heights, and that fed another virtualizer measurement. Polling and scrollbar appearance amplified the loop rather than causing it.

## UI change

Screenshot of the Logs & Debug panel, captured live against a running proxy with real request rows.

Before — `dev` at `3d3c4fe`, automatic table layout:

![Logs panel before](https://raw.githubusercontent.com/lidge-jun/opencodex/media/3152-log-panel-evidence/.github/media/3152-before-logs-panel.png)

After — this branch, `table-layout: fixed` with the ten-column schema:

![Logs panel after](https://raw.githubusercontent.com/lidge-jun/opencodex/media/3152-log-panel-evidence/.github/media/3152-after-logs-panel.png)

The rendered content is deliberately the same; what changes is that column boundaries stop moving as rows scroll in. Verified in the running dashboard rather than only in tests — with this branch built and served on port 10877, the live DOM reports:

```
{"rows":26,"layout":"fixed","cols":10}
```

On `dev` the same query returns no `table-layout` declaration and no `<colgroup>` at all.

## Verification

- Red-first: `bun test ./gui/tests/viewport-scroll-caps.test.ts` failed with `property not found: table.logs-table { table-layout }`, and `./gui/tests/logs-auto-refresh.test.tsx` failed with `expect(colgroup).not.toBeNull()` receiving `null`.
- After the fix: 6 pass / 0 fail and 10 pass / 0 fail respectively.
- `bun run lint:gui` — passed. `bun run typecheck` — passed. GUI production build — passed.
- Live browser verification as shown above.
- Per maintainer instruction for this campaign, the repository-wide suite was not run locally; CI is the full-suite gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This is a rendering fix with no user-facing contract change.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Dashboard rendering only.

Closes #3152

Stacked on #3289; retarget to `dev` once that lands.