### PR TITLE
fix(cli): print a dashboard URL that matches the real listener layout

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -120,20 +120,35 @@ export type ListenTarget = {
   dashboardUrl: string;
 };
 
+type StatusListenConfig = Pick<OcxConfig, "port" | "hostname" | "runtimeRole" | "hub">;
+
+function statusDashboardUrl(config: StatusListenConfig, hostname: string | undefined, port: number): string {
+  const managementOrigin = config.runtimeRole === "hub" ? config.hub?.managementPublicOrigin : undefined;
+  if (managementOrigin) return managementOrigin.endsWith("/") ? managementOrigin : `${managementOrigin}/`;
+
+  const reachableHostname = probeHostname(hostname);
+  const dashboardHostname = reachableHostname === "127.0.0.1"
+    || reachableHostname === "[::1]"
+    || reachableHostname.toLowerCase() === "localhost"
+    ? "localhost"
+    : reachableHostname;
+  return `http://${dashboardHostname}:${port}/`;
+}
+
 export function selectListenTarget(
-  config: Pick<OcxConfig, "port" | "hostname">,
+  config: StatusListenConfig,
   pid: number | null,
   runtimePort: RuntimePortState | null,
 ): ListenTarget {
   const currentRuntimePort = pid && runtimePort?.pid === pid ? runtimePort : null;
   const port = currentRuntimePort ? currentRuntimePort.port : config.port ?? 10100;
-  const hostname = currentRuntimePort ? currentRuntimePort.hostname : config.hostname;
+  const hostname = currentRuntimePort?.hostname ?? config.hostname;
   return {
     port,
     hostname,
     source: currentRuntimePort ? "runtime" : "config",
     healthUrl: `http://${probeHostname(hostname)}:${port}/healthz`,
-    dashboardUrl: `http://localhost:${port}/`,
+    dashboardUrl: statusDashboardUrl(config, hostname, port),
   };
 }
 
@@ -341,7 +356,7 @@ export async function collectStatus(): Promise<CliStatusView> {
       hostname: live.hostname,
       source: live.source,
       healthUrl: `http://${probeHostname(live.hostname)}:${live.port}/healthz`,
-      dashboardUrl: `http://localhost:${live.port}/`,
+      dashboardUrl: statusDashboardUrl(config, live.hostname, live.port),
     }
     : selectListenTarget(config, pidFile, pidFile ? readRuntimePort(pidFile) : null);
   // findLiveProxy already identity-probed /healthz; avoid a second fetch that can race.

--- a/tests/cli-status-json.test.ts
+++ b/tests/cli-status-json.test.ts
@@ -300,6 +300,41 @@ describe("CLI status JSON", () => {
     expect(target.dashboardUrl).toBe("http://localhost:58195/");
   });
 
+  test("listen target keeps the loopback dashboard URL unchanged", () => {
+    const target = selectListenTarget(
+      { port: 10100, hostname: "127.0.0.1" },
+      null,
+      null,
+    );
+
+    expect(target.dashboardUrl).toBe("http://localhost:10100/");
+  });
+
+  test("hub listen target prefers its management public origin", () => {
+    const target = selectListenTarget(
+      {
+        port: 10100,
+        hostname: "100.64.0.10",
+        runtimeRole: "hub",
+        hub: { managementPublicOrigin: "https://hub.example.test" },
+      },
+      null,
+      null,
+    );
+
+    expect(target.dashboardUrl).toBe("https://hub.example.test/");
+  });
+
+  test("non-loopback listen target uses its configured hostname", () => {
+    const target = selectListenTarget(
+      { port: 10100, hostname: "100.64.0.11" },
+      null,
+      null,
+    );
+
+    expect(target.dashboardUrl).toBe("http://100.64.0.11:10100/");
+  });
+
   test("resolveStatusPid preserves an authoritative null from live orphan checks", () => {
     expect(resolveStatusPid({ pid: null }, 4242)).toBeNull();
     expect(resolveStatusPid({ pid: 1111 }, 4242)).toBe(1111);


### PR DESCRIPTION
## Summary

`ocx status` printed `Dashboard: http://localhost:10100/` regardless of the actual listener layout. On a hub that binds a non-loopback hostname nothing listens there — the public listener moved to the tailnet IP and the loopback data listener serves only the API — so the printed URL sent the operator hunting for a broken GUI.

The URL is now derived from the layout that actually exists: a hub with `hub.managementPublicOrigin` set reports that origin, and otherwise status reflects the real bound hostname and port. Ordinary loopback setups print exactly what they printed before.

## Verification

- Red-first, `tests/cli-status-json.test.ts`: "hub listen target prefers its management public origin" and "non-loopback listen target uses its configured hostname" both failed — 24 pass / 2 fail.
- After the fix: 26 pass / 0 fail, covering the loopback case (unchanged), the hub-with-management-origin case, and a non-loopback hostname without a management origin.
- `bun run typecheck` — passed.
- Per maintainer instruction for this campaign, the repository-wide suite was not run locally; CI is the full-suite gate.

Worth flagging honestly: no live tailnet hub was available here, so the three listener layouts are verified through the focused test rather than against a real remote hub.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. CLI output only, no contract change.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Status now prints an origin already present in config; nothing new is exposed.

Closes #3304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard links now use the correct reachable hostname instead of always pointing to localhost.
  * Hub configurations now direct dashboard links to the configured management origin.
  * Live proxy status links now use the appropriate dashboard address.

* **Tests**
  * Added coverage for loopback addresses, custom hostnames, and hub management origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->