### PR TITLE
feat(meta): read Muse subscription usage from the response stream

### DIFF
--- a/devlog/_plan/260903_muse_provider_parity/000_plan.md
+++ b/devlog/_plan/260903_muse_provider_parity/000_plan.md
@@ -1,0 +1,132 @@
+# Meta Muse: from credential import to a first-class provider
+
+- Date: 2026-09-03
+- Session: `01a0670b-54e5-7d41-9f86-b7cf5983b334`
+- Work class: **C4** — the request path, a persisted cache, the management API, and a
+  user-visible dashboard surface move together, and the cache is keyed by a credential
+  identity that failover can change mid-turn.
+- Status: **P (wp0)**.
+
+## Loop spec
+
+- Archetype: satisfy-spec integration. The verifier defines done; there is no metric to
+  maximize.
+- Trigger: the user opened `http://localhost:10100/#providers`, expected Muse usage to
+  render, and found nothing. The investigation documents existed; the code did not.
+- Goal: `meta-muse` behaves like a first-class OAuth provider in the dashboard — usage
+  windows visible, and every other parity surface either closed or recorded as a
+  deliberate, evidence-backed non-goal.
+- Non-goals: Meta console GraphQL, Muse Voice/Image models, translated docs locales,
+  `meta-model`'s key path, and any inference call issued to obtain a quota.
+- Verifier: focused `bun test` on the touched suites, `bun run test:changed`,
+  `bun x tsc --noEmit`, `bun run privacy:scan`, `bun run lint:gui`, `cd gui && bun run build`.
+  **The repository-wide local suite is forbidden by standing user instruction.**
+  Exact-head GitHub CI is the authoritative gate.
+- Stop condition: every work-phase closed and each PR green at its exact head SHA and
+  merged into `dev`.
+- Memory artifact: this unit.
+- Terminal outcomes: `DONE` for each phase; `BLOCKED` if CI or branch protection refuses
+  for an unrelated reason; `NEEDS_HUMAN` if a display decision needs the user.
+- Escalation: each A gate dispatches an independent read-only reviewer on
+  `xai/grok-4.6`. Two failed correction loops on the same packet stops the phase.
+- HOTL resource bounds: write scope is the IN list below; `gh` for PR and CI; subagents
+  are read-only reviewers plus bounded workers with disjoint write scopes. No token or
+  wall-clock bound was set, so `BUDGET_EXHAUSTED` is not an available outcome.
+
+## What the predecessor unit got right, and the three things it did not
+
+`260903_muse_spark_plan_oauth/050_wp5_passive_muse_quota.md` designed this feature and
+was never built. Its core judgment holds and is adopted wholesale: Meta publishes no
+quota endpoint (`003` §E probed 17 paths, all 404), the value arrives only as an SSE
+event on a streaming turn, so the seam inverts — writes come from the request path,
+reads are cache-only, and refresh does not exist. `supportsPerAccountQuota` must stay
+false because that predicate gates `fetchAccountQuota`, whose fallback branch at
+`src/providers/quota.ts:1629` sends any non-Kiro/non-Antigravity bearer to Anthropic's
+usage endpoint.
+
+Three of its file-change decisions are **wrong against the current tree**, and this unit
+corrects them. Each was measured, not reasoned:
+
+| `050` said | Measured | Consequence |
+|---|---|---|
+| add `onSubscriptionUsage` to `SseInspectorHandlers` in `relay.ts` | `onParsedPayload` already exists (`src/server/relay.ts:834`), fires for **every** parsed frame before terminal handling (`:1020`), and is already threaded through all three passthrough construction sites | **`relay.ts` is not modified at all.** A new handler would duplicate a seam that exists |
+| the GUI account row needs new rendering | `ProviderAuthPanel.tsx:517` already renders `QuotaBars` for any account carrying `quota`, and `useProviderAccountPools.ts:100` already requests `?quota=1` for every OAuth provider | wp2 shrinks to the observation-age affordance; bars appear the moment the API returns them |
+| `hasPassiveAccountQuota` guards the read path | the read path also runs `fetchProviderAccountQuotas` (`quota.ts:1683`), which **probes**; a passive provider needs a different function, not the same one behind a second flag | wp1 adds a cache-only reader, not an allowlist entry |
+
+The general lesson, and the reason wp0 exists at all: a plan written against a tree
+three commits ago names files that have since grown the seam it was going to add.
+
+## The decision this unit turns on
+
+A passive quota is **an observation, not a measurement**. Every other provider's bars
+answer "what is true now"; a Muse bar answers "what was true at the last streaming
+turn", which may be days old. Rendering the two identically is the one way this feature
+can actively mislead — a user reading 4% and deciding to start a long job, when the
+real figure moved hours ago.
+
+So observation age is not decoration on this feature; it is the feature's honesty
+condition, and it is why wp2 is a work-phase rather than a footnote in wp1.
+
+## Work-phase map (dependency-ordered, PHASE-SPLIT-01)
+
+| Phase | Doc | Delivers | PR |
+|---|---|---|---|
+| wp0 | this folder + `001` | measured parity inventory, diff-level decade docs | — |
+| wp1 | `010_wp1_passive_quota_core.md` | parser, observation seam, generation-fenced write, cache-only read path | PR 1, base `dev` |
+| wp2 | `020_wp2_observation_age_ui.md` | the dashboard states the observation age; absent renders nothing | PR 2, base `dev` |
+| wp3 | `030_wp3_parity_closeout.md` | remaining surfaces closed or recorded NOT-APPLICABLE with evidence | PR 3, base `dev` |
+
+wp1 → wp2 → wp3 is a real dependency chain: wp2 renders what wp1 caches, wp3's docs and
+provider-note corrections are only true once both have landed. They are **independent
+PRs off `dev`, not a stack** (`DEV-STACK-01`): wp1 is server-side, wp2 is
+`gui/` plus one API field, wp3 is prose and small allowlists. The diffs do not overlap,
+so stacking would impose a false merge order.
+
+## Scope
+
+### IN
+
+- `src/providers/muse-subscription-usage.ts` (NEW) — the parser
+- `src/providers/quota.ts` — `hasPassiveAccountQuota`, `recordPassiveAccountQuota`,
+  `readPassiveProviderAccountQuotas`
+- `src/server/responses/core.ts` — the observation handler on the existing
+  `noteInspectedPayload` seam
+- `src/server/management/oauth-account-routes.ts` — cache-only enrichment for a passive
+  provider
+- `gui/src/components/QuotaBars.tsx`, `gui/src/components/provider-workspace/ProviderAuthPanel.tsx`,
+  `gui/src/i18n/en.ts` (+ the other locale files' single new key)
+- `src/providers/registry.ts` — the `meta-muse` note's quota sentence, in wp3 only
+- `docs-site/src/content/docs/guides/providers.md` — English only
+- `tests/` — focused suites beside the existing provider tests
+- `devlog/_plan/260903_muse_provider_parity/`
+
+### OUT
+
+- `src/server/relay.ts` — the seam already exists; see the correction table above
+- `src/generated/model-metadata.ts`, `scripts/model-metadata.source.json` — generated
+- `supportsPerAccountQuota` — must stay false; `tests/meta-muse-oauth.test.ts:92` locks it
+- `src/adapters/openai-responses.ts` — the translated path drops the event
+  (`004` Q3, ANSWERED: no). Documented gap, not a silent one
+- Meta console GraphQL (`fb_dtsg` + rotating `doc_id`), Muse Voice/Image, translated
+  docs locales, `meta-model`'s key path
+- `src/lab/` must stay off the core request path — `core.ts` is one of the three files
+  `tests/core-lab-boundary.test.ts` guards, and this unit edits it
+
+## Accept criteria
+
+1. `c1` (wp0) — this unit holds 000-range measured research plus one diff-level decade
+   doc per implementation phase; the wp0 commit contains no production code.
+2. `c2` (wp1) — the parser maps both windows through `normalizePercent` /
+   `normalizeResetAt`, drops `tier`, returns `null` (never throws) on junk, and routes a
+   non-300-minute window to `customWindows` rather than the five-hour slot.
+3. `c3` (wp1) — the write lands under the account that **served** the turn, is discarded
+   when the config generation moved, persists across restart, and
+   `supportsPerAccountQuota("meta-muse")` stays false.
+4. `c4` (wp1) — no code path issues an inference call to refresh a Muse quota.
+5. `c5` (wp2) — the account row shows the percentages with their observation age, and
+   renders nothing (not a zero bar) when no observation exists.
+6. `c6` (wp3) — every remaining parity surface is closed or recorded NOT-APPLICABLE with
+   file-level evidence.
+7. `c7` — `tsc` exits 0, focused suites pass, `privacy:scan` and `lint:gui` green, the
+   GUI builds, and the full local suite was never run.
+8. `c8` — each PR targets `dev`, is green at its exact head SHA, and is merged.

--- a/devlog/_plan/260903_muse_provider_parity/001_parity_inventory.md
+++ b/devlog/_plan/260903_muse_provider_parity/001_parity_inventory.md
@@ -1,0 +1,186 @@
+# Measured: what `meta-muse` has, and what a first-class OAuth provider has
+
+Research doc (000-range). No diffs here; the implementation lives in the decade docs.
+
+Measured against this checkout on 2026-09-03 (`dev` at `162d11e18`) by an independent
+read-only reviewer, then spot-verified by the main agent on the load-bearing rows. Every
+claim carries a file:line. Reference providers: `anthropic`, `kiro`, `google-antigravity`.
+
+## A. The user-visible defect, traced end to end
+
+The dashboard shows no Muse usage because of exactly one predicate:
+
+```ts
+// src/providers/quota.ts:1477
+export function supportsPerAccountQuota(provider: string): boolean {
+  return provider === "anthropic" || provider === "kiro" || provider === "google-antigravity";
+}
+```
+
+The chain, in order:
+
+1. `gui/src/hooks/useProviderAccountPools.ts:100` requests
+   `/api/oauth/accounts?provider=meta-muse&quota=1` — for **every** OAuth provider, with
+   no allowlist. The GUI is already asking.
+2. `src/server/management/oauth-account-routes.ts:284` computes
+   `wantQuota = url.searchParams.get("quota") === "1" && supportsPerAccountQuota(provider)`,
+   which is false, and returns the plain account list.
+3. `gui/src/components/provider-workspace/ProviderAuthPanel.tsx:517` renders `QuotaBars`
+   only when `account.quota != null || account.quotaUnavailable || reserveQuotaSlots`.
+   None hold, so after the reserve timer expires the row shows nothing.
+
+**Nothing is broken.** Every layer behaves correctly for a provider that reports no
+quota. The provider note says so itself (`src/providers/registry.ts:1543`): "Meta
+reports subscription window usage inside streaming responses, but OpenCodex does not yet
+read or display it."
+
+That matters for the fix: the GUI request and the bar component both already exist and
+are provider-agnostic, so the server-side write is the whole of the missing machinery.
+
+## B. Surfaces `meta-muse` already inherits, with no code
+
+Recorded so wp3 does not "fix" something that works. All follow from
+`authMode: "oauth"` plus absence from an exclusion set.
+
+| Surface | Why it already applies | Evidence |
+|---|---|---|
+| login / status / logout, account list, switch active, remove, alias | `isPublicOAuthProvider` is `name !== "chatgpt" && isOAuthProvider(name)` | `src/oauth/index.ts:296`; routes at `oauth-account-routes.ts:145,254,305,521,535` |
+| GUI account rows, switch, reauth, add-account | the panel keys on the OAuth surface, not the provider id | `ProviderAuthPanel.tsx:224` |
+| HIGH_RISK ToS modal | explicitly listed | `gui/src/oauth-tos-risk.ts:10` |
+| 429 rotation across accounts | `EXCLUDED_PROVIDERS = new Set(["openai", "anthropic"])`; everything else with `authMode: "oauth"` is in | `src/oauth/generic-account-failover.ts:52,100` |
+| serving-account attribution | `stampOAuthAccountLabel(..., resolved.accountId)` runs for every OAuth provider | `src/server/responses/core.ts:3440` |
+| SSE inspection on the passthrough path | `createSseInspector` has no provider allowlist | `src/server/relay.ts:886` |
+| per-token cost rows | both Muse Spark 1.3 tiers already priced | `src/usage/expected-prices.ts:169-170` |
+| CLI `list` / `current` / `use` / `remove` / `alias` / `login` | classified `"oauth"` generically | `src/cli/account-api.ts:85` |
+
+Two more **compile and run today but are inert** for want of a cached quota row:
+headroom-ranked pre-dispatch selection (`generic-account-failover.ts:281` returns null
+when `hasHeadroomEvidence` is false) and quota-aware cooldown. wp1 arms both as a side
+effect — worth knowing, because it means wp1 changes routing behaviour for a user with
+two Muse accounts, not only a display.
+
+## C. The real gaps
+
+| # | Surface | Gap | Evidence | Disposition |
+|---|---|---|---|---|
+| 1 | per-account quota read | `supportsPerAccountQuota` excludes `meta-muse`, and it is the wrong predicate anyway — it gates a **probe** | `quota.ts:1477`, `:1683`, `:1629` | wp1: a separate cache-only reader |
+| 2 | quota write | nothing ever keys `meta-muse\0<account>` in `accountQuotaCache` | `quota.ts:1430` | wp1 |
+| 3 | `?quota=1` enrichment | gated on the probe predicate | `oauth-account-routes.ts:284` | wp1 |
+| 4 | observation age | `QuotaBars` renders no timestamp; `AccountQuota.updatedAt` exists but is unread | `QuotaBars.tsx:164`, `codex-quota-utils.ts:21` | wp2 |
+| 5 | provider-level row | `maybeFetchProviderQuota` has no `meta-muse` branch, so the Providers overview card is empty | `quota.ts:2298-2301` | wp3 decides: derive from the cache or record NOT-APPLICABLE |
+| 6 | provider note | says the quota is unread — false once wp1 lands | `registry.ts:1543` | wp3 |
+| 7 | docs-site | same stale sentence | `docs-site/.../providers.md:475` | wp3 |
+| 8 | `ocx account refresh` | prints "no quota report" | `src/cli/account-extended.ts:328` | wp3: must stay probe-free by design; make the message honest |
+| 9 | `skills/ocx` recipes | no `meta-muse` account recipe | `skills/ocx/references/03_recipes.md:16` | wp3 |
+
+## D. Surfaces that are NOT gaps, and why
+
+Recorded now so wp3 does not spend effort proving them twice.
+
+- **Connection test.** `provider-routes.ts:1195` short-circuits any provider with
+  `liveModels === false` to `{ applicable: false, reason: "static_catalog" }` before any
+  network call. `meta-muse` sets `liveModels: false` deliberately (`registry.ts:1538`):
+  the authenticated roster carries `muse-image-1.0` and `muse-voice-transcribe-1.0`,
+  which a Responses-agent provider cannot drive. `kiro` is in exactly the same class.
+  **NOT-APPLICABLE by design, not a gap.**
+- **`clear-cooldown`.** Anthropic-only (`oauth-account-routes.ts:465`) because the
+  generic failover health map is process-local (`generic-account-failover.ts:78`).
+  Provider-wide absence; out of scope for a Muse unit.
+- **Account import.** `ACCOUNT_IMPORT_PROVIDER = "google-antigravity"`
+  (`src/oauth/account-import/types.ts:3`) — a cockpit-tools document format with no Meta
+  analogue.
+- **401 replay.** `FORCE_REFRESH_PROVIDERS = new Set(["xai", "github-copilot", "kiro"])`
+  (`src/oauth/index.ts:540`). Muse holds a **static API key** — `003` §B measured the
+  OAuth `access_token` returning 401 while the sibling `api_key` returns 200 — so there
+  is nothing to force-refresh. Adding it would replay an identical credential.
+- **Background refresh.** `defaultRefreshPolicy: "disabled"` (`src/oauth/index.ts:240`),
+  the same posture as `anthropic`, for the same reason: the vendor restricts use outside
+  its own client, so every exchange stays attributable to a user action.
+
+## E. The seam wp1 uses, measured
+
+`050` planned to add `onSubscriptionUsage` to `SseInspectorHandlers`. That handler is
+unnecessary — the general seam already exists and is strictly better placed:
+
+```ts
+// src/server/relay.ts:834
+onParsedPayload?: (payload: unknown) => void;
+```
+
+It fires for **every** parsed SSE frame, and critically it fires *before* terminal
+handling (`relay.ts:1020`), inside a `try/catch` that guarantees inspection never throws
+into the pump (`:1021`). All three passthrough construction sites already thread it:
+
+| Site | Line | How |
+|---|---|---|
+| eager relay | `core.ts:4811` | `onParsedPayload: noteInspectedPayload` |
+| tee + terminal | `core.ts:4862` → `relay.ts:1357` | via `inspectionConsumerOptions` |
+| tee metadata-only | `core.ts:4862` → `relay.ts:1411` | same options object |
+
+Both tee consumers read the same `inspectionConsumerOptions` literal built at
+`core.ts:4857`, so extending `noteInspectedPayload` covers every passthrough shape at
+once. **This is why `relay.ts` is not in wp1's file list.**
+
+### The serving account, in that scope
+
+`runResponses` holds these at the point the inspector is constructed:
+
+| Variable | Declared | Meaning |
+|---|---|---|
+| `genericFailoverAccountId` | `core.ts:3309`, set `:3444` | the account `meta-muse` actually dispatched on; rebound at each rotation site (`:5131`, `:5445`, `:6134`) |
+| `resolved: OAuthAccessSnapshot` | `:3397` | carries `.accountId` and `.generation` |
+| `replayOAuthCredentialSnapshot` | `:3304`, filled `:3431` | `{ accountId, generation }` |
+| `anthropicPoolAccountId` | `:3305` | Anthropic only |
+
+`genericFailoverAccountId` is rebound by every rotation, so reading it **at event time**
+— not at handler-construction time — is what makes attribution survive a mid-turn
+failover. That is the difference between recording the quota of the account that served
+the turn and recording it against the account that failed.
+
+## F. Generation fencing: the correction `050` already carried, verified
+
+`050` recorded an A-gate finding that capturing the generation immediately before the
+write cannot see a config change that happened **earlier in the turn**. The tree
+confirms the mechanism it must use:
+
+```ts
+// src/providers/quota.ts:1470
+function mayCommitAccountQuotaKey(key: string, writerGeneration: number): boolean {
+  return writerGeneration >= lastReconciledGeneration || liveAccountQuotaKeys.has(key);
+}
+```
+
+Every existing writer follows the same shape: `captureConfigGeneration()` before the
+await, `mayCommitAccountQuotaKey` before the `set` (`quota.ts:1378`, `:1404`, `:1648`).
+A streaming turn is a long await, so the caller must capture when it resolves the
+credential and pass the number in.
+
+Reconciliation removes rows whose account no longer exists
+(`reconcileProviderAccountQuotaRows`, registered as `provider-quota-history` in
+`src/lib/state-store-registrations.ts:109`), so a logged-out account cannot leave a stale
+bar behind.
+
+## G. Persistence, measured
+
+`persistAccountQuotaCache` (`quota.ts:1449`) debounces into
+`schedulePersistAccountQuotas` (`src/providers/account-quota-disk.ts:59`), and
+`readPersistedAccountQuotas` (`:40`) drops rows older than `DISK_MAX_AGE_MS` = 6 hours
+(`:28`).
+
+**This bounds the honesty problem in wp2.** A passive observation can be arbitrarily old
+in memory, but a restart discards anything past six hours. The in-memory TTL
+(`ACCOUNT_QUOTA_TTL_MS` = 10 minutes, `quota-wire.ts:22`) is a **probe** TTL — it decides
+when to re-probe, and `sweepExpiredProviderAccountQuotaRows` is exported but not
+registered as a `sweepExpired` callback (`src/lib/state-store-registrations.ts:109`
+registers only `reconcileGeneration`), so an unprobed row is not swept on the TTL tick.
+A passive row therefore survives in memory past 10 minutes, which is correct for this
+feature and is exactly why the age must be displayed.
+
+## H. Method note
+
+The parity inventory was dispatched as a read-only reviewer packet demanding a file:line
+for every claim, precisely because the predecessor unit's plan had drifted from the tree
+in three places. Two of its findings — the pre-existing `onParsedPayload` seam and the
+already-generic GUI bar rendering — deleted planned work rather than adding it. A
+roadmap written from the old plan alone would have shipped a duplicate handler and a
+redundant component change.

--- a/devlog/_plan/260903_muse_provider_parity/001_parity_inventory.md
+++ b/devlog/_plan/260903_muse_provider_parity/001_parity_inventory.md
@@ -59,6 +59,20 @@ when `hasHeadroomEvidence` is false) and quota-aware cooldown. wp1 arms both as 
 effect — worth knowing, because it means wp1 changes routing behaviour for a user with
 two Muse accounts, not only a display.
 
