### PR TITLE
fix(connect): return the rotation creation time so ocx connect rotate works

### DIFF
--- a/src/server/management/api-key-rotation.ts
+++ b/src/server/management/api-key-rotation.ts
@@ -7,6 +7,7 @@ export type ApiKeyRotationStart = {
   id: string;
   name: string;
   key: string;
+  createdAt: string;
   rotationId: string;
   expiresAt: string;
 };
@@ -44,7 +45,7 @@ export function startApiKeyRotation(
   const createdAt = new Date(now).toISOString();
   const expiresAt = new Date(now + API_KEY_ROTATION_TTL_MS).toISOString();
   entry.pendingRotation = { id: rotationId, key, createdAt, expiresAt };
-  return { id: entry.id, name: entry.name, key, rotationId, expiresAt };
+  return { id: entry.id, name: entry.name, key, createdAt, rotationId, expiresAt };
 }
 
 export function commitApiKeyRotation(

--- a/tests/api-keys-routes.test.ts
+++ b/tests/api-keys-routes.test.ts
@@ -6,6 +6,7 @@ import { loadConfig, readConfigDiagnostics, saveConfig } from "../src/config";
 import { startServer } from "../src/server";
 import { isDataPlaneAdmissionSecret } from "../src/server/auth-cors";
 import { ownAdmissionTokens } from "../src/claude/auth-detect";
+import { commitClientKeyRotation, startClientKeyRotation } from "../src/client/hub-client";
 import type { OcxConfig } from "../src/types";
 import { removeTreeWithRetry } from "./helpers/remove-tree";
 
@@ -94,6 +95,45 @@ afterEach(() => {
 });
 
 describe("API key rotation", () => {
+  test("BUG-R3303 completes the server-to-client rotation round trip with the persisted creation time", async () => {
+    saveConfig(baseConfig());
+    const server = startServer(0);
+    try {
+      const created = await keysRequest(server, "POST", { name: "client" });
+      const oldKey = created.json.key as string;
+      const id = created.json.id as string;
+      const fetchImpl: typeof fetch = async (input, init) => {
+        const requested = new URL(String(input));
+        return fetch(new URL(`${requested.pathname}${requested.search}`, server.url), init);
+      };
+      const credential = { kind: "admin" as const, value: new TextEncoder().encode(ADMIN_TOKEN) };
+
+      const started = await startClientKeyRotation(
+        "https://hub.example.test",
+        credential,
+        id,
+        { fetchImpl },
+      );
+      const pending = (loadConfig().apiKeys ?? [])[0]?.pendingRotation;
+      expect(started.createdAt).toBe(pending?.createdAt);
+      expect(started.expiresAt).toBe(pending?.expiresAt);
+      expect(isDataPlaneAdmissionSecret(oldKey, loadConfig())).toBe(true);
+      expect(isDataPlaneAdmissionSecret(started.key, loadConfig())).toBe(true);
+
+      await commitClientKeyRotation(
+        "https://hub.example.test",
+        credential,
+        id,
+        started.rotationId,
+        { fetchImpl },
+      );
+      expect(isDataPlaneAdmissionSecret(oldKey, loadConfig())).toBe(false);
+      expect(isDataPlaneAdmissionSecret(started.key, loadConfig())).toBe(true);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test("overlaps under one id, masks the pending secret, and commits atomically", async () => {
     saveConfig(baseConfig());
     const server = startServer(0);


### PR DESCRIPTION
## Summary

`ocx connect rotate` failed on every attempt with "Hub returned an invalid key rotation response". The server's `POST /api/keys/rotate` omitted `createdAt`, which the client parser requires.

The server was the side violating the contract: `StartedClientKeyRotation` declares `createdAt` as required and the CLI persists it as `newKeyIssuedAt`, so relaxing the parser instead would have silently dropped key lifecycle metadata. The route now returns the `createdAt` actually persisted in `pendingRotation` rather than a fabricated timestamp.

Everything else in the client lifecycle already worked on the same pair — connect, catalog sync, real model calls, disconnect, revocation — so rotate was the only unusable verb.

## Verification

- Red-first: a new full server → client-parser → commit round trip in `tests/api-keys-routes.test.ts` failed with `HubClientError: Hub returned an invalid key rotation response` (status 201, code `key_rotation_invalid`) — 44 pass / 1 fail.
- After the fix: 45 pass / 0 fail, including equality against the persisted timestamp so a missing or invented field fails loudly.
- `bun run typecheck` and `bun run privacy:scan` — passed.
- Per maintainer instruction for this campaign, the repository-wide suite was not run locally; CI is the full-suite gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This restores the documented response shape rather than changing it.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The response carries a creation timestamp only; no key material or account identifier is added.

Closes #3303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key rotation results now include the timestamp when rotation was initiated.
  * Improved end-to-end key rotation flow, including confirmation that old keys are rejected after the new key is committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->