### PR TITLE
test: isolate the route scanner probe in a unique temp directory

### DIFF
--- a/tests/management-route-registry.test.ts
+++ b/tests/management-route-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { MANAGEMENT_ROUTES } from "../src/server/management/route-registry";
@@ -122,7 +123,8 @@ describe("management route registry reconciliation", () => {
     // Drives the fail-loud path red on purpose: without this, a scanner that silently
     // defaulted to GET would satisfy every other test in this file while producing a
     // route table nobody could trust.
-    const tmp = join(repoRoot, ".tmp-scanner-probe.ts");
+    const tempDir = mkdtempSync(join(tmpdir(), "ocx-route-scanner-"));
+    const tmp = join(tempDir, "scanner-probe.ts");
     const source = [
       "export async function handleProbe(ctx: any): Promise<Response | null> {",
       "  const { url, req } = ctx;",
@@ -133,13 +135,13 @@ describe("management route registry reconciliation", () => {
       "  return null;",
       "}",
     ].join("\n");
-    require("node:fs").writeFileSync(tmp, source);
+    writeFileSync(tmp, source);
     try {
       const { unresolved } = distinctRoutes(scanRoutes(tmp));
       expect(unresolved.map(r => r.path)).toEqual(["/api/probe/unknowable"]);
       expect(unresolved[0]?.method).toBeNull();
     } finally {
-      require("node:fs").rmSync(tmp, { force: true });
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/management-route-registry.test.ts
+++ b/tests/management-route-registry.test.ts
@@ -135,8 +135,8 @@ describe("management route registry reconciliation", () => {
       "  return null;",
       "}",
     ].join("\n");
-    writeFileSync(tmp, source);
     try {
+      writeFileSync(tmp, source);
       const { unresolved } = distinctRoutes(scanRoutes(tmp));
       expect(unresolved.map(r => r.path)).toEqual(["/api/probe/unknowable"]);
       expect(unresolved[0]?.method).toBeNull();


### PR DESCRIPTION
## Summary

- Move the management route scanner's negative probe out of the repository root and into a uniquely named OS temporary directory.
- Use static `node:fs` imports for fixture creation and cleanup.
- Remove the temporary directory recursively in `finally` while preserving the existing fail-loud scanner assertions.

The fixed `.tmp-scanner-probe.ts` path was shared by concurrent runs, so one run could remove another run's fixture. An interrupted run could also leave an untracked TypeScript file in the worktree. A per-run directory created with `mkdtempSync` removes the shared-path race and keeps interruption residue outside the repository.

This addresses the concurrency and residue concern raised in [review feedback on #2826](https://github.com/lidge-jun/opencodex/pull/2826#discussion_r3881573894).

## Verification

- `bun test --isolate ./tests/management-route-registry.test.ts` — 13 pass, 0 fail, 28 expect() calls on Bun 1.4.0 (`34cbb9a40`).
- `git diff origin/dev..HEAD --check` — clean.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No documentation or release-note change is needed because this only changes test-fixture placement; runtime behavior and public interfaces are unchanged.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Scanner probe tests now use isolated temporary directories instead of repository-local paths.
  * Temporary probe files and directories are automatically removed after testing.
  * This keeps test artifacts contained and ensures the test environment is cleaned up consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

