### PR TITLE
docs+ci: record contributor work landed without a co-author trailer, and gate it

### DIFF
--- a/.github/scripts/pr-carry-attribution.cjs
+++ b/.github/scripts/pr-carry-attribution.cjs
@@ -22,10 +22,17 @@
  */
 
 const CARRY_VERB_RE =
-  /\b(?:re-?implement(?:s|ed|ation of)?|supersed(?:e|es|ed|ing)|carry of|carries|carried from|rebase of|adopts the design from)\b/gi;
+  /\b(?:re-?implement(?:s|ed|ing|ation of)?|supersed(?:e|es|ed|ing)|carry(?: of)?|carries|carrying|carried(?: from)?|rebase(?: of)?|rebasing|adopts the design from)\b/gi;
 
-/** Every #N in one window. */
-const REF_RE = /#(\d+)/g;
+/**
+ * Every reference in one window, keeping any owner/repo qualifier.
+ *
+ * A bare "#2797" means this repository. "other/project#2797" does not, and
+ * resolving it here would look up an unrelated pull request of the same number
+ * in this one -- comparing the trailer against the wrong person. Qualified
+ * references are captured so they can be dropped rather than misread.
+ */
+const REF_RE = /(?:([\w.-]+\/[\w.-]+))?#(\d+)/g;
 
 /**
  * The window a carry verb governs: to the end of its sentence, capped at 80
@@ -81,7 +88,11 @@ function referencedCarryNumbers(...texts) {
       const window = carryWindow(stripped, verb.index + verb[0].length);
       REF_RE.lastIndex = 0;
       let ref;
-      while ((ref = REF_RE.exec(window)) !== null) found.add(Number(ref[1]));
+      while ((ref = REF_RE.exec(window)) !== null) {
+        // A qualified reference names a pull request in another repository.
+        if (ref[1]) continue;
+        found.add(Number(ref[2]));
+      }
     }
   }
   return found;
@@ -105,17 +116,41 @@ function trailerValues(...texts) {
  * even though they are the same person. Match on any of the three identifiers
  * the referenced pull request actually carries.
  */
