### PR TITLE
docs(skill): keep access-key secrets out of agent sessions

### DIFF
--- a/skills/ocx/SKILL.md
+++ b/skills/ocx/SKILL.md
@@ -98,8 +98,10 @@ the equivalent `opencodex` forms, and direct `POST /api/keys` or `POST /api/keys
 Their one-time responses contain a new plaintext data-plane credential, and command output can
 enter the agent transcript. Ask the user to perform that step in a terminal outside the agent
 session, configure the replacement, and confirm only that it is configured plus any non-secret key
-or rotation id needed for follow-up. Never ask the user to paste the key into chat, and do not
-remove the old key before that configuration confirmation.
+or rotation id needed for follow-up. Never ask the user to paste the key into chat. Configuration
+confirmation is not approval to revoke the existing credential. Before committing an in-place
+rotation or removing an old key after a separately created replacement, identify the existing key
+id that will be revoked and obtain separate explicit user approval immediately before that command.
 
 ## Destructive verbs
 

--- a/skills/ocx/SKILL.md
+++ b/skills/ocx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ocx
-description: Drive a running opencodex (`ocx`) proxy from the CLI — account pools, provider routing, model catalog, usage and cost attribution, request logs, access keys, storage cleanup, and the management API. Use when a task involves controlling or inspecting an opencodex proxy rather than editing the opencodex codebase. Triggers: ocx, opencodex, proxy control, account pool, pause account, pool strategy, provider routing, usage report, cost attribution, access key, request log, conversation trace, storage cleanup, management API.
+description: "Drive a running opencodex (`ocx`) proxy from the CLI — account pools, provider routing, model catalog, usage and cost attribution, request logs, access keys, storage cleanup, and the management API. Use when a task involves controlling or inspecting an opencodex proxy rather than editing the opencodex codebase. Triggers: ocx, opencodex, proxy control, account pool, pause account, pool strategy, provider routing, usage report, cost attribution, access key, request log, conversation trace, storage cleanup, management API."
 ---
 
 # Operating `ocx`
@@ -89,6 +89,17 @@ starring would be useful, say so and let the user decide.
 
 The same boundary covers the session-gated `/api/codex-prompt` writes: read them with
 `ocx inspect codex-prompt`, and leave the writes to the dashboard.
+
+## Secret-bearing commands
+
+**Do not run a command that creates an access key or starts a rotation.** This includes
+`ocx access key create`, its `access keys` and `api-key` aliases, `ocx access key rotate <id>`,
+the equivalent `opencodex` forms, and direct `POST /api/keys` or `POST /api/keys/rotate` calls.
+Their one-time responses contain a new plaintext data-plane credential, and command output can
+enter the agent transcript. Ask the user to perform that step in a terminal outside the agent
+session, configure the replacement, and confirm only that it is configured plus any non-secret key
+or rotation id needed for follow-up. Never ask the user to paste the key into chat, and do not
+remove the old key before that configuration confirmation.
 
 ## Destructive verbs
 

--- a/skills/ocx/references/03_recipes.md
+++ b/skills/ocx/references/03_recipes.md
@@ -106,14 +106,31 @@ run either secret-returning command from an agent session, including through the
 step in a separate terminal, configure the replacement, and report only that it is configured plus
 any non-secret key or rotation id needed for follow-up. Never ask for the key itself.
 
-After the user confirms that the replacement is configured, remove the old key:
+Configuration confirmation is not approval to revoke the existing credential. After confirmation,
+identify the existing key id that will be revoked and obtain separate explicit user approval
+immediately before one of the following paths.
+
+For an in-place rotation, commit the pending replacement on the same id:
+
+```bash
+ocx access key rotate commit <id> <rotation-id> --json
+```
+
+For a separately created replacement key, remove the old id:
 
 ```bash
 ocx access key remove <old-id> --yes --json
