### PR TITLE
fix(combos): fail over provider-scoped quota caps

### DIFF
--- a/src/combos/failover.ts
+++ b/src/combos/failover.ts
@@ -156,6 +156,7 @@ export function isTransientRequestRateLimit(input: {
   code?: string | null;
   message?: string;
 }): boolean {
+  if (isProviderScopedQuotaCap(input.status, input.message ?? "", input.code)) return false;
   const code = (input.code ?? "").trim().toLowerCase().replaceAll("-", "_");
   if (QUOTA_LIMIT_CODES.has(code)) return false;
   if (TRANSIENT_REQUEST_RATE_CODES.has(code)) return true;
@@ -252,6 +253,37 @@ export function clearComboTargetCooldowns(comboId?: string): void {
 }
 
 export type ComboFailureDecision = "hop" | "stop";
+export type ComboFailureCooldownScope = "target" | "provider";
+
+function normalizedFailureCode(code?: string | null): string {
+  return code?.trim().toLowerCase().replaceAll("-", "_") ?? "";
+}
+
+function isProviderScopedQuotaCap(
+  status: number | undefined,
+  message: string,
+  code?: string | null,
+): boolean {
+  const normalizedCode = normalizedFailureCode(code);
+  const text = message.toLowerCase();
+  if (
+    status === 429
+    && (normalizedCode === "gousagelimiterror" || text.includes("monthly usage limit reached"))
+  ) {
+    return true;
+  }
+  return normalizedCode === "free_rate_limited"
+    || text.includes("err_free_prompt_cap")
+    || (text.includes("free tier") && text.includes("single request"));
+}
+
+export function comboFailureCooldownScope(
+  status: number,
+  message: string,
+  options?: { code?: string | null },
+): ComboFailureCooldownScope {
+  return isProviderScopedQuotaCap(status, message, options?.code) ? "provider" : "target";
+}
 
 function isModelLifecycleGone(
   status: number,
@@ -310,6 +342,9 @@ export function comboFailureDecision(
   // tries each candidate once via `tried`, and combo excludes each attempted target. So this is
   // structured-code-only, not provably local.
   if (options?.code === "input_admission_refused" || error.code === "input_admission_refused") {
+    return "hop";
+  }
+  if (isProviderScopedQuotaCap(status, message, options?.code || error.code)) {
     return "hop";
   }
   if (["origin_rejected", "context_length_exceeded", "invalid_request_error"].includes(error.code ?? "")) {

--- a/src/combos/index.ts
+++ b/src/combos/index.ts
@@ -39,7 +39,9 @@ export {
   parseRetryAfterMs,
   remainingComboCooldownMs,
   comboFailureDecision,
+  comboFailureCooldownScope,
   type ComboFailureDecision,
+  type ComboFailureCooldownScope,
 } from "./failover";
 export {
   comboIdFromRawBody,

--- a/src/combos/resolve.ts
+++ b/src/combos/resolve.ts
@@ -1,6 +1,6 @@
 import type { OcxComboTarget, OcxConfig } from "../types";
 import { getCachedProviderQuota } from "../providers/quota-routing-cache";
-import { coolComboTarget, isComboTargetInCooldown } from "./failover";
+import { coolComboTarget, isComboTargetInCooldown, type ComboFailureCooldownScope } from "./failover";
 import { quotaResetRemainingMs } from "./reset-window";
 import { getCombo, resolveComboId, targetKey } from "./types";
 import type { NormalizedComboConfig } from "./types";
@@ -250,16 +250,23 @@ export function advanceComboAfterFailure(
     retryAfter?: string | null;
     now?: number;
     eligible?: (target: Required<OcxComboTarget>) => boolean;
+    cooldownScope?: ComboFailureCooldownScope;
     status?: number;
     code?: string | null;
     message?: string;
   } = {},
 ): ComboPick | null {
   noteComboFailure(pick.comboId, pick.target, pick.writerGeneration);
-  coolComboTarget(pick.comboId, pick.target, {
-    ...options,
-    writerGeneration: pick.writerGeneration,
-  });
+  const combo = getCombo(config, pick.comboId);
+  const cooldownTargets = options.cooldownScope === "provider" && combo
+    ? combo.targets.filter(target => target.provider === pick.target.provider)
+    : [pick.target];
+  for (const target of cooldownTargets) {
+    coolComboTarget(pick.comboId, target, {
+      ...options,
+      writerGeneration: pick.writerGeneration,
+    });
+  }
   return pickComboTarget(config, pick.comboId, {
     exclude: pick.attempted,
     eligible: target => !isComboTargetInCooldown(pick.comboId, target, options.now)

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -68,6 +68,7 @@ import { resolvePassiveRouteSubjectId } from "../passive-route-linker";
 import {
   advanceComboAfterFailure,
   comboDefaultEffort,
+  comboFailureCooldownScope,
   comboFailureDecision,
   comboIdFromRawBody,
   comboRequestHasImageInput,
@@ -2557,6 +2558,9 @@ export async function handleComboResponses(
     const nextPick = advanceComboAfterFailure(config, pick, {
       retryAfter: failure.retryAfter,
       now: Date.now(),
+      cooldownScope: comboFailureCooldownScope(failure.response.status, failure.classificationText, {
+        code: failure.upstreamCode,
+      }),
       eligible: payloadEligible,
       status: failure.response.status,
       code: failure.upstreamCode,

--- a/tests/combos.test.ts
+++ b/tests/combos.test.ts
@@ -40,7 +40,11 @@ import {
   tryPickComboModel,
   UnknownComboError,
 } from "../src/combos";
-import { comboFailureDecision } from "../src/combos/failover";
+import {
+  comboFailureCooldownScope,
+  comboFailureDecision,
+  isTransientRequestRateLimit,
+} from "../src/combos/failover";
 import { comboUnavailableResponse } from "../src/server/responses/core";
 import { getConfigPath, readConfigDiagnostics, saveConfig } from "../src/config";
 import { routeModel } from "../src/router";
@@ -497,6 +501,51 @@ describe("combo failure policy and advancement", () => {
     // generic 413 with no structured code keeps its existing conservative handling.
     expect(comboFailureDecision(400, "context_length_exceeded")).toBe("stop");
     expect(comboFailureDecision(413, "request too large")).toBe("stop");
+  });
+
+  test("provider-scoped free-tier and monthly quota failures hop without weakening generic 400 handling", () => {
+    const orca = JSON.stringify({ error: {
+      type: "invalid_request_error",
+      code: "free_rate_limited",
+      message: "This prompt is longer than the free tier allows for a single request.",
+    }});
+    expect(comboFailureDecision(400, orca, { code: "free_rate_limited" })).toBe("hop");
+    expect(comboFailureCooldownScope(400, orca, { code: "free_rate_limited" })).toBe("provider");
+    expect(comboFailureDecision(400, "ordinary invalid request", { code: "invalid_request_error" })).toBe("stop");
+    expect(comboFailureCooldownScope(429, "Monthly usage limit reached. Resets in 14 days.", {
+      code: "GoUsageLimitError",
+    })).toBe("provider");
+    expect(isTransientRequestRateLimit({
+      status: 429,
+      code: "GoUsageLimitError",
+      message: "Monthly usage limit reached. Resets in 14 days.",
+    })).toBe(false);
+    expect(comboFailureCooldownScope(429, "Rate limit reached for requests", { code: "1302" })).toBe("target");
+    expect(isTransientRequestRateLimit({
+      status: 429,
+      code: "1302",
+      message: "Rate limit reached for requests",
+    })).toBe(true);
+  });
+
+  test("provider-scoped cooldown skips sibling models but leaves other providers eligible", () => {
+    const config = baseConfig({
+      combos: {
+        free: {
+          targets: [
+            { provider: "a", model: "m1" },
+            { provider: "a", model: "m1b" },
+            { provider: "b", model: "m2" },
+          ],
+        },
+      },
+    });
+    config.providers.a!.models = ["m1", "m1b"];
+    const first = pickComboTarget(config, "free", { now: 1_000 })!;
+    const next = advanceComboAfterFailure(config, first, { now: 1_000, cooldownScope: "provider" })!;
+    expect(next.target.provider).toBe("b");
+    expect(isComboTargetInCooldown("free", { provider: "a", model: "m1b" }, 1_001)).toBe(true);
+    expect(isComboTargetInCooldown("free", { provider: "b", model: "m2" }, 1_001)).toBe(false);
   });
 
   test("failure clears the active sticky target without adding a success", () => {


### PR DESCRIPTION
Treat provider-specific free-tier prompt caps (HTTP 400 + free_rate_limited) as combo-local failover instead of terminal invalid requests. When an upstream signals provider/account-wide exhaustion such as OpenCode Go monthly quota, cool sibling models from the same provider together so the combo moves directly to another provider. Generic invalid_request_error remains terminal.\n\nTests: bun test tests/combos.test.ts (46/46); bun run typecheck.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failover now recognizes free-tier rate limits and monthly usage limits.
  * Provider-level limits place affected provider models on cooldown while continuing to route requests to eligible models from other providers.

* **Bug Fixes**
  * Generic invalid-request errors no longer incorrectly trigger failover.
  * Rate-limit handling now distinguishes provider-wide quota limits from target-specific failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->