### PR TITLE
fix(combos): harden safe pre-output failover

### DIFF
--- a/src/combos/resolve.ts
+++ b/src/combos/resolve.ts
@@ -1,5 +1,6 @@
 import type { OcxComboTarget, OcxConfig } from "../types";
 import { getCachedProviderQuota } from "../providers/quota-routing-cache";
+import type { ProviderQuota } from "../providers/quota-types";
 import { coolComboTarget, isComboTargetInCooldown, type ComboFailureCooldownScope } from "./failover";
 import { quotaResetRemainingMs } from "./reset-window";
 import { getCombo, resolveComboId, targetKey } from "./types";
@@ -56,6 +57,28 @@ export class NoAvailableComboTargetsError extends Error {
 function targetProviderIsUsable(config: OcxConfig, target: OcxComboTarget): boolean {
   return Object.hasOwn(config.providers, target.provider)
     && config.providers[target.provider]?.disabled !== true;
+}
+
+function quotaWindowExhausted(percent: number | undefined, resetAt: number | undefined, now: number): boolean {
+  if (typeof percent !== "number" || !Number.isFinite(percent) || percent < 100) return false;
+  return typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt > now;
+}
+
+export function cachedProviderQuotaIsExhausted(
+  quota: ProviderQuota | null,
+  now = Date.now(),
+): boolean {
+  if (!quota) return false;
+  if (quotaWindowExhausted(quota.fiveHourPercent, quota.fiveHourResetAt, now)) return true;
+  if (quotaWindowExhausted(quota.weeklyPercent, quota.weeklyResetAt, now)) return true;
+  if (quotaWindowExhausted(quota.monthlyPercent, quota.monthlyResetAt, now)) return true;
+  if (quota.customWindows?.some(window => quotaWindowExhausted(window.percent, window.resetAt, now))) return true;
+  if (quota.creditsUsd?.unlimited !== true
+      && typeof quota.creditsUsd?.percent === "number"
+      && Number.isFinite(quota.creditsUsd.percent)
+      && quota.creditsUsd.percent >= 100
+      && quota.creditsUsd.remaining <= 0) return true;
+  return false;
 }
 
 function smoothWeightedIndex(
@@ -121,14 +144,17 @@ export function pickComboTarget(
   options: {
     exclude?: Iterable<string>;
     eligible?: (target: Required<OcxComboTarget>) => boolean;
+    now?: number;
   } = {},
 ): ComboPick | null {
   const writerGeneration = captureConfigGeneration();
   const combo = getCombo(config, comboId);
   if (!combo) throw new UnknownComboError(comboId);
   const excluded = new Set(options.exclude ?? []);
+  const now = options.now ?? Date.now();
   const eligible = (target: Required<OcxComboTarget>): boolean =>
     targetProviderIsUsable(config, target)
+    && !cachedProviderQuotaIsExhausted(getCachedProviderQuota(target.provider, now), now)
     && !excluded.has(targetKey(target))
     && (options.eligible?.(target) ?? true);
 
@@ -187,7 +213,7 @@ export function pickComboTarget(
       }
     }
   } else if (combo.strategy === "reset-window") {
-    targetIndex = resetWindowIndex(combo.targets, eligible);
+    targetIndex = resetWindowIndex(combo.targets, eligible, now);
   } else {
     targetIndex = combo.targets.findIndex(eligible);
   }
@@ -269,6 +295,7 @@ export function advanceComboAfterFailure(
   }
   return pickComboTarget(config, pick.comboId, {
     exclude: pick.attempted,
+    now: options.now,
     eligible: target => !isComboTargetInCooldown(pick.comboId, target, options.now)
       && (options.eligible?.(target) ?? true),
   });

--- a/tests/combos.test.ts
+++ b/tests/combos.test.ts
@@ -528,6 +528,40 @@ describe("combo failure policy and advancement", () => {
     })).toBe(true);
   });
 