-ocx access key list --json                    # the old id is gone; check usage on the rest
 ```
 
-Note the argument style: `remove <id>` is positional, not `--id`, and refuses without `--yes`.
+Then verify the matching result:
+
+```bash
+ocx access key list --json
+```
+
+For an in-place rotation, the same id remains and `pendingRotation` disappears. For a separately
+created replacement, the old id disappears; check usage on the remaining keys. Note the argument
+style: `remove <id>` is positional, not `--id`, and refuses without `--yes`.
 
 The list carries per-key usage, so a key whose count stops advancing is genuinely unused. The
 replacement key's plaintext is never retrievable after creation.

--- a/skills/ocx/references/03_recipes.md
+++ b/skills/ocx/references/03_recipes.md
@@ -93,20 +93,30 @@ Read `accounts[]`. Two things to respect:
 `providers[]` and `models[]` carry `estimatedCostUsd`. Costs are estimates; `estimateReasons` in the
 log rows tells you why (for example `usage_estimated`, `expected_price_overlay`).
 
-## 5. Rotate an access key and confirm it went quiet
+## 5. Prepare an access-key rotation without exposing the new key
 
 ```bash
 ocx access key list --json
-ocx access key create rotated --json          # the plaintext key is in THIS response only
+```
+
+Creating a key or starting an in-place rotation returns a one-time plaintext credential. **Do not
+run either secret-returning command from an agent session, including through the `access keys` or
+`api-key` aliases, the `opencodex` executable, or direct management-API POSTs to `/api/keys` and
+`/api/keys/rotate`:** terminal output can enter the model transcript. Ask the user to perform that
+step in a separate terminal, configure the replacement, and report only that it is configured plus
+any non-secret key or rotation id needed for follow-up. Never ask for the key itself.
+
+After the user confirms that the replacement is configured, remove the old key:
+
+```bash
 ocx access key remove <old-id> --yes --json
 ocx access key list --json                    # the old id is gone; check usage on the rest
 ```
 
-Note the argument style: `create <name>` and `remove <id>` are **positionals**, not `--label` and
-`--id`. `remove` also refuses without `--yes`.
+Note the argument style: `remove <id>` is positional, not `--id`, and refuses without `--yes`.
 
 The list carries per-key usage, so a key whose count stops advancing is genuinely unused. The
-plaintext key appears once, in the `create` response, and is never retrievable again.
+replacement key's plaintext is never retrievable after creation.
 
 An `ambiguous` footer on the list means two configured keys share an id, so per-key totals do not
 exist for them — do not attribute usage to either.

--- a/tests/skill-ocx.test.ts
+++ b/tests/skill-ocx.test.ts
@@ -161,4 +161,44 @@ describe("the consent boundary is stated, not implied", () => {
     expect(recipes).toContain("PREVIEW");
     expect(recipes).toContain("get approval");
   });
+
+  const secretBearingAccessKeyCommand =
+    /\b(?:ocx|opencodex)(?:\.(?:exe|mjs))?["']?\s+(?:access\s+keys?|api-key)\s+(?:create\b|rotate\b(?!\s+(?:commit|abort)\b))/gim;
+  const secretBearingManagementRequest =
+    /(?:(?:\bPOST\b|(?:--request|-X|-Method)\s+["']?POST["']?|method\s*:\s*["']POST["'])[^\n]{0,240}\/api\/keys(?:\/rotate)?(?=$|[\s"'?#])|\/api\/keys(?:\/rotate)?(?=$|[\s"'?#])[^\n]{0,240}(?:\bPOST\b|(?:--request|-X|-Method)\s+["']?POST["']?|method\s*:\s*["']POST["']))/gim;
+
+  function secretBearingCommandsInFences(text: string): string[] {
+    const matches: string[] = [];
+    for (const block of text.matchAll(/```[^\n]*\n([\s\S]*?)```/g)) {
+      // Fold common shell continuations so a wrapped command cannot evade the check.
+      const executableText = block[1]!.replace(/(?:\\|`|\^)\r?\n\s*/g, " ");
+      matches.push(...executableText.matchAll(secretBearingAccessKeyCommand).map(match => match[0]));
+      matches.push(...executableText.matchAll(secretBearingManagementRequest).map(match => match[0]));
+    }
+    return matches;
+  }
+
+  test("the secret-bearing command detector covers aliases and shell wrappers", () => {
+    for (const command of [
+      "ocx access key create rotated --json",
+      "& ocx access keys create rotated --json",
+      "opencodex api-key rotate old-id --json",
+      "ocx access key \\\n  create rotated --json",
+      "curl -X POST http://127.0.0.1:3000/api/keys",
+      "Invoke-RestMethod http://127.0.0.1:3000/api/keys/rotate -Method Post",
+    ]) {
+      expect(secretBearingCommandsInFences("```bash\n" + command + "\n```"), command).toHaveLength(1);
+    }
+    expect(secretBearingCommandsInFences("```bash\nocx access key rotate commit old-id rotation-id\n```")).toEqual([]);
+    expect(secretBearingCommandsInFences("```bash\ncurl -X POST http://127.0.0.1:3000/api/keys/rotate/commit\n```")).toEqual([]);
+  });
+
+  test("agent-facing guidance never exposes secret-bearing access-key commands", () => {
+    for (const file of ["SKILL.md", ...REFERENCES.map(ref => join("references", ref))]) {
+      expect(secretBearingCommandsInFences(read(file)), file).toEqual([]);
+    }
+    const skill = readFileSync(SKILL, "utf8");
+    expect(skill).toMatch(/outside the agent\s+session/);
+    expect(skill).toMatch(/do not\s+remove the old key before/);
+  });
 });

