### PR TITLE
fix(integrations): let a hub-local client use the loopback listener

### DIFF
--- a/src/clients/config-export.ts
+++ b/src/clients/config-export.ts
@@ -22,7 +22,7 @@
 import { homedir } from "node:os";
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
-import { shouldInjectApiAuthHeader } from "../codex/inject";
+import { shouldInjectApiAuthHeader, standaloneCodexRoutingTarget } from "../codex/inject";
 import { FORMAT_MEDIA_TYPE, serializeDocument, type ConfigFormat } from "../integrations/serialize";
 import { providerCodexAccountMode } from "../providers/registry";
 import { canonicalizeReasoningEfforts, sanitizeCodexReasoningEfforts } from "../reasoning-effort";
@@ -301,7 +301,17 @@ export function ompModelsConfigPath(env: OpencodeLaunchEnv = process.env, home: 
 }
 
 /** Compose the OpenAI-compatible proxy base URL from a live probe result. */
-export function opencodeProxyBaseUrl(port: number, hostname?: string): string {
+export function opencodeProxyBaseUrl(
+  port: number,
+  hostname?: string,
+  config?: Pick<OcxConfig, "unauthenticatedLoopbackListener">,
+): string {
+  if (config?.unauthenticatedLoopbackListener?.enabled) {
+    return standaloneCodexRoutingTarget(port, {
+      hostname,
+      unauthenticatedLoopbackListener: config.unauthenticatedLoopbackListener,
+    }).baseUrl;
+  }
   return `http://${probeHostname(hostname)}:${port}/v1`;
 }
 

--- a/src/codex/desired-state.ts
+++ b/src/codex/desired-state.ts
@@ -71,15 +71,25 @@ export function codexIntegrationEnabled(config: Pick<OcxConfig, "clientIntegrati
 }
 
 /** Whether a Codex sync is permitted for this admitted config snapshot. */
-export function shouldSyncCodexOnStart(config: Pick<OcxConfig, "clientIntegrations" | "runtimeRole">): boolean {
+type LocalClientSyncConfig = Pick<
+  OcxConfig,
+  "clientIntegrations" | "runtimeRole" | "unauthenticatedLoopbackListener"
+>;
+
+function localClientSyncAllowed(config: LocalClientSyncConfig): boolean {
+  return config.runtimeRole !== "hub"
+    || config.unauthenticatedLoopbackListener?.enabled === true;
+}
+
+export function shouldSyncCodexOnStart(config: LocalClientSyncConfig): boolean {
   // A hub is a server for OTHER machines: it must not rewrite its own host's
   // Codex/Claude/Grok client configs on startup (interview decision Q6, and the
   // first clisu-oracle dogfood boot proved the failure mode — the hub marked
   // /readyz failed because it tried to run the full local client sync).
-  // "Hub is also a client" stays possible by explicitly enabling integrations
-  // later; the ROLE alone never injects.
-  if (config.runtimeRole === "hub") return false;
-  return codexIntegrationEnabled(config);
+  // A hub can be a local client only through its explicitly enabled loopback
+  // listener. The public hub bind remains outside this gate and still requires
+  // admission; an explicit client OFF continues to win.
+  return localClientSyncAllowed(config) && codexIntegrationEnabled(config);
 }
 
 /**
@@ -189,7 +199,7 @@ export function setClaudeDesktopIntegrationEnabled(enabled: boolean): CodexDesir
  */
 export async function syncCodexOnStartIfEnabled(
   port: number,
-  config: Pick<OcxConfig, "clientIntegrations" | "runtimeRole">,
+  config: LocalClientSyncConfig,
   sync: CodexStartupSync = defaultStartupSync,
   readinessGate?: ReadinessGate,
 ): Promise<{ ran: boolean; catalogWritten: boolean; cacheSynced: boolean }> {
@@ -232,9 +242,6 @@ async function defaultStartupSync(port: number): Promise<CodexStartupSyncOutcome
  * startup and its diagnostic is worth printing. This only answers whether to
  * attempt the sync at all.
  */
-export function shouldSyncGrokOnStart(config: Pick<OcxConfig, "clientIntegrations" | "runtimeRole">): boolean {
-  // Same hub rule as shouldSyncCodexOnStart: the hub role never rewrites its
-  // host's client configs on startup.
-  if (config.runtimeRole === "hub") return false;
-  return grokIntegrationEnabled(config);
+export function shouldSyncGrokOnStart(config: LocalClientSyncConfig): boolean {
+  return localClientSyncAllowed(config) && grokIntegrationEnabled(config);
 }

--- a/src/grok/sync.ts
+++ b/src/grok/sync.ts
@@ -7,6 +7,7 @@
  * Deps are injectable (mirrors src/codex/sync.ts) so tests can run without a live proxy.
  */
 import type { CatalogModel } from "../codex/catalog";
+import { standaloneCodexRoutingTarget } from "../codex/inject";
 import type { OcxConfig } from "../types";
 import { projectGrokCatalog } from "./catalog";
 import { injectGrokConfig, type GrokInjectResult } from "./inject";
@@ -47,8 +48,15 @@ export async function syncGrokConfig(
   // Pass the FULL list plus the exclusion set: the writer allocates aliases over
   // everything and emits only what is switched on, so a model's alias never depends on
   // its neighbours' switches. Absent/empty selection keeps today's behaviour exactly.
-  return deps.injectGrokConfig(port, projection.models, {
-    ...(opts.hostname !== undefined ? { hostname: opts.hostname } : {}),
+  const target = standaloneCodexRoutingTarget(port, {
+    hostname: opts.hostname ?? config.hostname,
+    unauthenticatedLoopbackListener: config.unauthenticatedLoopbackListener,
+  });
+  const targetUrl = new URL(target.baseUrl);
+  return deps.injectGrokConfig(Number(targetUrl.port), projection.models, {
+    hostname: target.requiresAdmissionToken
+      ? (opts.hostname ?? config.hostname)
+      : targetUrl.hostname,
     ...(opts.grokHome !== undefined ? { grokHome: opts.grokHome } : {}),
     excluded: new Set(config.grokExcludedModels ?? []),
     catalogModelIds: projection.catalogModelIds,

--- a/src/integrations/state.ts
+++ b/src/integrations/state.ts
@@ -369,7 +369,7 @@ export function exportContextOf(input: {
      * loopback, and every client we write into deserves the same answer the
      * export command already gives.
      */
-    baseUrl: opencodeProxyBaseUrl(input.port, input.config.hostname),
+    baseUrl: opencodeProxyBaseUrl(input.port, input.config.hostname, input.config),
     models: input.models,
     config: input.config,
   };

--- a/src/integrations/writer.ts
+++ b/src/integrations/writer.ts
@@ -12,7 +12,7 @@
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { EXPORT_CLIENTS, type ExportModel, type ManagedContribution } from "../clients/config-export";
-import { isLoopbackHostname } from "../codex/inject";
+import { shouldInjectApiAuthHeader } from "../codex/inject";
 import type { OcxConfig } from "../types";
 import { PARSE_FAILED, defaultIntegrationIO, loadTarget, parseConfig, type IntegrationIO } from "./config-io";
 import {
@@ -290,7 +290,7 @@ function applyOrRefreshIntegration(
   if (io.statKind(detectDir) !== "dir") {
     return refuse(clientId, "not_installed", "absent", `${clientId} is not installed`);
   }
-  if (isLoopbackOnly(clientId) && !isLoopbackHostname(input.config.hostname)) {
+  if (isLoopbackOnly(clientId) && shouldInjectApiAuthHeader(input.config)) {
     return refuse(clientId, "non_loopback", classified.state,
       `The generated ${clientId} integration is loopback-only and does not emit the admission header a non-loopback bind requires. Give it loopback access instead, through a tunnel or a local forwarder.`);
   }

--- a/tests/codex-desired-state.test.ts
+++ b/tests/codex-desired-state.test.ts
@@ -204,6 +204,35 @@ describe("the startup gate", () => {
     expect(shouldSyncGrokOnStart({ ...baseConfig(), runtimeRole: "standalone" })).toBe(true);
   });
 
+  test("a hub with an unauthenticated loopback listener syncs only enabled local clients (#3306)", async () => {
+    const hubClient = {
+      ...baseConfig(),
+      runtimeRole: "hub" as const,
+      hostname: "100.64.0.10",
+      unauthenticatedLoopbackListener: { enabled: true as const, port: 10102 },
+    };
+
+    expect(shouldSyncCodexOnStart(hubClient)).toBe(true);
+    expect(shouldSyncGrokOnStart(hubClient)).toBe(true);
+    expect(shouldSyncCodexOnStart({
+      ...hubClient,
+      clientIntegrations: { codex: false },
+    })).toBe(false);
+    expect(shouldSyncGrokOnStart({
+      ...hubClient,
+      clientIntegrations: { grok: false },
+    })).toBe(false);
+
+    let calls = 0;
+    const result = await syncCodexOnStartIfEnabled(
+      10100,
+      hubClient,
+      async () => { calls += 1; return undefined; },
+    );
+    expect(result.ran).toBe(true);
+    expect(calls).toBe(1);
+  });
+
   test("absence, an empty object, and an explicit true all still sync", async () => {
     for (const clientIntegrations of [undefined, {}, { codex: true }]) {
       let calls = 0;

--- a/tests/grok-sync.test.ts
+++ b/tests/grok-sync.test.ts
@@ -248,6 +248,32 @@ describe("syncGrokConfig", () => {
     }
   });
 
+  test("a hub targets its unauthenticated loopback listener instead of skipping (#3306)", async () => {
+    const { root, grokHome } = tempGrokHome();
+    try {
+      const config = {
+        ...baseConfig,
+        runtimeRole: "hub",
+        hostname: "100.64.0.10",
+        unauthenticatedLoopbackListener: { enabled: true, port: 10102 },
+      } as OcxConfig;
+      const result = await syncGrokConfig(10100, config, {
+        grokHome,
+        hostname: "100.64.0.10",
+      }, {
+        fetchAllModels: async () => [],
+        injectGrokConfig,
+      });
+
+      expect(result).toMatchObject({ ok: true, changed: true });
+      const content = readFileSync(join(grokHome, "config.toml"), "utf8");
+      expect(content).toContain('base_url = "http://127.0.0.1:10102/v1"');
+      expect(content).not.toContain("100.64.0.10");
+    } finally {
+      removeTreeWithRetry(root);
+    }
+  });
+
   test("catalog failure surfaces ok:false without touching the config", async () => {
     const { root, grokHome } = tempGrokHome();
     try {

--- a/tests/integrations-writer.test.ts
+++ b/tests/integrations-writer.test.ts
@@ -360,6 +360,31 @@ describe("apply", () => {
     expect(after.provider.opencodex!.models["mystery/model"]!.limit).toBeUndefined();
   });
 
+  test("ZCode on a hub writes and recognizes the unauthenticated loopback listener (#3306)", () => {
+    const configPath = installZcode();
+    const request = input({
+      clientId: "zcode",
+      config: {
+        ...CONFIG,
+        runtimeRole: "hub",
+        hostname: "100.64.0.10",
+        unauthenticatedLoopbackListener: { enabled: true, port: 10102 },
+      },
+    });
+
+    const result = applyIntegration(request);
+    expect(result.ok).toBe(true);
+
+    const document = JSON.parse(readFileSync(configPath, "utf8")) as {
+      provider: Record<string, { options: { apiKey: string; baseURL: string } }>;
+    };
+    expect(document.provider.opencodex!.options).toMatchObject({
+      apiKey: "opencodex-loopback",
+      baseURL: "http://127.0.0.1:10102/v1",
+    });
+    expect(readIntegrationState(request)).toMatchObject({ state: "current" });
+  });
+
   test("ZCode key-order normalization stays refreshable with derived metadata (#2759)", () => {
     const configPath = installZcode();
     const models: ExportModel[] = [


### PR DESCRIPTION
## Summary

A hub that is also a heavy local client had three broken integrations, all from the same cause: the client-integration writers did not know about `unauthenticatedLoopbackListener`. The dashboard showed a permanent zcode "conflict" whose replacement block could not authenticate, Grok auto-registration skipped entirely, and Codex injection was refused by the hub-role gate with no escape hatch. Each had a one-line manual workaround pointing at the loopback listener, which is what made the diagnosis obvious.

The three writers now resolve their endpoint through one shared seam (`standaloneCodexRoutingTarget` via `src/clients/config-export.ts`) rather than three separate mechanisms, so a hub-local integration targets the loopback listener instead of being skipped or refused.

## Security

The public hub listener and its authentication are unchanged. Hub-local integrations are enabled only when `unauthenticatedLoopbackListener.enabled === true`; otherwise the existing hub refusal and non-loopback admission requirements apply exactly as before.

Off-box callers cannot reach the selected endpoint: the listener is created on `127.0.0.1`, so the kernel never exposes that socket on an external interface, and its route allowlist plus Host/Origin checks are untouched. Grok additionally preserves the original non-loopback hostname whenever the target requires admission, so a wildcard or public bind still hits the existing fail-closed skip rather than silently borrowing loopback trust.

## Verification

Red-first, one failing assertion per reported symptom:

- ZCode: apply returned `false` with `non_loopback`.
- Grok: `changed: false` with `skippedReason: "non-loopback"`.
- Codex: the hub sync predicate returned `false`.

After the fix: `tests/integrations-writer.test.ts` 59 pass, `tests/grok-sync.test.ts` 10 pass, `tests/codex-desired-state.test.ts` 22 pass, all 0 fail. `bun run typecheck` passed.

Per maintainer instruction for this campaign, the repository-wide suite was not run locally; CI is the full-suite gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This makes an existing topology work rather than adding a new option.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults — see the Security section above.

Closes #3306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local client synchronization for hub setups using an unauthenticated loopback listener.
  * Corrected Codex and Grok routing so injected configurations use the appropriate loopback listener address and port.
  * Fixed integration configuration and authentication handling for non-loopback hub hosts.
  * Prevented incorrect refusal of valid non-loopback integration configurations.

* **Tests**
  * Added coverage for hub startup synchronization, Grok routing, and integration configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->