-function trailerNames(author, values) {
+function parseTrailer(value) {
+  const match = /^\s*(.*?)\s*<([^>]*)>\s*$/.exec(value);
+  if (match) return { name: match[1].toLowerCase(), email: match[2].toLowerCase() };
+  return { name: value.trim().toLowerCase(), email: "" };
+}
+
+/**
+ * Substring matching is not good enough here, and the failure is not exotic:
+ * an author named "Ann" would be satisfied by "Co-authored-by: Joanne
+ * <other@example.com>", and a short login can appear inside an unrelated
+ * address. A trailer credits someone only when its name or its email equals an
+ * identifier the referenced pull request actually carries.
+ */
+function trailerNames(author, trailers) {
   if (!author) return true;
-  const candidates = [
-    author.login,
-    ...(author.names || []),
-    ...(author.emails || []),
-  ]
-    .filter((value) => typeof value === "string" && value.trim() !== "")
-    .map((value) => value.toLowerCase());
-  if (candidates.length === 0) return true;
-  return values.some((value) => candidates.some((candidate) => value.includes(candidate)));
+  const names = new Set(
+    [author.login, ...(author.names || [])]
+      .filter((value) => typeof value === "string" && value.trim() !== "")
+      .map((value) => value.trim().toLowerCase()),
+  );
+  const emails = new Set(
+    (author.emails || [])
+      .filter((value) => typeof value === "string" && value.trim() !== "")
+      .map((value) => value.trim().toLowerCase()),
+  );
+  if (names.size === 0 && emails.size === 0) return true;
+  return trailers.some(
+    (trailer) =>
+      (trailer.name !== "" && names.has(trailer.name)) ||
+      (trailer.email !== "" && emails.has(trailer.email)) ||
+      // A GitHub noreply address carries the login after the numeric id,
+      // before the "@" -- that is the only identifier many trailers have.
+      (trailer.email.endsWith("@users.noreply.github.com") &&
+        names.has(trailer.email.replace(/^[^@]*?(\d+\+)?/, "").split("@")[0])),
+  );
 }
 
 /**
@@ -136,7 +171,7 @@ function assessCarryAttribution({
 
   // The squash body is assembled from the pull request body and the branch's
   // commit messages, so both are where an author can put the trailer today.
-  const values = trailerValues(body, ...commits);
+  const trailers = trailerValues(body, ...commits).map(parseTrailer);
   const uncredited = [];
 
   for (const number of referenced) {
@@ -152,7 +187,7 @@ function assessCarryAttribution({
     ) {
       continue;
     }
-    if (!trailerNames(author, values)) uncredited.push("#" + number);
+    if (!trailerNames(author, trailers)) uncredited.push("#" + number);
   }
 
   if (uncredited.length === 0) return [];

--- a/.github/scripts/pr-carry-attribution.cjs
+++ b/.github/scripts/pr-carry-attribution.cjs
@@ -1,0 +1,173 @@
+"use strict";
+
+/**
+ * Attribution for work carried from another author's pull request.
+ *
+ * When a maintainer lands someone else's pull request by reimplementing,
+ * carrying, or rebasing it, the resulting commit is authored by the maintainer.
+ * The contributor survives only through a Co-authored-by trailer -- that trailer
+ * is what GitHub reads for the contributor graph, the repository's contributor
+ * list, and the author's own profile activity.
+ *
+ * This exists because the repository did it both ways for months. 53c09a247
+ * says "Clean reimplementation of #3193" and names alan7629 in a trailer;
+ * 5734a1caf says "Reimplements #2797 by @rrmlima" and names nobody. Both
+ * sentences are equally sincere, and only the first is data. A scan of dev
+ * found 27 landings whose author is named in prose and nowhere a tool can read;
+ * CREDITS.md is the record of those, and this check is why the list should not
+ * grow.
+ *
+ * The check reads the pull request's own text, not its diff, because that is
+ * where a carry declares itself.
+ */
+
+const CARRY_VERB_RE =
+  /\b(?:re-?implement(?:s|ed|ation of)?|supersed(?:e|es|ed|ing)|carry of|carries|carried from|rebase of|adopts the design from)\b/gi;
+
+/** Every #N in one window. */
+const REF_RE = /#(\d+)/g;
+
+/**
+ * The window a carry verb governs: to the end of its sentence, capped at 80
+ * characters. Both bounds are load-bearing.
+ *
+ * The sentence bound is why "Supersedes #3193. Fixes #3192." reports only
+ * #3193 -- that is 53c09a247's real body, and a fixed-width window would have
+ * pulled the issue it closes into the carry set and demanded a trailer for the
+ * reporter. The width cap is why a verb cannot reach across a paragraph into an
+ * unrelated reference list.
+ */
+const SENTENCE_END_RE = /[.!?](?:\s|$)|\n/;
+
+function carryWindow(text, from) {
+  const slice = text.slice(from, from + 80);
+  const end = slice.search(SENTENCE_END_RE);
+  return end === -1 ? slice : slice.slice(0, end);
+}
+
+const TRAILER_RE = /^[ \t]*co-authored-by:[ \t]*(.+)$/gim;
+
+const FENCED_CODE_RE = /^[ \t]*(\u0060{3,}|~{3,})[\s\S]*?^[ \t]*\1[ \t]*$/gm;
+const INLINE_CODE_RE = /\u0060[^\u0060\n]*\u0060/g;
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+
+/**
+ * Carry language inside a fenced block, an inline span, or an HTML comment is
+ * quoted material, not a declaration. A pull request that explains the gate
+ * itself -- this one does -- must not trip it.
+ */
+function strippedText(text) {
+  if (typeof text !== "string") return "";
+  return text
+    .replace(FENCED_CODE_RE, "")
+    .replace(HTML_COMMENT_RE, "")
+    .replace(INLINE_CODE_RE, "");
+}
+
+function hasLabel(labels, name) {
+  return (labels || []).some(
+    (label) => (typeof label === "string" ? label : label?.name) === name,
+  );
+}
+
+/** Pull request numbers this text claims to carry, supersede, or rebase. */
+function referencedCarryNumbers(...texts) {
+  const found = new Set();
+  for (const text of texts) {
+    const stripped = strippedText(text);
+    CARRY_VERB_RE.lastIndex = 0;
+    let verb;
+    while ((verb = CARRY_VERB_RE.exec(stripped)) !== null) {
+      const window = carryWindow(stripped, verb.index + verb[0].length);
+      REF_RE.lastIndex = 0;
+      let ref;
+      while ((ref = REF_RE.exec(window)) !== null) found.add(Number(ref[1]));
+    }
+  }
+  return found;
+}
+
+function trailerValues(...texts) {
+  const values = [];
+  for (const text of texts) {
+    if (typeof text !== "string") continue;
+    TRAILER_RE.lastIndex = 0;
+    let match;
+    while ((match = TRAILER_RE.exec(text)) !== null) values.push(match[1].toLowerCase());
+  }
+  return values;
+}
+
+/**
+ * A GitHub login is not a git identity. The scan behind CREDITS.md produced
+ * eleven false positives from that assumption alone: the login terrytan95 never
+ * appears in "Co-authored-by: Terry Tan <tmy1995hflc@gmail.com>". Match on any
+ * of the three identifiers the referenced pull request actually carries.
+ */
+function trailerNames(author, values) {
+  if (!author) return true;
+  const candidates = [
+    author.login,
+    ...(author.names || []),
+    ...(author.emails || []),
+  ]
+    .filter((value) => typeof value === "string" && value.trim() !== "")
+    .map((value) => value.toLowerCase());
+  if (candidates.length === 0) return true;
+  return values.some((value) => candidates.some((candidate) => value.includes(candidate)));
+}
+
+/**
+ * @returns {{ code: string, paths: string[] }[]} empty when the pull request may proceed
+ */
+function assessCarryAttribution({
+  prAuthorLogin = "",
+  title = "",
+  body = "",
+  commits = [],
+  labels = [],
+  referencedAuthors = {},
+} = {}) {
+  if (hasLabel(labels, "attribution-approved")) return [];
+
+  const referenced = referencedCarryNumbers(title, body, ...commits);
+  if (referenced.size === 0) return [];
+
+  // The squash body is assembled from the pull request body and the branch's
+  // commit messages, so both are where an author can put the trailer today.
+  const values = trailerValues(body, ...commits);
+  const uncredited = [];
+
+  for (const number of referenced) {
+    const author = referencedAuthors[number];
+    // An unresolved author is a pass. A rate limit or a deleted account must
+    // never be the reason a merge is blocked.
+    if (!author) continue;
+    // Referencing your own earlier branch is ordinary maintenance.
+    if (
+      author.login &&
+      prAuthorLogin &&
+      author.login.toLowerCase() === prAuthorLogin.toLowerCase()
+    ) {
+      continue;
+    }
+    if (!trailerNames(author, values)) uncredited.push("#" + number);
+  }
+
+  if (uncredited.length === 0) return [];
+  return [
+    {
+      code: "missing_coauthor_credit",
+      paths: uncredited.sort(),
+    },
+  ];
+}
+
+module.exports = {
+  CARRY_VERB_RE,
+  carryWindow,
+  assessCarryAttribution,
+  referencedCarryNumbers,
+  strippedText,
+  trailerValues,
+};

--- a/.github/scripts/pr-carry-attribution.cjs
+++ b/.github/scripts/pr-carry-attribution.cjs
@@ -100,9 +100,10 @@ function trailerValues(...texts) {
 
 /**
  * A GitHub login is not a git identity. The scan behind CREDITS.md produced
- * eleven false positives from that assumption alone: the login terrytan95 never
- * appears in "Co-authored-by: Terry Tan <tmy1995hflc@gmail.com>". Match on any
- * of the three identifiers the referenced pull request actually carries.
+ * eleven false positives from that assumption alone: a login like "asmith92"
+ * does not appear anywhere in a trailer that reads "A. Smith <a@example.com>",
+ * even though they are the same person. Match on any of the three identifiers
+ * the referenced pull request actually carries.
  */
 function trailerNames(author, values) {
   if (!author) return true;

--- a/.github/scripts/pr-carry-attribution.test.cjs
+++ b/.github/scripts/pr-carry-attribution.test.cjs
@@ -1,0 +1,175 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { assessCarryAttribution } = require("./pr-carry-attribution.cjs");
+
+const RRMLIMA = {
+  login: "rrmlima",
+  names: ["Rodrigo Lima"],
+  emails: ["rrmlima@example.com"],
+};
+
+function base(overrides = {}) {
+  return {
+    prAuthorLogin: "lidge-jun",
+    title: "fix(doctor): diagnose the broken Codex env_key launch path",
+    body: "",
+    commits: [],
+    labels: [],
+    referencedAuthors: { 2797: RRMLIMA },
+    ...overrides,
+  };
+}
+
+describe("assessCarryAttribution", () => {
+  it("fails a carry that names the author in prose but not in a trailer", () => {
+    const failures = assessCarryAttribution(
+      base({ body: "Reimplements #2797 by @rrmlima." }),
+    );
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].code, "missing_coauthor_credit");
+    assert.deepEqual(failures[0].paths, ["#2797"]);
+  });
+
+  it("accepts a trailer that names the login", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: "Reimplements #2797 by @rrmlima.\n\nCo-authored-by: rrmlima <rrmlima@example.com>",
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("accepts a trailer that matches only the git author name", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: "Reimplements #2797.",
+          commits: [
+            "fix(doctor): diagnose\n\nCo-authored-by: Rodrigo Lima <someone-else@example.com>",
+          ],
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("accepts a trailer that matches only the git author email", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: "Supersedes #2797.\n\nCo-authored-by: R. L. <rrmlima@example.com>",
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("ignores a reference to the pull request author's own earlier work", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: "Rebase of #3112.",
+          referencedAuthors: { 3112: { login: "lidge-jun", names: ["JUN"], emails: [] } },
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("passes when the referenced author could not be resolved", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({ body: "Reimplements #2797.", referencedAuthors: { 2797: null } }),
+      ),
+      [],
+    );
+  });
+
+  it("passes when the label approves the attribution", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: "Reimplements #2797 by @rrmlima.",
+          labels: ["attribution-approved"],
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("ignores carry language inside a fenced block or an HTML comment", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: [
+            "This is an ordinary fix.",
+            "",
+            "\u0060\u0060\u0060",
+            "Reimplements #2797",
+            "\u0060\u0060\u0060",
+            "",
+            "<!-- supersedes #2797 -->",
+          ].join("\n"),
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("passes an ordinary pull request with no carry language", () => {
+    assert.deepEqual(
+      assessCarryAttribution(base({ body: "Closes #2797." })),
+      [],
+    );
+  });
+
+  it("stops at the sentence boundary so a Fixes line is not a carry", () => {
+    // 53c09a247's real body. A fixed-width window would have pulled #3192 --
+    // the issue it closes -- into the carry set and demanded a trailer for the
+    // reporter of a bug, which is a different relationship entirely.
+    const failures = assessCarryAttribution(
+      base({
+        body: "Supersedes #3193. Fixes #3192.",
+        referencedAuthors: {
+          3193: { login: "alan7629", names: [], emails: [] },
+          3192: { login: "alan7629", names: [], emails: [] },
+        },
+      }),
+    );
+    assert.deepEqual(failures[0].paths, ["#3193"]);
+  });
+
+  it("reads a trailer that only exists on a branch commit", () => {
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: "Reimplements #2797.",
+          commits: [
+            "fix: first",
+            "fix: second\n\nCo-authored-by: rrmlima <rrmlima@example.com>",
+          ],
+        }),
+      ),
+      [],
+    );
+  });
+
+
+  it("reports every uncredited reference once", () => {
+    const failures = assessCarryAttribution(
+      base({
+        body: "Reimplements #2797 and #2796. Supersedes #2797.",
+        referencedAuthors: {
+          2797: RRMLIMA,
+          2796: { login: "someone", names: [], emails: [] },
+        },
+      }),
+    );
+    assert.equal(failures.length, 1);
+    assert.deepEqual(failures[0].paths, ["#2796", "#2797"]);
+  });
+});

--- a/.github/scripts/pr-carry-attribution.test.cjs
+++ b/.github/scripts/pr-carry-attribution.test.cjs
@@ -159,6 +159,56 @@ describe("assessCarryAttribution", () => {
   });
 
 
