### PR TITLE
test(openai): keep provider-option E2E hermetic

### DIFF
--- a/tests/fixtures/openai-provider-option-migration-child.ts
+++ b/tests/fixtures/openai-provider-option-migration-child.ts
@@ -7,6 +7,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../../src/lib/windows-secret-acl";
+import {
+  setAsyncWindowsPrincipalRunnerForTests,
+  setWindowsPrincipalRunnerForTests,
+} from "../../src/lib/windows-user-principal";
 
 const [opencodexHome, codexHome] = Bun.argv.slice(2);
 if (!opencodexHome || !codexHome) {
@@ -16,6 +21,18 @@ mkdirSync(opencodexHome, { recursive: true, mode: 0o700 });
 mkdirSync(codexHome, { recursive: true, mode: 0o700 });
 process.env.OPENCODEX_HOME = opencodexHome;
 process.env.CODEX_HOME = codexHome;
+
+const icaclsOk = { success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" };
+const windowsPrincipalOk = {
+  success: true,
+  exitCode: 0,
+  timedOut: false,
+  stdout: "S-1-5-21-111-222-333-1001\r\nOPENCODEX\\Fixture\r\n",
+};
+setIcaclsRunnerForTests(() => icaclsOk);
+setAsyncIcaclsRunnerForTests(async () => icaclsOk);
+setWindowsPrincipalRunnerForTests(() => windowsPrincipalOk);
+setAsyncWindowsPrincipalRunnerForTests(async () => windowsPrincipalOk);
 
 const forward = {
   adapter: "openai-responses",

--- a/tests/openai-provider-option-e2e.test.ts
+++ b/tests/openai-provider-option-e2e.test.ts
@@ -16,6 +16,16 @@ import {
 import { homedir, tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
+import {
+  resetHardenedStateForTests,
+  setAsyncIcaclsRunnerForTests,
+  setIcaclsRunnerForTests,
+} from "../src/lib/windows-secret-acl";
+import {
+  resetWindowsPrincipalForTests,
+  setAsyncWindowsPrincipalRunnerForTests,
+  setWindowsPrincipalRunnerForTests,
+} from "../src/lib/windows-user-principal";
 import { watchdogMs } from "./helpers/ci-watchdog";
 import { removeTreeWithRetry } from "./helpers/remove-tree";
 type Capture = {
@@ -48,6 +58,14 @@ type MigrationReceipt = {
   remigrated: boolean;
   absencePreserved: boolean;
   collisionFailsBeforeSave: boolean;
+};
+
+const ICACLS_OK = { success: true, exitCode: 0, timedOut: false, stdout: "processed file: 1" };
+const WINDOWS_PRINCIPAL_OK = {
+  success: true,
+  exitCode: 0,
+  timedOut: false,
+  stdout: "S-1-5-21-111-222-333-1001\r\nOPENCODEX\\Fixture\r\n",
 };
 
 function hashTree(path: string): string {
@@ -122,7 +140,9 @@ describe("OpenAI provider-option integration spine", () => {
       CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
     };
     const savedFetch = globalThis.fetch;
+    const NativeWebSocket = globalThis.WebSocket;
     const captures: Capture[] = [];
+    const blockedUpstreamWebSocketUrls: string[] = [];
     const resets: Array<() => void> = [];
     let loopbackOrigin: string | null = null;
     let server: { url: URL; stop(closeActiveConnections?: boolean): Promise<void> } | null = null;
@@ -150,6 +170,18 @@ describe("OpenAI provider-option integration spine", () => {
     ]);
 
     try {
+      setIcaclsRunnerForTests(() => ICACLS_OK);
+      setAsyncIcaclsRunnerForTests(async () => ICACLS_OK);
+      setWindowsPrincipalRunnerForTests(() => WINDOWS_PRINCIPAL_OK);
+      setAsyncWindowsPrincipalRunnerForTests(async () => WINDOWS_PRINCIPAL_OK);
+      resets.push(
+        () => setIcaclsRunnerForTests(null),
+        () => setAsyncIcaclsRunnerForTests(null),
+        resetHardenedStateForTests,
+        () => setWindowsPrincipalRunnerForTests(null),
+        () => setAsyncWindowsPrincipalRunnerForTests(null),
+        resetWindowsPrincipalForTests,
+      );
       for (const dir of [opencodexHome, codexHome, claudeConfigDir]) {
         mkdirSync(dir, { recursive: true, mode: 0o700 });
       }
@@ -216,6 +248,19 @@ describe("OpenAI provider-option integration spine", () => {
           usage: { input_tokens: 3, output_tokens: 1, total_tokens: 4 },
         });
       }) as typeof fetch;
+      globalThis.WebSocket = class extends NativeWebSocket {
+        constructor(url: string | URL, protocols?: string | string[] | Record<string, unknown>) {
+          const parsed = new URL(String(url));
+          const loopback = parsed.hostname === "localhost"
+            || parsed.hostname === "127.0.0.1"
+            || parsed.hostname === "[::1]";
+          if (!loopback) {
+            blockedUpstreamWebSocketUrls.push(parsed.href);
+            throw new Error(`deny-by-default WebSocket blocked: ${parsed.origin}${parsed.pathname}`);
+          }
+          super(url, protocols as string[]);
+        }
+      } as typeof WebSocket;
 
       const [
         configModule,
@@ -351,7 +396,6 @@ describe("OpenAI provider-option integration spine", () => {
       expect(captures.at(-1)).toMatchObject({ authorization: "Bearer fixture-pool-access", accountId: "fixture-pool-account" });
       expect(captures.at(-1)?.body.reasoning).toBeUndefined();
 
-      const NativeWebSocket = globalThis.WebSocket;
       const expectedWsUrl = new URL("/v1/responses", server.url);
       expectedWsUrl.protocol = "ws:";
       const ws = new NativeWebSocket(expectedWsUrl, {
@@ -572,6 +616,9 @@ describe("OpenAI provider-option integration spine", () => {
       }
 
       expect(captures.every(capture => upstreamTuples.has(`${capture.method} ${capture.url}`))).toBe(true);
+      expect(new Set(blockedUpstreamWebSocketUrls)).toEqual(new Set([
+        "wss://chatgpt.com/backend-api/codex/responses",
+      ]));
       const evidenceDir = process.env.OCX_EVIDENCE_DIR;
       if (evidenceDir) {
         mkdirSync(evidenceDir, { recursive: true, mode: 0o700 });
@@ -595,6 +642,7 @@ describe("OpenAI provider-option integration spine", () => {
         if (server) await server.stop(true);
       } finally {
         globalThis.fetch = savedFetch;
+        globalThis.WebSocket = NativeWebSocket;
         for (const reset of resets) reset();
         restoreEnv("OPENCODEX_HOME", previousEnv.OPENCODEX_HOME);
         restoreEnv("CODEX_HOME", previousEnv.CODEX_HOME);


### PR DESCRIPTION
## Summary

- Closes #3299.
- Fix two sources of non-hermetic behavior in `tests/openai-provider-option-e2e.test.ts`: the test enables `websockets: true` but previously mocked only `fetch`, so OpenCodex could attempt a real upstream connection to `wss://chatgpt.com/backend-api/codex/responses`; its setup and migration paths could also invoke real Windows ACL and principal subprocesses.
- Guard `globalThis.WebSocket` inside the test: loopback URLs continue through Bun's native WebSocket to the real local OpenCodex test server, while non-loopback URLs are blocked and recorded. Blocking the upstream attempt exercises production's existing fallback through the mocked HTTP/SSE `fetch` boundary.
- Reuse the existing ACL and Windows-principal test seams in both the parent test (`tests/openai-provider-option-e2e.test.ts`) and migration child (`tests/fixtures/openai-provider-option-migration-child.ts`), avoiding real `icacls.exe` and principal-lookup subprocesses.
- Leave production code and the existing 30-second test timeout unchanged.

## Verification

- BEFORE — clean detached `dev` at `85d40ca35`, with all proxy environment variables removed:
  - `bun test --isolate --parallel=1 tests/openai-provider-option-e2e.test.ts`
  - `0 pass`, `1 fail`, `21 expect() calls` in 28.73 seconds
  - failure: `fixture websocket timeout: gpt-5.6-sol`
- AFTER — final HEAD `98beec015`, using the same machine, Bun 1.4.0, environment, and command:
  - `1 pass`, `0 fail`, `80 expect() calls` in 16.53 seconds
  - Bun's `80 expect() calls` means 80 runtime checks within the single integration-spine test, not 80 tests. The source has 64 `expect()` sites; parameterized cases execute some sites more than once. Together they cover:
  - provider registration and preset derivation;
  - local server health and configuration APIs;
  - Pool, Direct, and API-key credential ownership across HTTP, SSE streaming, compact responses, and a real loopback WebSocket;
  - Pool/Direct mode switching and Direct-mode request isolation from account, quota, health, and persisted configuration state;
  - model-management APIs, request logs, and usage persistence;
  - migration execution, idempotency, backup/restore, and unrelated-provider preservation;
  - outbound confinement: HTTP calls must match the mock allowlist, the set of blocked upstream WebSocket URLs must equal `wss://chatgpt.com/backend-api/codex/responses`, and the user's real Claude state must remain unchanged.
- Host-only runner note: both controlled reruns set `OCX_TEST_NO_QUEUE=1` after process inspection confirmed that a stale test-lock PID had been reused by an unrelated non-test Node process; no concurrent test runner was active, and the test preload's isolated homes remained enabled.
- PASS — `bun run typecheck` on final HEAD.
- NOT APPLICABLE — `bun run lint:gui:if-changed` and `bun run doctor:gui:if-changed`: no `gui/` changes in the push range.
- PASS — `bun run privacy:scan` on final HEAD.
- PASS — `git diff --check origin/dev...HEAD`.
- INCOMPLETE — on pre-rebase HEAD `5d94268eb`, the official `bun run prepush` reached the full `bun run test` gate, where the repository runner terminated at its 900-second cap with exit `124`. That run produced broad timeout, Windows ACL, and process/lock failures in unchanged test files before termination; it did not report a failure in either changed file, but it was not a green full-suite result. The 900-second full-suite run was not repeated after the conflict-free rebase; therefore final HEAD `98beec015` has no valid full-suite result. The focused before/after regression, typecheck, privacy scan, diff check, and applicable conditional gates are complete on this host; a valid full-suite result is still required before marking the PR Ready.
- NOT APPLICABLE — real authenticated external end-to-end. This test-only change deliberately uses fixture credentials and confines network activity to its local server and mocked upstream boundaries; it does not validate a live external account.

## Draft status

This PR must remain Draft. The local commit is rebased onto current `dev` at `85d40ca35`; the branch is one commit ahead with no pending upstream commits. The focused and standalone checks listed above pass, but the local-CI readiness box must remain unchecked because the full-suite gate is not green.

Before marking it Ready for review:

- obtain a valid `bun run test` result on the final HEAD;
- require the PR's aggregate `ci` check to complete successfully;
- resolve actionable maintainer or automated-review findings.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. Not applicable: test-only change with no user-facing behavior change.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved migration and end-to-end test reliability across non-Windows environments.
  - Added coverage to verify that only the expected external WebSocket connection is blocked.
  - Added cleanup safeguards to restore the original WebSocket behavior after tests complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->