### PR TITLE
fix(deps): override fast-uri to ^3.1.7 and qs to ^6.16.0 to resolve CVEs (#3313)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,9 +22,10 @@
   ],
   "overrides": {
     "@hono/node-server": "2.1.0",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "hono": "4.13.1",
     "ip-address": "^10.4.0",
+    "qs": "^6.16.0",
   },
   "packages": {
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.14.0", "", {}, "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w=="],
@@ -187,7 +188,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -261,7 +262,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 

--- a/package.json
+++ b/package.json
@@ -74,9 +74,10 @@
   },
   "overrides": {
     "@hono/node-server": "2.1.0",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "hono": "4.13.1",
-    "ip-address": "^10.4.0"
+    "ip-address": "^10.4.0",
+    "qs": "^6.16.0"
   },
   "keywords": [
     "codex",


### PR DESCRIPTION
## Summary

- `fast-uri@3.1.5` carries four high-severity advisories, all reachable through `@modelcontextprotocol/sdk > ajv > fast-uri`: host confusion via skipped IDN canonicalization (GHSA-5jgf-p345-68v8), SSRF via malformed IPv6 normalization (GHSA-f65p-4m7j-42xc), SSRF via repeated hostname percent-decoding (GHSA-fph4-wmhf-6fwf), and host confusion via percent-encoded scheme normalization (GHSA-jqff-g426-hqxp). `qs@6.15.3` carries two moderate ones.
- This is not a latent finding. The `v2.41.0-preview.20260903` publish dispatched today failed in `release.yml`'s own dependency-audit step ([run 33738740649](https://github.com/lidge-jun/opencodex/actions/runs/33738740649)) — the gate working as designed. The release train cannot move until this lands on `dev`.

Carried from #3314 by @agentHits, who found it and wrote the overrides. Landed directly because the release is blocked on it and that PR's contributor readiness gate cannot clear from a fork. Co-author trailer on the commit.

Closes #3313

## Verification

- `bun install` then `bun run audit:high` — `No vulnerabilities found` at both levels (143 packages root, 81 packages GUI). Same command and same step the release workflow failed on.
- `bun test tests/repo-hygiene.test.ts` — 12 pass, 0 fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions to incorporate newer fixes and improvements.
  * Added a dependency override for `qs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->