+**That side effect carries the unit's one Critical finding.** `headroomOf`
+(`account-quota-rank.ts:36`) reads `getCachedProviderAccountQuota`, which applies no
+staleness check (`quota.ts:1489` returns `entry.quota` without consulting `entry.ts`).
+Every existing caller is safe by construction — a row exists only because a probe wrote
+it, and `fetchAccountQuota` re-probes past `ACCOUNT_QUOTA_TTL_MS` (`quota.ts:1602`) — so
+freshness is an invariant of the probe path rather than a property of the cache.
+
+A passive row is the first row in this system that no probe refreshes. Feeding one to a
+routing decision would make the proxy confidently prefer an account whose measurement is
+arbitrarily old. wp1 therefore bounds the ROUTING read at one hour
+(`010` §`account-quota-rank.ts`) while leaving the DISPLAY read unbounded, because wp2
+shows the age and a human can discount it. Same number, two consumers, different
+obligations.
+
 ## C. The real gaps
 
 | # | Surface | Gap | Evidence | Disposition |

--- a/devlog/_plan/260903_muse_provider_parity/010_wp1_passive_quota_core.md
+++ b/devlog/_plan/260903_muse_provider_parity/010_wp1_passive_quota_core.md
@@ -193,6 +193,66 @@ the row does not carry it.
 refresh for every provider, and a 400 would surface an error for an action that is simply
 a no-op here.
 
+## MODIFY `src/oauth/account-quota-rank.ts` — A-gate amendment
+
+**Blocker found at the audit gate, folded here.** `headroomOf` (`:36`) reads
+`getCachedProviderAccountQuota` and applies **no staleness bound**:
+
+```ts
+// src/providers/quota.ts:1489
+export function getCachedProviderAccountQuota(provider: string, accountId: string): ProviderQuota | null {
+  const entry = accountQuotaCache.get(accountCacheKey(provider, accountId));
+  return entry?.quota ?? null;   // no ts check
+}
+```
+
+For every provider that exists today this is safe by construction: a row is only written by
+a probe, and `fetchAccountQuota` re-probes once `ACCOUNT_QUOTA_TTL_MS` (10 minutes,
+`quota-wire.ts:22`) has passed, so a row consulted for routing is at most that old.
+**The passive path breaks that invariant.** Nothing re-probes, and `001` §G established
+that account-quota rows are not swept on the TTL tick, so a Muse row can be hours or days
+old in memory and up to six hours old after a restart.
+
+Left unfixed, `preferredInitialAccount` (`generic-account-failover.ts:281`) would send the
+first attempt of every turn to whichever account looked best whenever it was last
+observed — plausibly the one that has since been exhausted. That is worse than the
+current unranked behaviour, because it is confidently wrong rather than uninformed.
+
+```ts
+/**
+ * How old a PASSIVELY observed quota may be and still steer routing.
+ *
+ * A probed row is implicitly fresh: fetchAccountQuota re-probes after
+ * ACCOUNT_QUOTA_TTL_MS. A passive row has no such refresh, so the bound is explicit
+ * here. It is deliberately longer than the probe TTL — an hour-old reading of a
+ * five-hour window is still informative — and deliberately far shorter than the
+ * six-hour disk horizon, which exists to preserve a value for DISPLAY, where the age is
+ * shown to the user and no automatic decision rides on it.
+ */
+const PASSIVE_HEADROOM_MAX_AGE_MS = 60 * 60_000;
+```
+
+In `headroomOf`, immediately after the null check:
+
+```ts
+  if (hasPassiveAccountQuota(provider) && Date.now() - quota.updatedAt > PASSIVE_HEADROOM_MAX_AGE_MS) return null;
+```
+
+Returning `null` is the correct shape, not a zero or a low rank: it reproduces "no
+evidence", which `rankAccountsByHeadroom` (`:71`) and `hasHeadroomEvidence` (`:87`)
+already handle by leaving the ring untouched. The stale-row case therefore degrades to
+exactly today's behaviour rather than to a different wrong answer.
+
+The display path is deliberately **not** bounded this way. wp2 shows the age, so an old
+number is labelled rather than hidden — the user can judge it, and a routing algorithm
+cannot.
+
+Added tests in `tests/muse-passive-quota-cache.test.ts`:
+
+- a passive row younger than the bound produces headroom; one older produces `null`
+- `hasHeadroomEvidence` is false for a roster whose only rows are stale
+- an `anthropic` row of the same age is unaffected (the bound is passive-only)
+
 ## Tests
 
 `tests/muse-subscription-usage.test.ts` — parser, fixture-driven:

