### PR TITLE
fix(release): ignore fork PRs in dev bump guard

### DIFF
--- a/.github/workflows/dev-version-bump.yml
+++ b/.github/workflows/dev-version-bump.yml
@@ -119,7 +119,17 @@ jobs:
           # leaves the branch check passing, so the job would recreate the branch and then
           # fail on `gh pr create` with "already exists" — turning a successful release red
           # for a repair that was already queued.
-          open_prs="$(gh pr list --base dev --head "${branch}" --state open --json number --jq 'length')"
+          # Apply the repository owner and branch filter on the server. Filtering a
+          # paginated `gh pr list` result locally can miss this repository's pull request
+          # when newer same-named fork pull requests fill the fetched page.
+          open_prs="$(
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f state=open \
+              -f base=dev \
+              -f "head=${GITHUB_REPOSITORY_OWNER}:${branch}" \
+              -F per_page=1 \
+              --jq 'length'
+          )"
           if [ "${open_prs}" != "0" ]; then
             echo "::notice::a bump pull request for ${branch} is already open; nothing to do"
             exit 0

--- a/tests/bump-dev-version.test.ts
+++ b/tests/bump-dev-version.test.ts
@@ -17,6 +17,7 @@ import { decideDevVersion } from "../scripts/bump-dev-version";
 // which bun cannot open, so every CLI case exited 1 before reaching the code under test —
 // and the malformed-input case read that same load failure as a correct rejection.
 const CLI = fileURLToPath(new URL("../scripts/bump-dev-version.ts", import.meta.url));
+const WORKFLOW = fileURLToPath(new URL("../.github/workflows/dev-version-bump.yml", import.meta.url));
 
 function runCli(...args: string[]) {
   const proc = Bun.spawnSync([process.execPath, CLI, ...args]);
@@ -41,6 +42,20 @@ function tempPackageJson(version: string): string {
 }
 
 describe("dev version bump rule", () => {
+  test("the idempotency check filters the repository-owned head before pagination", () => {
+    const workflow = readFileSync(WORKFLOW, "utf8");
+    const block = workflow.match(/open_prs="\$\(([\s\S]*?)\n\s*\)"/)?.[1];
+    expect(block).toBeDefined();
+    expect(block).toContain('gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls"');
+    expect(block).toContain("-f state=open");
+    expect(block).toContain("-f base=dev");
+    expect(block).toContain('-f "head=${GITHUB_REPOSITORY_OWNER}:${branch}"');
+    expect(block).toContain("-F per_page=1");
+    expect(block).toContain("--jq 'length'");
+    expect(block).not.toContain("gh pr list");
+    expect(block).not.toContain("isCrossRepository");
+  });
+
   test("a stable release moves dev to the next minor", () => {
     // e4a85d134 (2.33.0 -> 2.34.0) and 076ad3036 (2.34.0 -> 2.35.0).
     expect(decideDevVersion("2.36.0", "2.36.0")).toMatchObject({ changed: true, version: "2.37.0" });


### PR DESCRIPTION
## Summary

Prevent fork-origin pull requests from satisfying the dev version-bump workflow's repository-owned idempotency guard.

## Problem

The release workflow checks for an existing bump pull request with:

`gh pr list --base dev --head "${branch}"`

The `--head` filter matches pull requests by branch name, including heads from forks. Because the generated `codex/dev-version-${NEXT_VERSION}` name is predictable, a fork pull request using that name can make the check exit early even though the repository-owned bump has not been queued.

## Changes

- Query the repository pulls endpoint with state, base, and repository-owner-qualified head filters applied on the server.
- Limit the already-scoped response to one result instead of filtering a paginated client-side list.
- Add regression coverage that pins the server-side owner filter and rejects the prior client-side query.

## Verification

Rebased onto current `dev` and re-ran the local gates on the rebased head `871ae50`:

- `bun test tests/bump-dev-version.test.ts` — `10 pass, 1 skip, 0 fail, 39 expect() calls` (Bun 1.4.0). The single skip is the platform-conditional unwritable-target case.
- `bun run typecheck` (`bun x tsc --noEmit`) — clean, no diagnostics.
- `git diff --check` and `git diff 330d6c4..HEAD --check` — clean, no whitespace errors.
- Live GitHub API readback confirmed that a fork PR can share the branch name while an owner-qualified head selects only the repository-owned branch.
- Exact rebase readback confirmed HEAD `871ae50` has current `dev` `330d6c4` as its parent, is exactly 1 commit ahead of `dev`, and touches exactly 2 files (`.github/workflows/dev-version-bump.yml`, `tests/bump-dev-version.test.ts`).
- The rebase was a content-preserving replay: the diff against the new base hashes identically to the diff against the old base (`git hash-object` `a47ac52` before and after), and the patch ID is still the reviewed `cc096d7`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No documentation or release-note change is needed because this is a release-workflow guard correction with focused regression coverage.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated development-version pull request checks by applying repository and branch filters directly when querying open pull requests.
  * Prevented incorrect matches from pull requests originating outside the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