+  test("failover skips providers with fresh exhausted quota evidence before dispatch", () => {
+    const now = 50_000;
+    const config = baseConfig();
+    setCachedProviderQuotaForTests("a", {
+      monthlyPercent: 100,
+      monthlyResetAt: now + 14 * 24 * 60 * 60_000,
+      updatedAt: now,
+    });
+    const pick = pickComboTarget(config, "free", { now });
+    expect(pick?.target.provider).toBe("b");
+  });
+
+  test("elapsed quota reset does not permanently blacklist a provider", () => {
+    const now = 50_000;
+    const config = baseConfig();
+    setCachedProviderQuotaForTests("a", {
+      monthlyPercent: 100,
+      monthlyResetAt: now - 1,
+      updatedAt: now,
+    });
+    const pick = pickComboTarget(config, "free", { now });
+    expect(pick?.target.provider).toBe("a");
+  });
+
+  test("exhausted credits without an unlimited flag skip the provider", () => {
+    const now = 50_000;
+    const config = baseConfig();
+    setCachedProviderQuotaForTests("a", {
+      creditsUsd: { used: 10, limit: 10, remaining: 0, percent: 100 },
+      updatedAt: now,
+    });
+    expect(pickComboTarget(config, "free", { now })?.target.provider).toBe("b");
+  });
+
   test("provider-scoped cooldown skips sibling models but leaves other providers eligible", () => {
     const config = baseConfig({
       combos: {

--- a/tests/server-combo-failover-e2e.test.ts
+++ b/tests/server-combo-failover-e2e.test.ts
@@ -440,6 +440,46 @@ describe("server combo failover 030 activation matrix", () => {
     expect(hits).toEqual(["a:m1:SECRET_PROMPT_X"]);
   });
 
+  test("monthly quota then Orca free-prompt cap continues to a healthy third provider", async () => {
+    const hits: string[] = [];
+    const go = serve(async request => {
+      const body = await request.json() as { model?: string };
+      hits.push(`go:${body.model}`);
+      return Response.json({
+        error: { type: "GoUsageLimitError", message: "Monthly usage limit reached. Resets in 14 days." },
+      }, { status: 429 });
+    });
+    const orca = serve(async request => {
+      const body = await request.json() as { model?: string };
+      hits.push(`orca:${body.model}`);
+      return Response.json({ error: {
+        message: "This prompt is longer than the free tier allows for a single request.",
+        type: "invalid_request_error",
+        code: "free_rate_limited",
+        metadata: { reason: "err_free_prompt_cap" },
+      } }, { status: 400 });
+    });
+    const backup = serve(async request => {
+      const body = await request.json() as { model?: string };
+      hits.push(`backup:${body.model}`);
+      return chatSuccess("healthy fallback", "m3");
+    });
+    const config = comboConfig({
+      a: provider("openai-chat", baseUrl(go), "key-a"),
+      b: provider("openai-chat", baseUrl(orca), "key-b"),
+      c: provider("openai-chat", baseUrl(backup), "key-c"),
+    }, [
+      { provider: "a", model: "m1" },
+      { provider: "b", model: "m2" },
+      { provider: "c", model: "m3" },
+    ]);
+
+    const response = await post(config);
+    expect(response.status).toBe(200);
+    expect(JSON.stringify(await response.json())).toContain("healthy fallback");
+    expect(hits).toEqual(["go:m1", "orca:m2", "backup:m3"]);
+  });
+
   test("ordinary openai-chat 503 hops to backup for non-stream and stream", async () => {
     const hits: string[] = [];
     const a = serve(async request => {


### PR DESCRIPTION
## Summary

Hardens explicit combo failover so provider- or target-local failures cannot escape to the Claude Code client while a later declared target can still serve the turn.

This expands the production fix from the original quota/free-tier cases after an end-to-end audit of selection, quota prefiltering, error classification, cooldown scope, stored Codex credential replay, local pacing admission, stream commitment, and the paid DeepSeek final-fallback path.

## Root causes fixed

- Fresh exhausted provider quota is skipped before dispatch.
- OrcaRouter `free_rate_limited` / free-prompt caps hop provider-wide instead of terminating as generic `invalid_request_error`.
- Structured billing/auth failures (`insufficient_quota`, `subscription_required`, `payment_required`, `billing_error`, `insufficient_balance`, `invalid_api_key`) hop instead of being swallowed by generic HTTP classification.
- Target-local incompatibilities (`context_length_exceeded`, `tool_catalog_too_large`, `model_not_found`, `model_unavailable`, `unsupported_model`) hop to the next declared target.
- A local request-pacing queue overload before provider dispatch is converted to a retryable combo failure rather than escaping the combo loop.
- A stored Codex 401 refresh/replay that fails before first output may continue to the next provider in an explicit combo; once output has been emitted it remains terminal to prevent duplicate visible content.
- DeepSeek quota discovery now recognizes a title-cased provider name on the canonical destination and marks an authoritative zero balance as exhausted. Canonical-host credential guards remain unchanged.

## Deliberately still terminal

Client cancellation, cyber-policy refusal, generic malformed/invalid requests, unrelated resource conflicts, generic oversized requests without target-local context evidence, and any failure after visible output has already been committed remain terminal. Replaying those could duplicate output or weaken fail-closed policy.

## Evidence

- Focused audit suite: **270/270 PASS**, 1226 assertions.
- TypeScript: **PASS**.
- Privacy scan: **PASS**.
- E2E chain: context 400 -> billing 402 -> unsupported-model 400 -> healthy provider 200.
- E2E local pacing overload -> backup 200.
- E2E stored Codex replay 429 / transport failure / zero-output stream failure -> explicit combo backup 200.
- Non-combo Codex pool replay still refuses silent account composition.
- Stream-after-output tests still prove no replay after committed output.

No GUI changes.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev-derived branch state available when this head was certified.
- [x] I resolved all correct Codex and CodeRabbit findings known at this head.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->