### PR TITLE
fix(cursor): break repeated narration across tool cycles

### DIFF
--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -306,7 +306,9 @@ function rootPromptMessages(
     entry: RootBlobCandidate;
     length: number;
   }>();
+  const toolCallCounts = new Map<string, number>();
   let maxRunLength = 1;
+  let maxToolCallCount = 1;
   const pushDeduped = (
     payload: { role: string; content: [{ type: "text"; text: string }] },
     role: RootBlobCandidate["role"],
@@ -337,12 +339,13 @@ function rootPromptMessages(
     const message = messages[i];
     if (!message) continue;
     if (message.role === "user" || message.role === "developer") {
+      replayRuns.clear();
+      toolCallCounts.clear();
       const text = historyContentText(message).trim();
       // Cursor root replay expects OpenAI-style content parts for historical user messages.
       // A bare string survives blob hydration but external workers reject the completed replay
       // before tokenization (`usedTokens: 0`, then invalid_argument).
       if (text.length > 0) {
-        replayRuns.clear();
         entries.push(rootBlobCandidate({
           role: "user",
           content: [{ type: "text", text }],
@@ -359,6 +362,20 @@ function rootPromptMessages(
           { messageIndex: i },
           text,
         );
+      }
+      if (externalModel && Array.isArray(message.content)) {
+        const callsInMessage = new Set<string>();
+        for (const part of message.content) {
+          if (part.type !== "toolCall") continue;
+          const args = serializeToolCallArguments(part.arguments);
+          if (args === undefined) continue;
+          callsInMessage.add(JSON.stringify([namespacedToolName(part.namespace, part.name), args]));
+        }
+        for (const call of callsInMessage) {
+          const count = (toolCallCounts.get(call) ?? 0) + 1;
+          toolCallCounts.set(call, count);
+          if (count > maxToolCallCount) maxToolCallCount = count;
+        }
       }
       // Assistant tool CALLS are NOT replayed as a separate visible "[Tool Call]" entry: a model
        // few-shot-mimics that marker and emits later tool calls as inert text (363-B guard in
@@ -380,7 +397,12 @@ function rootPromptMessages(
     }
   }
   // Severe repetition: tell the model ONCE, imperatively, to change strategy.
-  if (externalModel && maxRunLength >= 3) {
+  if (externalModel && maxToolCallCount >= 3) {
+    entries.push(rootBlobCandidate({
+      role: "user",
+      content: [{ type: "text", text: `[context note] The transcript above contains the same tool call repeated ${maxToolCallCount} times in this user turn. Repeating it again is a failure. Take a DIFFERENT action now, or state plainly what is blocking progress.` }],
+    }, "user", {}));
+  } else if (externalModel && maxRunLength >= 3) {
     entries.push(rootBlobCandidate({
       role: "user",
       content: [{ type: "text", text: `[context note] The transcript above contains the same output repeated ${maxRunLength} times in a row. Repeating it again is a failure. Take a DIFFERENT action now, or state plainly what is blocking progress.` }],

--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -298,38 +298,38 @@ function rootPromptMessages(
   // Repetition breaker (devlog 260826 gap-9): external full-replay flattens history to text,
   // so N identical assistant/tool-result rounds replay as N identical lines and PRIME the model
   // to emit the same line again (self-reinforcing loop: S2a 180x, identical-probe repetition).
-  // Collapse consecutive duplicates into one entry + a count marker, and count collapses so a
-  // strategy-change note can be appended when the pattern is severe.
-  let lastReplayText: string | undefined;
-  let lastReplayEntry: RootBlobCandidate | undefined;
-  let collapsedRepeats = 0;
+  // Collapse consecutive same-role duplicates within one user turn into one entry + a count marker.
+  // Track assistant narration separately from tool results so a real narration→tool→result cycle
+  // cannot reset the breaker before the next identical narration arrives.
+  const replayRuns = new Map<RootBlobCandidate["role"], {
+    text: string;
+    entry: RootBlobCandidate;
+    length: number;
+  }>();
   let maxRunLength = 1;
-  let currentRun = 1;
   const pushDeduped = (
     payload: { role: string; content: [{ type: "text"; text: string }] },
     role: RootBlobCandidate["role"],
     opts: { messageIndex: number; text?: string },
     normalized: string,
   ): void => {
-    if (externalModel && lastReplayText !== undefined && normalized === lastReplayText && lastReplayEntry) {
-      collapsedRepeats++;
-      currentRun++;
-      if (currentRun > maxRunLength) maxRunLength = currentRun;
-      const marked = `${normalized}\n[note: this exact output was produced ${currentRun} times in a row]`;
+    const previous = replayRuns.get(role);
+    if (externalModel && previous?.text === normalized) {
+      const runLength = previous.length + 1;
+      if (runLength > maxRunLength) maxRunLength = runLength;
+      const marked = `${normalized}\n[note: this exact output was produced ${runLength} times in a row]`;
       const replacement = rootBlobCandidate(
         { role: payload.role, content: [{ type: "text", text: marked }] },
         role,
-        opts,
+        { ...opts, messageIndex: previous.entry.messageIndex ?? opts.messageIndex },
       );
-      entries[entries.indexOf(lastReplayEntry)] = replacement;
-      lastReplayEntry = replacement;
+      entries[entries.indexOf(previous.entry)] = replacement;
+      replayRuns.set(role, { text: normalized, entry: replacement, length: runLength });
       return;
     }
-    currentRun = 1;
     const entry = rootBlobCandidate(payload, role, opts);
     entries.push(entry);
-    lastReplayText = normalized;
-    lastReplayEntry = entry;
+    replayRuns.set(role, { text: normalized, entry, length: 1 });
   };
 
   for (let i = 0; i < messages.length; i++) {
@@ -342,9 +342,7 @@ function rootPromptMessages(
       // A bare string survives blob hydration but external workers reject the completed replay
       // before tokenization (`usedTokens: 0`, then invalid_argument).
       if (text.length > 0) {
-        lastReplayText = undefined;
-        lastReplayEntry = undefined;
-        currentRun = 1;
+        replayRuns.clear();
         entries.push(rootBlobCandidate({
           role: "user",
           content: [{ type: "text", text }],

--- a/tests/cursor-repetition-breaker.test.ts
+++ b/tests/cursor-repetition-breaker.test.ts
@@ -41,6 +41,30 @@ function repeatedHistory(times: number): OcxMessage[] {
   return messages;
 }
 
+function repeatedToolHistory(times: number): OcxMessage[] {
+  const messages: OcxMessage[] = [{ role: "user", content: "熟悉一下当前项目", timestamp: 1 }];
+  for (let i = 0; i < times; i++) {
+    const callId = `call_${i}`;
+    messages.push({
+      role: "assistant",
+      content: [
+        { type: "text", text: REPEAT },
+        { type: "toolCall", id: callId, name: "exec_command", arguments: { cmd: `echo ${i}` } },
+      ],
+      timestamp: 2 + i * 2,
+    });
+    messages.push({
+      role: "toolResult",
+      toolCallId: callId,
+      toolName: "exec_command",
+      content: `result ${i}`,
+      isError: false,
+      timestamp: 3 + i * 2,
+    });
+  }
+  return messages;
+}
+
 function encode(messages: OcxMessage[], modelId = "grok-4.6-high") {
   return encodeCursorRunRequest({
     modelId,
@@ -69,6 +93,16 @@ describe("cursor external-replay repetition breaker (devlog 260826 gap-9)", () =
     const texts = rootTexts(encode(repeatedHistory(2)));
     expect(texts.filter(text => text.includes("2 times in a row"))).toHaveLength(1);
     expect(texts.filter(text => text.includes("Take a DIFFERENT action now"))).toHaveLength(0);
+  });
+
+  test("repeated assistant narration across tool-result cycles still trips the breaker", () => {
+    const bytes = encode(repeatedToolHistory(4));
+    const texts = rootTexts(bytes);
+    const repeats = texts.filter(text => text.startsWith(REPEAT));
+    expect(repeats).toHaveLength(1);
+    expect(repeats[0]).toContain("4 times in a row");
+    expect(texts.filter(text => text.startsWith("[Tool Result]"))).toHaveLength(4);
+    expect(texts.filter(text => text.includes("Take a DIFFERENT action now"))).toHaveLength(1);
   });
 
   test("distinct assistant entries stay untouched", () => {

--- a/tests/cursor-repetition-breaker.test.ts
+++ b/tests/cursor-repetition-breaker.test.ts
@@ -129,4 +129,44 @@ describe("cursor external-replay repetition breaker (devlog 260826 gap-9)", () =
     const texts = rootTexts(encode(messages));
     expect(texts.filter(text => text === REPEAT)).toHaveLength(2);
   });
+
+  test("empty user boundaries still reset repetition tracking", () => {
+    const messages: OcxMessage[] = [
+      { role: "user", content: "go", timestamp: 1 },
+      { role: "assistant", content: REPEAT, timestamp: 2 },
+      { role: "user", content: "   ", timestamp: 3 },
+      { role: "assistant", content: REPEAT, timestamp: 4 },
+      { role: "user", content: "final", timestamp: 5 },
+    ] as OcxMessage[];
+    const texts = rootTexts(encode(messages));
+    expect(texts.filter(text => text === REPEAT)).toHaveLength(2);
+  });
+
+  test("three identical tool calls with changing narration trigger a strategy change", () => {
+    const messages: OcxMessage[] = [{ role: "user", content: "find the i18n bug", timestamp: 1 }];
+    for (let i = 0; i < 3; i++) {
+      const callId = `view_${i}`;
+      messages.push({
+        role: "assistant",
+        content: [
+          { type: "text", text: `investigation step ${i}` },
+          { type: "toolCall", id: callId, name: "view_image", arguments: { path: "C:\\tmp\\same.png" } },
+        ],
+        timestamp: 2 + i * 2,
+      });
+      messages.push({
+        role: "toolResult",
+        toolCallId: callId,
+        toolName: "view_image",
+        content: `viewed image ${i}`,
+        isError: false,
+        timestamp: 3 + i * 2,
+      });
+    }
+
+    const texts = rootTexts(encode(messages));
+    expect(texts.filter(text => text.startsWith("investigation step"))).toHaveLength(3);
+    expect(texts.filter(text => text.startsWith("[Tool Result]"))).toHaveLength(3);
+    expect(texts.filter(text => text.includes("same tool call repeated 3 times"))).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

- Fix Cursor external-model replay so repeated assistant narration is detected across intervening tool-call/result messages.
- Detect the same exact tool invocation repeated three times in one user turn even when narration and results differ, then append one strategy-change note without dropping history.
- Reset repetition state on every user/developer boundary, including empty content, with regressions for both observed loop patterns.

## Verification

- `bun run typecheck` — passed.
- `bun test tests/cursor-repetition-breaker.test.ts tests/cursor-tool-continuation.test.ts tests/cursor-tool-result-invocation.test.ts` — 44 passed, 0 failed.
- `bun run privacy:scan` — passed.
- `git diff upstream/dev...HEAD --check` — passed.
- `bun run test:changed` — stopped after 2m30s without output on this Windows host; not counted as passing. The Draft PR remains available for repository CI.
## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No user-facing behavior or configuration changed, so no docs update is needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This change does not alter a security boundary.

<!-- pr-quality-readiness-checklist:start -->
- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeated-content detection during conversations that include tool calls and results.
  * Repeated assistant narration is now consolidated correctly without being reset by intervening tool-result messages.
  * Tool-result entries remain preserved, and the repetition-breaker notification is shown when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->