### PR TITLE
fix(combos): shorten request-rate cooldowns and send Retry-After on combo 503

### DIFF
--- a/src/combos/failover.ts
+++ b/src/combos/failover.ts
@@ -13,6 +13,21 @@ interface TargetCooldown {
 
 const DEFAULT_COOLDOWN_MS = 60_000;
 const MAX_COOLDOWN_MS = 10 * 60_000;
+/** Short cooldown for request-rate 429s (for example provider code 1302) that omit Retry-After. */
+export const COMBO_REQUEST_RATE_COOLDOWN_MS = 5_000;
+
+const QUOTA_LIMIT_CODES = new Set([
+  "1308",
+  "1310",
+  "1316",
+  "1317",
+  "1318",
+  "1319",
+  "1320",
+  "1321",
+  "insufficient_quota",
+]);
+const TRANSIENT_REQUEST_RATE_CODES = new Set(["1302", "1305"]);
 const IMF_FIXDATE_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/i;
 const RFC850_DATE_RE = /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2}) GMT$/i;
 const ASCTIME_DATE_RE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d{2}) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/i;
@@ -136,10 +151,58 @@ export function isComboTargetInCooldown(
   return true;
 }
 
+export function isTransientRequestRateLimit(input: {
+  status?: number;
+  code?: string | null;
+  message?: string;
+}): boolean {
+  const code = (input.code ?? "").trim().toLowerCase().replaceAll("-", "_");
+  if (QUOTA_LIMIT_CODES.has(code)) return false;
+  if (TRANSIENT_REQUEST_RATE_CODES.has(code)) return true;
+  const text = (input.message ?? "").toLowerCase();
+  if (
+    text.includes("usage limit reached")
+    || text.includes("insufficient_quota")
+    || text.includes("quota exhausted")
+  ) {
+    return false;
+  }
+  return text.includes("rate limit reached for requests");
+}
+
+export function remainingComboCooldownMs(comboId: string, now = Date.now()): number | undefined {
+  const prefix = `${comboId}\0`;
+  let soonest: number | undefined;
+  for (const [key, cooldown] of targetCooldowns) {
+    if (!key.startsWith(prefix)) continue;
+    const remaining = cooldown.cooldownUntil - now;
+    if (remaining <= 0) {
+      targetCooldowns.delete(key);
+      continue;
+    }
+    if (soonest === undefined || remaining < soonest) soonest = remaining;
+  }
+  return soonest;
+}
+
+export function comboCooldownRetryAfterSeconds(comboId: string, now = Date.now()): string | undefined {
+  const remainingMs = remainingComboCooldownMs(comboId, now);
+  if (remainingMs === undefined) return undefined;
+  return String(Math.max(1, Math.ceil(remainingMs / 1000)));
+}
+
 export function coolComboTarget(
   comboId: string,
   target: Pick<OcxComboTarget, "provider" | "model">,
-  options?: { retryAfter?: string | null; now?: number; cooldownMs?: number; writerGeneration?: number },
+  options?: {
+    retryAfter?: string | null;
+    now?: number;
+    cooldownMs?: number;
+    writerGeneration?: number;
+    status?: number;
+    code?: string | null;
+    message?: string;
+  },
 ): void {
   const now = options?.now ?? Date.now();
   const writerGeneration = options?.writerGeneration ?? captureConfigGeneration();
@@ -147,7 +210,11 @@ export function coolComboTarget(
   if (writerGeneration < lastReconciledGeneration && !liveComboTargets.has(ownerKey)) return;
   const cooldownMs = options?.cooldownMs
     ?? parseRetryAfterMs(options?.retryAfter, now)
-    ?? DEFAULT_COOLDOWN_MS;
+    ?? (isTransientRequestRateLimit({
+      status: options?.status,
+      code: options?.code,
+      message: options?.message,
+    }) ? COMBO_REQUEST_RATE_COOLDOWN_MS : DEFAULT_COOLDOWN_MS);
   targetCooldowns.set(cooldownMapKey(comboId, target), {
     cooldownUntil: now + Math.min(Math.max(cooldownMs, 1), MAX_COOLDOWN_MS),
   });

--- a/src/combos/index.ts
+++ b/src/combos/index.ts
@@ -31,9 +31,13 @@ export {
 } from "./resolve";
 export {
   clearComboTargetCooldowns,
+  comboCooldownRetryAfterSeconds,
+  COMBO_REQUEST_RATE_COOLDOWN_MS,
   coolComboTarget,
   isComboTargetInCooldown,
+  isTransientRequestRateLimit,
   parseRetryAfterMs,
+  remainingComboCooldownMs,
   comboFailureDecision,
   type ComboFailureDecision,
 } from "./failover";

--- a/src/combos/resolve.ts
+++ b/src/combos/resolve.ts
@@ -250,6 +250,9 @@ export function advanceComboAfterFailure(
     retryAfter?: string | null;
     now?: number;
     eligible?: (target: Required<OcxComboTarget>) => boolean;
+    status?: number;
+    code?: string | null;
+    message?: string;
   } = {},
 ): ComboPick | null {
   noteComboFailure(pick.comboId, pick.target, pick.writerGeneration);

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -74,6 +74,7 @@ import {
   concreteComboRequestBody,
   getCombo,
   isComboTargetInCooldown,
+  comboCooldownRetryAfterSeconds,
   NoAvailableComboTargetsError,
   noteComboSuccess,
   parseRetryAfterMs,
@@ -1435,13 +1436,27 @@ export function decodeRequestErrorResponse(err: unknown, label: string): Respons
 
 
 
-export function comboUnavailableResponse(message: string): Response {
+export function comboUnavailableResponse(
+  message: string,
+  options?: { retryAfter?: string | null },
+): Response {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  const retryAfter = options?.retryAfter?.trim();
+  if (retryAfter && retryAfter.length > 0 && retryAfter.length <= 128) {
+    headers.set("Retry-After", retryAfter);
+  }
   return new Response(
     JSON.stringify({
       error: { message, type: "server_error", code: "combo_unavailable" },
     }),
-    { status: 503, headers: { "Content-Type": "application/json" } },
+    { status: 503, headers },
   );
+}
+
+function comboUnavailable(comboId: string, now = Date.now()): Response {
+  return comboUnavailableResponse(`No available targets for combo: ${comboId}`, {
+    retryAfter: comboCooldownRetryAfterSeconds(comboId, now),
+  });
 }
 
 
@@ -2298,7 +2313,7 @@ export async function handleComboResponses(
         config,
         { parentThreadId: inboundClientThreadId },
       );
-      return comboUnavailableResponse(`No available targets for combo: ${comboId}`);
+      return comboUnavailable(comboId);
     }
     let recovered = false;
     try {
@@ -2335,7 +2350,7 @@ export async function handleComboResponses(
   }
 
   if (!pick) {
-    return comboUnavailableResponse(`No available targets for combo: ${comboId}`);
+    return comboUnavailable(comboId);
   }
   // One immutable combo selection trace, before any child dispatch; child
   // adoption below must never replace it with a concrete child route trace.
@@ -2543,6 +2558,9 @@ export async function handleComboResponses(
       retryAfter: failure.retryAfter,
       now: Date.now(),
       eligible: payloadEligible,
+      status: failure.response.status,
+      code: failure.upstreamCode,
+      message: failure.classificationText,
     });
     if (!nextPick) adoptFailedChildLog(childLog);
     pick = nextPick;
@@ -2913,7 +2931,7 @@ async function handleResponsesInner(
     logCtx.routeDecision = route.routeDecision;
   } catch (err) {
     if (err instanceof NoAvailableComboTargetsError) {
-      return comboUnavailableResponse(err.message);
+      return comboUnavailable(err.comboId);
     }
     if (err instanceof NoEligiblePolicyCandidateError) {
       // Persist the evaluation trace (per-candidate exclusions + the
@@ -3023,7 +3041,7 @@ async function handleResponsesInner(
         logCtx.routeDecision = route.routeDecision;
       } catch (err) {
         if (err instanceof NoAvailableComboTargetsError) {
-          return comboUnavailableResponse(err.message);
+          return comboUnavailable(err.comboId);
         }
         if (err instanceof NoEligiblePolicyCandidateError) {
           logCtx.routeDecision = err.trace;
@@ -3147,7 +3165,7 @@ async function handleResponsesInner(
               logCtx.routeDecision = route.routeDecision;
             } catch (err) {
               if (err instanceof NoAvailableComboTargetsError) {
-                return comboUnavailableResponse(err.message);
+                return comboUnavailable(err.comboId);
               }
               if (err instanceof NoEligiblePolicyCandidateError) {
                 logCtx.routeDecision = err.trace;

--- a/tests/combos.test.ts
+++ b/tests/combos.test.ts
@@ -17,6 +17,8 @@ import {
   comboPublicModelId,
   comboRequestHasImageInput,
   concreteComboRequestBody,
+  comboCooldownRetryAfterSeconds,
+  COMBO_REQUEST_RATE_COOLDOWN_MS,
   coolComboTarget,
   earliestQuotaResetAt,
   getCombo,
@@ -29,6 +31,7 @@ import {
   normalizeComboConfig,
   parseComboModelId,
   parseRetryAfterMs,
+  remainingComboCooldownMs,
   pickComboTarget,
   preservesPhysicalComboProvider,
   resetComboEffortWarningStateForTests,
@@ -38,6 +41,7 @@ import {
   UnknownComboError,
 } from "../src/combos";
 import { comboFailureDecision } from "../src/combos/failover";
+import { comboUnavailableResponse } from "../src/server/responses/core";
 import { getConfigPath, readConfigDiagnostics, saveConfig } from "../src/config";
 import { routeModel } from "../src/router";
 import { handleManagementAPI } from "../src/server/management-api";
@@ -413,6 +417,55 @@ describe("combo target cooldowns", () => {
     expect(isComboTargetInCooldown("other", target, 1_050)).toBe(true);
     clearComboTargetCooldowns("other");
     expect(isComboTargetInCooldown("other", target, 1_050)).toBe(false);
+  });
+
+  test("uses a short cooldown for request-rate 1302 without Retry-After", () => {
+    coolComboTarget("free", target, {
+      now: 1_000,
+      code: "1302",
+      message: "Rate limit reached for requests",
+    });
+    expect(isComboTargetInCooldown("free", target, 1_000 + COMBO_REQUEST_RATE_COOLDOWN_MS - 1)).toBe(true);
+    expect(isComboTargetInCooldown("free", target, 1_000 + COMBO_REQUEST_RATE_COOLDOWN_MS)).toBe(false);
+  });
+
+  test("keeps the default cooldown for usage-window 1308", () => {
+    coolComboTarget("free", target, {
+      now: 1_000,
+      code: "1308",
+      message: "Usage limit reached for 5 hour",
+    });
+    expect(isComboTargetInCooldown("free", target, 1_000 + 59_999)).toBe(true);
+    expect(isComboTargetInCooldown("free", target, 1_000 + 60_000)).toBe(false);
+  });
+
+  test("honors explicit Retry-After over the request-rate default", () => {
+    coolComboTarget("free", target, {
+      now: 1_000,
+      retryAfter: "30",
+      code: "1302",
+    });
+    expect(isComboTargetInCooldown("free", target, 1_000 + 29_999)).toBe(true);
+    expect(isComboTargetInCooldown("free", target, 1_000 + 30_000)).toBe(false);
+  });
+
+  test("reports the soonest remaining cooldown as Retry-After seconds", () => {
+    const later = { provider: "b", model: "m2" };
+    coolComboTarget("free", target, { now: 1_000, cooldownMs: 5_000 });
+    coolComboTarget("free", later, { now: 1_000, cooldownMs: 20_000 });
+    expect(remainingComboCooldownMs("free", 1_000)).toBe(5_000);
+    expect(comboCooldownRetryAfterSeconds("free", 1_000)).toBe("5");
+    expect(comboCooldownRetryAfterSeconds("free", 3_500)).toBe("3");
+    expect(comboCooldownRetryAfterSeconds("missing", 1_000)).toBeUndefined();
+  });
+
+  test("combo unavailable responses advertise remaining cooldown as Retry-After", () => {
+    coolComboTarget("free", target, { now: 1_000, cooldownMs: 5_000 });
+    const response = comboUnavailableResponse("No available targets for combo: free", {
+      retryAfter: comboCooldownRetryAfterSeconds("free", 1_000),
+    });
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("5");
   });
 });
 


### PR DESCRIPTION
## Summary

When every combo target is in cooldown, the proxy returns HTTP 503 `combo_unavailable` with no `Retry-After`. Clients that retry immediately then spend the cooldown window on local failures instead of waiting for a target to thaw.

Request-rate 429s that omit `Retry-After` currently inherit the same 60s target cooldown as usage-window exhaustion. That is longer than the recovery time for a short request-rate limit.

This change:

1. Uses a 5s combo-target cooldown for transient request-rate codes (`1302`, `1305`) and the `Rate limit reached for requests` message, when the upstream response has no `Retry-After`.
2. Leaves usage-window codes (`1308` and related) and generic 429s on the existing 60s default.
3. Continues to honor an explicit `Retry-After` or `cooldownMs`.
4. Sets `Retry-After` on 503 `combo_unavailable` to the soonest remaining target cooldown.

Quota 429s, auth failures, and explicit backoff headers are unchanged. This is not the first-byte stall hop in #3266.

## Test plan

- [x] `bun test tests/combos.test.ts`

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added short cooldown handling for transient request-rate limits.
  - Combo-unavailable responses now include a `Retry-After` value when a cooldown remains.
  - Cooldown status and retry timing can be reported to callers.

- **Bug Fixes**
  - Prevented transient request-rate limits from using the longer default cooldown.
  - Preserved longer cooldown behavior for usage-limit errors.
  - Explicit retry instructions continue to override automatic cooldown timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->