--- a/tests/skill-ocx.test.ts
+++ b/tests/skill-ocx.test.ts
@@ -163,7 +163,7 @@ describe("the consent boundary is stated, not implied", () => {
   });
 
   const secretBearingAccessKeyCommand =
-    /\b(?:ocx|opencodex)(?:\.(?:exe|mjs))?["']?\s+(?:access\s+keys?|api-key)\s+(?:create\b|rotate\b(?!\s+(?:commit|abort)\b))/gim;
+    /\b(?:ocx|opencodex)(?:\.(?:exe|mjs))?["']?\s+(?:access\s+keys?|api-key)\s+(?:create\b|rotate\b(?!\s+(?:--json\s+)?(?:commit|abort)\b))/gim;
   const secretBearingManagementRequest =
     /(?:(?:\bPOST\b|(?:--request|-X|-Method)\s+["']?POST["']?|method\s*:\s*["']POST["'])[^\n]{0,240}\/api\/keys(?:\/rotate)?(?=$|[\s"'?#])|\/api\/keys(?:\/rotate)?(?=$|[\s"'?#])[^\n]{0,240}(?:\bPOST\b|(?:--request|-X|-Method)\s+["']?POST["']?|method\s*:\s*["']POST["']))/gim;
 
@@ -183,13 +183,20 @@ describe("the consent boundary is stated, not implied", () => {
       "ocx access key create rotated --json",
       "& ocx access keys create rotated --json",
       "opencodex api-key rotate old-id --json",
+      "ocx access key rotate --json old-id",
       "ocx access key \\\n  create rotated --json",
       "curl -X POST http://127.0.0.1:3000/api/keys",
       "Invoke-RestMethod http://127.0.0.1:3000/api/keys/rotate -Method Post",
     ]) {
       expect(secretBearingCommandsInFences("```bash\n" + command + "\n```"), command).toHaveLength(1);
     }
-    expect(secretBearingCommandsInFences("```bash\nocx access key rotate commit old-id rotation-id\n```")).toEqual([]);
+    for (const command of [
+      "ocx access key rotate commit old-id rotation-id",
+      "ocx access key rotate --json commit old-id rotation-id",
+      "ocx access key rotate --json abort old-id rotation-id",
+    ]) {
+      expect(secretBearingCommandsInFences("```bash\n" + command + "\n```"), command).toEqual([]);
+    }
     expect(secretBearingCommandsInFences("```bash\ncurl -X POST http://127.0.0.1:3000/api/keys/rotate/commit\n```")).toEqual([]);
   });
 
@@ -198,7 +205,13 @@ describe("the consent boundary is stated, not implied", () => {
       expect(secretBearingCommandsInFences(read(file)), file).toEqual([]);
     }
     const skill = readFileSync(SKILL, "utf8");
+    const recipes = read("references/03_recipes.md");
     expect(skill).toMatch(/outside the agent\s+session/);
-    expect(skill).toMatch(/do not\s+remove the old key before/);
+    expect(skill).toMatch(/configuration\s+confirmation is not approval/i);
+    expect(skill).toMatch(/separate explicit user approval/i);
+    const approvalAt = recipes.indexOf("obtain separate explicit user approval");
+    expect(approvalAt).toBeGreaterThanOrEqual(0);
+    expect(approvalAt).toBeLessThan(recipes.indexOf("ocx access key rotate commit"));
+    expect(approvalAt).toBeLessThan(recipes.indexOf("ocx access key remove"));
   });
 });