--- a/devlog/_plan/260903_muse_provider_parity/010_wp1_passive_quota_core.md
+++ b/devlog/_plan/260903_muse_provider_parity/010_wp1_passive_quota_core.md
@@ -1,0 +1,254 @@
+# wp1 — passive Muse subscription quota: parser, seam, cache
+
+Own PR, base `dev`. Branch: `codex/meta-muse-passive-quota`.
+
+Research: `001` (this unit) and `260903_muse_spark_plan_oauth/003` §E. Implementation only.
+
+## Decisions taken here, so Build does not have to make them
+
+| Question | Decision | Why |
+|---|---|---|
+| Where to observe | `noteInspectedPayload` in `core.ts:3891`, on the existing `onParsedPayload` seam | `001` §E: covers all three passthrough sites at once; `relay.ts` untouched |
+| Which account | `genericFailoverAccountId` read **at event time** | it is rebound at every rotation site; reading it at construction attributes the turn to the account that failed |
+| Translated path | **not covered**, deliberately | `openai-responses.ts`'s switch drops unknown types (`004` Q3, answered) |
+| `supportsPerAccountQuota` | **stays false** | it gates a probe whose fallback ships a Meta bearer to Anthropic (`quota.ts:1629`) |
+| Read path | a new cache-only function, not the probe function behind a flag | `fetchProviderAccountQuotas` probes; a passive provider has nothing to probe |
+| Refresh | does not exist | obtaining a fresh value would mean spending an inference turn |
+| `tier` | dropped | an opaque numeric id, not the label the CLI prints |
+
+## NEW `src/providers/muse-subscription-usage.ts`
+
+```ts
+import { normalizePercent, normalizeResetAt, asRecord } from "./quota-wire";
+import type { ProviderQuota, ProviderQuotaWindow } from "./quota-types";
+
+/** The SSE frame type Meta emits on streaming turns. */
+export const MUSE_SUBSCRIPTION_USAGE_TYPE = "response.subscription_usage";
+
+export function parseMuseSubscriptionUsage(payload: unknown): ProviderQuota | null;
+```
+
+Mapping table, all mandatory:
+
+| Source | Target | Rule |
+|---|---|---|
+| `subscription.window.used_percent` | `fiveHourPercent` | `normalizePercent`; assign **only** if `window_duration_mins === 300` |
+| `subscription.window.resets_at` | `fiveHourResetAt` | `normalizeResetAt` (unix seconds; `epochMillis` scales) |
+| `subscription.weekly.used_percent` | `weeklyPercent` | `normalizePercent` |
+| `subscription.weekly.resets_at` | `weeklyResetAt` | `normalizeResetAt` |
+| `window` with any other `window_duration_mins` | `customWindows[]` | label `"${duration}m"`; never forced into the 5h slot |
+| `subscription.tier` | — | dropped |
+| — | `updatedAt` | `Date.now()`, never from the payload |
+
+Returns `null` — never throws — when the payload is not an object, carries no
+`subscription`, or yields no usable window. Either window may be absent independently.
+A window present but unparseable yields no slot rather than a zero.
+
+**Why `window_duration_mins` is checked rather than assumed:** the measured payload says
+300, but a plan change could move it, and silently filing a 10-hour window in the
+five-hour slot would understate usage by the ratio of the windows — a wrong number
+presented with full confidence.
+
+## MODIFY `src/providers/quota.ts`
+
+Three additions, all beside the existing per-account block (after
+`setCachedProviderAccountQuotaForTests`, `:1494`).
+
+```ts
+/**
+ * Providers whose per-account quota is OBSERVED in-band, never probed.
+ *
+ * Deliberately separate from supportsPerAccountQuota: that predicate gates
+ * fetchAccountQuota, whose fallback branch sends any non-Kiro/non-Antigravity bearer to
+ * Anthropic's usage endpoint. Meta exposes no quota endpoint at all (17 paths probed,
+ * all 404), so there is nothing for that path to call.
+ */
+export function hasPassiveAccountQuota(provider: string): boolean {
+  return provider === "meta-muse";
+}
+
+/**
+ * Record a quota observed on a streaming turn.
+ *
+ * The CALLER captures writerGeneration when it resolves the serving credential, not
+ * here: a streaming turn is a long await, and capturing at write time cannot see a
+ * config change that happened earlier in the same turn.
+ */
+export function recordPassiveAccountQuota(
+  provider: string,
+  accountId: string,
+  quota: ProviderQuota,
+  writerGeneration: number,
+): void {
+  if (!hasPassiveAccountQuota(provider) || !accountId) return;
+  const key = accountCacheKey(provider, accountId);
+  if (!mayCommitAccountQuotaKey(key, writerGeneration)) return;
+  accountQuotaCache.set(key, { ts: Date.now(), quota });
+  persistAccountQuotaCache();
+}
+
+/** Cache-only per-account rows for a passive provider. Never probes. */
+export function readPassiveProviderAccountQuotas(provider: string): ProviderAccountQuota[] {
+  if (!hasPassiveAccountQuota(provider)) return [];
+  hydrateAccountQuotaCache();
+  const set = getAccountSet(provider);
+  if (!set) return [];
+  const rows: ProviderAccountQuota[] = [];
+  for (const account of set.accounts) {
+    const entry = accountQuotaCache.get(accountCacheKey(provider, account.id));
+    if (entry?.quota) rows.push({ accountId: account.id, quota: entry.quota });
+  }
+  return rows;
+}
+```
+
+Three details that are not arbitrary:
+
+- `hydrateAccountQuotaCache()` must be called in the reader. It is idempotent
+  (`diskHydrated`, `quota.ts:1440`) and is otherwise only reached from probe paths that a
+  passive provider never enters — without it, a restart shows nothing until the next
+  streaming turn even though the row is on disk.
+- Absent rows are **omitted**, not returned with `quota: null`. A user who has not run a
+  streaming turn has no observation, and `unavailable` would claim a failed probe that
+  never happened.
+- `sweepExpiredOnWrite` is **not** called here. Existing probe writers call it because
+  they run on a poll; this runs on every streaming turn, and a state sweep on the request
+  path is exactly the hot-path work `state-store-registrations.ts:97` warns against.
+
+## MODIFY `src/server/responses/core.ts`
+
+One capture at credential resolution, one branch in the existing payload handler.
+
+Near `genericFailoverAccountId` (`:3309`), add:
+
+```ts
+// Captured where the credential is resolved, not at write time: see quota.ts
+// recordPassiveAccountQuota. Only meta-muse observes a quota, so this stays 0 elsewhere.
+let passiveQuotaWriterGeneration = 0;
+```
+
+set alongside `genericFailoverAccountId = resolved.accountId` (`:3444`):
+
+```ts
+if (hasPassiveAccountQuota(route.providerName)) passiveQuotaWriterGeneration = captureConfigGeneration();
+```
+
+Extend `noteInspectedPayload` (`:3891`). The existing body opens with an early return
+for the undeclared-tool guard, so the observation goes **before** it:
+
+```ts
+const noteInspectedPayload = (payload: unknown) => {
+  if (passiveQuotaObserved && route.providerName === "meta-muse") {
+    const record = payload as { type?: unknown } | null;
+    if (record && typeof record === "object" && record.type === MUSE_SUBSCRIPTION_USAGE_TYPE) {
+      const quota = parseMuseSubscriptionUsage(payload);
+      // Read the account HERE, not at construction: rotation rebinds it mid-turn.
+      const accountId = genericFailoverAccountId;
+      if (quota && accountId) {
+        recordPassiveAccountQuota("meta-muse", accountId, quota, passiveQuotaWriterGeneration);
+      }
+    }
+  }
+  if (!undeclaredToolGuardActive || inspectionSawUndeclaredTool) return;
+  // ... unchanged
+};
+```
+
+where `passiveQuotaObserved` is a `const` computed once beside the handler:
+
+```ts
+const passiveQuotaObserved = hasPassiveAccountQuota(route.providerName)
+  && route.provider.authMode === "oauth";
+```
+
+**Ordering is load-bearing.** The undeclared-tool guard returns early once it has fired
+(`inspectionSawUndeclaredTool`), so an observation placed after it would be dropped for
+the rest of any turn that tripped the guard — a turn that still legitimately reports
+usage.
+
+**Import discipline.** `core.ts` is one of the three files `tests/core-lab-boundary.test.ts`
+guards. Both new imports (`src/providers/quota`, `src/providers/muse-subscription-usage`)
+are already-reachable or leaf modules: `quota.ts` is imported by `core.ts` today, and the
+parser imports only `quota-wire` and `quota-types`. Neither reaches `src/lab/`. The
+parser must **not** import `quota.ts` — that would be a cycle.
+
+## MODIFY `src/server/management/oauth-account-routes.ts`
+
+At `:284`, the enrichment gate becomes:
+
+```ts
+const passiveQuota = url.searchParams.get("quota") === "1" && hasPassiveAccountQuota(provider);
+const wantQuota = url.searchParams.get("quota") === "1" && supportsPerAccountQuota(provider);
+if (!wantQuota && !passiveQuota) return jsonResponse(projectAccounts());
+const rows = passiveQuota
+  // No probe, and ?refresh=1 is ignored: there is nothing to refresh.
+  ? readPassiveProviderAccountQuotas(provider)
+  : await fetchProviderAccountQuotas(provider, url.searchParams.get("refresh") === "1");
+```
+
+The existing `byId` merge below is unchanged and already omits `quotaUnavailable` when
+the row does not carry it.
+
+`?refresh=1` is accepted and ignored rather than rejected: the GUI sends it on a manual
+refresh for every provider, and a 400 would surface an error for an action that is simply
+a no-op here.
+
+## Tests
+
+`tests/muse-subscription-usage.test.ts` — parser, fixture-driven:
+
+- the measured payload from `003` §E → both windows, correct millisecond resets
+- `window_duration_mins: 600` → `customWindows`, and `fiveHourPercent` **undefined**
+- weekly-only; window-only (each independently absent)
+- `used_percent: 150` → clamped to 100 (`normalizePercent` clamps rather than rejects)
+- `used_percent: "12"` → 12 (`toFiniteNumber` accepts numeric strings)
+- missing `subscription`; non-object; `null`; array → `null`, no throw
+- `tier` never appears in the output
+- `updatedAt` is local, not the payload's `resets_at`
+
+`tests/muse-passive-quota-cache.test.ts`:
+
+- `recordPassiveAccountQuota` writes under the serving account key and
+  `getCachedProviderAccountQuota` reads it back
+- a stale `writerGeneration` discards the write
+- `readPassiveProviderAccountQuotas` omits accounts with no observation
+- the row persists and rehydrates after a simulated restart
+- `hasPassiveAccountQuota("meta-muse")` is true while
+  `supportsPerAccountQuota("meta-muse")` stays **false** — the exfiltration guard from
+  wp4 must survive this phase
+- `recordPassiveAccountQuota("anthropic", ...)` is a no-op
+
+`tests/muse-passive-quota-observation.test.ts` — the seam, driven through
+`createSseInspector` with a recorded transcript:
+
+- a transcript containing the event invokes the handler exactly once
+- a transcript without it never does
+- the payload is delivered before the terminal frame is processed
+- a handler that throws does not break the pump (guaranteed by `relay.ts:1021`; asserted
+  so a future refactor cannot silently remove the guarantee)
+
+No live call, no real Keychain, no network in any test.
+
+## Verification
+
+```bash
+bun test tests/muse-subscription-usage.test.ts tests/muse-passive-quota-cache.test.ts \
+         tests/muse-passive-quota-observation.test.ts tests/meta-muse-oauth.test.ts \
+         tests/provider-account-quota.test.ts tests/oauth-accounts-api.test.ts \
+         tests/core-lab-boundary.test.ts
+bun run test:changed
+bun x tsc --noEmit
+bun run privacy:scan
+```
+
+`tests/core-lab-boundary.test.ts` is listed explicitly because this phase edits
+`core.ts`, one of the three files it guards, and `test:changed` follows the import graph
+from changed modules — it would select that test only if the boundary test itself
+imports `core.ts`, which is not something to assume.
+
+## Terminal outcome
+
+`DONE` when a streaming `meta-muse` turn populates the serving account's five-hour and
+weekly percentages, `/api/oauth/accounts?provider=meta-muse&quota=1` returns them, a
+restart preserves the observation, and no code path issues an inference call to refresh a
+quota.

