### PR TITLE
fix(ci): close the carry gate on an unclosed HTML comment

### DIFF
--- a/.github/scripts/pr-carry-attribution.cjs
+++ b/.github/scripts/pr-carry-attribution.cjs
@@ -56,7 +56,23 @@ const TRAILER_RE = /^[ \t]*co-authored-by:[ \t]*(.+)$/gim;
 
 const FENCED_CODE_RE = /^[ \t]*(\u0060{3,}|~{3,})[\s\S]*?^[ \t]*\1[ \t]*$/gm;
 const INLINE_CODE_RE = /\u0060[^\u0060\n]*\u0060/g;
-const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+/**
+ * HTML comments, which GitHub never renders.
+ *
+ * The `(?:-->|$)` alternative is load-bearing and matches `pr-quality.cjs`: an
+ * UNCLOSED comment runs to the end of the text, because that is what GitHub
+ * does with it. Without the alternative, `<!--` with no terminator matched
+ * nothing, so everything after it stayed in the scanned text while GitHub
+ * rendered none of it — an author could write a carry claim that the gate reads
+ * and no human ever sees, or bury one the gate misses in text that renders.
+ * Either direction is a divergence between what is enforced and what is shown.
+ *
+ * CodeQL flagged the same shape as `js/incomplete-multi-character-sanitization`
+ * on #3342. The alert's own framing (HTML element injection) does not apply —
+ * this output is matched by regex, never rendered — but the underlying
+ * observation, that the strip is incomplete, is correct for this gate's purpose.
+ */
+const HTML_COMMENT_RE = /<!--[\s\S]*?(?:-->|$)/g;
 
 /**
  * Carry language inside a fenced block, an inline span, or an HTML comment is

--- a/.github/scripts/pr-carry-attribution.test.cjs
+++ b/.github/scripts/pr-carry-attribution.test.cjs
@@ -120,6 +120,35 @@ describe("assessCarryAttribution", () => {
     );
   });
 
+  it("ignores carry language after an unclosed HTML comment", () => {
+    // GitHub renders nothing after an unterminated `<!--`, so neither does the
+    // gate. The closing-delimiter-only pattern used to match nothing here and
+    // leave the whole tail in the scanned text, which is the divergence CodeQL
+    // flagged on #3342: enforced text and rendered text stopped agreeing.
+    assert.deepEqual(
+      assessCarryAttribution(
+        base({
+          body: ["This is an ordinary fix.", "", "<!-- supersedes #2797"].join("\n"),
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("still reads carry language that follows a CLOSED comment", () => {
+    // The guard above must not swallow the rest of the body wholesale: a
+    // properly closed comment ends at its own `-->`, and a real claim after it
+    // is still a claim.
+    assert.equal(
+      assessCarryAttribution(
+        base({
+          body: ["<!-- a note -->", "", "Supersedes #2797."].join("\n"),
+        }),
+      ).length,
+      1,
+    );
+  });
+
   it("passes an ordinary pull request with no carry language", () => {
     assert.deepEqual(
       assessCarryAttribution(base({ body: "Closes #2797." })),


### PR DESCRIPTION
## Summary

- The carry-attribution scanner stripped HTML comments with a pattern that required the closing delimiter, so an unterminated `<!--` matched nothing and the entire tail stayed in the scanned text — while GitHub renders none of it.
- That is a divergence between what the gate enforces and what a reader sees, and it runs both ways: a carry claim the gate reads but nobody can see, or one the gate misses because the author closed the comment somewhere the scanner did not expect.
- `pr-quality.cjs` already carries the `(?:-->|$)` alternative for exactly this reason, so this is the two files agreeing rather than a new rule.

CodeQL raised it as `js/incomplete-multi-character-sanitization` (high) on the v2.41.0 promotion (#3342). Its own framing does not apply here — this output is fed to a regex, never to a renderer, so there is no HTML element injection — but the underlying observation, that the strip is incomplete, is correct for what the strip is actually for.

Two regression tests, one per direction: carry language after an unclosed comment is ignored, and carry language after a properly closed one is still read. The second exists because the obvious fix would otherwise swallow the rest of the body wholesale.

## Verification

- `node --test .github/scripts/*.test.cjs` — 543 pass, 0 fail (18 in the carry-attribution suite, including the two new cases).
- `bun test tests/ci-workflows.test.ts` — 135 pass, 0 fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated carry-attribution checks to handle unclosed HTML comments consistently with GitHub rendering.
  * Prevented carry language inside unclosed comments from being incorrectly flagged.
  * Continued detecting carry language that appears after a properly closed comment.

* **Tests**
  * Added coverage for unclosed HTML comments and content following closed comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->