### PR TITLE
fix(connect): bound the catalog download by inactivity, not total duration

### DIFF
--- a/docs-site/src/content/docs/reference/cli/lifecycle.md
+++ b/docs-site/src/content/docs/reference/cli/lifecycle.md
@@ -486,4 +486,4 @@ publishes them to npm.
 
 ## Remote Hub client lifecycle
 
-Use `ocx connect <url> --pairing-code-stdin`, `ocx connect status`, `ocx sync`, and `ocx connect rotate --pairing-code-stdin`. `ocx disconnect` restores local state offline and does not revoke the hub key. While connected only, `ocx connect revoke --admin-token-stdin` revokes the persisted `apiKeyId`; after disconnect use the hub's **Integrations → API Keys** page. Secrets are stdin-only and never belong in argv.
+Use `ocx connect <url> --pairing-code-stdin`, `ocx connect status`, `ocx sync`, and `ocx connect rotate --pairing-code-stdin`. The initial catalog download fails after five seconds without incoming bytes, but active transfers may run longer; use `--catalog-timeout <seconds>` (1–120) to override that inactivity window. `ocx disconnect` restores local state offline and does not revoke the hub key. While connected only, `ocx connect revoke --admin-token-stdin` revokes the persisted `apiKeyId`; after disconnect use the hub's **Integrations → API Keys** page. Secrets are stdin-only and never belong in argv.

--- a/skills/ocx/references/05_remote_hub.md
+++ b/skills/ocx/references/05_remote_hub.md
@@ -87,7 +87,8 @@ Connect flags: `--clients codex,claude` (which client configs to point at the hu
 `--management-url <url>` (when management lives at a different address),
 `--management-transport direct|relay` (`relay` tunnels management over the data
 connection when no management port can be opened), `--no-sync` (connect without pulling
-the catalog).
+the catalog), and `--catalog-timeout <seconds>` (1–120 seconds of catalog-transfer
+inactivity before failing; arriving bytes reset the deadline).
 
 `ocx gui pair` refuses an origin that is not in `hub.managementPublicOrigin` or
 `corsAllowOrigins`. Grants are single-use, expire in five minutes, are origin-bound,
@@ -160,4 +161,3 @@ Do not work around these. Each one means unwinding would damage state that
   new one is issued, or a client that has not yet been updated is stranded.
 - *"Why is there no remote UI on my machine?"* Expected — `runtimeRole` is not `hub`.
 - *"Can I pass the pairing code as an argument?"* No. Credentials are stdin-only by design.
-

--- a/src/cli/connect.ts
+++ b/src/cli/connect.ts
@@ -17,6 +17,7 @@ import {
   rejectArgs,
   runCliAction,
   takeFlag,
+  takeIntegerOption,
   takeOption,
   type RuntimeApiDeps,
 } from "./runtime-api";