--- a/devlog/_plan/260903_muse_provider_parity/020_wp2_observation_age_ui.md
+++ b/devlog/_plan/260903_muse_provider_parity/020_wp2_observation_age_ui.md
@@ -1,0 +1,134 @@
+# wp2 — the dashboard states how old the observation is
+
+Own PR, base `dev`, after wp1 lands. Branch: `codex/muse-quota-observation-age`.
+
+## Why this is a work-phase and not a line in wp1
+
+Every other quota bar in this dashboard answers *what is true now*: Anthropic's is at
+most `ACCOUNT_QUOTA_TTL_MS` (10 minutes) old, and a stale probe is marked
+`quotaUnavailable` (`oauth-account-routes.ts:298`). A Muse bar answers *what was true at
+the last streaming turn*, which can be hours old — bounded only by the six-hour disk
+horizon (`account-quota-disk.ts:28`), and unbounded in memory because the account-quota
+TTL sweep is not registered as a `sweepExpired` callback (`001` §G).
+
+Rendering the two identically is the one way this feature can actively mislead. So the
+age is the honesty condition, not decoration.
+
+## Scope boundary
+
+`QuotaBars` is shared by the Codex account pool, the provider overview, the combo
+workspace, and every OAuth account row. **The change must be additive and opt-in**: a
+component that starts rendering a timestamp for every caller would put an age on
+Anthropic's bars, where it is noise.
+
+## MODIFY `gui/src/components/QuotaBars.tsx`
+
+One optional prop, rendered only when passed:
+
+```ts
+  /**
+   * Render "observed <age> ago" beside the bars. Set ONLY for a passively observed
+   * quota (meta-muse), where the value can be arbitrarily old. A probed provider
+   * refreshes on its own TTL and must not carry this.
+   */
+  observedAt?: number;
+```
+
+Rendered above the rows in both layouts, from the existing `quota.updatedAt`:
+
+```tsx
+{observedAt !== undefined && (
+  <p className="quota-observed muted">{t("quota.observedAgo").replace("{age}", formatObservedAge(observedAt, t, locale))}</p>
+)}
+```
+
+`formatObservedAge` is a new exported helper in the same file (co-located with
+`buildQuotaRows`, which is already exported for the same reason). Buckets, chosen so the
+string never implies more precision than an observation has:
+
+| Elapsed | Output |
+|---|---|
+| < 60s | `quota.observedJustNow` |
+| < 60m | `${n}m` |
+| < 24h | `${n}h` |
+| otherwise | `${n}d` |
+
+A negative elapsed (clock skew between the write and the browser) renders as just-now
+rather than a negative number.
+
+## MODIFY `gui/src/components/provider-workspace/ProviderAuthPanel.tsx`
+
+At the `QuotaBars` call (`:522`), pass the prop **only** for the passive provider:
+
+```tsx
+<QuotaBars
+  quota={account.quota ?? null}
+  plan={null}
+  threshold={80}
+  t={t}
+  layout="stacked"
+  pending={account.quota == null}
+  {...(item.name === "meta-muse" && account.quota ? { observedAt: account.quota.updatedAt } : {})}
+/>
+```
+
+The provider id is compared here rather than a capability being plumbed through the
+account payload: the GUI has no other consumer for such a flag, and one string in one
+render site is easier to audit than a new field on every account row. If a second passive
+provider appears, this becomes a server-sent boolean — recorded as the migration, not
+done speculatively.
+
+**The absent case needs no change.** `ProviderAuthPanel.tsx:517` already renders the
+quota block only when `account.quota != null || account.quotaUnavailable ||
+reserveQuotaSlots`, and `QuotaBars` returns `null` when `buildQuotaRows` is empty and
+`pending` is false (`QuotaBars.tsx:193`). An account with no observation renders nothing,
+which is already correct — c5's "not a zero bar" half is asserted, not implemented.
+
+## MODIFY the locale files
+
+Three keys in `gui/src/i18n/en.ts`, near the existing `quota.*` block:
+
+```ts
+  "quota.observedAgo": "Observed {age} ago",
+  "quota.observedJustNow": "Observed just now",
+  "quota.observedHint": "Meta reports usage only during a streaming response, so this is the last value seen — not a live reading.",
+```
+
+`quota.observedHint` is the `title` on the age line. Without it the user has no way to
+know why this one provider's number lags.
+
+Every other locale file (`ko`, `ja`, `zh`, `zh-TW`, `fr`, `de`, `ru`, `tr`) gets the
+same three keys. Translate `ko` and leave the rest on the English string if no confident
+translation exists — a missing key breaks the typed `TFn` lookup, which is the failure
+mode to avoid.
+
+## Tests
+
+`gui/tests/quota-observed-age.test.tsx`:
+
+- `formatObservedAge` bucket boundaries: 59s, 60s, 59m, 60m, 23h, 24h, and a negative
+- `QuotaBars` without `observedAt` renders no age line (the regression that protects
+  every other caller)
+- with `observedAt` renders it in both `compact` and `stacked` layouts
+- a `meta-muse` account row with a quota shows the age; an account without a quota
+  renders no bars and no age
+
+## Verification
+
+```bash
+bun test gui/tests/quota-observed-age.test.tsx gui/tests/oauth-tos-warning-gate.test.tsx
+bun x tsc --noEmit
+bun run lint:gui
+cd gui && bun run build
+```
+
+Plus render grounding (C-RENDER-GROUNDING-01): this phase changes a rendered surface, so
+C loads `http://localhost:10100/#providers` against a proxy carrying a real observation,
+screenshots the Muse account row, and reads the screenshot back. A built-but-unviewed
+bundle is not evidence.
+
+## Terminal outcome
+
+`DONE` when the Muse account row shows both windows with a truthful age, the same
+component renders no age for Anthropic, and an account with no observation renders
+nothing at all.

--- a/devlog/_plan/260903_muse_provider_parity/030_wp3_parity_closeout.md
+++ b/devlog/_plan/260903_muse_provider_parity/030_wp3_parity_closeout.md
@@ -111,6 +111,16 @@ selection order to change. `001` §B and `003` §F establish the soundness: the 
 limits are per team, but subscription windows are per subscription, so two Muse accounts
 carry genuinely different headroom.
 
