### PR TITLE
test(quota): correct the contract comment and close the coverage holes from #3200

### DIFF
--- a/gui/tests/provider-capacity-shell.test.tsx
+++ b/gui/tests/provider-capacity-shell.test.tsx
@@ -328,6 +328,50 @@ test("all-stale response renders coverage only without a numeric fallback", asyn
   expect(text).toContain("Incomplete coverage: 2 account(s) excluded");
 });
 
+test("a fully included pool still surfaces the uncalibrated-plan notice", async () => {
+  // The #3155 reporter's own shape: every seat included, complete coverage, one seat counted
+  // at the baseline weight. The uncalibrated notice is the ONLY remaining uncertainty signal
+  // here, so it must render independently of the incomplete gate — folding it under the
+  // incomplete branch would pass every other fixture in this file and silently hide it.
+  quotaPayload = {
+    reports: [{
+      provider: "openai",
+      label: "OpenAI (Codex login)",
+      source: "chatgpt:wham",
+      updatedAt: Date.now(),
+      quota: { weeklyPercent: 44, updatedAt: Date.now() },
+      aggregation: {
+        kind: "capacity-weighted-v1",
+        scope: "routable-known",
+        presentation: "aggregate",
+        includedAccounts: 2,
+        excludedAccounts: 0,
+        unknownPlanAccounts: 1,
+        missingQuotaAccounts: 0,
+        pausedAccounts: 0,
+        reauthAccounts: 0,
+        staleQuotaAccounts: 0,
+        incomplete: false,
+        weekly: {
+          usedPercent: 44,
+          includedAccounts: 2,
+          excludedAccounts: 0,
+          incomplete: false,
+          updatedAt: Date.now(),
+        },
+        currentAccount: { isMain: false, quota: { weeklyPercent: 77, updatedAt: Date.now() } },
+      },
+    }],
+  };
+
+  await mountShell();
+
+  const text = host.textContent ?? "";
+  expect(text).toContain("1 account(s) on an uncalibrated plan are counted at the baseline seat weight");
+  expect(text).not.toContain("Incomplete coverage");
+  expect(text).toContain("44% used");
+});
+
 test("coverage-only API report remains visible in the rate-limit overview", async () => {
   quotaPayload = {
     reports: [{

--- a/tests/provider-quota.test.ts
+++ b/tests/provider-quota.test.ts
@@ -1859,13 +1859,16 @@ describe("fetchProviderQuotaReports", () => {
     expect(JSON.stringify(openai?.aggregation)).not.toMatch(/(?:total|consumed|remaining)Weight|projectedUsedPercent/i);
   });
 
-  // #3198 changed what "tolerate" means here: an uncalibrated plan — a name the weight map
-  // does not list, or a malformed non-string value like the `{ tier: "pro" }` below (both
-  // normalize to undefined via codexPlanKey) — is now counted at the baseline seat weight
-  // instead of being excluded from the aggregate. Exclusion silently overstated coverage;
-  // baseline counting is the visibly conservative estimate. The account still shows up in
-  // `unknownPlanAccounts` so the operator can see the estimate is conservative for that seat.
-  test("pool reports tolerate a malformed persisted plan through cache and aggregation", async () => {
+  // #3155 (PR #3198) changed what "tolerate" means here: an uncalibrated plan is counted at
+  // the baseline seat weight instead of being excluded (rationale on
+  // CODEX_DEFAULT_CAPACITY_WEIGHT in src/providers/codex-capacity.ts). Two distinct inputs
+  // converge on that weight by different routes: an unlisted plan NAME normalizes to a defined
+  // key that fails the weight-map lookup, while a malformed non-string like the
+  // `{ tier: "pro" }` below never reaches the aggregation at all — poolAccountDto strips it via
+  // codexPlanValue, so the aggregate sees an ABSENT plan. This test pins the second route end
+  // to end: baseline weight, `unknownPlanAccounts` flagged, and the malformed value kept out of
+  // the public report shape.
+  test("pool reports count a malformed persisted plan at baseline and keep it out of the public shape", async () => {
     saveCodexAccountCredential("added", {
       accessToken: "added-access",
       refreshToken: "added-refresh",
@@ -1886,6 +1889,9 @@ describe("fetchProviderQuotaReports", () => {
       calls += 1;
       const added = (init?.headers as Record<string, string> | undefined)?.["ChatGPT-Account-Id"] === "added-chatgpt-id";
       return new Response(JSON.stringify({
+        // Load-bearing: a fetched plan_type outranks the persisted plan (auth-api.ts freshPlan),
+        // so this mock must stay non-string too — a string here would recalibrate the weight and
+        // change every aggregate value asserted below.
         plan_type: added ? { tier: "pro" } : "plus",
         rate_limit: { secondary_window: { used_percent: added ? 77 : 11, reset_at: 1_999_000_000 } },
       }), { status: 200, headers: { "content-type": "application/json" } });
@@ -1893,21 +1899,31 @@ describe("fetchProviderQuotaReports", () => {
 
     const refreshed = await fetchProviderQuotaReports(config, true);
     const openai = refreshed.reports.find(row => row.provider === "openai");
-    // Both seats weigh the same (malformed -> baseline, "plus" -> calibrated baseline), so the
-    // blend of 77 and 11 lands at 44 — not the 11 the old exclusion contract produced.
+    // The blend leans on CODEX_DEFAULT_CAPACITY_WEIGHT equalling the calibrated "plus" weight
+    // (both 1 today), so 77 and 11 land at 44 — not the 11 the old exclusion contract produced.
     expect(openai?.quota.weeklyPercent).toBe(44);
     expect(openai?.aggregation).toMatchObject({
       includedAccounts: 2,
       excludedAccounts: 0,
       unknownPlanAccounts: 1,
       incomplete: false,
+      // The per-window flags are what the dashboard renders per bar; #3155 flipped them
+      // together with the top-level flag, so pin both.
+      weekly: { includedAccounts: 2, excludedAccounts: 0, incomplete: false },
       currentAccount: { quota: { weeklyPercent: 77 } },
     });
     expect(openai?.aggregation?.currentAccount).not.toHaveProperty("plan");
+    // The malformed value must not escape into the public report shape anywhere, and the
+    // internal weight fields must not either (same guard as the sibling test above).
+    expect(JSON.stringify(refreshed)).not.toContain("tier");
+    expect(JSON.stringify(openai?.aggregation)).not.toMatch(/(?:total|consumed|remaining)Weight|projectedUsedPercent/i);
     expect(calls).toBe(2);
 
+    // The unforced path returns the cached response BY IDENTITY (no clone, no recompute), so
+    // re-asserting its fields would only re-read the object checked above. Pin the identity
+    // contract itself plus the call count; content is covered once, honestly, up there.
     const cached = await fetchProviderQuotaReports(config);
-    expect(cached.reports[0]?.aggregation?.unknownPlanAccounts).toBe(1);
+    expect(cached.reports[0]?.aggregation).toBe(openai?.aggregation);
     expect(calls).toBe(2);
   });
 


### PR DESCRIPTION
Follow-up to #3200, which landed the contract move itself (`fcf0da257`).

An adversarial multi-agent review of that change produced eleven findings seventeen minutes after it merged, so none of them made that train. No wrong assertion values — three reviewers independently re-derived all four numbers by executing the aggregator — but one factual error in the comment I wrote, now sitting on `dev`, plus several coverage holes the contract move opened.

## The comment on `dev` is wrong, in two ways

It claims an unlisted plan name and a malformed non-string "both normalize to undefined via `codexPlanKey`". Neither half survives contact with the code:

- `codexPlanKey("edu_plus")` returns `"edu_plus"` — a **defined** key that then fails the `Object.hasOwn` lookup in `configuredWeight`. Only a non-string normalizes to `undefined`.
- On this test's integration path the malformed value never reaches `codexPlanKey` at all: `poolAccountDto` (`src/codex/auth-api.ts:265`) strips it via `codexPlanValue`, so the aggregation sees an **absent** plan.

The second point has a corollary the test's own name got wrong: it cannot distinguish "malformed plan" from "no plan at all". Rewritten to state both routes, and renamed to what it actually pins — counted at baseline, kept out of the public shape. Reference normalized to `#3155 (PR #3198)`, matching the ten sibling citations; the fourth prose copy of the policy rationale replaced with a pointer to `CODEX_DEFAULT_CAPACITY_WEIGHT`'s own doc comment.

## Assertions added where a regression would now ship green

| added | catches |
| --- | --- |
| `weekly: { includedAccounts, excludedAccounts, incomplete }` | the per-window flags are what `ProviderCapacityQuota.tsx` renders per bar — a `finalizeWindow` `totalAccounts` regression leaves the weekly bar struck through while the top-level flag stays clean |
| `JSON.stringify(refreshed)` free of `"tier"` | with exclusion gone, nothing proved the malformed value cannot escape to the wire or persisted config — loosening `nonEmptyPlan` corrupts `config.json` while every prior assertion passes |
| the sibling's weight-field anti-leak regex | `publicCapacityWindow` dropping its destructure leaks `totalWeight`/`consumedWeight` here silently; the sibling catches it, this test did not |
| `toBe` on the aggregation object | the cached half re-read a field of the object asserted one line up — the cache fast path returns it by identity, so a clone-introducing change was invisible |

The load-bearing mocked `plan_type` is now documented at the mock: a fetched plan outranks the persisted one, so tidying it to a plain string silently recalibrates the weight and breaks four assertions at once with only a numeric mismatch to explain it.

## GUI: the one missing pairing

`gui/tests/provider-capacity-shell.test.tsx` had no fixture with `incomplete: false` **and** `unknownPlanAccounts > 0` — both uncalibrated-notice tests rode on aggregations also incomplete for another reason. That pairing is the #3155 reporter's own fully-included pool, where the notice is the *only* remaining uncertainty signal.

Mutation-checked rather than asserted: gating the notice under the `aggregation.incomplete` branch — a plausible tidy-up of three similar warning blocks sharing a CSS class — fails **only** the new test; all eleven prior fixtures pass. That is exactly the silent hide the review predicted.

## Verification

- `bun run test` — **17419 pass, 0 fail, exit 0**; all six serial lanes green.
- `tests/provider-quota.test.ts` 110/0, `gui/tests/provider-capacity-shell.test.tsx` 12/0.
- `bun run typecheck` / `bun run privacy:scan` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage to ensure complete aggregates continue showing the uncalibrated-plan notice while preserving usage percentages.
  - Expanded quota reporting tests to verify baseline weighting, unknown-plan handling, per-window aggregation details, sanitized public results, and consistent cached aggregation behavior when plan data is malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->