### PR DESCRIPTION
<!-- four-track-landing-status:start -->
### Delivered — superseded by merged work

Verified in `dev` at `5759d9ea2f1e7281cdc01eb9628f2e0a123fb59c`: [#3789](https://github.com/lidge-jun/opencodex/pull/3789) (`26fa36424a`).

Original contribution: **docs(skill): keep access-key secrets out of agent sessions**, by @luvs01.

Agent-facing secret-bearing command and rotation-recipe restrictions, including aliases and management API spellings.

The original PR is closed as superseded; its contribution remains credited in the landed history.

Attribution strengthened by [#3811](https://github.com/lidge-jun/opencodex/pull/3811), merged as `cf9f662190c4c6770697c45c870941509cc98f9c`. See [CREDITS.md](https://github.com/lidge-jun/opencodex/blob/dev/CREDITS.md#2026-09-07-follow-up-four-track-source-to-landing-attribution) for the source-to-landing attribution record.
<!-- four-track-landing-status:end -->

## Summary

- Remove executable access-key creation from the agent-facing `ocx` rotation recipe and explicitly forbid agents from creating a key or starting a rotation because those operations return a one-time plaintext credential that can enter the agent transcript.
- Cover `ocx` and `opencodex`, the `access key`, `access keys`, and `api-key` spellings, plus direct `POST /api/keys` and `POST /api/keys/rotate` calls.
- Require configuration confirmation and then separate explicit approval before revoking the old credential; commit in-place rotations and reserve removal for separately created replacements.
- Add non-vacuous regressions that scan `SKILL.md` and every shipped `ocx` reference while allowing non-secret rotation commit and abort operations, including `--json` before the operation.

The human CLI contract is unchanged: key creation and rotation-start remain supported for an operator-run terminal. This PR changes only the agent skill safety boundary.

## Verification

- `bun test --isolate ./tests/skill-ocx.test.ts` — 13 pass, 0 fail, 105 expect() calls on Bun 1.4.0 at rebased HEAD `7734e758b7`.
- `bun test --isolate ./tests/skill-ocx.test.ts ./tests/api-keys-routes.test.ts` — 58 pass, 0 fail, 226 assertions in 61.28s on Bun 1.4.0 at the rebased HEAD.
- `bun run skill:surface:check` — passed.
- `bun run privacy:scan` — passed.
- `bun run typecheck` — passed.
- `bun run test` — the broad-suite attempt reached the 900s Windows guard and was terminated after timeout and ACL-hardening contention spread across unrelated suites; exact process readback found no survivor. GitHub CI is the broad-suite gate for this rebased HEAD.
- Codex skill validation — passed.
- Independent focused security review — clean. It covered creation and rotation-start, CLI aliases and executable wrappers, direct management-API POST routes, every shipped skill reference, the separate revocation approval, in-place commit versus separate-key removal, flag ordering, and non-vacuous detector fixtures.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added guidance preventing agents from creating or rotating access keys directly, including through aliases, command-line tools, or management API requests.
  * Added safeguards against sharing plaintext credentials or deleting existing keys before replacement configuration is confirmed.
  * Clarified that secret-bearing operations must occur outside the agent session with explicit approval.

* **Documentation**
  * Updated access-key procedures to allow reporting only non-secret identifiers and clarify one-time credential handling.
  * Retained verification guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