+It is desirable **only within the staleness bound wp1 adds**. Unbounded, it is the
+opposite: a routing preference computed from a days-old observation is worse than no
+preference, because the unranked ring at least rotates. wp1 caps the routing read at one
+hour and returns "no evidence" beyond it, which degrades to today's behaviour rather than
+to a different wrong answer (`010`, `001` §B).
+
+wp3's PR description must therefore describe the routing change **and** its bound. A
+reviewer told only "quota now steers account selection" would reasonably object; the
+bound is what makes the claim defensible.
+
 ## Verification
 
 ```bash

--- a/devlog/_plan/260903_muse_provider_parity/030_wp3_parity_closeout.md
+++ b/devlog/_plan/260903_muse_provider_parity/030_wp3_parity_closeout.md
@@ -1,0 +1,130 @@
+# wp3 — close or record every remaining parity surface
+
+Own PR, base `dev`, after wp1 and wp2 land. Branch: `codex/meta-muse-parity-closeout`.
+
+This phase exists because "make Meta first-class" is only verifiable against an
+enumerated list. `001` §C is that list; this doc dispositions every row.
+
+## The rule this phase applies
+
+A surface is closed when `meta-muse` behaves like a first-class provider, or recorded
+NOT-APPLICABLE when the difference follows from a **measured property of Meta's API** —
+never from "we did not get to it". Every NOT-APPLICABLE carries a file:line and a reason
+that would survive a reviewer asking "why not just add it to the allowlist?".
+
+## 1. Provider note — CLOSE (`src/providers/registry.ts:1543`)
+
+The note currently says:
+
+> Meta reports subscription window usage inside streaming responses, but OpenCodex does
+> not yet read or display it, and there is no endpoint to query it on demand.
+
+False after wp1. Replace that sentence with:
+
+> OpenCodex reads Meta's subscription windows from streaming responses and shows the
+> last observed value with its age; there is no endpoint to query them on demand, so a
+> fresh reading requires a streaming turn and translated (non-passthrough) turns do not
+> report one.
+
+Both clauses after the semicolon are load-bearing: the first explains why the number can
+be stale, the second is the documented gap from `004` Q3 rather than a silent one.
+
+`tests/meta-model-api-provider.test.ts` asserts note substrings — check before editing.
+
+## 2. docs-site — CLOSE (`docs-site/src/content/docs/guides/providers.md:475`)
+
+Same correction, English only. The surrounding paragraphs about the ToS boundary and
+per-team rate limits are unchanged and remain accurate.
+
+## 3. `ocx account refresh meta-muse` — CLOSE the message, keep the behaviour
+
+`src/cli/account-extended.ts:328` prints "no quota report" because
+`maybeFetchProviderQuota` has no `meta-muse` branch. **The behaviour is correct and must
+not change** (c4: no path may issue an inference call to refresh a quota). The message is
+what misleads — it reads like a failure.
+
+Emit, for a provider where `hasPassiveAccountQuota` is true:
+
+> meta-muse reports usage only during a streaming response; there is nothing to refresh.
+> Run a request through this provider to update it.
+
+A CLI that explains an intentional absence is the difference between a documented design
+and an apparent bug.
+
+## 4. Provider-level overview card — DECIDE, then close
+
+`quota.ts:2298-2301` gives `/api/provider-quotas` a row for anthropic, antigravity and
+kiro; `meta-muse` has none, so `ProviderCapacityQuota.tsx:47` renders "No quota data".
+
+Two honest options, decided in wp3's P against the tree at that time:
+
+- **(a)** derive the provider row from the cached active account's observation — no
+  probe, consistent with wp1's seam, and it fills a visibly empty card.
+- **(b)** record NOT-APPLICABLE: the provider card means "the provider's capacity", and
+  Meta's documented limits are **per team, not per key** (`001`, `003` §E), so a
+  per-account subscription window is the wrong quantity to promote to provider level.
+
+**Current lean: (b), with the empty card given an explanatory string** rather than a
+number that means something different from every other provider's provider-level bar.
+wp3's audit gate decides; whichever is chosen, the reason is recorded here.
+
+## 5. `skills/ocx` — CLOSE (`skills/ocx/references/03_recipes.md`)
+
+Add a `meta-muse` account recipe covering import login, `ocx account list meta-muse`,
+and the passive-quota caveat. `bun run skill:surface:check` must stay green; the surface
+map is generated from `src/cli/capabilities.ts`, and `tests/skill-ocx.test.ts` fails if a
+hand-written page names a command the registry does not have.
+
+`src/cli/capabilities.ts:250` also carries a stale line — "`anthropic` is the only OAuth
+pool with this setting; other OAuth providers are refused without a round-trip" — which
+`001` shows is wrong: generic OAuth providers do reach the pool endpoint, and their
+settings persist inertly (`pool-settings-capability.ts:40`). Correct it while here.
+
+## 6. Recorded NOT-APPLICABLE (no code)
+
+Each with the measured reason, written into this doc's closing section at D:
+
+| Surface | Reason | Evidence |
+|---|---|---|
+| Connection test | `liveModels: false` short-circuits to `static_catalog` before any network call; the authenticated roster carries image and voice models a Responses-agent provider cannot drive. `kiro` is the same class | `provider-routes.ts:1195`; `registry.ts:1538`; `003` §C |
+| 401 replay / `FORCE_REFRESH_PROVIDERS` | the credential is a **static API key**; the OAuth `access_token` 401s while the `api_key` returns 200, so there is nothing to force-refresh | `src/oauth/index.ts:540`; `003` §B |
+| Background refresh | `defaultRefreshPolicy: "disabled"`, same posture as `anthropic`: the vendor restricts use outside its own client, so every exchange stays attributable to a user action | `src/oauth/index.ts:240` |
+| Account import | `ACCOUNT_IMPORT_PROVIDER` is a cockpit-tools document format with no Meta analogue | `src/oauth/account-import/types.ts:3` |
+| `clear-cooldown` | anthropic-only because the generic failover health map is process-local — a provider-wide gap, not a Muse gap | `oauth-account-routes.ts:465`; `generic-account-failover.ts:78` |
+| GUI generic pool card | no dashboard editor exists for **any** generic OAuth provider | `ProviderAuthPanel.tsx:353` |
+| Translated-path quota | `openai-responses.ts` dispatches on `payload.type` through a switch with no case for the event | `004` Q3 |
+
+The last two are the honest ones to resist closing: both are real absences a user could
+hit, and both are provider-wide rather than Meta-specific. Fixing either inside a Muse
+unit would be scope creep that lands untested for its other providers.
+
+## 7. Side effect worth stating: routing changes, not just display
+
+`001` §B measured that headroom-ranked pre-dispatch selection
+(`generic-account-failover.ts:281`) and quota-aware cooldown are already wired for any
+generic failover provider but inert while `hasHeadroomEvidence` is false. wp1's cache
+**arms both** for a user with two or more Muse accounts.
+
+That is desirable — it is what "first-class" means here — but it must be stated in the
+PR description, because a reviewer reading a quota-display PR would not expect account
+selection order to change. `001` §B and `003` §F establish the soundness: the RPM/TPM
+limits are per team, but subscription windows are per subscription, so two Muse accounts
+carry genuinely different headroom.
+
+## Verification
+
+```bash
+bun test tests/meta-muse-oauth.test.ts tests/meta-model-api-provider.test.ts \
+         tests/skill-ocx.test.ts tests/cli-account.test.ts tests/provider-registry-parity.test.ts
+bun run skill:surface:check
+bun run test:changed
+bun x tsc --noEmit
+bun run privacy:scan
+cd docs-site && bun install --frozen-lockfile && bun run build
+```
+
+## Terminal outcome
+
+`DONE` when every row in `001` §C is either closed with a diff or recorded here as
+NOT-APPLICABLE with its measured reason, and no user-facing text claims OpenCodex cannot
+read a value it now reads.

--- a/src/oauth/account-quota-rank.ts
+++ b/src/oauth/account-quota-rank.ts
@@ -10,7 +10,7 @@
  * categories answer the only question rotation asks — "which of these is most likely to
  * serve the retry" — and within the healthy group a simple headroom sort is enough.
  */
-import { getCachedProviderAccountQuota } from "../providers/quota";
+import { getCachedProviderAccountQuota, hasPassiveAccountQuota } from "../providers/quota";
 import { getKiroAccountExhaustion } from "../providers/kiro-usage";
 
 /** Lower sorts earlier. Unknown sits between measured-healthy and measured-empty. */
@@ -28,6 +28,24 @@ interface Ranked {
 }
 
 /**
+ * How old a PASSIVELY observed quota may be and still steer routing.
+ *
+ * A probed row is fresh by construction: it exists only because a probe wrote it, and
+ * `fetchAccountQuota` re-probes once `ACCOUNT_QUOTA_TTL_MS` has passed. So no caller has
+ * ever needed an explicit age check, and `getCachedProviderAccountQuota` does not apply
+ * one.
+ *
+ * A passive row breaks that invariant — nothing re-probes it, so it can be hours or days
+ * old. Routing on such a reading is worse than routing on none: the unranked ring at
+ * least rotates, while a stale ranking sends every first attempt to an account that may
+ * have been spent since. The bound is longer than the probe TTL (an hour-old reading of
+ * a five-hour window is still informative) and far shorter than the six-hour disk
+ * horizon, which exists to preserve a value for DISPLAY — where the age is shown to the
+ * user and no automatic decision rides on it.
+ */
+const PASSIVE_HEADROOM_MAX_AGE_MS = 60 * 60_000;
+
+/**
  * Remaining headroom across every window the provider reports.
  *
  * The minimum wins: an account at 5% of its five-hour window is unusable right now even if
@@ -36,6 +54,9 @@ interface Ranked {
 function headroomOf(provider: string, accountId: string): number | null {
   const quota = getCachedProviderAccountQuota(provider, accountId);
   if (!quota) return null;
+  // Null, not a low rank: this must reproduce "no evidence" so a stale roster degrades to
+  // the unranked ring rather than to a differently wrong answer.
+  if (hasPassiveAccountQuota(provider) && Date.now() - quota.updatedAt > PASSIVE_HEADROOM_MAX_AGE_MS) return null;
   const percents = [
     quota.fiveHourPercent,
     quota.weeklyPercent,

--- a/src/oauth/account-quota-rank.ts
+++ b/src/oauth/account-quota-rank.ts
@@ -77,6 +77,12 @@ export function rankAccountsByHeadroom(provider: string, ring: readonly string[]
   if (ring.length < 2) return [...ring];
 
   let sawEvidence = false;
+  // Same rule as hasHeadroomEvidence: a passive provider's partial roster must not rank
+  // at all. The failover path calls this directly (selectFailoverAccount), so the guard
+  // cannot live only in the pre-dispatch predicate.
+  if (hasPassiveAccountQuota(provider) && !ring.every(id => headroomOf(provider, id) !== null)) {
+    return [...ring];
+  }
   const ranked: Ranked[] = ring.map((id, index) => {
     // A provider-declared exhaustion verdict outranks the percentage: an account may sit at
     // 100% and still be servable when overage is enabled, and the verdict knows that.
@@ -105,6 +111,18 @@ export function rankAccountsByHeadroom(provider: string, ring: readonly string[]
  * can decline to act on a roster it knows nothing about.
  */
 export function hasHeadroomEvidence(provider: string, ids: readonly string[]): boolean {
+  // A PASSIVE provider needs evidence for EVERY candidate, not any one of them.
+  //
+  // A probe fills the whole roster in one pass (fetchProviderAccountQuotas), so "any"
+  // and "every" coincide there. An observation arrives one account at a time, so the
+  // normal passive state is "one measured, N unknown" -- and RANK_UNKNOWN (1) sorts
+  // AFTER RANK_HEALTHY (0), including behind a measured row sitting at 100% with zero
+  // headroom. Accepting partial evidence would therefore redirect the first attempt
+  // AWAY from an unmeasured account and TOWARD the one account known to be spent, which
+  // is the exact inversion of what ranking is for.
+  if (hasPassiveAccountQuota(provider)) {
+    return ids.length > 0 && ids.every(id => headroomOf(provider, id) !== null);
+  }
   return ids.some(id =>
     headroomOf(provider, id) !== null
     || (provider === "kiro" && getKiroAccountExhaustion(`${provider}\u0000${id}`) !== null));

--- a/src/providers/muse-subscription-usage.ts
+++ b/src/providers/muse-subscription-usage.ts
@@ -1,0 +1,95 @@
+/**
+ * Meta's subscription-usage SSE frame.
+ *
+ * Meta publishes no quota endpoint — 17 plausible REST paths were probed and every one
+ * 404s, and no `x-ratelimit-*` header appears on any of three measured request shapes
+ * (devlog/_plan/260903_muse_spark_plan_oauth/003 §E). The only machine-readable usage
+ * Meta emits arrives mid-stream, as one extra event alongside the ordinary
+ * `response.*` sequence on a streaming `POST /v1/responses`.
+ *
+ * That inverts the usual seam: this module is fed by the request path, not by a probe,
+ * and nothing can refresh its output on demand — obtaining a newer value would mean
+ * spending a real inference turn.
+ *
+ * Measured payload (2026-09-03):
+ *
+ * ```json
+ * { "type": "response.subscription_usage",
+ *   "subscription": {
+ *     "tier": "27681393394859588",
+ *     "window": { "used_percent": 0, "resets_at": 1788431188, "window_duration_mins": 300 },
+ *     "weekly": { "used_percent": 0, "resets_at": 1788739200 } } }
+ * ```
+ */
+import { asRecord, normalizePercent, normalizeResetAt, toFiniteNumber } from "./quota-wire";
+import type { ProviderQuota, ProviderQuotaWindow } from "./quota-types";
+
+/** The SSE frame type Meta emits on streaming turns. */
+export const MUSE_SUBSCRIPTION_USAGE_TYPE = "response.subscription_usage";
+
+/** Meta's five-hour window, identified by its declared duration rather than assumed. */
+const FIVE_HOUR_WINDOW_MINS = 300;
+
+/** True when a parsed SSE payload is the subscription-usage frame. */
+export function isMuseSubscriptionUsagePayload(payload: unknown): boolean {
+  return asRecord(payload)?.type === MUSE_SUBSCRIPTION_USAGE_TYPE;
+}
+
+/**
+ * Translate the frame into a `ProviderQuota`.
+ *
+ * Returns null — never throws — for anything unrecognizable. This runs inside SSE
+ * inspection on a live request, where the only acceptable failure is silence: a parse
+ * error must not cost the user their turn.
+ *
+ * `subscription.tier` is deliberately dropped. It is an opaque numeric id, not the plan
+ * label the Muse CLI prints, so surfacing it would show a meaningless number.
+ */
+export function parseMuseSubscriptionUsage(payload: unknown): ProviderQuota | null {
+  const subscription = asRecord(asRecord(payload)?.subscription);
+  if (!subscription) return null;
+
+  const quota: ProviderQuota = { updatedAt: Date.now() };
+  let sawWindow = false;
+
+  const window = asRecord(subscription.window);
+  if (window) {
+    const percent = normalizePercent(window.used_percent);
+    const resetAt = normalizeResetAt(window.resets_at);
+    const durationMins = toFiniteNumber(window.window_duration_mins);
+    if (percent !== undefined) {
+      if (durationMins === FIVE_HOUR_WINDOW_MINS) {
+        quota.fiveHourPercent = percent;
+        if (resetAt !== undefined) quota.fiveHourResetAt = resetAt;
+        sawWindow = true;
+      } else {
+        // A window of some other length is NOT forced into the five-hour slot: filing a
+        // ten-hour window there would understate usage by the ratio of the two windows,
+        // and would do so with full confidence. Carry it with its real duration instead.
+        const custom: ProviderQuotaWindow = {
+          label: durationMins === undefined ? "subscription" : `${durationMins}m`,
+          percent,
+          ...(resetAt !== undefined ? { resetAt } : {}),
+        };
+        quota.customWindows = [...(quota.customWindows ?? []), custom];
+        sawWindow = true;
+      }
+    }
+  }
+
+  const weekly = asRecord(subscription.weekly);
+  if (weekly) {
+    const percent = normalizePercent(weekly.used_percent);
+    if (percent !== undefined) {
+      quota.weeklyPercent = percent;
+      const resetAt = normalizeResetAt(weekly.resets_at);
+      if (resetAt !== undefined) quota.weeklyResetAt = resetAt;
+      sawWindow = true;
+    }
+  }
+
+  // Either window may be absent independently, but a payload carrying neither says
+  // nothing — returning a bare `updatedAt` would publish an empty row that the GUI
+  // would render as a quota with no bars.
+  return sawWindow ? quota : null;
+}

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -1505,6 +1505,71 @@ export function setCachedProviderAccountQuotaForTests(
   accountQuotaCache.set(key, { ts: Date.now(), quota });
 }
 
+/**
+ * Providers whose per-account quota is OBSERVED in-band, never probed.
+ *
+ * Deliberately separate from `supportsPerAccountQuota` rather than folded into it. That
+ * predicate gates `fetchAccountQuota`, whose fallback branch sends any
+ * non-Kiro/non-Antigravity bearer to Anthropic's usage endpoint — so adding `meta-muse`
+ * there without a dedicated branch would ship a Meta credential to Anthropic. And even
+ * with a branch it would be the wrong predicate: it means "this provider can be probed",
+ * and Meta publishes no quota endpoint to probe.
+ */
+export function hasPassiveAccountQuota(provider: string): boolean {
+  return provider === "meta-muse";
+}
+
+/**
+ * Record a quota observed in-band on a streaming turn.
+ *
+ * The CALLER captures `writerGeneration` when it resolves the serving credential, not
+ * this function at write time. A streaming turn is a long await, and a generation
+ * captured immediately before the write cannot see a config or account change that
+ * happened EARLIER in the same turn — which is exactly the case the fence exists for.
+ */
+export function recordPassiveAccountQuota(
+  provider: string,
+  accountId: string,
+  quota: ProviderQuota,
+  writerGeneration: number,
+): void {
+  if (!hasPassiveAccountQuota(provider) || !accountId) return;
+  const key = accountCacheKey(provider, accountId);
+  if (!mayCommitAccountQuotaKey(key, writerGeneration)) return;
+  accountQuotaCache.set(key, { ts: Date.now(), quota });
+  // Persisted so a restart keeps the last observation: with no probe to re-establish it,
+  // a forgotten row stays forgotten until the user happens to run another streaming turn.
+  persistAccountQuotaCache();
+  // sweepExpiredOnWrite is deliberately NOT called. Existing probe writers call it
+  // because they run on a poll; this runs on the request path, where a state sweep does
+  // not belong. Passive rows are still reclaimed by generation reconciliation
+  // (reconcileProviderAccountQuotaRows) and by the disk reader's age bound.
+}
+
+/**
+ * Cache-only per-account rows for a passive provider. Never probes, never refreshes.
+ *
+ * An account with no observation is OMITTED rather than returned with `quota: null` and
+ * `unavailable`: that pair means "a probe was attempted and failed", and no probe was
+ * ever attempted here. A user who has not yet run a streaming turn simply has no
+ * measurement, which is not an error state.
+ */
+export function readPassiveProviderAccountQuotas(provider: string): ProviderAccountQuota[] {
+  if (!hasPassiveAccountQuota(provider)) return [];
+  // Idempotent, and otherwise only reached from probe paths a passive provider never
+  // enters — without it a restart shows nothing until the next streaming turn, even
+  // though the row is sitting on disk.
+  hydrateAccountQuotaCache();
+  const set = getAccountSet(provider);
+  if (!set) return [];
+  const rows: ProviderAccountQuota[] = [];
+  for (const account of set.accounts) {
+    const entry = accountQuotaCache.get(accountCacheKey(provider, account.id));
+    if (entry?.quota) rows.push({ accountId: account.id, quota: entry.quota });
+  }
+  return rows;
+}
+
 export function sweepExpiredProviderAccountQuotaRows(now = Date.now()): number {
   let removed = 0;
   for (const [key, entry] of accountQuotaCache) {

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -1536,6 +1536,13 @@ export function recordPassiveAccountQuota(
   if (!hasPassiveAccountQuota(provider) || !accountId) return;
   const key = accountCacheKey(provider, accountId);
   if (!mayCommitAccountQuotaKey(key, writerGeneration)) return;
+  // Hydrate BEFORE writing, not only on the read path. `persistAccountQuotaCache`
+  // serializes the whole in-memory map, so a passive write that lands before anything
+  // has read the cache would persist this one row and erase every other provider's
+  // saved row -- and `diskHydrated` would then stop any later reader from recovering
+  // them. A probe writer cannot hit this because its own read hydrates first; an
+  // observation arrives unprompted, so it must hydrate itself.
+  hydrateAccountQuotaCache();
   accountQuotaCache.set(key, { ts: Date.now(), quota });
   // Persisted so a restart keeps the last observation: with no probe to re-establish it,
   // a forgotten row stays forgotten until the user happens to run another streaming turn.

--- a/src/server/management/oauth-account-routes.ts
+++ b/src/server/management/oauth-account-routes.ts
@@ -30,7 +30,7 @@ import { enrichProviderFromCatalog, listKeyLoginProviders } from "../../oauth/ke
 import { deriveProviderPresets } from "../../providers/derive";
 import { providerCodexAccountMode } from "../../providers/registry";
 import { routedSlug, slugEquals } from "../../providers/slug-codec";
-import { clearAccountQuotaCache, clearProviderQuotaCache, fetchProviderAccountQuotas, fetchProviderQuotaReports, supportsPerAccountQuota } from "../../providers/quota";
+import { clearAccountQuotaCache, clearProviderQuotaCache, fetchProviderAccountQuotas, fetchProviderQuotaReports, hasPassiveAccountQuota, readPassiveProviderAccountQuotas, supportsPerAccountQuota } from "../../providers/quota";
 import { isCanonicalOpenAiForwardProvider } from "../../providers/openai-tiers";
 import { clearThreadAccountMap } from "../../codex/routing";
 import {
@@ -282,11 +282,18 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
     // account can show its own 5h/weekly bars (not just the active one). Opt-in via ?quota=1
     // so the plain account list stays a cheap local read; ?refresh=1 bypasses the TTL.
     const wantQuota = url.searchParams.get("quota") === "1" && supportsPerAccountQuota(provider);
-    if (!wantQuota) return jsonResponse(projectAccounts());
+    // Meta publishes no quota endpoint: its usage is observed in-band on streaming turns
+    // and read back from the cache here. `?refresh=1` is accepted and ignored on this
+    // path rather than rejected -- the GUI sends it for every provider on a manual
+    // refresh, and a 400 would report an error for what is simply a no-op.
+    const passiveQuota = url.searchParams.get("quota") === "1" && hasPassiveAccountQuota(provider);
+    if (!wantQuota && !passiveQuota) return jsonResponse(projectAccounts());
     const forceRefresh = url.searchParams.get("refresh") === "1";
     // Probing may refresh the active credential and mark needsReauth — project health
     // from the post-probe store so the response is not stale.
-    const rows = await fetchProviderAccountQuotas(provider, forceRefresh);
+    const rows = passiveQuota
+      ? readPassiveProviderAccountQuotas(provider)
+      : await fetchProviderAccountQuotas(provider, forceRefresh);
     const byId = new Map(rows.map(row => [row.accountId, row]));
     const projected = projectAccounts();
     return jsonResponse({

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -219,6 +219,9 @@ import {
   waitForProviderRequestSlot,
 } from "../../providers/request-pacing";
 import { slugsEquivalent } from "../../providers/slug-codec";
+import { isMuseSubscriptionUsagePayload, parseMuseSubscriptionUsage } from "../../providers/muse-subscription-usage";
+import { hasPassiveAccountQuota, recordPassiveAccountQuota } from "../../providers/quota";
+import { captureConfigGeneration } from "../../lib/state-store-sweeper";
 import { applyOpenAiVirtualModel, resolveOpenAiCompactModel } from "../../providers/openai-virtual-models";
 import { isUsageDebugEnabled } from "../../usage/debug";
 import { readJsonRequestBody, DecompressedBodyTooLargeError, UnsupportedContentEncodingError } from "../request-decompress";
@@ -3309,6 +3312,13 @@ async function handleResponsesInner(
   let genericFailoverAccountId: string | null = null;
   let genericFailovers = 0;
   /**
+   * Config generation captured where the serving credential is RESOLVED, not where the
+   * quota is written. A streaming turn is a long await, so a generation captured at write
+   * time cannot see a config or account change that happened earlier in the same turn —
+   * the case the fence exists for. Stays 0 for every provider without a passive quota.
+   */
+  let passiveQuotaWriterGeneration = 0;
+  /**
    * Apply a rotated account's FULL credential snapshot to the live route (#2568d).
    *
    * One helper for all three rotation sites on purpose. Each site used to inline the same four
@@ -3442,6 +3452,10 @@ async function handleResponsesInner(
         // whichever account is active by the time the response comes back (#2568).
         if (isGenericFailoverProvider(route.providerName, route.provider)) {
           genericFailoverAccountId = resolved.accountId;
+        }
+        // Captured beside the account it fences, so the two can never disagree.
+        if (hasPassiveAccountQuota(route.providerName)) {
+          passiveQuotaWriterGeneration = captureConfigGeneration();
         }
         if (route.providerName === "kiro") {
           // `{}` is intentional: this is an account-scoped request with no stored routing metadata.
@@ -3888,7 +3902,27 @@ async function handleResponsesInner(
     // check sees nothing undeclared, and the refused turn enters continuation state anyway. So the
     // rejection is sticky for the whole turn, set from every parsed payload on the inspection side.
     let inspectionSawUndeclaredTool = false;
+    const passiveQuotaObserved = hasPassiveAccountQuota(route.providerName)
+      && route.provider.authMode === "oauth";
     const noteInspectedPayload = (payload: unknown) => {
+      // Meta reports subscription usage ONLY as an in-stream event; there is no endpoint
+      // to poll (003 §E probed 17 paths, all 404). Observed here rather than behind a
+      // dedicated inspector handler because onParsedPayload already reaches every
+      // passthrough shape -- eager relay and both tee consumers -- through this one
+      // function.
+      //
+      // Placed BEFORE the undeclared-tool early return below, which is load-bearing: that
+      // guard latches for the rest of the turn once it fires, and a turn that tripped it
+      // still legitimately reports usage.
+      if (passiveQuotaObserved && isMuseSubscriptionUsagePayload(payload)) {
+        const quota = parseMuseSubscriptionUsage(payload);
+        // Read at EVENT time, not at handler construction: failover rebinds this, and the
+        // quota belongs to the account that actually served the turn.
+        const servingAccountId = genericFailoverAccountId;
+        if (quota && servingAccountId) {
+          recordPassiveAccountQuota(route.providerName, servingAccountId, quota, passiveQuotaWriterGeneration);
+        }
+      }
       // Gated on the same flag as the guard itself: with no readable catalog (or a forward-auth
       // provider) every name looks undeclared, and flipping this would stop recording continuation
       // state for exactly the passthrough traffic the guard deliberately stands down for.

--- a/tests/muse-passive-quota-cache.test.ts
+++ b/tests/muse-passive-quota-cache.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAccountSet, saveCredential } from "../src/oauth/store";
+import {
+  clearAccountQuotaCache,
+  getCachedProviderAccountQuota,
+  hasPassiveAccountQuota,
+  readPassiveProviderAccountQuotas,
+  recordPassiveAccountQuota,
+  resetProviderQuotaReconcileStateForTests,
+  setCachedProviderAccountQuotaForTests,
+  supportsPerAccountQuota,
+} from "../src/providers/quota";
+import { hasHeadroomEvidence, rankAccountsByHeadroom } from "../src/oauth/account-quota-rank";
+import { captureConfigGeneration } from "../src/lib/state-store-sweeper";
+import type { ProviderQuota } from "../src/providers/quota-types";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
+
+const previousOpencodexHome = process.env.OPENCODEX_HOME;
+let opencodexHome: string;
+
+const FIRST = { accountId: "muse-first", email: "first@example.com" };
+const SECOND = { accountId: "muse-second", email: "second@example.com" };
+
+function quotaAt(fiveHour: number, updatedAt = Date.now()): ProviderQuota {
+  return { fiveHourPercent: fiveHour, weeklyPercent: 10, updatedAt };
+}
+
+/**
+ * Seed logged-in accounts and return the STORE-ASSIGNED ids.
+ *
+ * The store derives its slot id by hashing the credential identity
+ * (`store.ts:newAccountId`), so the `accountId` handed to `saveCredential` is not the
+ * key the cache is filed under. A test that assumed otherwise would pass against a
+ * cache that never matched a real account.
+ */
+async function seedAccounts(...accounts: Array<{ accountId: string; email: string }>): Promise<string[]> {
+  for (const account of accounts) {
+    await saveCredential("meta-muse", {
+      access: `key-${account.accountId}`,
+      refresh: `key-${account.accountId}`,
+      expires: Number.MAX_SAFE_INTEGER,
+      ...account,
+    });
+  }
+  return (getAccountSet("meta-muse")?.accounts ?? []).map(account => account.id);
+}
+
+beforeEach(() => {
+  opencodexHome = mkdtempSync(join(tmpdir(), "ocx-muse-quota-"));
+  process.env.OPENCODEX_HOME = opencodexHome;
+  clearAccountQuotaCache();
+  // The generation-fence test below reconciles with an empty live-key set, which raises
+  // lastReconciledGeneration process-wide. Without this reset every later write in the
+  // file would be discarded as stale -- a failure of the harness, not of the code.
+  resetProviderQuotaReconcileStateForTests();
+});
+
+afterEach(() => {
+  clearAccountQuotaCache();
+  if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousOpencodexHome;
+  removeTreeWithRetry(opencodexHome);
+});
+
+describe("passive Muse quota cache", () => {
+  /*
+   * supportsPerAccountQuota gates fetchAccountQuota, whose fallback sends any
+   * non-Kiro/non-Antigravity bearer to Anthropic's usage endpoint. The passive path must
+   * never flip it -- this is the exfiltration guard the meta-muse OAuth unit installed.
+   */
+  test("is passive without entering the probe allowlist", () => {
+    expect(hasPassiveAccountQuota("meta-muse")).toBe(true);
+    expect(supportsPerAccountQuota("meta-muse")).toBe(false);
+  });
+
+  test("ignores providers that are not passive", () => {
+    expect(hasPassiveAccountQuota("anthropic")).toBe(false);
+    recordPassiveAccountQuota("anthropic", FIRST.accountId, quotaAt(5), captureConfigGeneration());
+    expect(getCachedProviderAccountQuota("anthropic", FIRST.accountId)).toBeNull();
+  });
+
+  test("writes under the account that served the turn", () => {
+    recordPassiveAccountQuota("meta-muse", SECOND.accountId, quotaAt(42), captureConfigGeneration());
+    expect(getCachedProviderAccountQuota("meta-muse", SECOND.accountId)?.fiveHourPercent).toBe(42);
+    expect(getCachedProviderAccountQuota("meta-muse", FIRST.accountId)).toBeNull();
+  });
+
+  test("ignores a write with no account id", () => {
+    recordPassiveAccountQuota("meta-muse", "", quotaAt(42), captureConfigGeneration());
+    expect(readPassiveProviderAccountQuotas("meta-muse")).toEqual([]);
+  });
+
+  test("discards a write whose config generation has been superseded", () => {
+    // Generation 0 predates any reconciliation; a stale writer must not commit.
+    const { reconcileStateGeneration } = require("../src/lib/state-store-sweeper");
+    reconcileStateGeneration({ generation: 0, oauthAccountKeys: new Set<string>(), providerNames: new Set<string>() });
+    recordPassiveAccountQuota("meta-muse", FIRST.accountId, quotaAt(42), -1);
+    expect(getCachedProviderAccountQuota("meta-muse", FIRST.accountId)).toBeNull();
+  });
+
+  test("omits accounts with no observation rather than reporting a failed probe", async () => {
+    const [firstId] = await seedAccounts(FIRST, SECOND);
+    clearAccountQuotaCache();
+    recordPassiveAccountQuota("meta-muse", firstId!, quotaAt(7), captureConfigGeneration());
+    const rows = readPassiveProviderAccountQuotas("meta-muse");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.accountId).toBe(firstId!);
+    expect(rows[0]!.quota?.fiveHourPercent).toBe(7);
+    expect(rows[0]).not.toHaveProperty("unavailable");
+  });
+
+  test("returns nothing for a provider that is not passive", () => {
+    setCachedProviderAccountQuotaForTests("anthropic", FIRST.accountId, quotaAt(1));
+    expect(readPassiveProviderAccountQuotas("anthropic")).toEqual([]);
+  });
+
+  /*
+   * persistAccountQuotaCache serializes the WHOLE in-memory map. A passive write that
+   * landed before anything hydrated would persist its single row and erase every other
+   * provider's saved row, with diskHydrated then blocking recovery.
+   */
+  /*
+   * persistAccountQuotaCache serializes the WHOLE in-memory map. A passive write that
+   * landed before anything hydrated would persist its single row and erase every other
+   * provider's saved row, with diskHydrated then blocking recovery.
+   *
+   * The disk file is written directly here rather than through the debounced scheduler:
+   * clearAccountQuotaCache cancels any pending write, so a scheduled one cannot be
+   * relied on to have landed across the restart this test simulates.
+   */
+  test("hydrates before persisting so an observation cannot erase other providers' rows", async () => {
+    const [firstId] = await seedAccounts(FIRST);
+    writeDiskRows({ [`anthropic\u0000other-acct`]: quotaAt(55) });
+
+    // Restart with an empty map, then observe BEFORE anything reads the cache.
+    clearAccountQuotaCache();
+    recordPassiveAccountQuota("meta-muse", firstId!, quotaAt(3), captureConfigGeneration());
+    // The foreign row is in memory, which is only possible if the write hydrated first.
+    expect(getCachedProviderAccountQuota("anthropic", "other-acct")?.fiveHourPercent).toBe(55);
+
+    await Bun.sleep(PERSIST_SETTLE_MS);
+    const persisted = readPersistedAccountQuotas();
+    expect(persisted.get(`anthropic\u0000other-acct`)?.fiveHourPercent).toBe(55);
+    expect(persisted.get(`meta-muse\u0000${firstId!}`)?.fiveHourPercent).toBe(3);
+  });
+
+  test("an observation survives a restart", async () => {
+    const [firstId] = await seedAccounts(FIRST);
+    clearAccountQuotaCache();
+    recordPassiveAccountQuota("meta-muse", firstId!, quotaAt(19), captureConfigGeneration());
+    await Bun.sleep(PERSIST_SETTLE_MS);
+    expect(readPersistedAccountQuotas().get(`meta-muse\u0000${firstId!}`)?.fiveHourPercent).toBe(19);
+
+    // Simulate a restart: the in-memory map is gone, the file is not.
+    clearAccountQuotaCache();
+    const rows = readPassiveProviderAccountQuotas("meta-muse");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.quota?.fiveHourPercent).toBe(19);
+  });
+});
+
+describe("passive quota and routing headroom", () => {
+  const ids = [FIRST.accountId, SECOND.accountId];
+
+  test("a fresh observation for every account is usable evidence", () => {
+    setCachedProviderAccountQuotaForTests("meta-muse", FIRST.accountId, quotaAt(10));
+    setCachedProviderAccountQuotaForTests("meta-muse", SECOND.accountId, quotaAt(90));
+    expect(hasHeadroomEvidence("meta-muse", ids)).toBe(true);
+    expect(rankAccountsByHeadroom("meta-muse", ids)[0]).toBe(FIRST.accountId);
+  });
+
+  /*
+   * A probe fills the whole roster at once; an observation arrives one account at a time.
+   * RANK_UNKNOWN sorts AFTER RANK_HEALTHY, so accepting partial evidence would redirect
+   * the first attempt away from an unmeasured account and toward the one known to be
+   * spent -- the exact inversion ranking exists to prevent.
+   */
+  test("a partial roster is not evidence and does not reorder", () => {
+    setCachedProviderAccountQuotaForTests("meta-muse", FIRST.accountId, quotaAt(100));
+    expect(hasHeadroomEvidence("meta-muse", ids)).toBe(false);
+    expect(rankAccountsByHeadroom("meta-muse", ids)).toEqual(ids);
+  });
+
+  test("an observation older than the routing bound is not evidence", () => {
+    const stale = Date.now() - 2 * 60 * 60_000;
+    setCachedProviderAccountQuotaForTests("meta-muse", FIRST.accountId, quotaAt(10, stale));
+    setCachedProviderAccountQuotaForTests("meta-muse", SECOND.accountId, quotaAt(90, stale));
+    expect(hasHeadroomEvidence("meta-muse", ids)).toBe(false);
+    expect(rankAccountsByHeadroom("meta-muse", ids)).toEqual(ids);
+  });
+
+  test("the staleness bound applies only to passive providers", () => {
+    const stale = Date.now() - 2 * 60 * 60_000;
+    setCachedProviderAccountQuotaForTests("anthropic", FIRST.accountId, quotaAt(10, stale));
+    expect(hasHeadroomEvidence("anthropic", [FIRST.accountId])).toBe(true);
+  });
+});
+import { readPersistedAccountQuotas } from "../src/providers/account-quota-disk";
+
+/** PERSIST_DEBOUNCE_MS is 250ms in account-quota-disk.ts; wait past it. */
+const PERSIST_SETTLE_MS = 400;
+
+/** Write the on-disk snapshot directly, bypassing the debounce. */
+function writeDiskRows(rows: Record<string, ProviderQuota>): void {
+  writeFileSync(join(opencodexHome, "provider-account-quota-cache.json"), `${JSON.stringify({ version: 1, rows })}\n`);
+}

--- a/tests/muse-passive-quota-observation.test.ts
+++ b/tests/muse-passive-quota-observation.test.ts
@@ -1,0 +1,203 @@
+/**
+ * End-to-end cover for the two seams the parser and cache tests cannot reach: the SSE
+ * observation that WRITES the quota, and the management route that READS it back.
+ *
+ * A green parser plus a green cache still leaves the feature able to record nothing --
+ * that is exactly the gap an audit flagged here -- so these tests drive the real
+ * inspector and the real route handler rather than the helpers underneath them.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSseInspector } from "../src/server/relay";
+import { handleOauthAccountRoutes } from "../src/server/management/oauth-account-routes";
+import {
+  clearAccountQuotaCache,
+  getCachedProviderAccountQuota,
+  recordPassiveAccountQuota,
+  resetProviderQuotaReconcileStateForTests,
+} from "../src/providers/quota";
+import {
+  isMuseSubscriptionUsagePayload,
+  MUSE_SUBSCRIPTION_USAGE_TYPE,
+  parseMuseSubscriptionUsage,
+} from "../src/providers/muse-subscription-usage";
+import { captureConfigGeneration } from "../src/lib/state-store-sweeper";
+import type { OcxConfig } from "../src/types";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
+
+const previousHome = process.env.OPENCODEX_HOME;
+let testDir = "";
+
+const ACCOUNT_ID = "muse-acct-1";
+
+function museConfig(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "meta-muse",
+    providers: {
+      "meta-muse": { adapter: "openai-responses", baseUrl: "https://api.meta.ai/v1", authMode: "oauth" },
+    },
+  } as OcxConfig;
+}
+
+function writeMuseAccount(): void {
+  writeFileSync(join(testDir, "auth.json"), JSON.stringify({
+    "meta-muse": {
+      activeAccountId: ACCOUNT_ID,
+      accounts: [
+        { id: ACCOUNT_ID, credential: { access: "LLM|1|k", refresh: "LLM|1|k", expires: 9999999999999, email: "muse@example.com", accountId: "muse-1" } },
+      ],
+    },
+  }), { mode: 0o600 });
+}
+
+/** The frame Meta emits, wrapped as it arrives on the wire. */
+function usageFrame(fiveHour: number, weekly: number): string {
+  return `data: ${JSON.stringify({
+    type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+    subscription: {
+      tier: "27681393394859588",
+      window: { used_percent: fiveHour, resets_at: 1788431188, window_duration_mins: 300 },
+      weekly: { used_percent: weekly, resets_at: 1788739200 },
+    },
+  })}\n\n`;
+}
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "ocx-muse-observe-"));
+  process.env.OPENCODEX_HOME = testDir;
+  writeMuseAccount();
+  clearAccountQuotaCache();
+  resetProviderQuotaReconcileStateForTests();
+});
+
+afterEach(() => {
+  clearAccountQuotaCache();
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  if (testDir) removeTreeWithRetry(testDir);
+});
+
+/**
+ * Mirrors the handler core.ts installs on onParsedPayload. Kept in the test rather than
+ * exported from core.ts so the assertion is about the OBSERVED BEHAVIOUR of the seam --
+ * a frame in, a cache row out -- not about a helper's signature.
+ */
+function observePayload(payload: unknown, servingAccountId: string | null, generation: number): void {
+  if (!isMuseSubscriptionUsagePayload(payload)) return;
+  const quota = parseMuseSubscriptionUsage(payload);
+  if (quota && servingAccountId) recordPassiveAccountQuota("meta-muse", servingAccountId, quota, generation);
+}
+
+describe("Muse subscription usage observed on the SSE seam", () => {
+  test("a stream carrying the frame writes the serving account's quota", () => {
+    const generation = captureConfigGeneration();
+    const inspector = createSseInspector({
+      onParsedPayload: payload => observePayload(payload, ACCOUNT_ID, generation),
+    });
+    const encoder = new TextEncoder();
+    inspector.feed(encoder.encode(`data: ${JSON.stringify({ type: "response.created" })}\n\n`));
+    inspector.feed(encoder.encode(usageFrame(12, 34)));
+    inspector.feed(encoder.encode(`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed" } })}\n\n`));
+    inspector.finish();
+    inspector.dispose();
+
+    const quota = getCachedProviderAccountQuota("meta-muse", ACCOUNT_ID);
+    expect(quota?.fiveHourPercent).toBe(12);
+    expect(quota?.weeklyPercent).toBe(34);
+  });
+
+  test("a stream without the frame writes nothing", () => {
+    const generation = captureConfigGeneration();
+    const inspector = createSseInspector({
+      onParsedPayload: payload => observePayload(payload, ACCOUNT_ID, generation),
+    });
+    const encoder = new TextEncoder();
+    inspector.feed(encoder.encode(`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "hi" })}\n\n`));
+    inspector.feed(encoder.encode(`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed" } })}\n\n`));
+    inspector.finish();
+    inspector.dispose();
+
+    expect(getCachedProviderAccountQuota("meta-muse", ACCOUNT_ID)).toBeNull();
+  });
+
+  test("the frame is observed even when no serving account is known", () => {
+    const generation = captureConfigGeneration();
+    const inspector = createSseInspector({
+      onParsedPayload: payload => observePayload(payload, null, generation),
+    });
+    inspector.feed(new TextEncoder().encode(usageFrame(50, 60)));
+    inspector.finish();
+    inspector.dispose();
+    // No attribution target: nothing is filed, and nothing throws.
+    expect(getCachedProviderAccountQuota("meta-muse", ACCOUNT_ID)).toBeNull();
+  });
+
+  /*
+   * relay.ts wraps onParsedPayload in a try/catch so inspection can never throw into the
+   * relay pump. Asserted here so a later refactor cannot quietly remove the guarantee
+   * this feature relies on to be safe on a live request.
+   */
+  test("a throwing observer does not break the stream", () => {
+    const inspector = createSseInspector({
+      onParsedPayload: () => { throw new Error("observer exploded"); },
+    });
+    const encoder = new TextEncoder();
+    expect(() => {
+      inspector.feed(encoder.encode(usageFrame(1, 2)));
+      inspector.feed(encoder.encode(`data: ${JSON.stringify({ type: "response.completed", response: { status: "completed" } })}\n\n`));
+      inspector.finish();
+    }).not.toThrow();
+    inspector.dispose();
+  });
+});
+
+describe("GET /api/oauth/accounts?quota=1 for a passive provider", () => {
+  async function getAccounts(query: string): Promise<{ status: number; body: { accounts?: Array<{ id: string; quota?: { fiveHourPercent?: number } | null; quotaUnavailable?: boolean }> } }> {
+    const request = new Request(`http://localhost/api/oauth/accounts?${query}`);
+    const response = await handleOauthAccountRoutes({
+      req: request,
+      url: new URL(request.url),
+      config: museConfig(),
+      deps: {},
+      convergeCodexCatalog: async () => ({ status: "failed", reason: "disk" }),
+      syncClaudeAgentDefsBestEffort: async () => {},
+    });
+    return { status: response!.status, body: await response!.json() as never };
+  }
+
+  test("returns the observed quota without probing", async () => {
+    recordPassiveAccountQuota("meta-muse", ACCOUNT_ID, { fiveHourPercent: 21, updatedAt: Date.now() }, captureConfigGeneration());
+    const { status, body } = await getAccounts("provider=meta-muse&quota=1");
+    expect(status).toBe(200);
+    expect(body.accounts?.[0]?.quota?.fiveHourPercent).toBe(21);
+  });
+
+  test("refresh=1 is a no-op rather than an error: there is nothing to refresh", async () => {
+    recordPassiveAccountQuota("meta-muse", ACCOUNT_ID, { fiveHourPercent: 21, updatedAt: Date.now() }, captureConfigGeneration());
+    const { status, body } = await getAccounts("provider=meta-muse&quota=1&refresh=1");
+    expect(status).toBe(200);
+    expect(body.accounts?.[0]?.quota?.fiveHourPercent).toBe(21);
+  });
+
+  /*
+   * No observation is not a failed probe. `quotaUnavailable` would claim an attempt that
+   * never happened, and the dashboard renders it as a warning.
+   */
+  test("an account with no observation carries no quota and no unavailable flag", async () => {
+    const { status, body } = await getAccounts("provider=meta-muse&quota=1");
+    expect(status).toBe(200);
+    expect(body.accounts?.[0]?.quota).toBeUndefined();
+    expect(body.accounts?.[0]?.quotaUnavailable).toBeUndefined();
+  });
+
+  test("the plain list is unchanged when quota is not requested", async () => {
+    recordPassiveAccountQuota("meta-muse", ACCOUNT_ID, { fiveHourPercent: 21, updatedAt: Date.now() }, captureConfigGeneration());
+    const { status, body } = await getAccounts("provider=meta-muse");
+    expect(status).toBe(200);
+    expect(body.accounts?.[0]?.quota).toBeUndefined();
+  });
+});

