### PR TITLE
fix(cli): retry liveness probes before ocx claude spawns a proxy

### DIFF
--- a/src/cli/claude.ts
+++ b/src/cli/claude.ts
@@ -354,8 +354,17 @@ export function readConnectedClaudeContextWindows(path = DEFAULT_CATALOG_PATH): 
   }
 }
 
-async function ensureProxyForClaude(): Promise<number | null> {
-  const live = await findLiveProxy();
+export type ClaudeProxyEnsureDeps = {
+  findLiveProxy?: typeof findLiveProxy;
+};
+
+export async function ensureProxyForClaude(deps: ClaudeProxyEnsureDeps = {}): Promise<number | null> {
+  // A proxy that has only just bound can miss a single probe while its event loop
+  // is still settling startup work — the same just-started race the stop paths
+  // already retry for (#764, SERVICE_STOP_LIVENESS). Only the attempts budget is
+  // borrowed here; the probe timeout remains DEFAULT_PROBE_TIMEOUT_MS (750 ms).
+  // Without this, `ocx claude` can spawn a second proxy while the first is serving.
+  const live = await (deps.findLiveProxy ?? findLiveProxy)({ attempts: 3 });
   if (live) return live.port;
   const cfgPort = loadConfig().port;
   const pinPort = typeof cfgPort === "number" && cfgPort > 0 ? cfgPort : 10100;

--- a/tests/claude-cli.test.ts
+++ b/tests/claude-cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { buildClaudeEnv, claudeNotFoundHint, rootSkipPermissionsNotice, shouldAllowRootSkipPermissions } from "../src/cli/claude";
+import { buildClaudeEnv, claudeNotFoundHint, ensureProxyForClaude, rootSkipPermissionsNotice, shouldAllowRootSkipPermissions } from "../src/cli/claude";
 import { commandInvocation } from "../src/lib/win-exec";
+import type { LivenessIo, LiveProxy } from "../src/server/proxy-liveness";
 import type { OcxConfig } from "../src/types";
 
 function cfg(extra?: Partial<OcxConfig>): OcxConfig {
@@ -24,6 +25,20 @@ const AUTH_PRESENT = {
     keychainProbe: () => "present" as const,
   },
 };
+
+describe("ocx claude proxy liveness", () => {
+  test("retries the initial liveness probe before spawning a proxy", async () => {
+    const seen: (number | undefined)[] = [];
+    const findLiveProxy = async (io?: LivenessIo): Promise<LiveProxy> => {
+      seen.push(io?.attempts);
+      // retry semantics are covered by tests/proxy-liveness.test.ts:102-119; this pins that the launcher hands the stop-path budget down.
+      return { pid: 4242, port: 10100, source: "runtime" };
+    };
+
+    expect(await ensureProxyForClaude({ findLiveProxy })).toBe(10100);
+    expect(seen).toEqual([3]);
+  });
+});
 
 describe("ocx claude env assembly", () => {
   test("connected target injects only the hub base and client admission token", () => {


### PR DESCRIPTION
## Summary

- Mirror #3106 (health) for the `ocx claude` pre-spawn `findLiveProxy` probe, borrowing only the `attempts` budget from #764 (`SERVICE_STOP_LIVENESS`) while keeping the probe timeout at `DEFAULT_PROBE_TIMEOUT_MS` (750 ms).
- Add a focused regression test that asserts the budget propagation from the launcher to its injected liveness probe.
- The post-spawn loop keeps a single probe because it already retries via 250 ms polling inside the 8 s deadline; an inner attempts budget could exceed that deadline.
- The sibling launchers `src/cli/opencode.ts:592-612` and `src/cli/minimax.ts:265-280` share this shape and are deliberately left for a separate focused change.

## Verification

- `bun test tests/claude-cli.test.ts` — 34 pass, 0 fail.
- `bun run typecheck` — passed (`tsc --noEmit`).
- `bun run test:changed` — 139 pass, 0 fail across 7 files.
- `bun run test` — the full suite did not complete in this environment: it was terminated after ~5 min while tests/native-profile-drain-server.test.ts / tests/management-provider-validation.test.ts were still starting proxies, so there are no totals. The only failure recorded before termination was tests/test-runner.test.ts ("changed-mode uses the shared merge base…"), caused by a machine-local git pre-commit secret scanner blocking the test's temporary fixture-repo commit — unrelated to this change.
- Mutation check (temporarily removing `{ attempts: 3 }`) — focused regression failed on `expect(seen).toEqual([3])`; `ps -axo args= | grep -c 'start --port'` was unchanged before and after.
- `git diff --check` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not needed for this focused CLI reliability fix).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (no authentication or secret-handling code changed).

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude proxy startup reliability by retrying liveness checks before launching an additional proxy.
  * Reduced the likelihood of unnecessary proxy processes being started when an existing proxy is still becoming available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->