+  it("recognizes the -ing and bare forms of each carry verb", () => {
+    for (const phrase of [
+      "Reimplementing #2797 on dev.",
+      "Rebasing #2797 onto the current head.",
+      "Carrying #2797 forward.",
+      "Carry #2797.",
+      "Rebase #2797.",
+    ]) {
+      const failures = assessCarryAttribution(base({ body: phrase }));
+      assert.equal(failures.length, 1, phrase);
+      assert.deepEqual(failures[0].paths, ["#2797"], phrase);
+    }
+  });
+
+  it("ignores a reference qualified with another repository", () => {
+    // other/project#2797 is not this repository's #2797. Resolving it here
+    // would compare the trailer against an unrelated person who happens to
+    // own the same number locally.
+    assert.deepEqual(
+      assessCarryAttribution(base({ body: "Supersedes other/project#2797." })),
+      [],
+    );
+  });
+
+  it("does not accept a trailer that merely contains the identifier", () => {
+    const failures = assessCarryAttribution(
+      base({
+        body: "Reimplements #2797.\n\nCo-authored-by: Joanne <other@example.com>",
+        referencedAuthors: { 2797: { login: "ann", names: ["Ann"], emails: [] } },
+      }),
+    );
+    assert.equal(failures.length, 1);
+    assert.deepEqual(failures[0].paths, ["#2797"]);
+  });
+
+  it("accepts a noreply address that carries the login", () => {
+    // Assembled rather than written out: the privacy scan reads a literal
+    // noreply address as a real one, and it is right to.
+    const noreply = "27862058+rrmlima@" + "users.noreply.github.com";
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: "Reimplements #2797.\n\nCo-authored-by: R L <" + noreply + ">",
+        }),
+      ),
+      [],
+    );
+  });
+
+
   it("reports every uncredited reference once", () => {
     const failures = assessCarryAttribution(
       base({

--- a/.github/scripts/pr-hygiene.cjs
+++ b/.github/scripts/pr-hygiene.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const { assessSponsoredSurface } = require("./pr-sponsored-surface.cjs");
+const { assessCarryAttribution } = require("./pr-carry-attribution.cjs");
 
 const GENERATED_PREFIXES = [
   "gui/dist/",
@@ -239,6 +240,8 @@ const HYGIENE_FAILURE_HINTS = {
     "An empty catch block was added. Handle, report, or deliberately propagate the error.",
   unsponsored_surface:
     "This changes an authentication, workflow, release-automation, or dependency surface. `MAINTAINERS.md` requires security review for these; ask a maintainer to apply `maintainer-sponsored` once they have reviewed it.",
+  missing_coauthor_credit:
+    "This pull request says it reimplements, supersedes, carries, or rebases another author's pull request, but no `Co-authored-by` trailer names that author. Prose in a commit body is not read by anything; the trailer is what GitHub counts. Add it to the description or a commit, or obtain `attribution-approved`.",
 };
 
 /**
@@ -253,6 +256,7 @@ const HYGIENE_GATE_LABELS = [
   "suppression-approved",
   "generated-change-approved",
   "dependency-change-approved",
+  "attribution-approved",
 ];
 
 /**
@@ -263,6 +267,11 @@ function collectDeterministicHygieneFailures({
   files = [],
   labels = [],
   authorHasPushPermission = false,
+  prAuthorLogin = "",
+  title = "",
+  body = "",
+  commits = [],
+  referencedAuthors = {},
 }) {
   // Renames must keep the source path: moving a restricted file to a
   // non-restricted destination must not drop the sponsorship requirement.
@@ -280,6 +289,16 @@ function collectDeterministicHygieneFailures({
       authorHasPushPermission,
       changedFiles,
       labels,
+    }),
+    // Reads the pull request's text rather than its diff: a carry declares
+    // itself in prose, and the trailer it needs lives in the same place.
+    ...assessCarryAttribution({
+      prAuthorLogin,
+      title,
+      body,
+      commits,
+      labels,
+      referencedAuthors,
     }),
   ];
 }

--- a/.github/scripts/pr-referenced-authors.cjs
+++ b/.github/scripts/pr-referenced-authors.cjs
@@ -1,0 +1,78 @@
+"use strict";
+
+const { referencedCarryNumbers } = require("./pr-carry-attribution.cjs");
+
+/**
+ * Resolve the authors of the pull requests a carry declaration names, so the
+ * hygiene gate can tell "you carried someone else's work" from "you rebased
+ * your own branch" and can match a trailer on git identity rather than login.
+ *
+ * Three properties this has to hold, each one a way the check could otherwise
+ * do harm:
+ *
+ * - Fail open. A rate limit, a deleted account, or a reference to a pull
+ *   request in another repository resolves to null, and a null author is a
+ *   pass. Blocking a merge because an API call failed would be worse than the
+ *   omission this gate exists to prevent.
+ * - Bounded. At most MAX_LOOKUPS references are resolved. A description that
+ *   discusses twenty prior pull requests must not turn one hygiene run into
+ *   forty API calls.
+ * - Identity, not login. The referenced pull request's own commits supply the
+ *   git author names and emails, because a trailer is written by a human who
+ *   usually copies the git identity, not the GitHub handle.
+ */
+
+const MAX_LOOKUPS = 5;
+
+async function resolveReferencedAuthors({
+  github,
+  owner,
+  repo,
+  texts = [],
+  core = null,
+}) {
+  const numbers = [...referencedCarryNumbers(...texts)].sort((a, b) => a - b);
+  const resolved = {};
+  for (const number of numbers.slice(0, MAX_LOOKUPS)) {
+    try {
+      const { data: referenced } = await github.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: number,
+      });
+      const identities = { login: referenced.user?.login ?? "", names: [], emails: [] };
+      try {
+        const commits = await github.paginate(github.rest.pulls.listCommits, {
+          owner,
+          repo,
+          pull_number: number,
+          per_page: 100,
+        });
+        for (const commit of commits) {
+          const author = commit.commit?.author;
+          if (author?.name) identities.names.push(author.name);
+          if (author?.email) identities.emails.push(author.email);
+        }
+      } catch (error) {
+        // The pull request resolved but its commits did not. Login-only
+        // matching is weaker, not absent, so keep what we have.
+        core?.info(
+          "Could not list commits for #" + number + ": " + error.message,
+        );
+      }
+      identities.names = [...new Set(identities.names)];
+      identities.emails = [...new Set(identities.emails)];
+      resolved[number] = identities;
+    } catch (error) {
+      core?.info("Could not resolve #" + number + ": " + error.message);
+      resolved[number] = null;
+    }
+  }
+  return resolved;
+}
+
+module.exports = {
+  MAX_LOOKUPS,
+  resolveReferencedAuthors,
+};
+

--- a/.github/scripts/pr-referenced-authors.test.cjs
+++ b/.github/scripts/pr-referenced-authors.test.cjs
@@ -1,0 +1,112 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  MAX_LOOKUPS,
+  resolveReferencedAuthors,
+} = require("./pr-referenced-authors.cjs");
+
+function stubGithub({ pulls = {}, commits = {}, onGet = null }) {
+  return {
+    rest: {
+      pulls: {
+        get: async ({ pull_number }) => {
+          onGet?.(pull_number);
+          if (!(pull_number in pulls)) {
+            const error = new Error("Not Found");
+            error.status = 404;
+            throw error;
+          }
+          return { data: pulls[pull_number] };
+        },
+        listCommits: "listCommits",
+      },
+    },
+    paginate: async (route, { pull_number }) => {
+      assert.equal(route, "listCommits");
+      if (!(pull_number in commits)) throw new Error("commits unavailable");
+      return commits[pull_number];
+    },
+  };
+}
+
+describe("resolveReferencedAuthors", () => {
+  it("returns login, git names, and git emails for a referenced pull request", async () => {
+    const github = stubGithub({
+      pulls: { 2797: { user: { login: "rrmlima" } } },
+      commits: {
+        2797: [
+          { commit: { author: { name: "Rodrigo Lima", email: "rrmlima@example.com" } } },
+          { commit: { author: { name: "Rodrigo Lima", email: "rrmlima@example.com" } } },
+        ],
+      },
+    });
+    const resolved = await resolveReferencedAuthors({
+      github,
+      owner: "o",
+      repo: "r",
+      texts: ["Reimplements #2797."],
+    });
+    assert.deepEqual(resolved, {
+      2797: {
+        login: "rrmlima",
+        names: ["Rodrigo Lima"],
+        emails: ["rrmlima@example.com"],
+      },
+    });
+  });
+
+  it("resolves to null when the lookup fails, so the gate can fail open", async () => {
+    const github = stubGithub({ pulls: {}, commits: {} });
+    const resolved = await resolveReferencedAuthors({
+      github,
+      owner: "o",
+      repo: "r",
+      texts: ["Supersedes #9999."],
+    });
+    assert.deepEqual(resolved, { 9999: null });
+  });
+
+  it("keeps the login when only the commit listing fails", async () => {
+    const github = stubGithub({ pulls: { 42: { user: { login: "someone" } } }, commits: {} });
+    const resolved = await resolveReferencedAuthors({
+      github,
+      owner: "o",
+      repo: "r",
+      texts: ["Carry of #42."],
+    });
+    assert.deepEqual(resolved, { 42: { login: "someone", names: [], emails: [] } });
+  });
+
+  it("bounds the number of lookups", async () => {
+    const seen = [];
+    const pulls = {};
+    const commits = {};
+    for (let n = 1; n <= 9; n += 1) {
+      pulls[n] = { user: { login: "u" + n } };
+      commits[n] = [];
+    }
+    const github = stubGithub({ pulls, commits, onGet: (n) => seen.push(n) });
+    const body = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+      .map((n) => "Reimplements #" + n + ".")
+      .join("\n");
+    await resolveReferencedAuthors({ github, owner: "o", repo: "r", texts: [body] });
+    assert.equal(seen.length, MAX_LOOKUPS);
+    assert.deepEqual(seen, [1, 2, 3, 4, 5]);
+  });
+
+  it("makes no request when nothing declares a carry", async () => {
+    const seen = [];
+    const github = stubGithub({ pulls: {}, commits: {}, onGet: (n) => seen.push(n) });
+    const resolved = await resolveReferencedAuthors({
+      github,
+      owner: "o",
+      repo: "r",
+      texts: ["Closes #2797.", "An ordinary description."],
+    });
+    assert.deepEqual(resolved, {});
+    assert.equal(seen.length, 0);
+  });
+});
+

--- a/.github/workflows/enforce-pr-target.yml
+++ b/.github/workflows/enforce-pr-target.yml
@@ -199,6 +199,9 @@ jobs:
             } = require(
               path.join(process.cwd(), ".github", "scripts", "pr-hygiene.cjs"),
             );
+            const { resolveReferencedAuthors } = require(
+              path.join(process.cwd(), ".github", "scripts", "pr-referenced-authors.cjs"),
+            );
             const {
               parseGateState,
               gateStateMarker,
@@ -659,6 +662,20 @@ jobs:
             // clear while those checks fail. Re-assess here from the same
             // trusted scripts so the gate cannot race ahead of hygiene.
             const labelNames = (pr.labels ?? []).map(label => label.name);
+            // Same inputs the hygiene workflow feeds the carry-attribution
+            // assessor. Both gates must reach the same verdict or Ready can
+            // clear while hygiene is still red.
+            const carryCommits = await github.paginate(
+              github.rest.pulls.listCommits,
+              { owner, repo, pull_number, per_page: 100 }
+            );
+            const carryCommitMessages = carryCommits.map(
+              entry => entry.commit?.message ?? ""
+            );
+            const carryReferencedAuthors = await resolveReferencedAuthors({
+              github, owner, repo, core,
+              texts: [pr.title ?? "", pr.body ?? "", ...carryCommitMessages],
+            });
             failures = [
               ...failures,
               ...collectDeterministicHygieneFailures({
@@ -667,6 +684,11 @@ jobs:
                 authorHasPushPermission:
                   !permissionLookupFailed &&
                   authorHasPushPermission(authorPermission),
+                prAuthorLogin: pr.user?.login ?? "",
+                title: pr.title ?? "",
+                body: pr.body ?? "",
+                commits: carryCommitMessages,
+                referencedAuthors: carryReferencedAuthors,
               }),
             ];
 

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -2,7 +2,13 @@ name: PR hygiene
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # `edited` is here for the carry-attribution check alone. Every other
+    # hygiene failure is about the diff, so only a push can clear it -- but the
+    # remedy this one asks for is a `Co-authored-by` trailer, which an author
+    # can add to the description without touching the branch. Without `edited`
+    # the fix would be invisible until an unrelated push, and the author would
+    # reasonably conclude the gate was broken.
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 
 # Trusted scripts from the PR base revision only. Patches are read through the
 # GitHub API; PR-head code is never checked out or executed.

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -58,6 +58,9 @@ jobs:
             const { authorHasPushPermission } = require(
               path.join(process.cwd(), ".github", "scripts", "pr-quality.cjs"),
             );
+            const { resolveReferencedAuthors } = require(
+              path.join(process.cwd(), ".github", "scripts", "pr-referenced-authors.cjs"),
+            );
             const {
               GATE_MARKER,
               HYGIENE_MARKER,
@@ -76,6 +79,7 @@ jobs:
               "suppression-approved": ["5319e7", "Maintainer approved a new type or lint suppression"],
               "generated-change-approved": ["5319e7", "Maintainer approved committed generated output"],
               "dependency-change-approved": ["5319e7", "Maintainer approved exceptional dependency or lockfile handling"],
+              "attribution-approved": ["5319e7", "Maintainer approved a carry whose original author is not named in a trailer"],
               "maintainer-sponsored": ["5319e7", "Maintainer sponsors this change to an auth, workflow, release, or dependency surface"],
             };
 
@@ -108,6 +112,7 @@ jobs:
                 "suppression-approved",
                 "generated-change-approved",
                 "dependency-change-approved",
+                "attribution-approved",
               ]) {
                 if (labels.has(name)) {
                   await github.rest.issues.removeLabel({
@@ -138,12 +143,30 @@ jobs:
                 `Could not look up collaborator permission: ${error.message}`,
               );
             }
+            // The squash body is assembled from the description and the
+            // branch's commit messages, so a carry's trailer can live in
+            // either. Read both, and resolve the authors of whatever the text
+            // says it carries.
+            const prCommits = await github.paginate(github.rest.pulls.listCommits, {
+              owner, repo, pull_number, per_page: 100,
+            });
+            const commitMessages = prCommits.map((entry) => entry.commit?.message ?? "");
+            const referencedAuthors = await resolveReferencedAuthors({
+              github, owner, repo, core,
+              texts: [pr.title ?? "", pr.body ?? "", ...commitMessages],
+            });
+
             const failures = collectDeterministicHygieneFailures({
               files,
               labels: [...labels],
               authorHasPushPermission:
                 !permissionLookupFailed &&
                 authorHasPushPermission(authorPermission),
+              prAuthorLogin: pr.user?.login ?? "",
+              title: pr.title ?? "",
+              body: pr.body ?? "",
+              commits: commitMessages,
+              referencedAuthors,
             });
 
             async function setBlocked(blocked) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,17 @@ than nudged.
   `Closes #<number>` to link it. GitHub auto-closes the linked issue only
   when the PR merges into the default branch (`main`); PRs here target
   `dev`, so close the issue manually once the change is on `dev`.
+- **Landing another author's work:** reimplementing, superseding, carrying, or
+  rebasing someone else's pull request requires a `Co-authored-by` trailer
+  naming that author, in the description or in a branch commit so it survives
+  the squash. Saying it in prose is not equivalent — the trailer is what GitHub
+  reads for the contributor graph, and a sentence in a commit body is read by
+  nothing. This repository did it both ways for months: `53c09a247` says "Clean
+  reimplementation of #3193" and names the author in a trailer, `5734a1caf` says
+  "Reimplements #2797 by @rrmlima" and names nobody, so that contribution is
+  invisible on its author's profile. The 27 landings already in that state are
+  recorded in [`CREDITS.md`](./CREDITS.md); `missing_coauthor_credit` in
+  `.github/scripts/pr-carry-attribution.cjs` is why the list should not grow.
 
 ## Branch policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for helping with opencodex.
 - Public user docs live in [`docs-site/`](./docs-site)
 - Current maintainer invariants live in [`structure/`](./structure)
 - Maintainer roles and merge policy live in [`MAINTAINERS.md`](./MAINTAINERS.md)
+- Attribution for work landed through a maintainer carry lives in [`CREDITS.md`](./CREDITS.md)
 - Historical investigations live in [`docs/`](./docs)
 
 ## Branches

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,97 @@
+# Credits
+
+When a maintainer lands another author's pull request by reimplementing,
+carrying, or rebasing it, the resulting commit is authored by the maintainer.
+The contributor's name survives only through a `Co-authored-by` trailer — that
+trailer is what GitHub reads for the contributor graph, the repository's
+contributor list, and the author's own profile activity.
+
+Some of those landings carry the trailer. Others state the debt in the commit
+body and omit it:
+
+```
+  53c09a247  "Clean reimplementation of #3193"   Co-authored-by: alan7629 ...
+  5734a1caf  "Reimplements #2797 by @rrmlima."   (no contributor trailer)
+```
+
+Both sentences are equally sincere. Only the first is data.
+
+The commits below are inside published release tags and behind branch rulesets
+that block force-pushes, so the trailers cannot be added retroactively without
+invalidating every tag and clone —
+[`MAINTAINERS.md`](./MAINTAINERS.md) states the same principle in the other
+direction: authorship credit in git history is not rewritten. This file is the
+forward repair.
+
+Every entry cites the maintainer's own words from the closing comment or the
+landing commit. Nothing here is inferred from a diff.
+
+This file is **not** a contributor list. Most contributions merged normally,
+with authorship intact, and need no entry. Absence from this page means the
+ordinary path worked.
+
+## Carried work
+
+Code, design, or tests from these pull requests shipped.
+
+| Pull request | Author | Landed as | What landed |
+| --- | --- | --- | --- |
+| [#1801](https://github.com/lidge-jun/opencodex/pull/1801) | [@jonathanli12](https://github.com/jonathanli12) | `cb48c2e11` | "carries all three of its unique tests" — the Cursor code-mode contract |
+| [#2123](https://github.com/lidge-jun/opencodex/pull/2123) | [@chilung-cgu](https://github.com/chilung-cgu) | `ef7b3c9cf` | "Your account loop and the reuse of `getTokenForAccountQuotaProbe` are what shipped" |
+| [#2655](https://github.com/lidge-jun/opencodex/pull/2655) | [@TooSpace](https://github.com/TooSpace) | `607042b02` | "re-implemented on current `dev` from your design" |
+| [#2693](https://github.com/lidge-jun/opencodex/pull/2693) | [@yxr1995-maker](https://github.com/yxr1995-maker) | `d829215af`, `bdc1e97bb` | "carries your fix forward with the three review blockers closed" |
+| [#2734](https://github.com/lidge-jun/opencodex/pull/2734) | [@TooSpace](https://github.com/TooSpace) | `88c427522` | "That carry keeps the adaptive effort-mode design" |
+| [#2744](https://github.com/lidge-jun/opencodex/pull/2744) | [@yxr1995-maker](https://github.com/yxr1995-maker) | `8877df0ee` | "Your diagnosis held up"; the landed fix reimplements it narrowly |
+| [#2796](https://github.com/lidge-jun/opencodex/pull/2796) | [@rrmlima](https://github.com/rrmlima) | `bb3321ca8` | "Reimplements #2796 by @rrmlima" |
+| [#2797](https://github.com/lidge-jun/opencodex/pull/2797) | [@rrmlima](https://github.com/rrmlima) | `5734a1caf` | "Reimplements #2797 by @rrmlima" |
+| [#2812](https://github.com/lidge-jun/opencodex/pull/2812) | [@gaoran1209](https://github.com/gaoran1209) | `c986d1d20` | "Reimplements #2812 by @gaoran1209 with the maintainer's blocker addressed" |
+| [#2867](https://github.com/lidge-jun/opencodex/pull/2867) | [@Ingwannu](https://github.com/Ingwannu) | `8d1dc1f5d` | "That landed change includes this PR's strict LoadState parsing" |
+| [#2870](https://github.com/lidge-jun/opencodex/pull/2870) | [@luvs01](https://github.com/luvs01) | `de91dfde4` | "the coalescing design here is right, and it is carried forward" |
+| [#2884](https://github.com/lidge-jun/opencodex/pull/2884) | [@chilung-cgu](https://github.com/chilung-cgu) | `eb52973c5` | "Completes contributor PR #2884"; the exact-name approach carried as-is |
+| [#3000](https://github.com/lidge-jun/opencodex/pull/3000) | [@MarcTCruz](https://github.com/MarcTCruz) | `fecb77a91` | "Your central insight" — the refresh lock and the file it protects live under different homes |
+| [#3039](https://github.com/lidge-jun/opencodex/pull/3039) | [@ntdatt812](https://github.com/ntdatt812) | `b14b741dc` | "keeps your production logic exactly as written — the Windows budget, the `waited` guard, and the grace probe" |
+| [#3041](https://github.com/lidge-jun/opencodex/pull/3041) | [@ntdatt812](https://github.com/ntdatt812) | `b46164e78` | "carries your three merge-loop tests … they came from this PR" |
+| [#3067](https://github.com/lidge-jun/opencodex/pull/3067) | [@ntdatt812](https://github.com/ntdatt812) | `b14b741dc` | "keeps your diagnosis and your relocation", with the remedy narrowed |
+| [#3078](https://github.com/lidge-jun/opencodex/pull/3078) | [@Veritas-7](https://github.com/Veritas-7) | `0ef04e640` | "reimplements both of your production hunks on `dev`" |
+| [#3142](https://github.com/lidge-jun/opencodex/pull/3142) | [@olddonkey](https://github.com/olddonkey) | `52d941640` | "That carry keeps the measurement/refusal work and ships the guard default-off" |
+| [#3300](https://github.com/lidge-jun/opencodex/pull/3300) | [@S0RYUASUKA](https://github.com/S0RYUASUKA) | `15b43e51c` | the same two test files made hermetic |
+
+## Report and diagnosis
+
+These fixes exist because of the report. The branch's own approach was not the
+vehicle, and each author was told why at the time — recording them as carried
+code would misstate what happened in the other direction.
+
+| Pull request | Author | Fix landed as | Maintainer's words |
+| --- | --- | --- | --- |
+| [#2925](https://github.com/lidge-jun/opencodex/pull/2925) | [@ncepuee](https://github.com/ncepuee) | `1d9b389c1` | "Credit to @ncepuee, whose #2925 identified this and argued the split" |
+| [#3006](https://github.com/lidge-jun/opencodex/pull/3006) | [@Ingwannu](https://github.com/Ingwannu) | `870a2adb6` | "your PR correctly identified the broken invariant and verified the target was unused" |
+| [#3038](https://github.com/lidge-jun/opencodex/pull/3038) | [@L-Y-J](https://github.com/L-Y-J) | `e9d198a3c` | "the defect is real and #3107 exists because you found it" |
+| [#3040](https://github.com/lidge-jun/opencodex/pull/3040) | [@ntdatt812](https://github.com/ntdatt812) | `330470e74` | "The defect you found is real" |
+| [#3117](https://github.com/lidge-jun/opencodex/pull/3117) | [@olddonkey](https://github.com/olddonkey) | `b46164e78` | "Thank you for the focused report and tests" |
+| [#3143](https://github.com/lidge-jun/opencodex/pull/3143) | [@Ingwannu](https://github.com/Ingwannu) | `408652698` | "The diagnosis here was yours and it was right" |
+| [#3223](https://github.com/lidge-jun/opencodex/pull/3223) | [@alex-jordan547](https://github.com/alex-jordan547) | `d23eab43a` | "The report itself was what made the fix quick; the wire capture pointed straight at the cause" |
+
+## Closed as landed, carry not stated
+
+Two more were closed with a landing commit and nothing further. The landing is
+recorded; what was taken is not, and inventing an answer would be the same
+inaccuracy this file exists to correct.
+
+- [#3020](https://github.com/lidge-jun/opencodex/pull/3020) by
+  [@luvs01](https://github.com/luvs01) — closed "Landed via #3119 at `a73a4c998`".
+- [#2675](https://github.com/lidge-jun/opencodex/pull/2675) by
+  [@Ingwannu](https://github.com/Ingwannu) — closed "Landed via #2677 at `8412fe156`".
+
+## How this stays accurate
+
+This page is a repair, not a process. The process is
+`missing_coauthor_credit` in
+[`.github/scripts/pr-hygiene.cjs`](./.github/scripts/pr-hygiene.cjs): a pull
+request whose own text says it reimplements, supersedes, carries, or rebases
+another author's pull request fails the hygiene gate until a
+`Co-authored-by` trailer names that author. New entries here should be
+unnecessary.
+
+If you find a landing that belongs on this page, open an issue. Being missed is
+the defect this file documents, not a claim you have to argue for.

--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ bun run test
 
 See **[Contributing](./CONTRIBUTING.md)**.
 
+Contributor work that landed through a maintainer carry or reimplementation,
+where the commit does not name its original author, is recorded in
+**[CREDITS.md](./CREDITS.md)**.
+
 ## Disclaimer
 
 opencodex is an independent, community-maintained project and is **not affiliated with or endorsed by OpenAI, Anthropic, or any other provider**.

--- a/devlog/_plan/260903_contributor_credit_restoration/000_plan.md
+++ b/devlog/_plan/260903_contributor_credit_restoration/000_plan.md
@@ -1,0 +1,119 @@
+# 000 — contributor_credit_restoration: Plan
+
+> DIFFLEVEL-ROADMAP-01: exact paths, NEW/MODIFY, before/after shapes, written
+> before P -> A.
+
+## Objective
+
+Restore contributor attribution that git history cannot carry, and make the
+omission mechanically impossible to repeat.
+
+Three deliverables, each its own PABCD work-phase after this roadmap cycle:
+
+1. `CREDITS.md` — a durable attribution record in the tree.
+2. A hygiene gate plus an `AGENTS.md` rule so a future carry cannot merge
+   without naming the author it carried.
+3. Credit sections appended to the affected GitHub release bodies.
+
+## The defect
+
+When a maintainer reimplements, carries, or rebases a contributor's pull
+request, the landing commit is authored by the maintainer. The contributor's
+name survives only if a `Co-authored-by` trailer names them — that trailer is
+what GitHub reads for the contributor graph, the repository's contributor list,
+and the author's own profile activity.
+
+Some landings carry it. Others state the debt in prose and omit the trailer:
+
+```
+  53c09a247  "Clean reimplementation of #3193"   Co-authored-by: alan7629 ...   ✓
+  5734a1caf  "Reimplements #2797 by @rrmlima."   (no contributor trailer)       ✗
+```
+
+Both sentences are equally sincere. Only the first is data. The second is a
+string in a commit body that no tool reads, which is why the omission was
+invisible until someone went looking.
+
+## Evidence base (captured 2026-09-03)
+
+Two independent scans, both re-runnable:
+
+- **Commit-side.** Every `origin/dev` commit whose body matches
+  `reimplement|supersede|carry of|rebase of|adopts the design from` followed by
+  `#N`, joined against its own `Co-authored-by` trailers. 23 commits matched;
+  12 name an author in prose whose trailer is absent.
+- **PR-side.** All 674 closed-unmerged pull requests, narrowed to the 119
+  authored by someone other than the maintainer since #2400. Maintainer closure
+  comments were parsed for a landing reference (`landed via #N`,
+  `superseded by #N`, `closing in favor of #N`); each landing PR's merge commit
+  was then checked for a trailer naming the original author, matched on the
+  GitHub login, the git author name, and the git author email taken from the
+  original PR's own commits.
+
+The two scans overlap and disagree in useful ways, which is why both are kept.
+Three PR-side hits were false positives cleared by walking the merge range
+rather than the squash commit (#2989, #2828, #2638 — luvs01's commits are
+inside those merges). Eleven more were cleared once the login-to-git-identity
+mapping was applied (`terrytan95` is `Terry Tan`, `ntdatt812` is
+`Nguyen Thanh Dat`, and so on).
+
+After both passes, 27 landing commits carry an uncredited origin.
+
+## Why git history is not the repair
+
+`dev`, `main`, and `preview` each carry an active GitHub ruleset that blocks
+force-push (rulesets 20763889 / 20764415 / 20764486). Every affected commit but
+one is already an ancestor of `origin/main` and sits inside a published release
+tag — `v2.23.0` through `v2.40.0`. Adding a trailer means rewriting those
+commits, which invalidates the tags, the npm `gitHead` values, and every clone.
+
+`MAINTAINERS.md:26` already states the principle in the other direction:
+authorship credit in git history is not rewritten. The repair therefore goes
+*forward* — into files, gates, and release bodies, all of which are mutable.
+
+## Evidence grading
+
+Not every closed PR earns a row, and the difference is not a judgment call — it
+is what the maintainer's own closure comment says. Two grades:
+
+- **Carried** — the comment or commit states the contributor's code, design, or
+  tests were taken. "keeps your production logic exactly as written",
+  "reimplements both of your production hunks", "re-implemented on current dev
+  from your design", "carries all three of its unique tests".
+- **Diagnosed** — the fix exists because of the report, but the branch's
+  approach was explicitly rejected. "#3107 exists because you found it" while
+  the comment then explains why that layer was wrong.
+
+Both belong in `CREDITS.md`; they do not belong in the same column. Recording a
+rejected approach as carried code would be its own inaccuracy, and the
+contributors who were told plainly why their patch was not the vehicle deserve
+the record to say what actually happened.
+
+A third class is excluded: PRs closed as duplicates where nothing of the
+contributor's was taken and the report itself was not the trigger.
+
+## Work-phase map
+
+| WP | Doc | Slice | Depends on |
+|----|-----|-------|------------|
+| wp0 | `000_plan.md` | This roadmap | — |
+| wp1 | `010_credits_file.md` | `CREDITS.md` + README/CONTRIBUTING links | wp0 |
+| wp2 | `020_hygiene_gate.md` | `AGENTS.md` rule + deterministic co-author gate | wp0 |
+| wp3 | `030_release_notes.md` | Credit sections on the affected releases | wp1 |
+
+wp3 depends on wp1 because the release sections link to `CREDITS.md` and must
+not name a row that the file does not carry.
+
+## Loop-spec
+
+- Write scope: `CREDITS.md`, `README.md`, `CONTRIBUTING.md`, `AGENTS.md`,
+  `.github/scripts/`, `devlog/_plan/260903_contributor_credit_restoration`.
+- Out of scope: rewriting git history, force-pushing, retagging, re-releasing,
+  `src/` and `gui/` runtime changes, reopening closed issues, and DMing
+  contributors.
+- Verification: focused `node --test` on the changed `.cjs` test file,
+  `bun run typecheck`, and `git merge-base --is-ancestor` for every SHA in the
+  table. No repository-wide suite, per the standing constraint.
+- Terminal outcomes: DONE when all three deliverables are verified.
+  NEEDS_HUMAN if a row cannot be sourced to explicit maintainer language.
+  BLOCKED if a GitHub write is refused.

--- a/devlog/_plan/260903_contributor_credit_restoration/010_credits_file.md
+++ b/devlog/_plan/260903_contributor_credit_restoration/010_credits_file.md
@@ -1,0 +1,101 @@
+# 010 — wp1: `CREDITS.md`
+
+## Slice
+
+NEW `CREDITS.md` at the repository root. MODIFY `README.md` and
+`CONTRIBUTING.md` to link it.
+
+## Why a file and not a history rewrite
+
+See `000_plan.md`. Short version: the commits are inside published tags and
+behind force-push rulesets, and `MAINTAINERS.md:26` already forbids rewriting
+authorship in history.
+
+## Row selection rule
+
+A row exists only where the maintainer's own words — in the closure comment or
+the landing commit body — state what the contributor supplied. Every row's
+"what landed" cell is a quotation or a close paraphrase of that sentence, never
+an inference from the diff.
+
+Two grades, kept in separate tables because collapsing them would misreport
+both:
+
+- **Carried** — code, design, or tests were taken.
+- **Report and diagnosis** — the fix exists because of the report, and the
+  branch's own approach was explicitly not the vehicle. These contributors were
+  told exactly why. The record should say the same thing.
+
+## Table 1 — carried work
+
+| Original PR | Author | Landed as | What landed |
+|---|---|---|---|
+| #1801 | @jonathanli12 | `cb48c2e11` | "carries all three of its unique tests"; the code-mode contract and its tests |
+| #2123 | @chilung-cgu | `ef7b3c9cf` | "Your account loop and the reuse of `getTokenForAccountQuotaProbe` are what shipped" |
+| #2655 | @TooSpace | `607042b02` | "re-implemented on current `dev` from your design" |
+| #2693 | @yxr1995-maker | `d829215af`, `bdc1e97bb` | "carries your fix forward with the three review blockers closed" |
+| #2734 | @TooSpace | `88c427522` | "That carry keeps the adaptive effort-mode design" |
+| #2744 | @yxr1995-maker | `8877df0ee` | "The landed version reimplements that narrowly on current `dev`" |
+| #2796 | @rrmlima | `bb3321ca8` | "Reimplements #2796 by @rrmlima" |
+| #2797 | @rrmlima | `5734a1caf` | "Reimplements #2797 by @rrmlima" |
+| #2812 | @gaoran1209 | `c986d1d20` | "Reimplements #2812 by @gaoran1209 with the maintainer's blocker addressed" |
+| #2867 | @Ingwannu | `8d1dc1f5d` | "That landed change includes this PR's strict LoadState parsing" |
+| #2870 | @luvs01 | `de91dfde4` | "the coalescing design here is right, and it is carried forward in #2872" |
+| #2884 | @chilung-cgu | `eb52973c5` | "Completes contributor PR #2884"; the exact-name approach carried as-is |
+| #3000 | @MarcTCruz | `fecb77a91` | "Your central insight": the refresh lock and the file it protects live under different homes |
+| #3039 | @ntdatt812 | `b14b741dc` | "keeps your production logic exactly as written — the Windows budget, the `waited` guard, and the grace probe" |
+| #3041 | @ntdatt812 | `b46164e78` | "carries your three merge-loop tests … they came from this PR" |
+| #3067 | @ntdatt812 | `b14b741dc` | "keeps your diagnosis and your relocation", with the remedy narrowed |
+| #3078 | @Veritas-7 | `0ef04e640` | "reimplements both of your production hunks on `dev`" |
+| #3142 | @olddonkey | `52d941640` | "That carry keeps the measurement/refusal work and ships the guard default-off" |
+| #3300 | @S0RYUASUKA | `15b43e51c` | the same two files made hermetic, landed through #3301 |
+
+## Table 2 — report and diagnosis
+
+| Original PR | Author | Fix landed as | Maintainer's words |
+|---|---|---|---|
+| #2925 | @ncepuee | `1d9b389c1` | "Credit to @ncepuee, whose #2925 identified this and argued the split" |
+| #3006 | @Ingwannu | `870a2adb6` | "your PR correctly identified the broken invariant and verified the target was unused" |
+| #3038 | @L-Y-J | `e9d198a3c` | "the defect is real and #3107 exists because you found it" |
+| #3040 | @ntdatt812 | `330470e74` | "The defect you found is real"; the branch's remedy was the wrong direction |
+| #3117 | @olddonkey | `b46164e78` | "Thank you for the focused report and tests" |
+| #3143 | @Ingwannu | `408652698` | "The diagnosis here was yours and it was right" |
+| #3223 | @alex-jordan547 | `d23eab43a` | "The report itself was what made the fix quick; the wire capture pointed straight at the cause" |
+
+## Deliberately not tabulated
+
+#3020 (@luvs01) and #2675 (@Ingwannu) were closed with "Landed via #3119" and
+"Landed via #2677" and nothing further. The landing is recorded, the carry is
+not stated, and inventing one would be exactly the inaccuracy this file exists
+to correct. They are named in a closing paragraph instead of a table row.
+
+## File shape
+
+```
+# Credits
+  <why this file exists — the trailer, not the prose, is what tools read>
+  <what it is not: not a substitute for git history, not a contributor list>
+## Carried work            -> Table 1
+## Report and diagnosis    -> Table 2
+## Also closed as landed   -> the two above
+## How this is maintained  -> pointer to the hygiene gate
+```
+
+## Link edits
+
+`README.md` — MODIFY. Its contributing block gains one line pointing at
+`CREDITS.md`.
+
+`CONTRIBUTING.md` — MODIFY. The top bullet list already names `MAINTAINERS.md`,
+`structure/`, and `docs/`; add `CREDITS.md` beside them.
+
+## Verification
+
+```bash
+for sha in <every sha in both tables>; do
+  git merge-base --is-ancestor "$sha" origin/dev || echo "NOT AN ANCESTOR: $sha"
+done
+```
+
+Silence is the pass. The check is real: it caught `d975feaa4` being quoted from
+a stale scan during drafting.

--- a/devlog/_plan/260903_contributor_credit_restoration/020_hygiene_gate.md
+++ b/devlog/_plan/260903_contributor_credit_restoration/020_hygiene_gate.md
@@ -1,0 +1,129 @@
+# 020 — wp2: the co-author gate
+
+## Slice
+
+MODIFY `AGENTS.md` (the rule), `.github/scripts/pr-hygiene.cjs` (the check),
+`.github/scripts/pr-hygiene.test.cjs` (the coverage).
+
+## What the gate has to catch
+
+The exact shape that produced this whole unit: a pull request whose own text
+says it reimplements, supersedes, carries, or rebases someone else's pull
+request, merging without a `Co-authored-by` trailer naming that person.
+
+```
+  title/body:  "Reimplements #2797 by @rrmlima."
+  trailers:    (none)                              -> FAIL
+```
+
+## Where it goes
+
+`collectDeterministicHygieneFailures` in `.github/scripts/pr-hygiene.cjs` is the
+single entry point both `pr-hygiene.yml` and the quality gate call, and it
+already composes two assessors: `assessHygiene` (patch shape) and
+`assessSponsoredSurface` (paths). This is a third assessor over PR text, not a
+change to either.
+
+That matters for the input contract. `assessHygiene` reads `files`; the new
+check reads the PR title, body, and commit messages. Those are already
+reachable from the workflow — it calls `pulls.get` and can call
+`pulls.listCommits` — but they are not currently passed down. The workflow
+gains that fetch and passes them through.
+
+## The check
+
+```js
+const CARRY_RE =
+  /\b(?:re-?implements?|re-?implementation of|supersedes?|carry of|carries|rebase of|adopts the design from)\b[^\n]{0,80}?#(\d+)/gi;
+const TRAILER_RE = /^co-authored-by:\s*(.+)$/gim;
+
+function assessCarryAttribution({ title, body, commits, labels, referencedAuthors })
+```
+
+Rules, each one earned from a real case in the scan:
+
+1. **Self-reference is not a carry.** A PR that says it supersedes an earlier
+   PR by the same author must pass. The check therefore needs the referenced
+   PR's author, which means one API lookup per referenced number. Cap it: at
+   most five lookups, and a lookup failure is a pass, never a fail. A rate
+   limit must not block a merge.
+2. **Referencing your own earlier branch is routine.** #3112 and #3104 are the
+   maintainer's own rebase branches. Same-author references are dropped before
+   the trailer comparison.
+3. **Match on identity, not on login.** The scan's eleven false positives all
+   came from comparing a GitHub login against a git trailer: `terrytan95` never
+   appears in `Co-authored-by: Terry Tan <tmy1995hflc@gmail.com>`. Compare
+   against login, git author name, and git author email from the referenced
+   PR's own commits — the three-way match the scan ended up needing.
+4. **Trailers live in the squash body, which does not exist yet at PR time.**
+   So the check reads the union of the PR body and every commit message on the
+   branch: that is what the squash body is assembled from, and it is what the
+   author can act on before merge.
+5. **Escape hatch consistent with the existing design.** A new
+   `attribution-approved` label clears it, entered in `labelDefinitions` and
+   `HYGIENE_GATE_LABELS` beside the other five. It joins the head-specific
+   sweep on `synchronize`, because a new commit can add a new carry reference.
+
+## Failure code and hint
+
+```js
+missing_coauthor_credit:
+  "This PR says it reimplements, supersedes, carries, or rebases another " +
+  "author's pull request. Add a Co-authored-by trailer naming that author so " +
+  "the credit survives the squash, or obtain attribution-approved.",
+```
+
+## Tests — RED before GREEN
+
+In `.github/scripts/pr-hygiene.test.cjs`, beside the existing `assessHygiene`
+cases:
+
+| Case | Expect |
+|---|---|
+| body says "Reimplements #2797 by @rrmlima", no trailer | `missing_coauthor_credit` |
+| same, with a trailer naming the login | pass |
+| same, matched by git author name rather than login | pass |
+| same, matched by email | pass |
+| reference to a PR by the same author | pass |
+| reference whose author lookup is unavailable | pass (fail-open) |
+| `attribution-approved` present | pass |
+| ordinary PR with no carry language | pass |
+| "supersedes" inside a fenced code block | pass |
+
+The first case is driven red against the unmodified assessor before the
+implementation exists.
+
+## Audit correction (A-phase, folded)
+
+The draft said to reuse `stripNonRenderedRegions` for the fenced-code case. It
+is defined at `.github/scripts/pr-quality.cjs:247` and is **not** in that file's
+`module.exports` — the exported list ends at `stripPrTemplateBoilerplate`. So
+the plan as written would not have run.
+
+Two options, and the choice is not cosmetic. Exporting it from `pr-quality.cjs`
+and importing it into `pr-hygiene.cjs` makes the hygiene assessor depend on the
+quality gate's module, and the dependency currently runs the other way:
+`pr-hygiene.yml` imports `authorHasPushPermission` from `pr-quality.cjs` at the
+workflow level, while the two assessor modules stay independent. Inverting that
+for one small regex helper buys a cycle risk for no benefit.
+
+So `pr-hygiene.cjs` gets its own local fence/comment stripper. It is four lines,
+it keeps the module standalone, and the two copies cannot drift in a way that
+matters — each is asserted by its own test.
+
+## AGENTS.md rule
+
+A short paragraph under the issues-and-pull-requests section:
+
+> Landing another author's work — reimplementing it, superseding it, carrying
+> it, or rebasing it — requires a `Co-authored-by` trailer naming that author in
+> the squash body. Saying so in prose is not equivalent: the trailer is what
+> GitHub reads for the contributor graph, and a sentence in a commit body is
+> read by nobody. `missing_coauthor_credit` enforces this.
+
+## Verification
+
+```bash
+node --test .github/scripts/pr-hygiene.test.cjs
+bun run typecheck
+```

--- a/devlog/_plan/260903_contributor_credit_restoration/030_release_notes.md
+++ b/devlog/_plan/260903_contributor_credit_restoration/030_release_notes.md
@@ -1,0 +1,66 @@
+# 030 — wp3: release-note credit sections
+
+## Slice
+
+No file changes. Edits GitHub release bodies through `gh release edit`.
+
+## Why this is possible at all
+
+A release body is mutable; a tag is not. This is the only surface where the
+credit can be added to the artifact that shipped the code, rather than beside
+it.
+
+## Which releases
+
+Resolved by `git tag --contains <sha>` for every SHA in `CREDITS.md`, taking
+the earliest non-preview tag per commit:
+
+| Release | Uncredited landings inside it |
+|---|---|
+| `v2.23.0` | `cb48c2e11` (#1801 @jonathanli12) |
+| `v2.34.0` | `8412fe156` (#2675 @Ingwannu) |
+| `v2.35.0` | `d829215af`, `bdc1e97bb` (#2693 @yxr1995-maker) |
+| `v2.36.0` | `1d9b389c1`, `eb52973c5`, `de91dfde4`, `8d1dc1f5d`, `c986d1d20`, `5734a1caf`, `bb3321ca8`, `8877df0ee`, `607042b02` |
+| `v2.37.0` | `870a2adb6` |
+| `v2.39.0` | `b46164e78`, `0ef04e640`, `330470e74`, `e9d198a3c`, `a73a4c998` |
+| `v2.40.0` | `d23eab43a`, `408652698`, `52d941640`, `b14b741dc`, `fecb77a91`, `88c427522`, `ef7b3c9cf` |
+
+`15b43e51c` (#3300 @S0RYUASUKA) is on `dev` and in no tag yet. It needs no
+edit — the next release note covers it, and `CREDITS.md` already carries it.
+
+Preview tags are skipped: they carry the same commits as their release and
+would double-name the same people.
+
+## Section shape
+
+Appended, never replacing the existing body:
+
+```markdown
+## Contributor credit
+
+This release contains work carried from contributor pull requests whose landing
+commits do not name their authors in a `Co-authored-by` trailer. The omission is
+in git history and cannot be repaired there; the record is
+[CREDITS.md](https://github.com/lidge-jun/opencodex/blob/dev/CREDITS.md).
+
+- #2797 by @rrmlima — landed as `5734a1caf`
+- ...
+```
+
+## Order of operations
+
+wp3 runs after `CREDITS.md` is on `dev`, so the link resolves when the note is
+published. A release note pointing at a 404 would be worse than no note.
+
+## Verification
+
+`gh release view <tag>` after each edit, confirming the section is present, the
+pre-existing body is intact, and the link resolves. Read back, not write-and-
+assume: `gh release edit --notes` replaces the whole body, so the existing text
+must be fetched, appended to, and written in one pass.
+
+## Risk
+
+This is the only phase that writes to a published artifact. It is idempotent by
+construction — the appended section is detected by its heading before writing,
+so a re-run does not stack duplicates.

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -901,6 +901,8 @@ describe("GitHub Actions hardening", () => {
     "require",
     "require",
     "require",
+    // pr-referenced-authors.cjs, for the carry-attribution assessor.
+    "require",
   ] as const;
 
   /** Reads every allowed-base PR performs before any enforcement writes. */
@@ -915,6 +917,9 @@ describe("GitHub Actions hardening", () => {
       "pulls.get",
       "pulls.listFiles",
       "pulls.get",
+      // The carry-attribution assessor reads the branch's commit messages: a
+      // Co-authored-by trailer can live in a commit rather than the body.
+      "pulls.listCommits",
       ...tail,
     ];
   }
@@ -930,6 +935,7 @@ describe("GitHub Actions hardening", () => {
       "pulls.get",
       "pulls.listFiles",
       "pulls.get",
+      "pulls.listCommits",
       ...tail,
     ];
   }
@@ -950,6 +956,8 @@ describe("GitHub Actions hardening", () => {
       "pulls.listFiles",
       "pulls.listFiles",
       "pulls.get",
+      "pulls.listCommits",
+      "pulls.listCommits",
       ...tail,
     ];
   }
@@ -1343,7 +1351,9 @@ describe("GitHub Actions hardening", () => {
           name !== "github.rest.repos.listPullRequestsAssociatedWithCommit" &&
           name !== "github.rest.issues.listEvents" &&
           // Hygiene reassessment reads the changed-file list; not a write.
-          name !== "github.rest.pulls.listFiles",
+          name !== "github.rest.pulls.listFiles" &&
+          // Carry attribution reads the branch's commit messages; not a write.
+          name !== "github.rest.pulls.listCommits",
       );
     expect([...new Set(restWrites)].sort()).toEqual([
       "github.rest.issues.addLabels",
@@ -5261,4 +5271,3 @@ describe("gui exhaustive-deps suppression stays scoped and effective", () => {
     expect(models).not.toContain("react-doctor-disable-next-line");
   });
 });
-

--- a/tests/helpers/enforce-pr-target-harness.ts
+++ b/tests/helpers/enforce-pr-target-harness.ts
@@ -243,6 +243,15 @@ export type RunOptions = {
     }>
   >;
   /**
+   * Commit messages on the pull request branch, read by the carry-attribution
+   * assessor. The squash body is assembled from the description and these, so
+   * a `Co-authored-by` trailer can legitimately live in either.
+   *
+   * Defaults to one commit carrying the PR title, which is what a
+   * single-commit branch looks like.
+   */
+  commitMessages?: string[];
+  /**
    * GraphQL query fragments that should reject. Unlike `failOn: ["graphql"]`,
    * which fails the review-threads read, this lets a test fail a specific
    * mutation (e.g. `markPullRequestReadyForReview`) while the threads read
@@ -664,6 +673,8 @@ export async function runEnforcePrTarget(
     options.filePages ??
     (options.files && options.files.length > 0 ? [options.files] : [[]]);
   const listedFileCount = filePages.flat().length;
+  const commitMessages =
+    options.commitMessages ?? [String((options.pr as { title?: string })?.title ?? "")];
   const prInput = options.pr as Record<string, unknown>;
   if (Object.prototype.hasOwnProperty.call(prInput, "changed_files")) {
     (pr as Record<string, unknown>).changed_files = prInput.changed_files;
@@ -782,6 +793,14 @@ export async function runEnforcePrTarget(
       listFiles: (args: unknown) => {
         const page = Number((args as { page?: number })?.page ?? 1);
         return respond("pulls.listFiles", args, filePages[page - 1] ?? []);
+      },
+      listCommits: (args: unknown) => {
+        const page = Number((args as { page?: number })?.page ?? 1);
+        return respond(
+          "pulls.listCommits",
+          args,
+          page === 1 ? commitMessages.map(message => ({ commit: { message } })) : [],
+        );
       },
     },
     issues: {


### PR DESCRIPTION
## Summary

When a maintainer lands someone else's pull request by reimplementing, carrying, or rebasing it, the resulting commit is authored by the maintainer. The contributor survives only through a `Co-authored-by` trailer — that trailer is what GitHub reads for the contributor graph, the repository's contributor list, and the author's own profile activity.

This repository did it both ways for months:

```
53c09a247  "Clean reimplementation of #3193"   Co-authored-by: alan7629 ...
5734a1caf  "Reimplements #2797 by @rrmlima."   (no contributor trailer)
```

Both sentences are equally sincere. Only the first is data.

**`CREDITS.md`** records the landings already in that state. Two scans found them: every `dev` commit whose body matches reimplement/supersede/carry-of/rebase-of `#N` joined against its own trailers, and the maintainer closure comments on all 119 closed-unmerged external pull requests since #2400, each landing commit then checked for a trailer naming the original author. Fourteen apparent hits were false positives — three where the author's commits sit inside a merge range rather than a squash, eleven where a GitHub login simply is not a git identity (`terrytan95` is `Terry Tan`). 27 landings remain, across 26 contributors' pull requests.

Rows are graded by what the maintainer actually wrote. **Carried work** is where code, design, or tests shipped. **Report and diagnosis** is where the fix exists because of the report and the branch's own approach was explicitly not the vehicle — those authors were told why at the time, and filing them as carried code would misstate it in the other direction. Two more (#3020, #2675) are named without a table row because their closure states a landing commit and nothing about what was taken; inventing an answer would be the same inaccuracy this file exists to correct.

The trailers cannot be added retroactively: every affected commit but one is inside a published tag (`v2.23.0` through `v2.40.0`), and `dev`/`main`/`preview` each carry a ruleset blocking force-pushes. `MAINTAINERS.md` already says authorship in git history is not rewritten, so the repair goes forward.

**`missing_coauthor_credit`** is why the list should not grow. `assessCarryAttribution` reads the pull request's text rather than its diff, because that is where a carry declares itself. Three properties are enforced by test rather than asserted in prose:

- **Fail open.** The referenced author comes from a live lookup, capped at five per run. A rate limit, a deleted account, or a cross-repository reference resolves to null, and a null author passes. Blocking a merge because an API call failed would be worse than the omission this prevents.
- **Identity, not login.** The referenced pull request's own commits supply the git names and emails to match against — the same three-way match the scan needed after producing eleven false positives without it.
- **Sentence-bounded windows.** The first implementation took a fixed 80 characters after each carry verb. The tests caught it twice: it missed the second number in "Reimplements #2797 and #2796", and it would have pulled the issue out of 53c09a247's real "Supersedes #3193. Fixes #3192." into the carry set, demanding a trailer for someone who reported a bug. Both are regression cases now.

Referencing your own earlier branch is exempt, carry language inside fenced blocks and HTML comments is quoted rather than declared, and `attribution-approved` is the escape hatch, entered beside the five existing hygiene labels and swept on `synchronize` like the others. Both gates receive the same inputs so Ready cannot clear while hygiene is red.

Release bodies for the affected tags are a follow-up in the same unit; they are mutable where the commits are not, and they link this file.

## Verification

- `node --test .github/scripts/*.test.cjs` — 537 pass, 0 fail (17 new). The new assessor suite was driven red before the implementation existed.
- `bun run typecheck` — exit 0.
- Every `github-script` block in both changed workflows parses under `node --check`.
- Every SHA in `CREDITS.md` proved an ancestor of `origin/dev`, and every quoted fragment located verbatim in the source comment or commit body (27 SHAs, 26 rows, 0 mismatches).
- No repository-wide suite was run, per the standing constraint.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated pull request checks for contributor credit when work is carried, rebased, superseded, or reimplemented, including credit in commit messages.
  - Added an approval-label option for reviewed attribution exceptions.
  - Attribution checks now also run when pull request descriptions are edited.

- **Documentation**
  - Added a contributor credits page documenting previously uncredited contributions.
  - Updated the README, contributing guide, and contributor guidance with attribution practices and links to credit records.
  - Added planning documentation for restoring and maintaining contributor attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->