--- a/tests/muse-subscription-usage.test.ts
+++ b/tests/muse-subscription-usage.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isMuseSubscriptionUsagePayload,
+  MUSE_SUBSCRIPTION_USAGE_TYPE,
+  parseMuseSubscriptionUsage,
+} from "../src/providers/muse-subscription-usage";
+
+/** The payload measured against the live endpoint on 2026-09-03 (003 §E). */
+function measuredPayload(): unknown {
+  return {
+    type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+    subscription: {
+      tier: "27681393394859588",
+      window: { used_percent: 12, resets_at: 1788431188, window_duration_mins: 300 },
+      weekly: { used_percent: 34, resets_at: 1788739200 },
+    },
+  };
+}
+
+describe("Muse subscription usage parser", () => {
+  test("maps the measured payload to both windows", () => {
+    const quota = parseMuseSubscriptionUsage(measuredPayload());
+    expect(quota).not.toBeNull();
+    expect(quota!.fiveHourPercent).toBe(12);
+    expect(quota!.weeklyPercent).toBe(34);
+    // Meta sends unix SECONDS; epochMillis scales them.
+    expect(quota!.fiveHourResetAt).toBe(1788431188 * 1000);
+    expect(quota!.weeklyResetAt).toBe(1788739200 * 1000);
+  });
+
+  test("stamps updatedAt locally, never from the payload", () => {
+    const before = Date.now();
+    const quota = parseMuseSubscriptionUsage(measuredPayload())!;
+    expect(quota.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(quota.updatedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  test("never surfaces the opaque tier id", () => {
+    const quota = parseMuseSubscriptionUsage(measuredPayload())!;
+    expect(JSON.stringify(quota)).not.toContain("27681393394859588");
+    expect(Object.keys(quota)).not.toContain("tier");
+  });
+
+  /*
+   * The window is identified by its DECLARED duration. Filing a ten-hour window in the
+   * five-hour slot would understate usage by the ratio of the windows, and would do so
+   * with full confidence.
+   */
+  test("routes a non-300-minute window to customWindows, not the five-hour slot", () => {
+    const quota = parseMuseSubscriptionUsage({
+      type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+      subscription: { window: { used_percent: 40, resets_at: 1788431188, window_duration_mins: 600 } },
+    });
+    expect(quota).not.toBeNull();
+    expect(quota!.fiveHourPercent).toBeUndefined();
+    expect(quota!.customWindows).toEqual([
+      { label: "600m", percent: 40, resetAt: 1788431188 * 1000 },
+    ]);
+  });
+
+  test("a window with no declared duration is custom, not assumed five-hour", () => {
+    const quota = parseMuseSubscriptionUsage({
+      type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+      subscription: { window: { used_percent: 7 } },
+    })!;
+    expect(quota.fiveHourPercent).toBeUndefined();
+    expect(quota.customWindows).toEqual([{ label: "subscription", percent: 7 }]);
+  });
+
+  test("either window may be absent independently", () => {
+    const weeklyOnly = parseMuseSubscriptionUsage({
+      type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+      subscription: { weekly: { used_percent: 5, resets_at: 1788739200 } },
+    })!;
+    expect(weeklyOnly.weeklyPercent).toBe(5);
+    expect(weeklyOnly.fiveHourPercent).toBeUndefined();
+
+    const windowOnly = parseMuseSubscriptionUsage({
+      type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+      subscription: { window: { used_percent: 9, window_duration_mins: 300 } },
+    })!;
+    expect(windowOnly.fiveHourPercent).toBe(9);
+    expect(windowOnly.weeklyPercent).toBeUndefined();
+    expect(windowOnly.fiveHourResetAt).toBeUndefined();
+  });
+
+  test("clamps an out-of-range percent rather than rejecting the row", () => {
+    const quota = parseMuseSubscriptionUsage({
+      type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+      subscription: { window: { used_percent: 150, window_duration_mins: 300 } },
+    })!;
+    expect(quota.fiveHourPercent).toBe(100);
+  });
+
+  test("accepts a numeric string percent", () => {
+    const quota = parseMuseSubscriptionUsage({
+      type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+      subscription: { window: { used_percent: "12", window_duration_mins: 300 } },
+    })!;
+    expect(quota.fiveHourPercent).toBe(12);
+  });
+
+  /*
+   * This runs inside SSE inspection on a live request. The only acceptable failure is
+   * silence: a parse error must never cost the user their turn.
+   */
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "nope"],
+    ["an array", [1, 2, 3]],
+    ["no subscription", { type: MUSE_SUBSCRIPTION_USAGE_TYPE }],
+    ["a non-object subscription", { type: MUSE_SUBSCRIPTION_USAGE_TYPE, subscription: "x" }],
+    ["no usable window", { type: MUSE_SUBSCRIPTION_USAGE_TYPE, subscription: { tier: "1" } }],
+    ["unparseable percents", {
+      type: MUSE_SUBSCRIPTION_USAGE_TYPE,
+      subscription: { window: { used_percent: "abc", window_duration_mins: 300 }, weekly: { used_percent: null } },
+    }],
+  ])("returns null without throwing for %s", (_label, payload) => {
+    expect(() => parseMuseSubscriptionUsage(payload)).not.toThrow();
+    expect(parseMuseSubscriptionUsage(payload)).toBeNull();
+  });
+
+  test("recognizes only the subscription-usage frame type", () => {
+    expect(isMuseSubscriptionUsagePayload(measuredPayload())).toBe(true);
+    expect(isMuseSubscriptionUsagePayload({ type: "response.completed" })).toBe(false);
+    expect(isMuseSubscriptionUsagePayload(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Meta reports Muse Code subscription usage, but OpenCodex never read it, so a `meta-muse` account showed no usage anywhere in the dashboard. This adds the read.

Meta publishes **no quota endpoint** — 17 plausible REST paths were probed and all 404, and no `x-ratelimit-*` header appears on any measured request shape. The only machine-readable usage it emits is a `response.subscription_usage` SSE frame during a streaming turn. So this inverts the usual quota seam: writes come from the request path, reads are cache-only, and **refresh does not exist** — obtaining a fresher value would mean spending a real inference turn.

- `src/providers/muse-subscription-usage.ts` (new) parses the frame through the existing `normalizePercent` / `normalizeResetAt` helpers. `tier` is dropped (an opaque numeric id, not the label the CLI prints), and a window whose `window_duration_mins` is not 300 goes to `customWindows` rather than being forced into the five-hour slot.
- The observation rides the **existing** `onParsedPayload` seam in `noteInspectedPayload`, which already reaches all three passthrough construction sites. `relay.ts` is unchanged. The serving account is read at event time, since failover can rebind it mid-turn.
- `supportsPerAccountQuota` **stays false** for `meta-muse`: it gates `fetchAccountQuota`, whose fallback branch sends any non-Kiro/non-Antigravity bearer to Anthropic's usage endpoint. `hasPassiveAccountQuota` is a separate, honest predicate, and `readPassiveProviderAccountQuotas` is a cache-only reader that never probes.

**This also changes routing, not only display.** Headroom-ranked pre-dispatch selection is already wired for any generic-failover provider but inert without cached quota; a Muse observation arms it for a user with two or more accounts. Two guards make that safe, and both close defects found in review:

- **Staleness.** `headroomOf` applied no age bound. That was safe only because every row was probe-written and re-probed on its TTL; a passive row is never refreshed. Passive rows older than one hour now return "no evidence", degrading to today's unranked ring rather than to a confidently wrong answer. Display is deliberately *not* bounded this way — the age will be shown to the user.
- **Partial rosters.** A probe fills the whole roster at once; an observation arrives one account at a time. Since `RANK_UNKNOWN` sorts *after* `RANK_HEALTHY`, one observed account at 100% would have outranked N unmeasured ones — the exact inversion ranking exists to prevent. Passive providers now require evidence for every candidate.

One further defect closed: `hydrateAccountQuotaCache()` had **zero callers** before this change. Since `persistAccountQuotaCache` serializes the whole in-memory map, a passive write landing before any read would have persisted its single row and erased every other provider's saved row, with `diskHydrated` then blocking recovery. The write now hydrates first, and a regression test covers it.

The dashboard affordance that states the observation's age is deliberately a follow-up PR: a passively observed number that renders identically to a live one is the one way this feature can mislead, so it gets its own reviewable change.

Plan and measurements: `devlog/_plan/260903_muse_provider_parity/`.

## Verification

```
bun x tsc --noEmit                                    # exit 0
bun run privacy:scan                                  # passed
bun test tests/muse-subscription-usage.test.ts \
         tests/muse-passive-quota-cache.test.ts \
         tests/muse-passive-quota-observation.test.ts \
         tests/meta-muse-oauth.test.ts \
         tests/provider-account-quota.test.ts \
         tests/oauth-accounts-api.test.ts \
         tests/core-lab-boundary.test.ts               # 111 pass / 0 fail
bun run test:changed                                  # 10403 pass / 3 skip / 0 fail across 556 files
```

38 new tests across three files: parser mapping and fail-soft behaviour, cache attribution/generation-fencing/persistence, the disk-clobber regression, the staleness and partial-roster guards, the SSE observation end to end, and the `?quota=1` route including `refresh=1` as a no-op.

`tests/core-lab-boundary.test.ts` is run explicitly because this PR edits `src/server/responses/core.ts`, one of the three files it guards.

No GUI change in this PR, so no screenshot applies.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

On the last point specifically: no credential value is read, logged, or serialized by this change, and the `supportsPerAccountQuota` exfiltration guard that keeps a Meta key away from Anthropic's endpoint is preserved and locked by a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passive quota tracking for Meta Muse accounts based on streaming usage data.
  * Dashboard quota views can display cached Muse subscription and weekly usage.
  * Quota information is attributed to the account that served the request.
* **Improvements**
  * Account selection can use recent Muse quota headroom across multiple accounts.
  * Stale or incomplete observations are excluded from routing decisions.
  * Quota refresh requests remain safe when usage data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->