@@ -25,7 +26,7 @@ export const CONNECT_USAGE = `Usage:
   ocx connect <url> [--management-url <url>]
       (--pairing-code-stdin | --admin-token-stdin)
       [--clients codex,claude] [--management-transport direct|relay]
-      [--no-sync]
+      [--catalog-timeout <seconds>] [--no-sync]
   ocx connect status [--json]
   ocx connect rotate (--pairing-code-stdin | --admin-token-stdin)
       [--json]
@@ -147,6 +148,10 @@ async function runConnect(argv: string[], deps: RuntimeApiDeps): Promise<void> {
   if (!serverUrl || serverUrl.startsWith("--")) throw new CliUsageError("hub URL is required", CONNECT_USAGE);
   const managementUrl = takeOption(args, "--management-url");
   const clients = parseClients(takeOption(args, "--clients"));
+  const catalogTimeoutSeconds = takeIntegerOption(args, "--catalog-timeout", { min: 1 });
+  if (catalogTimeoutSeconds !== undefined && catalogTimeoutSeconds > 120) {
+    throw new CliUsageError("--catalog-timeout must be an integer between 1 and 120", CONNECT_USAGE);
+  }
   const managementTransport = takeOption(args, "--management-transport") ?? "direct";
   if (managementTransport !== "direct" && managementTransport !== "relay") {
     throw new CliUsageError("--management-transport must be direct or relay", CONNECT_USAGE);
@@ -167,6 +172,7 @@ async function runConnect(argv: string[], deps: RuntimeApiDeps): Promise<void> {
     selectedClients: clients,
     managementTransport,
     noSync,
+    ...(catalogTimeoutSeconds === undefined ? {} : { catalogTimeoutMs: catalogTimeoutSeconds * 1_000 }),
   }, { fetchImpl: deps.fetchImpl });
   console.log(`Connected to ${connection.serverUrl} as key ${connection.apiKeyId}.`);
 }

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -88,7 +88,7 @@ export const CLI_COMMANDS: CliCommandEntry[] = [
   { name: "ensure", usage: "ocx ensure", summary: "Ensure the proxy is running and Codex config/cache are current." },
   {
     name: "connect",
-    usage: "ocx connect <url> [--management-url <url>] (--pairing-code-stdin | --admin-token-stdin) [--clients codex,claude] [--management-transport direct|relay] [--no-sync]",
+    usage: "ocx connect <url> [--management-url <url>] (--pairing-code-stdin | --admin-token-stdin) [--clients codex,claude] [--management-transport direct|relay] [--catalog-timeout <seconds>] [--no-sync]",
     summary: "Connect this machine to a remote OpenCodex hub without persisting the one-time authority.",
     details: [
       "Status: ocx connect status [--json]",

--- a/src/client/connect.ts
+++ b/src/client/connect.ts
@@ -71,6 +71,7 @@ export interface ConnectOptions {
   selectedClients: OcxConnectedClientId[];
   managementTransport: "direct" | "relay";
   noSync?: boolean;
+  catalogTimeoutMs?: number;
 }
 
 export interface ClientConnectDeps {
@@ -408,7 +409,10 @@ export async function connectClient(
     const persisted = writeServiceApiTokenFile(issued.key);
     tokenFingerprint = persisted.fingerprint;
 
-    const catalog = await downloadClientCatalog(serverUrl, issued.key, { fetchImpl: deps.fetchImpl });
+    const catalog = await downloadClientCatalog(serverUrl, issued.key, {
+      fetchImpl: deps.fetchImpl,
+      timeoutMs: options.catalogTimeoutMs,
+    });
     atomicWriteFile(DEFAULT_CATALOG_PATH, catalog.body);
     writtenCatalogFingerprint = sha256(catalog.body);
 

--- a/src/client/hub-client.ts
+++ b/src/client/hub-client.ts
@@ -1,5 +1,6 @@
 import { MAX_REMOTE_CATALOG_BYTES } from "../server/catalog-download";
 import { readBoundedResponseBytes } from "../lib/bounded-body";
+import { clearableDeadline } from "../lib/abort";
 
 /**
  * A pairing grant may cross loopback or authenticated HTTPS, and nothing else.
@@ -84,13 +85,17 @@ async function fetchBounded(
   url: string,
   init: RequestInit,
   timeoutMs: number | undefined,
+  timeoutScope: "request" | "headers" = "request",
 ): Promise<Response> {
+  const timeout = safeTimeout(timeoutMs);
+  const headerDeadline = timeoutScope === "headers" ? clearableDeadline(timeout) : null;
   try {
     const response = await fetchImpl(url, {
       ...init,
       redirect: "manual",
-      signal: AbortSignal.timeout(safeTimeout(timeoutMs)),
+      signal: headerDeadline?.signal ?? AbortSignal.timeout(timeout),
     });
+    headerDeadline?.clear();
     if (response.status >= 300 && response.status < 400 && response.status !== 304) {
       throw new HubClientError("redirect_refused", "Hub request redirect was refused", response.status);
     }
@@ -98,15 +103,24 @@ async function fetchBounded(
   } catch (error) {
     if (error instanceof HubClientError) throw error;
     throw new HubClientError("unreachable", "Hub request did not complete", undefined, { cause: error });
+  } finally {
+    headerDeadline?.clear();
   }
 }
 
-async function boundedText(response: Response, maxBytes: number): Promise<string> {
+async function boundedText(
+  response: Response,
+  maxBytes: number,
+  options: { inactivityTimeoutMs?: number } = {},
+): Promise<string> {
   const declared = Number(response.headers.get("content-length") ?? "0");
   if (Number.isFinite(declared) && declared > maxBytes) {
     throw new HubClientError("body_too_large", "Hub response exceeded the allowed size", response.status);
   }
-  const result = await readBoundedResponseBytes(response, { maxBytes });
+  const result = await readBoundedResponseBytes(response, {
+    maxBytes,
+    ...(options.inactivityTimeoutMs === undefined ? {} : { inactivityTimeoutMs: options.inactivityTimeoutMs }),
+  });
   if (result.oversized) {
     throw new HubClientError("body_too_large", "Hub response exceeded the allowed size", response.status);
   }
@@ -422,7 +436,7 @@ export async function downloadClientCatalog(
   const response = await fetchBounded(options.fetchImpl ?? fetch, `${origin}/v1/catalog`, {
     method: "GET",
     headers,
-  }, options.timeoutMs);
+  }, options.timeoutMs, "headers");
   if (response.status === 304) {
     throw new HubClientError("catalog_unexpected_304", "Hub answered 304 to an unconditional catalog request", 304);
   }
@@ -434,7 +448,17 @@ export async function downloadClientCatalog(
     try { await response.body?.cancel(); } catch { /* best effort */ }
     throw new HubClientError("catalog_content_type_invalid", "Hub catalog response was not JSON", response.status);
   }
-  const body = await boundedText(response, options.maxBytes ?? MAX_REMOTE_CATALOG_BYTES);
+  let body: string;
+  try {
+    body = await boundedText(response, options.maxBytes ?? MAX_REMOTE_CATALOG_BYTES, {
+      inactivityTimeoutMs: safeTimeout(options.timeoutMs),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new HubClientError("unreachable", "Hub catalog download stalled", undefined, { cause: error });
+    }
+    throw error;
+  }
   const parsed = parseJson(body, "catalog_invalid");
   validateRemoteCatalog(parsed);
   const keyId = response.headers.get("x-opencodex-key-id")?.trim() || undefined;

--- a/src/lib/bounded-body.ts
+++ b/src/lib/bounded-body.ts
@@ -1,3 +1,5 @@
+import { idleDeadline } from "./abort";
+
 /** Maximum number of response-body bytes that may be retained for an error. */
 export const BOUNDED_BODY_MAX_BYTES = 65_536;
 
@@ -49,6 +51,8 @@ export interface BoundedBytesOptions {
 	signal?: AbortSignal;
 	/** Maximum number of raw bytes retained from the response body. */
 	maxBytes: number;
+	/** Deadline between non-empty raw chunks. Omitted means no body-read deadline. */
+	inactivityTimeoutMs?: number;
 }
 
 export interface BoundedBytesResult {
@@ -136,6 +140,15 @@ export async function readBoundedResponseBytes(
 	let retainedBytes = 0;
 	let mustCancel = false;
 	let cancelReason: unknown;
+	const inactivityReason = new DOMException("Response body stalled", "TimeoutError");
+	let rejectForInactivity: ((reason: unknown) => void) | undefined;
+	const inactive = new Promise<never>((_resolve, reject) => {
+		rejectForInactivity = reject;
+	});
+	const inactivity = options.inactivityTimeoutMs === undefined
+		? null
+		: idleDeadline(options.inactivityTimeoutMs, () => rejectForInactivity?.(inactivityReason));
+	inactivity?.reset();
 
 	let rejectForAbort: ((reason: unknown) => void) | undefined;
 	const aborted = new Promise<never>((_resolve, reject) => {
@@ -151,7 +164,7 @@ export async function readBoundedResponseBytes(
 			const read = reader.read();
 			// Observe a late read rejection when abort/cancellation wins the race.
 			void read.catch(() => undefined);
-			const outcome = await Promise.race([read, aborted]);
+			const outcome = await Promise.race([read, aborted, inactive]);
 			if (signal?.aborted) {
 				mustCancel = true;
 				cancelReason = signal.reason;
@@ -163,6 +176,7 @@ export async function readBoundedResponseBytes(
 				return { bytes: retained.subarray(0, retainedBytes), oversized: false };
 			}
 			if (!value || value.byteLength === 0) continue;
+			inactivity?.reset();
 
 			if (value.byteLength > maxBytes - retainedBytes) {
 				mustCancel = true;
@@ -187,6 +201,7 @@ export async function readBoundedResponseBytes(
 		cancelReason = error;
 		throw error;
 	} finally {
+		inactivity?.cancel();
 		signal?.removeEventListener("abort", onAbort);
 		if (mustCancel) cancelWithoutWaiting(reader, cancelReason);
 		try {

--- a/tests/client-connect.test.ts
+++ b/tests/client-connect.test.ts
@@ -184,6 +184,14 @@ describe("remote hub client boundary", () => {
       errors.length = 0;
       expect(await handleConnectCommand(["revoke", "client-key-override", "--admin-token-stdin"])).toBe(2);
       expect(errors.join(" ")).not.toContain("client-key-override");
+      errors.length = 0;
+      expect(await handleConnectCommand([
+        "https://hub.example.test",
+        "--admin-token-stdin",
+        "--catalog-timeout",
+        "0",
+      ])).toBe(2);
+      expect(errors.join(" ")).toContain("--catalog-timeout must be an integer >= 1");
     } finally {
       spy.mockRestore();
     }

--- a/tests/remote-catalog.test.ts
+++ b/tests/remote-catalog.test.ts
@@ -8,6 +8,56 @@ function response(body: string, headers: HeadersInit = JSON_HEADERS): Response {
 }
 
 describe("remote catalog adversarial consumer", () => {
+  test("allows a catalog download to exceed five seconds while bytes keep arriving", async () => {
+    const chunks = ['{"models":[', '{"slug":"provider/model"}', ']}'];
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        let index = 0;
+        return new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            const send = () => {
+              const chunk = chunks[index++];
+              if (chunk === undefined) return controller.close();
+              controller.enqueue(new TextEncoder().encode(chunk));
+              if (index < chunks.length) setTimeout(send, 2_600);
+              else controller.close();
+            };
+            send();
+          },
+        }), { headers: JSON_HEADERS });
+      },
+    });
+    try {
+      const result = await downloadClientCatalog(`http://127.0.0.1:${server.port}`, "ocx_data_test");
+      expect(JSON.parse(result.body)).toEqual({ models: [{ slug: "provider/model" }] });
+    } finally {
+      server.stop(true);
+    }
+  }, { timeout: 8_000 });
+
+  test("fails a stalled catalog download within the explicit inactivity bound", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"models":['));
+          },
+        }), { headers: JSON_HEADERS });
+      },
+    });
+    const startedAt = performance.now();
+    try {
+      await expect(downloadClientCatalog(`http://127.0.0.1:${server.port}`, "ocx_data_test", {
+        timeoutMs: 50,
+      })).rejects.toMatchObject({ code: "unreachable" });
+      expect(performance.now() - startedAt).toBeLessThan(1_000);
+    } finally {
+      server.stop(true);
+    }
+  });
+
   test("accepts additive fields only after the required model schema and key id pass", async () => {
     const body = JSON.stringify({ models: [{ slug: "provider/model", future: { enabled: true } }], futureTop: 1 });
     const result = await downloadClientCatalog("https://hub.example.test", "ocx_data_test", {


### PR DESCRIPTION
## Summary

Remote-hub `ocx connect` deterministically timed out downloading a large catalog. The client fetch carried a hard-coded 5 second total budget with no override, while a 416-model catalog (~8.4 MB, roughly 18 KB of `base_instructions` per entry) needs about 6 s over a healthy ~1.4 MB/s link. Connect then failed and rolled back, so any hub with a large model menu was unreachable from a slower link.

Raising the constant would only move the cliff, because no fixed total duration is correct for an unknown link speed. Instead the header deadline and the body deadline are now separate, and the body deadline is an **inactivity** timeout: it cannot fire while bytes are still arriving, but a genuinely stalled connection still fails within the bound. `--catalog-timeout <seconds>` (1–120) is available when an operator wants to be explicit.

## Verification

Red-first:

- `allows a catalog download to exceed five seconds while bytes keep arriving` failed at 5002 ms against the old total budget.
- `--catalog-timeout` was rejected as an unexpected argument before the flag existed.

After the fix: 35 pass / 0 fail across `tests/remote-catalog.test.ts` and `tests/client-connect.test.ts`, including a real local streaming HTTP response that runs past five seconds and a stalled connection that still fails inside the inactivity bound. `bun run typecheck` passed, the docs build completed (417 pages), and the skill-surface check passed.

Worth stating plainly: the reporter's 8.4 MB intercontinental transfer was not reproducible here, so the regression uses a real local streaming response held open past the old budget rather than the original link.

Per maintainer instruction for this campaign, the repository-wide suite was not run locally; CI is the full-suite gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed — the remote-hub reference and lifecycle docs describe the new flag and the inactivity semantics.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The bound still exists, so a dead connection cannot hang connect indefinitely.

Closes #3305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--catalog-timeout <seconds>` option to `ocx connect`.
  * Catalog downloads now fail after a configurable period of inactivity, from 1 to 120 seconds.
  * Active transfers can continue beyond the timeout while data keeps arriving.

* **Bug Fixes**
  * Stalled catalog downloads now report a clear unreachable-connection error.
  * Invalid timeout values are rejected with validation guidance.

* **Documentation**
  * Updated CLI and Remote Hub reference documentation with the new option and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->