### PR TITLE
fix(codex): inject experimental_realtime_ws_base_url so desktop voice sideband joins go through the proxy

### DIFF
--- a/devlog/_plan/260903_voice_sideband_regression/000_research.md
+++ b/devlog/_plan/260903_voice_sideband_regression/000_research.md
@@ -78,3 +78,13 @@ C. Proxy-side only (no config change) — impossible: the client never contacts 
 - The proxy's `loopbackRouteAllowed` (`src/server/index.ts:819`) allows WS upgrades on `/v1/realtime` and
   `/v1/live` only, NOT `/v1/live/{callId}`; a directly spawned app-server on the unauthenticated loopback
   listener would still 404 the sideband. Add the keyed paths for WS upgrades (020).
+
+## Audit notes (Sol reviewer, PASS)
+
+- `experimental_realtime_ws_base_url` redirects the sideband AND the standalone realtime WebSocket; it does
+  NOT redirect WebRTC call-create (that follows `openai_base_url`; `experimental_realtime_webrtc_call_base_url`
+  is the separate call-create override and stays un-injected).
+- codex-rs snapshots sideband auth headers before call-create; both legs carry the same app identity.
+- The app-server public Webrtc transport carries only `sdp` (`app-server-protocol/src/protocol/v2/realtime.rs:275`);
+  no client-side field can redirect the sideband, so the config key is the only lever.
+- With the override, the exact sideband URL is `ws://127.0.0.1:<port>/v1/live/{callId}` (methods.rs:1084/1129/1166).

--- a/devlog/_plan/260903_voice_sideband_regression/000_research.md
+++ b/devlog/_plan/260903_voice_sideband_regression/000_research.md
@@ -1,0 +1,80 @@
+# 260903_voice_sideband_regression — 000 research
+
+## Symptom (2026-09-03, live evidence)
+
+- ChatGPT.app (bundled codex-cli 0.153.0-alpha.5) voice session:
+  `Realtime voice session failed ... message="unexpected status 404 Not Found: realtime websocket handshake failed"`
+  — app log `~/Library/Logs/com.openai.codex/2026/09/03/codex-desktop-7bd4860e-...-t0-i1-000150-0.log`
+  lines 12425-12491 (two attempts, 11:29:04Z and 11:29:18Z).
+  Transport line: `Starting realtime voice transport clientOwnsCall=false ... model=gpt-live-1-codex ... version=v3`,
+  sideband line: `Starting realtime voice app-server sideband ... transport=webrtc`.
+- Proxy usage log (`~/.opencodex/usage.jsonl` 627511/627513): two `gpt-live` requests, `status:201`,
+  provider `openai-p3b640f` (a POOL account, not the app's own login). No `gpt-live` `status:101`
+  (sideband upgrade) since 2026-07-29 (line 294981).
+- `~/.codex/config.toml` line 10: `openai_base_url = "http://127.0.0.1:10100/v1"` (marker-owned, Design B).
+  No `experimental_realtime_ws_base_url` present.
+- App auth (`~/.codex/auth.json`) account hash `c602fb19` != every pool account hash in
+  `~/.opencodex/codex-accounts.json` (the four active: d1f8d4d6 / c6a3378e / 6eff99ad / f462cf1e).
+
+## Upstream contract (openai/codex main 728cb12fe, pulled 2026-09-03 into ~/Developer/codex/121_openai-codex)
+
+1. `codex-rs/core/src/realtime_conversation.rs:1189-1206` — for `Webrtc` transport the sideband base is
+   `config.experimental_realtime_ws_base_url` only; when unset the `RealtimeWebsocketClient` default applies.
+2. `codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs:60,784` —
+   `OPENAI_REALTIME_API_BASE_URL = "https://api.openai.com/v1"` is that default (since 438c9e98d / PR #35830,
+   2026-07-28: "Use https://api.openai.com/v1 for WebRTC sideband websocket joins instead of deriving the URL
+   from the model provider"). `normalize_realtime_path` (L1163-1172) maps FramelessBidi to `/v1/live/{callId}`.
+3. `codex-rs/core/src/client.rs:726-754` — call-create goes through the model provider (= `openai_base_url`
+   = the proxy) and the sideband reuses `sideband_websocket_auth_headers(client_setup.api_auth)`, i.e. the
+   APP'S OWN token, sent straight to api.openai.com.
+4. `codex-rs/codex-api/src/endpoint/realtime_call.rs:66-79` — API shape (non backend-api base) posts
+   `{base}/live` for FramelessBidi; `decode_call_id_from_location` (L259) reads the `Location` header.
+5. `codex-rs/config/src/config_toml.rs:404-408` — `experimental_realtime_ws_base_url` and
+   `experimental_realtime_webrtc_call_base_url` are root keys; `config/src/loader/mod.rs:85-86` denies them
+   only for PROJECT-LOCAL layers; user `~/.codex/config.toml` is honored.
+6. `codex-rs/app-server/src/request_processors/turn_processor.rs:1232-1240` — desktop `Webrtc` transport
+   never sets a per-call `sideband_base_url` (that override, PR #41923 34c4f7e72, exists only for
+   `ExistingCall`).
+
+Net: call-create is answered by pool account X (proxy choice); the sideband join goes to
+api.openai.com with the app's own account Y. The call does not exist for Y → 404. Upstream's own tracker
+has the same shape: openai/codex#35094 ("Realtime V3 WebRTC call succeeds, sideband WebSocket returns
+404 call_id_not_found", 2026-07-24). Independent proxies (Aether WebSocket-Mode.md) document the same
+rule: call-create and sideband must share origin + credential.
+
+## Upstream commits since 94cbbddaf (local clone was at 2026-08-30) touching voice
+
+- 34c4f7e72 #41923 per-call sideband endpoint for ExistingCall (no effect on desktop Webrtc path)
+- 64c9cde45 #41924 realtime history in Core (new RealtimeEvent::History* variants; transparent relay unaffected)
+- e1d0ef995 #42377 app-server realtime always available (feature flag removed)
+- deb147116 / dc0dc4f15 / eb10d91e4 / 8d01cd42f / 8813bd4b0 / 13bc770ea / d60560f14 / 65237aeca / fc7d34ad6 / 379d50be3
+  — third_party/voice helper runtime (local STT/TTS host), not a wire-contract change for the proxy.
+
+## Why the previous fixes did not cover this
+
+- 260724_gpt_live_hotfix (PR #379) added `/v1/live/{callId}` sideband relay on the proxy — correct, but the
+  client stopped sending the sideband to the provider base four days later (438c9e98d).
+- 260812_realtime_standalone_ws fixed the STANDALONE WebSocket transport (`GET /v1/realtime?intent=...`).
+  The desktop now uses WebRTC v3 again (`transport=webrtc`), which is the sideband path.
+
+## Fix options
+
+A. (chosen) `ocx start` injects `experimental_realtime_ws_base_url` (marker-owned, same value as
+   `openai_base_url`) so the sideband upgrade comes back to the proxy. The proxy already relays
+   `GET /v1/live/{callId}` → `wss://api.openai.com/v1/live/{callId}` with pool auth
+   (`src/server/live.ts:238-247, 348-368`). Both legs then run under the proxy-selected account, and
+   `codexPoolAffinityKey` (`src/codex/auth-context.ts:84-98`, keyed on `session-id` + `thread-id` which
+   codex-rs attaches via `build_session_headers`) keeps them on the same pool account.
+B. Also inject `experimental_realtime_webrtc_call_base_url` — unnecessary: call-create already follows
+   `openai_base_url`. Not injected (keeps the footprint to one key).
+C. Proxy-side only (no config change) — impossible: the client never contacts the proxy for the sideband.
+
+## Risks / residuals
+
+- Upstream key is named `experimental_*`; if renamed the injected line becomes a no-op (fails back to the
+  current broken state, not worse). Test pins the exact key.
+- Users on a hand-written `openai_base_url` (user-owned) are already not injected; the new key follows the
+  same ownership rule (never overwrite a user-owned value).
+- The proxy's `loopbackRouteAllowed` (`src/server/index.ts:819`) allows WS upgrades on `/v1/realtime` and
+  `/v1/live` only, NOT `/v1/live/{callId}`; a directly spawned app-server on the unauthenticated loopback
+  listener would still 404 the sideband. Add the keyed paths for WS upgrades (020).

--- a/devlog/_plan/260903_voice_sideband_regression/010_wp2_inject_realtime_ws_override.md
+++ b/devlog/_plan/260903_voice_sideband_regression/010_wp2_inject_realtime_ws_override.md
@@ -1,0 +1,38 @@
+# 010 — wp2: inject `experimental_realtime_ws_base_url` with the loopback override
+
+## Goal
+When `ocx start` installs Design B loopback routing (`openai_base_url = "http://127.0.0.1:<port>/v1"`),
+also install a marker-owned root `experimental_realtime_ws_base_url` with the SAME value, so codex-rs
+(`core/src/realtime_conversation.rs:1194-1206`) sends the WebRTC sideband join back through the proxy.
+
+## Files
+- `src/codex/injected-marker.ts`
+  - add `REALTIME_WS_BASE_URL_KEY = "experimental_realtime_ws_base_url"`, `isRootRealtimeWsBaseUrlLine(line)`.
+  - `stripJournaledOpenaiBaseUrl(content, injectedUrl)`: also drop a root `experimental_realtime_ws_base_url`
+    line whose value === injectedUrl (plus its marker line). Value evidence survives app reserialization (#1798).
+  - `hasInjectedOpenaiBaseUrl` unchanged (openai_base_url stays the ownership signal).
+- `src/codex/inject.ts`
+  - `buildRealtimeWsBaseUrlLine(target)` → `experimental_realtime_ws_base_url = <toml string of target.baseUrl>`.
+  - `stripInjectedOpenaiBaseUrl(content)`: drop marker-owned `experimental_realtime_ws_base_url` lines too
+    (same marker-adjacency rule). Must run before `removeOcxSection` (it keys on the marker line).
+  - new `setRootRealtimeWsBaseUrlForTarget(content, target)`: mirror of `setRootOpenaiBaseUrlForTarget`;
+    a user-owned (unmarked) key is kept, returns `keptUserRealtimeWsBaseUrl`.
+  - Design B branch (L972-978): after `setRootOpenaiBaseUrlForTarget`, if `!keptUserBaseUrl` call
+    `setRootRealtimeWsBaseUrlForTarget`. When the user owns `openai_base_url` we inject nothing (existing rule).
+  - Legacy provider-table mode: NOT injected (the public ingress needs the opencodex API key, which the
+    sideband auth headers cannot carry) — documented residual.
+  - `stripOpencodexConfigResult` (L1390-1401): `stripInjectedOpenaiBaseUrl` + journaled strip already cover it
+    after the helper changes; add a regression assertion.
+  - Summary message: mention "voice sideband override" in the Design B success line (L1304).
+
+## Tests (tests/codex-inject.test.ts, tests/codex-injected-marker.test.ts)
+1. loopback inject writes both keys, each preceded by the marker; second run is idempotent (byte-equal).
+2. user-owned `experimental_realtime_ws_base_url = "https://my.gateway/v1"` (no marker) survives injection
+   and restore.
+3. restore/strip removes both marker-owned keys; app-reserialized (comments dropped) config is restored via
+   journal value match.
+4. user-owned `openai_base_url` → neither key injected (keptUserBaseUrl path).
+5. legacy target (non-loopback) → no realtime key written.
+
+## Checks
+`bun run typecheck`; `bun test tests/codex-inject.test.ts tests/codex-injected-marker.test.ts tests/codex-inject-integration.test.ts`.

--- a/devlog/_plan/260903_voice_sideband_regression/020_wp3_proxy_affinity_probe.md
+++ b/devlog/_plan/260903_voice_sideband_regression/020_wp3_proxy_affinity_probe.md
@@ -1,0 +1,36 @@
+# 020 — wp3: proxy-side sideband parity + same-account affinity + probe
+
+## Goal
+With the sideband now arriving at the proxy as `GET /v1/live/{callId}` (Upgrade: websocket, headers from
+codex-rs `build_session_headers`: `session-id`, `thread-id`, plus the app's Authorization), prove both legs
+select the same pool account and that the unauthenticated loopback listener admits the keyed join paths.
+
+## Files
+- `src/server/index.ts` `loopbackRouteAllowed` (L807-822): allow WebSocket upgrades on
+  `/v1/live/{callId}` and `/v1/realtime/calls/{callId}` (regex `^/v1/(live|realtime/calls)/[^/]+/?$`) and
+  `/v1/realtime?call_id=`; plain HTTP on those paths stays 404. Same trust model as the existing
+  `/v1/realtime` / `/v1/live` upgrade allowance (260812 A1).
+- `src/server/live.ts`: no URL change needed (`buildLiveSidebandUpstreamWsUrl` already targets
+  `wss://api.openai.com/v1/live/{callId}`). Add a comment block tying the design to 438c9e98d and to the
+  injected override. Keep `LIVE_CLIENT_PROTOCOL_HEADERS` (session-id/thread-id are relayed verbatim).
+- Affinity: `resolveLiveRelay` → `resolveFirstUsableOpenAiSidecar` → `codexPoolAffinityKey(headers)`
+  (`src/codex/auth-context.ts:84-98`). The key is derived from `session-id` + `thread-id`; both legs carry
+  the same pair, so the binding created on call-create is reused on the sideband. Regression test only.
+
+## Tests
+- `tests/server-live.test.ts` (or new `tests/live-sideband-affinity.test.ts`): two pool accounts
+  configured; POST `/v1/live` with headers {session-id: S, thread-id: T} → record upstream account A;
+  then WS upgrade `GET /v1/live/rtc_x` with the same headers → assert upstream auth is account A.
+  Negative: different thread-id may pick a different account (no assertion on which).
+- `tests/loopback-listener-admission.test.ts`: WS upgrade on `/v1/live/rtc_x` admitted (not 404);
+  `GET /v1/live/rtc_x` without Upgrade → 404.
+
+## Probe (isolated, never port 10100)
+`OPENCODEX_HOME=$(mktemp -d) bun run src/cli/index.ts start --port <scratch>` with a copied pool credential
+is NOT allowed (auth files out of scope). Instead run the in-process server test harness with a fake
+upstream WebSocket (`experimentalRealtimeWsBaseUrl` pointing at a local ws server, as
+`tests/native-profile-drain-server.test.ts:211` does) and assert the relayed upgrade URL is
+`/v1/live/rtc_x` and the request reached the fake with pool auth. Record transcript in 021.
+
+## Checks
+`bun run typecheck`; `bun test tests/server-live.test.ts tests/loopback-listener-admission.test.ts tests/live-sideband-affinity.test.ts`.

--- a/devlog/_plan/260903_voice_sideband_regression/021_wp3_probe_transcript.md
+++ b/devlog/_plan/260903_voice_sideband_regression/021_wp3_probe_transcript.md
@@ -1,0 +1,43 @@
+# 021 — wp3 probe transcript (isolated home, ephemeral port, fake upstream)
+
+Command: `bun .tmp/voice-probe.ts` (scratch script, not committed; OPENCODEX_HOME + CODEX_HOME = mktemp,
+proxy on port 0, fake ChatGPT backend + fake sideband WS server, pool of two accounts under round-robin,
+`experimentalRealtimeWsBaseUrl` pointed at the fake so the relay's upstream sideband dial is observable).
+Port 10100 untouched.
+
+Exit code: 0
+
+```
+call-create status 201 location /v1/live/rtc_probe
+sideband relay reply echo:ping
+[
+ {
+  "leg": "call-create",
+  "path": "/realtime/calls?intent=quicksilver&architecture=avas",
+  "acct": "acct-a",
+  "sid": "sess_probe",
+  "tid": "thread_probe"
+ },
+ {
+  "leg": "call-create",
+  "path": "/realtime/calls?intent=quicksilver&architecture=avas",
+  "acct": "acct-b",
+  "sid": "s2",
+  "tid": "t2"
+ },
+ {
+  "leg": "sideband",
+  "path": "/v1/live/rtc_probe",
+  "acct": "acct-a",
+  "sid": "sess_probe",
+  "tid": "thread_probe"
+ }
+]
+SAME_ACCOUNT_BOTH_LEGS true | other-thread account acct-b
+```
+
+Reading: call-create for (sess_probe, thread_probe) went out under `acct-a`; an unrelated thread advanced
+round-robin to `acct-b`; the keyed sideband join `GET /v1/live/rtc_probe` with the same session/thread
+headers was relayed to `/v1/live/rtc_probe` under `acct-a` again and echoed a frame back. This is the
+exact request shape codex-rs produces with `experimental_realtime_ws_base_url = http://127.0.0.1:<port>/v1`
+(realtime_websocket/methods.rs:1084/1129/1166).

--- a/devlog/_plan/260903_voice_sideband_regression/030_wp4_docs_pr.md
+++ b/devlog/_plan/260903_voice_sideband_regression/030_wp4_docs_pr.md
@@ -1,0 +1,16 @@
+# 030 — wp4: docs + push + PR
+
+## Files
+- `docs-site/src/content/docs/troubleshooting/voice*.md` (or the page that documents GPT-Live / realtime):
+  add "sideband 404 after Codex 0.146+ (2026-07-28)" section — cause, that `ocx start` now writes
+  `experimental_realtime_ws_base_url`, how to verify (`grep experimental_realtime_ws_base_url ~/.codex/config.toml`,
+  a `gpt-live` `101` row in usage), and the manual line for hand-written configs.
+- Korean/other locales: only if the English page has a translated twin; keep them from contradicting.
+- `devlog/_plan/260903_voice_sideband_regression/040_d_record.md` with the terminal outcome.
+
+## Git
+- branch `codex/voice-sideband-override` off current HEAD (162d11e18 == origin/dev).
+- commits per B step; push `--no-verify` (authorized), PR against `dev` using
+  `.github/PULL_REQUEST_TEMPLATE.md` (Summary / Verification / Checklist), no `gui` mention.
+- After push: `gh pr checks <n>` / workflow runs for the EXACT head SHA; report status.
+- Stacked PR only if wp2 and wp3 need separate review; default single PR since wp3 is small.

--- a/devlog/_plan/260903_voice_sideband_regression/040_d_record.md
+++ b/devlog/_plan/260903_voice_sideband_regression/040_d_record.md
@@ -1,0 +1,24 @@
+# 040 — D record
+
+Terminal outcome: DONE (pending exact-head CI on the final push).
+
+- Branch `codex/voice-sideband-override`, PR https://github.com/lidge-jun/opencodex/pull/3361 against `dev`.
+- Commits: 1d5ffdf36 e6a73759f (roadmap), 5f351210c fff79258d (wp2 inject), bb3000dc8 5817505bb 2c296e1e8 (wp3 proxy),
+  17cfccf8f f36ff15d3 (wp4 docs).
+- First head 2c296e1e8: all CI checks green (test 1-4/4, gates, macos, keyring x3, npm-global x3, hygiene,
+  enforce-target, label, react-doctor, storage policy, api usage); Windows shard skipped by the runner
+  selector. Second head f36ff15d3 (docs only, CodeRabbit follow-ups): re-run in progress at close time.
+- Reviews: Sol auditors Dalton (root cause PASS), Carver (plan FAIL -> blockers folded), Zeno (wp2 FAIL ->
+  PASS round 2), Leibniz (wp3 FAIL -> PASS round 2); grok-bot maintainer review recommends merge after CI;
+  CodeRabbit 2 minor doc findings folded.
+- Gates run: typecheck, focused inject/live/loopback suites, test:changed (10550 pass), privacy:scan,
+  docs build. Full local suite deliberately not run (user instruction); CI covers it.
+
+## Residuals (follow-up material, not blockers)
+
+- User-owned root `openai_base_url` (hand-written proxy config): no realtime key injected; those users
+  need the manual line. Documented in the guide.
+- Provider-table forms (non-loopback admission, authless Desktop): desktop v3 voice stays broken because
+  the sideband cannot carry the admission token. Documented as residual.
+- Upstream key is `experimental_*`; a rename makes the injected line a no-op (back to today's failure).
+- Merge into `dev` is a maintainer action, not taken here.

--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -32,11 +32,13 @@ fast_mode = true
 
 The second key is the voice sideband override. Codex creates a WebRTC voice call through
 `openai_base_url`, but since codex 0.146 (openai/codex#35830) it joins that call's sideband
-WebSocket at `api.openai.com` directly unless `experimental_realtime_ws_base_url` redirects it. Through
-the proxy, the call is created under the Pool account opencodex selects, so a direct join under the
-app's own login fails with `realtime websocket handshake failed` (404). The injected key sends the
-join back through opencodex (`GET /v1/live/{callId}`), where the same Pool account is reused. It is
-written only on the loopback `openai_base_url` form, is removed together with it, and a user-owned
+WebSocket at `api.openai.com` directly unless `experimental_realtime_ws_base_url` redirects it. In
+Pool mode the call is created under the account opencodex selects, so a direct join under the app's
+own login fails with `realtime websocket handshake failed` (404). The injected key sends the join
+back through opencodex (`GET /v1/live/{callId}`), where the Pool reuses the account it bound to that
+session/thread pair (a process-local binding). In Direct mode both legs already use the caller's
+current bearer, so the key only keeps the join on the proxy path. It is written only on the loopback
+`openai_base_url` form, is removed together with it, and a user-owned
 `experimental_realtime_ws_base_url` is never overwritten.
 
 The injected `fast_mode` follows the tri-state `fastMode` setting: `true` writes `fast_mode = true`,

--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -22,11 +22,22 @@ Codex's built-in `openai` provider id and points that provider at opencodex:
 model_catalog_json = "/absolute/path/to/opencodex-catalog.json"
 # Auto-injected by opencodex
 openai_base_url = "http://127.0.0.1:10100/v1"
+# Auto-injected by opencodex
+experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"
 
 # only when fastMode is set; unset adds no [features] table
 [features]
 fast_mode = true
 ```
+
+The second key is the voice sideband override. Codex creates a WebRTC voice call through
+`openai_base_url`, but since codex 0.146 (openai/codex#35830) it joins that call's sideband
+WebSocket at `api.openai.com` directly unless `experimental_realtime_ws_base_url` redirects it. Through
+the proxy, the call is created under the Pool account opencodex selects, so a direct join under the
+app's own login fails with `realtime websocket handshake failed` (404). The injected key sends the
+join back through opencodex (`GET /v1/live/{callId}`), where the same Pool account is reused. It is
+written only on the loopback `openai_base_url` form, is removed together with it, and a user-owned
+`experimental_realtime_ws_base_url` is never overwritten.
 
 The injected `fast_mode` follows the tri-state `fastMode` setting: `true` writes `fast_mode = true`,
 `false` writes `fast_mode = false`, and unset leaves an existing `fast_mode` untouched without

--- a/docs-site/src/content/docs/ko/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ko/guides/codex-integration.md
@@ -16,11 +16,21 @@ opencodex는 Codex가 읽는 두 가지, 즉 설정(`$CODEX_HOME/config.toml`, �
 model_catalog_json = "/absolute/path/to/opencodex-catalog.json"
 # Auto-injected by opencodex
 openai_base_url = "http://127.0.0.1:10100/v1"
+# Auto-injected by opencodex
+experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"
 
 # fastMode를 설정했을 때만 들어갑니다. 설정하지 않으면 [features] 자체가 생기지 않습니다
 [features]
 fast_mode = true
 ```
+
+두 번째 키는 음성 sideband 오버라이드입니다. Codex는 WebRTC 음성 통화를 `openai_base_url`로 만들지만,
+codex 0.146(openai/codex#35830)부터는 `experimental_realtime_ws_base_url`이 없으면 그 통화의 sideband
+WebSocket을 `api.openai.com`에 직접 붙입니다. 프록시를 거치면 통화는 opencodex가 고른 Pool 계정으로
+만들어지므로, 앱 자체 로그인으로 직접 붙는 join은 `realtime websocket handshake failed`(404)로
+실패합니다. 주입된 키는 join을 다시 opencodex(`GET /v1/live/{callId}`)로 보내고, 거기서 같은 Pool
+계정이 재사용됩니다. 이 키는 loopback `openai_base_url` 형태에서만 쓰이고, 그 키와 함께 제거되며,
+사용자가 직접 적은 `experimental_realtime_ws_base_url`은 덮어쓰지 않습니다.
 
 주입되는 `fast_mode`는 3-상태 `fastMode` 설정을 따릅니다. `true`면 `fast_mode = true`를 쓰고,
 `false`면 `fast_mode = false`를 쓰며, 설정하지 않으면 기존 `fast_mode`를 그대로 두고

--- a/docs-site/src/content/docs/ko/guides/codex-integration.md
+++ b/docs-site/src/content/docs/ko/guides/codex-integration.md
@@ -26,11 +26,13 @@ fast_mode = true
 
 두 번째 키는 음성 sideband 오버라이드입니다. Codex는 WebRTC 음성 통화를 `openai_base_url`로 만들지만,
 codex 0.146(openai/codex#35830)부터는 `experimental_realtime_ws_base_url`이 없으면 그 통화의 sideband
-WebSocket을 `api.openai.com`에 직접 붙입니다. 프록시를 거치면 통화는 opencodex가 고른 Pool 계정으로
+WebSocket을 `api.openai.com`에 직접 붙입니다. Pool 모드에서는 통화가 opencodex가 고른 계정으로
 만들어지므로, 앱 자체 로그인으로 직접 붙는 join은 `realtime websocket handshake failed`(404)로
-실패합니다. 주입된 키는 join을 다시 opencodex(`GET /v1/live/{callId}`)로 보내고, 거기서 같은 Pool
-계정이 재사용됩니다. 이 키는 loopback `openai_base_url` 형태에서만 쓰이고, 그 키와 함께 제거되며,
-사용자가 직접 적은 `experimental_realtime_ws_base_url`은 덮어쓰지 않습니다.
+실패합니다. 주입된 키는 join을 다시 opencodex(`GET /v1/live/{callId}`)로 보내고, Pool은 그
+session/thread 쌍에 묶어 둔 계정(프로세스 로컬 바인딩)을 그대로 씁니다. Direct 모드는 두 요청 모두
+호출자의 현재 bearer를 쓰므로, 이 키는 join을 프록시 경로에 붙잡아 두는 역할만 합니다. 이 키는
+loopback `openai_base_url` 형태에서만 쓰이고, 그 키와 함께 제거되며, 사용자가 직접 적은
+`experimental_realtime_ws_base_url`은 덮어쓰지 않습니다.
 
 주입되는 `fast_mode`는 3-상태 `fastMode` 설정을 따릅니다. `true`면 `fast_mode = true`를 쓰고,
 `false`면 `fast_mode = false`를 쓰며, 설정하지 않으면 기존 `fast_mode`를 그대로 두고

--- a/docs-site/src/content/docs/ko/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/ko/reference/proxy-formats.md
@@ -224,6 +224,12 @@ call creation 이후 클라이언트는 다음의 지원되는 모든 inbound �
 프록시는 업스트림 join URL을 정규화한 뒤, 양방향 텍스트 및 바이너리 프레임을 투명하게 릴레이합니다. 업스트림
 인증은 프록시가 소유한 상태로 유지되며, 클라이언트 프로토콜 헤더는 보존됩니다.
 
+call creation과 sideband join은 같은 OpenAI 계정으로 이루어져야 하며, 그렇지 않으면 업스트림이 join을
+거부합니다(`404`). 두 요청 모두 Codex의 `session-id`와 `thread-id` 헤더를 실어 보내고 Pool은 계정 선택을
+그 쌍에 묶어 두므로, 프록시에 도착한 join은 통화를 만든 계정을 그대로 씁니다. Codex가 join을 프록시로 보내는
+것은 `experimental_realtime_ws_base_url`이 프록시를 가리킬 때뿐이며, `ocx start`가 이 키를
+`openai_base_url` 옆에 주입합니다([Codex 연동](/ko/guides/codex-integration/) 참고).
+
 ## `POST /v1/responses/compact`
 
 Compaction은 긴 Responses 대화를 줄여야 하는 클라이언트를 위해 대체 히스토리를 반환합니다.

--- a/docs-site/src/content/docs/ko/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/ko/reference/proxy-formats.md
@@ -225,9 +225,14 @@ call creation 이후 클라이언트는 다음의 지원되는 모든 inbound �
 인증은 프록시가 소유한 상태로 유지되며, 클라이언트 프로토콜 헤더는 보존됩니다.
 
 call creation과 sideband join은 같은 OpenAI 계정으로 이루어져야 하며, 그렇지 않으면 업스트림이 join을
-거부합니다(`404`). 두 요청 모두 Codex의 `session-id`와 `thread-id` 헤더를 실어 보내고 Pool은 계정 선택을
-그 쌍에 묶어 두므로, 프록시에 도착한 join은 통화를 만든 계정을 그대로 씁니다. Codex가 join을 프록시로 보내는
-것은 `experimental_realtime_ws_base_url`이 프록시를 가리킬 때뿐이며, `ocx start`가 이 키를
+거부합니다(`404`). 두 요청 모두 Codex의 `session-id`와 `thread-id` 헤더를 실어 보냅니다. Pool 모드는
+계정 선택을 그 쌍에 묶어 두므로(프로세스 로컬) 프록시에 도착한 join은 통화를 만든 계정을 그대로 쓰고,
+Direct 모드는 두 요청 모두 호출자의 현재 bearer를 전달합니다. 릴레이되는 클라이언트 헤더는 정확히
+`openai-alpha`, `x-session-id`, `session-id`, `thread-id`, `originator`, `x-oai-attestation`
+(`src/server/live.ts`의 `LIVE_CLIENT_PROTOCOL_HEADERS`)이며, `Authorization`과 ChatGPT 계정 id는
+ChatGPT 경로에서 프록시가 소유합니다(Pool은 저장된 계정으로 교체, Direct는 검증된 호출자 bearer를 전달).
+API 키 프로바이더는 자체 bearer를 씁니다. Codex가 join을 프록시로 보내는 것은
+`experimental_realtime_ws_base_url`이 프록시를 가리킬 때뿐이며, `ocx start`가 이 키를
 `openai_base_url` 옆에 주입합니다([Codex 연동](/ko/guides/codex-integration/) 참고).
 
 ## `POST /v1/responses/compact`

--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -115,9 +115,11 @@ The port is required and must differ from the proxy port. It is never OS-assigne
 would change across restarts while already-running app-servers kept the previous `base_url`.
 
 The listener serves only `POST /v1/responses`, its WebSocket upgrade, `POST /v1/responses/compact`,
-`POST /v1/alpha/search` (the native Codex web-search relay), `GET /v1/models`, and the standalone
-realtime voice WebSocket upgrades. Everything else, including `/api/*` and the dashboard, returns
-`404`.
+`POST /v1/alpha/search` (the native Codex web-search relay), `GET /v1/models`, and the realtime
+voice surface: the standalone WebSocket upgrades, WebRTC call creation (`POST /v1/live`,
+`POST /v1/realtime/calls`), and the keyed sideband join upgrades (`/v1/live/{callId}`,
+`/v1/realtime/calls/{callId}`, `/v1/realtime?call_id=`). Everything else, including `/api/*` and
+the dashboard, returns `404`.
 
 :::danger[This is an unauthenticated surface]
 Every process on the machine can use this listener. It spends account quota and paid provider

--- a/docs-site/src/content/docs/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/reference/proxy-formats.md
@@ -276,10 +276,15 @@ both directions. Client protocol headers are preserved while upstream authentica
 proxy-owned.
 
 Call creation and the sideband join must run under the same OpenAI account, or the join is refused
-upstream (`404`). Both legs carry Codex's `session-id` and `thread-id` headers, and the Pool binds
-its account choice to that pair, so a join that reaches the proxy reuses the account that created
-the call. Codex only sends the join to the proxy when `experimental_realtime_ws_base_url` points at
-it; `ocx start` injects that key next to `openai_base_url` (see
+upstream (`404`). Both legs carry Codex's `session-id` and `thread-id` headers; in Pool mode the
+account choice is bound to that pair (process-local), so a join that reaches the proxy reuses the
+account that created the call, while Direct mode forwards the caller's current bearer on both legs.
+The relayed client headers are exactly `openai-alpha`, `x-session-id`, `session-id`, `thread-id`,
+`originator`, and `x-oai-attestation` (`LIVE_CLIENT_PROTOCOL_HEADERS` in `src/server/live.ts`);
+`Authorization` and the ChatGPT account id are proxy-owned on ChatGPT-backed routes (Pool replaces
+them with the stored account, Direct forwards the validated caller bearer) and an API-key provider
+gets its own bearer. Codex only sends the join to the proxy when `experimental_realtime_ws_base_url`
+points at it; `ocx start` injects that key next to `openai_base_url` (see
 [Codex integration](/guides/codex-integration/)).
 
 ## `POST /v1/responses/compact`

--- a/docs-site/src/content/docs/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/reference/proxy-formats.md
@@ -275,6 +275,13 @@ The proxy normalizes the upstream join URL and then transparently relays text an
 both directions. Client protocol headers are preserved while upstream authentication remains
 proxy-owned.
 
+Call creation and the sideband join must run under the same OpenAI account, or the join is refused
+upstream (`404`). Both legs carry Codex's `session-id` and `thread-id` headers, and the Pool binds
+its account choice to that pair, so a join that reaches the proxy reuses the account that created
+the call. Codex only sends the join to the proxy when `experimental_realtime_ws_base_url` points at
+it; `ocx start` injects that key next to `openai_base_url` (see
+[Codex integration](/guides/codex-integration/)).
+
 ## `POST /v1/responses/compact`
 
 Compaction returns replacement history for clients that need to shorten a long Responses

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -445,23 +445,13 @@ function setRootOpenaiBaseUrlForTarget(
 }
 
 /**
- * True when line `index` is inside the marker-owned root block: the line right after the
- * marker, or the line right after a marker-owned `openai_base_url`. One marker owns both
- * routing keys so the "exactly one marker" invariant the rest of injection relies on holds.
- */
-function markerOwnedRootLine(lines: string[], index: number): boolean {
-  if (index > 0 && lines[index - 1].includes(OCX_SECTION_MARKER)) return true;
-  return index > 1
-    && isRootOpenaiBaseUrlLine(lines[index - 1])
-    && lines[index - 2].includes(OCX_SECTION_MARKER);
-}
-
-/**
  * Companion to `setRootOpenaiBaseUrlForTarget` for the realtime sideband override. Same
- * ownership rule: a marker-owned line is rewritten in place, a user's own line (not in the
- * marker block) is kept and nothing is injected. Placement: directly after the marker-owned
- * `openai_base_url` so the marker owns both keys as one block. Only ever called on the
- * Design B (loopback) path right after the routing override was written — the legacy
+ * ownership rule, applied per key: the line is ours only when the marker sits directly
+ * above it; a user's own line (no marker above it) is kept and nothing is injected. The
+ * key gets its OWN marker line rather than sharing the routing override's, so a user line
+ * that happens to sit right under our `openai_base_url` is never mistaken for ours.
+ * Placement: directly after the marker-owned `openai_base_url` pair. Only ever called on
+ * the Design B (loopback) path right after the routing override was written — the legacy
  * provider-table form needs the admission-token header, which the sideband cannot carry.
  */
 export function setRootRealtimeWsBaseUrl(
@@ -474,14 +464,15 @@ export function setRootRealtimeWsBaseUrl(
   const key = buildRealtimeWsBaseUrlLine(validateCodexRoutingTarget(target));
   for (let index = 0; index < rootEnd; index += 1) {
     if (!isRootRealtimeWsBaseUrlLine(lines[index])) continue;
-    if (!markerOwnedRootLine(lines, index)) return { content, keptUserRealtimeWsBaseUrl: true };
+    const markerOwned = index > 0 && lines[index - 1].includes(OCX_SECTION_MARKER);
+    if (!markerOwned) return { content, keptUserRealtimeWsBaseUrl: true };
     lines[index] = key;
     return { content: lines.join("\n"), keptUserRealtimeWsBaseUrl: false };
   }
   for (let index = 0; index < rootEnd; index += 1) {
     if (!isRootOpenaiBaseUrlLine(lines[index])) continue;
     if (!(index > 0 && lines[index - 1].includes(OCX_SECTION_MARKER))) continue;
-    lines.splice(index + 1, 0, key);
+    lines.splice(index + 1, 0, OCX_SECTION_MARKER, key);
     return { content: lines.join("\n"), keptUserRealtimeWsBaseUrl: false };
   }
   // No marker-owned routing override to attach to: the override has no owner, so inject nothing.
@@ -492,8 +483,7 @@ export function setRootRealtimeWsBaseUrl(
  * Remove the marker-owned root `openai_base_url` (marker line + the key line right after it).
  * A user's own root override (no marker) survives; an orphaned marker with no key line after
  * it is dropped too so repeated strip/inject cycles cannot accumulate marker comments.
- * The `experimental_realtime_ws_base_url` companion directly under that pair is part of the
- * same owned block and goes with it.
+ * A marker-owned `experimental_realtime_ws_base_url` pair is removed by the same rule.
  */
 export function stripInjectedOpenaiBaseUrl(content: string): string {
   const lines = content.split("\n");
@@ -502,10 +492,9 @@ export function stripInjectedOpenaiBaseUrl(content: string): string {
   const drop = new Set<number>();
   for (let i = 0; i < rootEnd; i++) {
     if (!lines[i].includes(OCX_SECTION_MARKER)) continue;
-    if (i + 1 < rootEnd && isRootOpenaiBaseUrlLine(lines[i + 1])) {
+    if (i + 1 < rootEnd && (isRootOpenaiBaseUrlLine(lines[i + 1]) || isRootRealtimeWsBaseUrlLine(lines[i + 1]))) {
       drop.add(i);
       drop.add(i + 1);
-      if (i + 2 < rootEnd && isRootRealtimeWsBaseUrlLine(lines[i + 2])) drop.add(i + 2);
     } else if (i + 1 >= rootEnd || lines[i + 1].trim() === "") {
       drop.add(i); // orphaned marker at root
     }
@@ -1003,6 +992,16 @@ export async function injectCodexConfig(
   // Design B form FIRST: removeOcxSection also keys on the marker line, so a root-level
   // marker + openai_base_url pair must be gone before it scans or it would swallow root keys.
   content = stripInjectedOpenaiBaseUrl(content);
+  // #1798: after a Codex app rewrite the markers are gone but the values we recorded writing
+  // are still ours. Consume them by value here, BEFORE the routing form is chosen, so a
+  // Design B -> provider-table transition (hostname change, authless opt-in) cannot leave our
+  // own root URLs behind as if they were the user's, and so re-inject never journals them as
+  // not-ours (which would make them unrestorable).
+  content = stripJournaledOpenaiBaseUrl(
+    content,
+    journaledInjectedOpenaiBaseUrl(),
+    journaledInjectedRealtimeWsBaseUrl(),
+  );
   if (hasOcxProviderTable(content)) {
     content = removeOcxSection(content);
   }
@@ -1040,14 +1039,6 @@ export async function injectCodexConfig(
     // Design B (loopback): a single root override; codex keeps its native `openai` provider id
     // so thread history is never remapped. Any legacy form was already stripped above.
     content = stripInjectedOpenaiBaseUrl(content); // normalize before idempotent re-insert
-    // #1798: after a Codex app rewrite the marker is gone but the values we recorded writing
-    // are still ours. Consume them by value so re-inject does not mistake our own routing
-    // for a user override (and then journal it as not-ours, making it unrestorable).
-    content = stripJournaledOpenaiBaseUrl(
-      content,
-      journaledInjectedOpenaiBaseUrl(),
-      journaledInjectedRealtimeWsBaseUrl(),
-    );
     const result = setRootOpenaiBaseUrlForTarget(content, routingTarget);
     content = result.content;
     keptUserBaseUrl = result.keptUserBaseUrl;

--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -32,6 +32,7 @@ import {
 import {
   markJournalInjectedState,
   journaledInjectedOpenaiBaseUrl,
+  journaledInjectedRealtimeWsBaseUrl,
   journaledInjectedCatalogPath,
   removeJournal,
   restoreJournalState,
@@ -49,9 +50,11 @@ import {
 } from "./history-job";
 import {
   OCX_SECTION_MARKER,
+  REALTIME_WS_BASE_URL_KEY,
   hasInjectedCodexRouting,
   hasInjectedOpenaiBaseUrl,
   isRootOpenaiBaseUrlLine,
+  isRootRealtimeWsBaseUrlLine,
   providerTableStart,
   providerTableString,
   rootTomlString,
@@ -347,6 +350,20 @@ function buildOpenaiBaseUrlLineForTarget(target: CodexRoutingTarget): string {
 }
 
 /**
+ * Realtime sideband override (codex-rs `experimental_realtime_ws_base_url`), written with the
+ * SAME value as `openai_base_url`. Desktop voice creates its WebRTC call through the proxy
+ * (`POST /v1/live`, answered under the Pool account the proxy selects) but, since openai/codex
+ * 438c9e98d (#35830), joins the sideband at `wss://api.openai.com/v1/live/{callId}` with the
+ * app's own login unless this key redirects it. Two accounts, one call: the join 404s. Pointing
+ * the key at the proxy sends the join through `GET /v1/live/{callId}` (src/server/live.ts),
+ * where the same Pool account is reused. codex-rs turns `http` into `ws` and appends
+ * `/live/{callId}` itself; the value must stay the canonical `/v1` root.
+ */
+export function buildRealtimeWsBaseUrlLine(target: CodexRoutingTarget): string {
+  return `${REALTIME_WS_BASE_URL_KEY} = ${tomlString(target.baseUrl)}`;
+}
+
+/**
  * Design B root-key injection: place `OCX_SECTION_MARKER` + `openai_base_url` at the document
  * ROOT (before the first table header). Idempotent: an existing marker-owned line is rewritten
  * in place. A user's OWN root `openai_base_url` (no marker above it) is respected — we keep it
@@ -428,9 +445,55 @@ function setRootOpenaiBaseUrlForTarget(
 }
 
 /**
+ * True when line `index` is inside the marker-owned root block: the line right after the
+ * marker, or the line right after a marker-owned `openai_base_url`. One marker owns both
+ * routing keys so the "exactly one marker" invariant the rest of injection relies on holds.
+ */
+function markerOwnedRootLine(lines: string[], index: number): boolean {
+  if (index > 0 && lines[index - 1].includes(OCX_SECTION_MARKER)) return true;
+  return index > 1
+    && isRootOpenaiBaseUrlLine(lines[index - 1])
+    && lines[index - 2].includes(OCX_SECTION_MARKER);
+}
+
+/**
+ * Companion to `setRootOpenaiBaseUrlForTarget` for the realtime sideband override. Same
+ * ownership rule: a marker-owned line is rewritten in place, a user's own line (not in the
+ * marker block) is kept and nothing is injected. Placement: directly after the marker-owned
+ * `openai_base_url` so the marker owns both keys as one block. Only ever called on the
+ * Design B (loopback) path right after the routing override was written — the legacy
+ * provider-table form needs the admission-token header, which the sideband cannot carry.
+ */
+export function setRootRealtimeWsBaseUrl(
+  content: string,
+  target: CodexRoutingTarget,
+): { content: string; keptUserRealtimeWsBaseUrl: boolean } {
+  const lines = content.split("\n");
+  const firstTable = lines.findIndex((line) => /^\s*\[/.test(line));
+  const rootEnd = firstTable === -1 ? lines.length : firstTable;
+  const key = buildRealtimeWsBaseUrlLine(validateCodexRoutingTarget(target));
+  for (let index = 0; index < rootEnd; index += 1) {
+    if (!isRootRealtimeWsBaseUrlLine(lines[index])) continue;
+    if (!markerOwnedRootLine(lines, index)) return { content, keptUserRealtimeWsBaseUrl: true };
+    lines[index] = key;
+    return { content: lines.join("\n"), keptUserRealtimeWsBaseUrl: false };
+  }
+  for (let index = 0; index < rootEnd; index += 1) {
+    if (!isRootOpenaiBaseUrlLine(lines[index])) continue;
+    if (!(index > 0 && lines[index - 1].includes(OCX_SECTION_MARKER))) continue;
+    lines.splice(index + 1, 0, key);
+    return { content: lines.join("\n"), keptUserRealtimeWsBaseUrl: false };
+  }
+  // No marker-owned routing override to attach to: the override has no owner, so inject nothing.
+  return { content, keptUserRealtimeWsBaseUrl: false };
+}
+
+/**
  * Remove the marker-owned root `openai_base_url` (marker line + the key line right after it).
  * A user's own root override (no marker) survives; an orphaned marker with no key line after
  * it is dropped too so repeated strip/inject cycles cannot accumulate marker comments.
+ * The `experimental_realtime_ws_base_url` companion directly under that pair is part of the
+ * same owned block and goes with it.
  */
 export function stripInjectedOpenaiBaseUrl(content: string): string {
   const lines = content.split("\n");
@@ -442,6 +505,7 @@ export function stripInjectedOpenaiBaseUrl(content: string): string {
     if (i + 1 < rootEnd && isRootOpenaiBaseUrlLine(lines[i + 1])) {
       drop.add(i);
       drop.add(i + 1);
+      if (i + 2 < rootEnd && isRootRealtimeWsBaseUrlLine(lines[i + 2])) drop.add(i + 2);
     } else if (i + 1 >= rootEnd || lines[i + 1].trim() === "") {
       drop.add(i); // orphaned marker at root
     }
@@ -959,6 +1023,7 @@ export async function injectCodexConfig(
   // Provider-table form: non-loopback admission (legacy) or the authless Desktop opt-in (#1107).
   const legacyMode = usesProviderTable(routingTarget);
   let keptUserBaseUrl = false;
+  let keptUserRealtimeWsBaseUrl = false;
   if (legacyMode) {
     // Legacy (non-loopback) injection: the built-in openai provider cannot carry the
     // x-opencodex-api-key env header, so keep the opencodex provider table + root re-tag.
@@ -975,9 +1040,24 @@ export async function injectCodexConfig(
     // Design B (loopback): a single root override; codex keeps its native `openai` provider id
     // so thread history is never remapped. Any legacy form was already stripped above.
     content = stripInjectedOpenaiBaseUrl(content); // normalize before idempotent re-insert
+    // #1798: after a Codex app rewrite the marker is gone but the values we recorded writing
+    // are still ours. Consume them by value so re-inject does not mistake our own routing
+    // for a user override (and then journal it as not-ours, making it unrestorable).
+    content = stripJournaledOpenaiBaseUrl(
+      content,
+      journaledInjectedOpenaiBaseUrl(),
+      journaledInjectedRealtimeWsBaseUrl(),
+    );
     const result = setRootOpenaiBaseUrlForTarget(content, routingTarget);
     content = result.content;
     keptUserBaseUrl = result.keptUserBaseUrl;
+    // Voice sideband override rides on the routing override: same value, same ownership rule,
+    // and never when the user owns the routing line (we inject nothing in that case).
+    if (!keptUserBaseUrl) {
+      const realtime = setRootRealtimeWsBaseUrl(content, routingTarget);
+      content = realtime.content;
+      keptUserRealtimeWsBaseUrl = realtime.keptUserRealtimeWsBaseUrl;
+    }
   }
 
   const desiredSubagentDefaults = configuredManagedSubagentDefaults(config);
@@ -1091,8 +1171,18 @@ export async function injectCodexConfig(
   }
 
   const applyNativeArtifacts = (): void => {
+    // #1798 again: a Codex app rewrite keeps values and drops the ownership comments, so
+    // marker evidence alone would classify our own routed config as the user's native
+    // baseline and replace the real original snapshot. Value evidence from the journal
+    // (the URLs the last injection recorded writing) blocks that misclassification.
+    const journaledBaseUrl = journaledInjectedOpenaiBaseUrl();
+    const journaledRealtimeWsBaseUrl = journaledInjectedRealtimeWsBaseUrl();
+    const looksInjectedByValue =
+      (journaledBaseUrl !== null && rootTomlString(rawContent, "openai_base_url") === journaledBaseUrl)
+      || (journaledRealtimeWsBaseUrl !== null
+        && rootTomlString(rawContent, REALTIME_WS_BASE_URL_KEY) === journaledRealtimeWsBaseUrl);
     writeJournal({
-      currentStateIsNative: !hasInjectedCodexRouting(rawContent),
+      currentStateIsNative: !hasInjectedCodexRouting(rawContent) && !looksInjectedByValue,
       configContent: baselineContent,
       owner: options.journalOwner,
     });
@@ -1103,6 +1193,11 @@ export async function injectCodexConfig(
       injectedOpenaiBaseUrl: legacyMode || keptUserBaseUrl
         ? null
         : rootTomlString(content, "openai_base_url"),
+      // The sideband override is ours only when we wrote it this pass (never in legacy mode,
+      // never when the user owns either key).
+      injectedRealtimeWsBaseUrl: legacyMode || keptUserBaseUrl || keptUserRealtimeWsBaseUrl
+        ? null
+        : rootTomlString(content, REALTIME_WS_BASE_URL_KEY),
       // This is the catalog artifact selected for this injection, even when config.toml
       // already points at that path and therefore needs no textual rewrite.
       injectedCatalogPath: catalogPath,
@@ -1301,7 +1396,7 @@ export async function injectCodexConfig(
     ? `Injected opencodex as default provider into Codex config (authless Desktop mode: requires_openai_auth = false).\n`
     : legacyMode
       ? `Injected opencodex as default provider into Codex config.\n`
-      : `Pointed Codex's built-in openai provider at the opencodex proxy (openai_base_url).\n`;
+      : `Pointed Codex's built-in openai provider at the opencodex proxy (openai_base_url + realtime sideband override).\n`;
   return {
     success: true,
     ...(nativeSubagentDefaultsWarning ? { nativeSubagentDefaultsWarning } : {}),
@@ -1388,6 +1483,7 @@ interface StripOpencodexConfigResult {
 function stripOpencodexConfigResult(
   content: string,
   journaledBaseUrl: string | null = null,
+  journaledRealtimeWsBaseUrl: string | null = null,
 ): StripOpencodexConfigResult {
   let out = content;
   const hadRootOcxProvider =
@@ -1398,7 +1494,7 @@ function stripOpencodexConfigResult(
   const hadInjectedBaseUrl = hasInjectedOpenaiBaseUrl(out)
     || (journaledBaseUrl !== null && rootTomlString(out, "openai_base_url") === journaledBaseUrl);
   out = stripInjectedOpenaiBaseUrl(out); // before removeOcxSection — it keys on the marker line too
-  out = stripJournaledOpenaiBaseUrl(out, journaledBaseUrl);
+  out = stripJournaledOpenaiBaseUrl(out, journaledBaseUrl, journaledRealtimeWsBaseUrl);
   if (hasOcxProviderTable(out)) {
     out = removeOcxSection(out);
   }
@@ -1453,9 +1549,12 @@ export function removeCodexConfig(
   // Read the recorded injection once: the strip below consumes it, and so does the
   // ownership verdict, which must agree with what was actually removed.
   const journaledBaseUrl = journaledInjectedOpenaiBaseUrl();
+  const journaledRealtimeWsBaseUrl = journaledInjectedRealtimeWsBaseUrl();
   const had = hasOpencodexRouting(content)
-    || (journaledBaseUrl !== null && rootTomlString(content, "openai_base_url") === journaledBaseUrl);
-  const stripped = stripOpencodexConfigResult(content, journaledBaseUrl);
+    || (journaledBaseUrl !== null && rootTomlString(content, "openai_base_url") === journaledBaseUrl)
+    || (journaledRealtimeWsBaseUrl !== null
+      && rootTomlString(content, REALTIME_WS_BASE_URL_KEY) === journaledRealtimeWsBaseUrl);
+  const stripped = stripOpencodexConfigResult(content, journaledBaseUrl, journaledRealtimeWsBaseUrl);
   if (had || stripped.content !== content) {
     atomicWriteFile(CODEX_CONFIG_PATH, applyEol(stripped.content, eol));
   }

--- a/src/codex/injected-marker.ts
+++ b/src/codex/injected-marker.ts
@@ -15,6 +15,20 @@ export function isRootOpenaiBaseUrlLine(line: string): boolean {
   return /^\s*openai_base_url\s*=/.test(line);
 }
 
+/**
+ * codex-rs root key that redirects the realtime sideband WebSocket (WebRTC voice
+ * join + standalone realtime WS) without touching ordinary provider HTTP. Since
+ * openai/codex 438c9e98d (#35830) the sideband ignores the provider base URL and
+ * dials `https://api.openai.com/v1` unless this key is set, so a Pool-routed
+ * call-create and a directly-joined sideband end up on different accounts (404).
+ * Injected next to `openai_base_url` with the same value.
+ */
+export const REALTIME_WS_BASE_URL_KEY = "experimental_realtime_ws_base_url";
+
+export function isRootRealtimeWsBaseUrlLine(line: string): boolean {
+  return /^\s*experimental_realtime_ws_base_url\s*=/.test(line);
+}
+
 export function tomlStringPattern(key: string): RegExp {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const keyToken = `(?:${escaped}|"${escaped}"|'${escaped}')`;
@@ -65,16 +79,28 @@ export function providerTableString(content: string, provider: string, key: stri
  * EXACT value match against what we recorded writing: a user gateway we never wrote
  * cannot match, so restore can never delete a URL that was not ours.
  */
-export function stripJournaledOpenaiBaseUrl(content: string, injectedUrl: string | null): string {
-  if (!injectedUrl) return content;
+export function stripJournaledOpenaiBaseUrl(
+  content: string,
+  injectedUrl: string | null,
+  injectedRealtimeWsUrl: string | null = null,
+): string {
+  if (!injectedUrl && !injectedRealtimeWsUrl) return content;
   const lines = content.split(String.fromCharCode(10));
   const firstTable = lines.findIndex(l => /^\s*\[/.test(l));
   const rootEnd = firstTable === -1 ? lines.length : firstTable;
   const drop = new Set<number>();
   for (let i = 0; i < rootEnd; i++) {
     const line = lines[i]!;
-    if (!isRootOpenaiBaseUrlLine(line)) continue;
-    if (rootTomlString(line, "openai_base_url") !== injectedUrl) continue;
+    // Each key is matched against ITS OWN recorded value. The realtime override is
+    // journaled separately so a user-owned override that happens to equal the proxy
+    // URL is never mistaken for ours.
+    if (isRootOpenaiBaseUrlLine(line)) {
+      if (!injectedUrl || rootTomlString(line, "openai_base_url") !== injectedUrl) continue;
+    } else if (isRootRealtimeWsBaseUrlLine(line)) {
+      if (!injectedRealtimeWsUrl || rootTomlString(line, REALTIME_WS_BASE_URL_KEY) !== injectedRealtimeWsUrl) continue;
+    } else {
+      continue;
+    }
     drop.add(i);
     // Take an ownership marker directly above it too, so repeated cycles cannot
     // accumulate orphaned comments.

--- a/src/codex/journal.ts
+++ b/src/codex/journal.ts
@@ -36,6 +36,13 @@ interface Journal {
    */
   injectedOpenaiBaseUrl?: string | null;
   /**
+   * The root `experimental_realtime_ws_base_url` this injection wrote, when it wrote one.
+   * Recorded on its own rather than inferred from `injectedOpenaiBaseUrl`: a user can own a
+   * realtime override whose value happens to equal the proxy URL, and restore must not treat
+   * that as ours. Null when the key was preserved or not injected.
+   */
+  injectedRealtimeWsBaseUrl?: string | null;
+  /**
    * The catalog path this injection actually wrote to.
    *
    * #1798: restore re-resolves the catalog from the CURRENT config, so a Codex app rewrite
@@ -119,6 +126,7 @@ export function writeJournal(options: WriteJournalOptions = {}): void {
 
 export interface InjectedJournalOwnership {
   injectedOpenaiBaseUrl: string | null;
+  injectedRealtimeWsBaseUrl: string | null;
   injectedCatalogPath: string | null;
 }
 
@@ -140,6 +148,7 @@ export function markJournalInjectedState(
   // Only the caller knows which values it actually owns. Deriving these from the final TOML
   // would mistake a preserved user override for injected routing.
   journal.injectedOpenaiBaseUrl = ownership.injectedOpenaiBaseUrl;
+  journal.injectedRealtimeWsBaseUrl = ownership.injectedRealtimeWsBaseUrl;
   journal.injectedCatalogPath = ownership.injectedCatalogPath;
   atomicWriteFile(JOURNAL_PATH, JSON.stringify(journal));
 }
@@ -154,6 +163,11 @@ export function markJournalInjectedState(
  */
 export function journaledInjectedOpenaiBaseUrl(): string | null {
   return readJournal()?.injectedOpenaiBaseUrl ?? null;
+}
+
+/** The root `experimental_realtime_ws_base_url` the last injection wrote, or null. */
+export function journaledInjectedRealtimeWsBaseUrl(): string | null {
+  return readJournal()?.injectedRealtimeWsBaseUrl ?? null;
 }
 
 /** The catalog path the last injection wrote to, or null when none was recorded. */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -812,13 +812,21 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
     if (path === "/v1/responses/compact") return req.method === "POST";
     if (path === "/v1/alpha/search") return req.method === "POST";
     if (path === "/v1/models") return req.method === "GET";
-    // Standalone realtime voice sessions (codex-rs thread/realtime/start, WebSocket
-    // transport) — a directly-spawned `codex app-server` needs these for desktop
-    // voice the same way it needs /v1/responses. WebSocket upgrades only; plain
-    // HTTP on these paths stays rejected.
-    if (path === "/v1/realtime" || path === "/v1/live") {
-      return req.headers.get("upgrade")?.toLowerCase() === "websocket";
-    }
+    // Realtime voice — a directly-spawned `codex app-server` needs these for desktop voice
+    // the same way it needs /v1/responses. Two shapes, same trust model as /v1/responses:
+    //  - standalone sessions (codex-rs thread/realtime/start, WebSocket transport):
+    //    WebSocket upgrades on the bare /v1/realtime and /v1/live paths only;
+    //  - WebRTC calls (desktop v3 voice): POST call-create on /v1/live or
+    //    /v1/realtime/calls, then the sideband join as a WebSocket upgrade on the keyed
+    //    /v1/live/{callId}, /v1/realtime/calls/{callId}, or /v1/realtime?call_id= form
+    //    (the join reaches this listener through the injected
+    //    experimental_realtime_ws_base_url; openai/codex #35830).
+    // Plain HTTP on the upgrade paths stays rejected.
+    const isWebSocketUpgrade = req.headers.get("upgrade")?.toLowerCase() === "websocket";
+    if (path === "/v1/realtime") return isWebSocketUpgrade;
+    if (path === "/v1/live") return isWebSocketUpgrade || req.method === "POST";
+    if (path === "/v1/realtime/calls") return req.method === "POST";
+    if (/^\/v1\/(?:live|realtime\/calls)\/[^/]+\/?$/.test(path)) return isWebSocketUpgrade;
     return false;
   }
 

--- a/src/server/live.ts
+++ b/src/server/live.ts
@@ -148,6 +148,20 @@ function clientProtocolHeaders(reqHeaders: Headers): Record<string, string> {
 const LIVE_CALL_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
 
 /**
+ * Decode one path-segment call id. A malformed percent escape (`%ZZ`) makes
+ * `decodeURIComponent` throw; that must read as "not a sideband target" (JSON 404),
+ * never escape the router as a 500.
+ */
+function decodeLiveCallId(segment: string): string | null {
+  try {
+    const callId = decodeURIComponent(segment);
+    return LIVE_CALL_ID_RE.test(callId) ? callId : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Credential-shaped query keys never forwarded upstream on a standalone realtime
  * relay. Auth on the upstream socket is proxy-owned (headers resolved by
  * `resolveLiveRelay`); a caller that puts `access_token=`/`api_key=`/... in the
@@ -238,8 +252,8 @@ function httpsToWss(httpUrl: string): string {
 export function parseLiveSidebandTarget(pathname: string, searchParams: URLSearchParams, rawQuery = ""): LiveSidebandTarget | null {
   const liveMatch = pathname.match(/^\/v1\/live\/([^/]+)\/?$/);
   if (liveMatch) {
-    const callId = decodeURIComponent(liveMatch[1]!);
-    if (!LIVE_CALL_ID_RE.test(callId)) return null;
+    const callId = decodeLiveCallId(liveMatch[1]!);
+    if (!callId) return null;
     return { style: "frameless-path", callId };
   }
   // Standalone Frameless session (no call-create): `GET /v1/live?model=`.
@@ -248,8 +262,8 @@ export function parseLiveSidebandTarget(pathname: string, searchParams: URLSearc
   }
   const callsMatch = pathname.match(/^\/v1\/realtime\/calls\/([^/]+)\/?$/);
   if (callsMatch) {
-    const callId = decodeURIComponent(callsMatch[1]!);
-    if (!LIVE_CALL_ID_RE.test(callId)) return null;
+    const callId = decodeLiveCallId(callsMatch[1]!);
+    if (!callId) return null;
     return { style: "realtime-calls-path", callId };
   }
   if (pathname === "/v1/realtime" || pathname === "/v1/realtime/") {

--- a/tests/codex-inject-integration.test.ts
+++ b/tests/codex-inject-integration.test.ts
@@ -49,6 +49,12 @@ function runRestore(codexHome: string, ocxHome: string): { stdout: string; statu
 }
 
 describe("injectCodexConfig integration (Design B)", () => {
+  const DESIGN_B_BLOCK = [
+    "# Auto-injected by opencodex",
+    'openai_base_url = "http://127.0.0.1:10100/v1"',
+    "# Auto-injected by opencodex",
+    'experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"',
+  ].join("\n");
   let codexHome: string;
   let ocxHome: string;
 
@@ -138,8 +144,9 @@ describe("injectCodexConfig integration (Design B)", () => {
     expect(config).not.toContain("[model_providers.opencodex]");
     expect(config).not.toContain('model_provider = "opencodex"');
     expect(config).toContain('model = "gpt-5.5"');
-    // Exactly one marker survives (the Design B one) — no duplicate accumulation.
-    expect(config.match(/Auto-injected by opencodex/g)?.length).toBe(1);
+    // Exactly the Design B markers survive (routing + realtime sideband) — no accumulation.
+    expect(config.match(/Auto-injected by opencodex/g)?.length).toBe(2);
+    expect(config).toContain(DESIGN_B_BLOCK);
   });
 
   test("upgrade path: a non-loopback legacy env_http_headers config converts to env_key (#2073)", () => {
@@ -176,7 +183,7 @@ describe("injectCodexConfig integration (Design B)", () => {
     const second = readFileSync(join(codexHome, "config.toml"), "utf8");
 
     expect(second.match(/openai_base_url/g)?.length).toBe(1);
-    expect(second.match(/Auto-injected by opencodex/g)?.length).toBe(1);
+    expect(second.match(/Auto-injected by opencodex/g)?.length).toBe(2);
     expect(second).toBe(first);
     // Voice sideband override rides along with the routing override (#35830 regression).
     expect(second.match(/experimental_realtime_ws_base_url/g)?.length).toBe(1);
@@ -190,7 +197,7 @@ describe("injectCodexConfig integration (Design B)", () => {
       writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
       expect(runInject(codexHome, ocxHome).status).toBe(0);
       const config = readFileSync(join(codexHome, "config.toml"), "utf8");
-      expect(config).toContain(`# Auto-injected by opencodex\nopenai_base_url = "${proxyUrl}"\nexperimental_realtime_ws_base_url = "${proxyUrl}"`);
+      expect(config).toContain(DESIGN_B_BLOCK);
       const journal = JSON.parse(readFileSync(join(codexHome, "opencodex-journal.json"), "utf8"));
       expect(journal.injectedOpenaiBaseUrl).toBe(proxyUrl);
       expect(journal.injectedRealtimeWsBaseUrl).toBe(proxyUrl);
@@ -264,6 +271,46 @@ describe("injectCodexConfig integration (Design B)", () => {
       writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
       expect(runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true })).status).toBe(0);
       expect(readFileSync(join(codexHome, "config.toml"), "utf8")).not.toContain("experimental_realtime_ws_base_url");
+    });
+
+    test("an app-reserialized Design B config switching to a provider-table form drops our root URLs", () => {
+      // Comment-dropping rewrite, then the operator turns on authless Desktop (provider-table
+      // form). Our old root URLs must not survive as if the user had written them.
+      writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      const rewritten = readFileSync(join(codexHome, "config.toml"), "utf8")
+        .split("\n").filter(line => !line.startsWith("#")).join("\n");
+      writeFileSync(join(codexHome, "config.toml"), rewritten, "utf8");
+
+      expect(runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true })).status).toBe(0);
+      const table = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(table).toContain("requires_openai_auth = false");
+      expect(table).not.toContain("openai_base_url");
+      expect(table).not.toContain("experimental_realtime_ws_base_url");
+
+      expect(runRestore(codexHome, ocxHome).status).toBe(0);
+      expect(readFileSync(join(codexHome, "config.toml"), "utf8")).toBe('model = "gpt-5.5"\n');
+    });
+
+    test("CRLF config: re-inject keeps both keys single and CRLF-pure; restore removes both", () => {
+      writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\r\n\r\n[features]\r\nfast_mode = true\r\n', "utf8");
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(config).not.toContain("\n\n\n");
+      expect(config.match(/openai_base_url/g)?.length).toBe(1);
+      expect(config.match(/experimental_realtime_ws_base_url/g)?.length).toBe(1);
+      expect(config.match(/Auto-injected by opencodex/g)?.length).toBe(2);
+      expect(config).toContain('openai_base_url = "http://127.0.0.1:10100/v1"');
+      expect(config).toContain('experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"');
+      expect(config.includes("\r\n")).toBe(true);
+      expect(config.replace(/\r\n/g, "").includes("\n")).toBe(false);
+
+      expect(runRestore(codexHome, ocxHome).status).toBe(0);
+      const restored = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(restored).not.toContain("openai_base_url");
+      expect(restored).not.toContain("experimental_realtime_ws_base_url");
+      expect(restored).toContain("fast_mode = true");
     });
   });
 
@@ -822,7 +869,8 @@ describe("injectCodexConfig integration (Design B)", () => {
     expect(back).toContain('openai_base_url = "http://127.0.0.1:10100/v1"');
     expect(back).not.toContain("[model_providers.opencodex]");
     expect(back).not.toContain('model_provider = "opencodex"');
-    expect(back.match(/Auto-injected by opencodex/g)?.length).toBe(1);
+    expect(back.match(/Auto-injected by opencodex/g)?.length).toBe(2);
+    expect(back).toContain(DESIGN_B_BLOCK);
 
     expect(runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true })).status).toBe(0);
     expect(runRestore(codexHome, ocxHome).status).toBe(0);

--- a/tests/codex-inject-integration.test.ts
+++ b/tests/codex-inject-integration.test.ts
@@ -178,6 +178,93 @@ describe("injectCodexConfig integration (Design B)", () => {
     expect(second.match(/openai_base_url/g)?.length).toBe(1);
     expect(second.match(/Auto-injected by opencodex/g)?.length).toBe(1);
     expect(second).toBe(first);
+    // Voice sideband override rides along with the routing override (#35830 regression).
+    expect(second.match(/experimental_realtime_ws_base_url/g)?.length).toBe(1);
+    expect(second).toContain('experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"');
+  });
+
+  describe("realtime sideband override (openai/codex #35830 regression)", () => {
+    const proxyUrl = "http://127.0.0.1:10100/v1";
+
+    test("inject writes it under the marker block, journals it, and restore removes both keys", () => {
+      writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(config).toContain(`# Auto-injected by opencodex\nopenai_base_url = "${proxyUrl}"\nexperimental_realtime_ws_base_url = "${proxyUrl}"`);
+      const journal = JSON.parse(readFileSync(join(codexHome, "opencodex-journal.json"), "utf8"));
+      expect(journal.injectedOpenaiBaseUrl).toBe(proxyUrl);
+      expect(journal.injectedRealtimeWsBaseUrl).toBe(proxyUrl);
+
+      expect(runRestore(codexHome, ocxHome).status).toBe(0);
+      const restored = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(restored).not.toContain("openai_base_url");
+      expect(restored).not.toContain("experimental_realtime_ws_base_url");
+      expect(restored).toContain('model = "gpt-5.5"');
+    });
+
+    test("a user-owned override survives injection and restore, even when it equals the proxy URL", () => {
+      const original = [
+        `experimental_realtime_ws_base_url = "${proxyUrl}"`,
+        'model = "gpt-5.5"',
+        "",
+      ].join("\n");
+      writeFileSync(join(codexHome, "config.toml"), original, "utf8");
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(config).toContain(`openai_base_url = "${proxyUrl}"`);
+      expect(config.match(/experimental_realtime_ws_base_url/g)?.length).toBe(1);
+      const journal = JSON.parse(readFileSync(join(codexHome, "opencodex-journal.json"), "utf8"));
+      expect(journal.injectedOpenaiBaseUrl).toBe(proxyUrl);
+      expect(journal.injectedRealtimeWsBaseUrl).toBeNull();
+
+      // Simulate the Codex app reserializing config.toml (values kept, comments dropped) so
+      // restore has to rely on journaled value evidence: the routing URL is ours, the
+      // realtime override is not, even though the two strings are identical.
+      const rewritten = readFileSync(join(codexHome, "config.toml"), "utf8")
+        .split("\n").filter(line => !line.startsWith("#")).join("\n");
+      writeFileSync(join(codexHome, "config.toml"), rewritten, "utf8");
+      expect(runRestore(codexHome, ocxHome).status).toBe(0);
+      const restored = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(restored).not.toContain("openai_base_url");
+      expect(restored).toContain(`experimental_realtime_ws_base_url = "${proxyUrl}"`);
+    });
+
+    test("an app-reserialized routed config is not mistaken for the user's native baseline on re-inject", () => {
+      writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      const journalPath = join(codexHome, "opencodex-journal.json");
+      const firstSnapshot = JSON.parse(readFileSync(journalPath, "utf8")).originalConfig;
+
+      const rewritten = readFileSync(join(codexHome, "config.toml"), "utf8")
+        .split("\n").filter(line => !line.startsWith("#")).join("\n");
+      writeFileSync(join(codexHome, "config.toml"), rewritten, "utf8");
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      expect(JSON.parse(readFileSync(journalPath, "utf8")).originalConfig).toBe(firstSnapshot);
+      const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+      expect(config.match(/openai_base_url/g)?.length).toBe(1);
+      expect(config.match(/experimental_realtime_ws_base_url/g)?.length).toBe(1);
+
+      expect(runRestore(codexHome, ocxHome).status).toBe(0);
+      expect(readFileSync(join(codexHome, "config.toml"), "utf8")).toBe('model = "gpt-5.5"\n');
+    });
+
+    test("a user-owned openai_base_url means no realtime override is injected either", () => {
+      const original = 'openai_base_url = "https://my-own-gateway.example/v1"\nmodel = "gpt-5.5"\n';
+      writeFileSync(join(codexHome, "config.toml"), original, "utf8");
+      expect(runInject(codexHome, ocxHome).status).toBe(0);
+      expect(readFileSync(join(codexHome, "config.toml"), "utf8")).not.toContain("experimental_realtime_ws_base_url");
+    });
+
+    test("provider-table forms (non-loopback admission, authless Desktop) do not write it", () => {
+      writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+      expect(runInject(codexHome, ocxHome, JSON.stringify({ hostname: "192.168.1.20" })).status).toBe(0);
+      expect(readFileSync(join(codexHome, "config.toml"), "utf8")).not.toContain("experimental_realtime_ws_base_url");
+      expect(runRestore(codexHome, ocxHome).status).toBe(0);
+
+      writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.5"\n', "utf8");
+      expect(runInject(codexHome, ocxHome, JSON.stringify({ codexDesktopAuthless: true })).status).toBe(0);
+      expect(readFileSync(join(codexHome, "config.toml"), "utf8")).not.toContain("experimental_realtime_ws_base_url");
+    });
   });
 
   test.each([

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -7,11 +7,13 @@ import {
   chooseCatalogPathForInjection,
   dominantEol,
   setRootOpenaiBaseUrl,
+  setRootRealtimeWsBaseUrl,
   stripInjectedOpenaiBaseUrl,
   stripOpencodexConfig,
   stripRootContextWindowOverrides,
   standaloneCodexRoutingTarget,
 } from "../src/codex/inject";
+import { stripJournaledOpenaiBaseUrl } from "../src/codex/injected-marker";
 import {
   MANAGED_AGENTS_TABLE_MARKER,
   MANAGED_SUBAGENT_DEFAULT_MARKER,
@@ -375,6 +377,91 @@ describe("Design B openai_base_url injection", () => {
 
     const userOwned = 'openai_base_url = "https://my-own-gateway.example/v1"\n\n[features]\n';
     expect(stripInjectedOpenaiBaseUrl(userOwned)).toBe(userOwned);
+  });
+
+  describe("realtime sideband override (experimental_realtime_ws_base_url)", () => {
+    const loopback = { baseUrl: "http://127.0.0.1:10100/v1", requiresAdmissionToken: false, tokenEnv: "OPENCODEX_API_AUTH_TOKEN" } as const;
+    const base = 'model = "gpt-5.5"\n\n[features]\nfast_mode = true\n';
+
+    test("is written directly under the marker-owned openai_base_url with the same value (one marker owns both)", () => {
+      const routed = setRootOpenaiBaseUrl(base, loopback).content;
+      const { content, keptUserRealtimeWsBaseUrl } = setRootRealtimeWsBaseUrl(routed, loopback);
+      expect(keptUserRealtimeWsBaseUrl).toBe(false);
+      const lines = content.split("\n");
+      const routing = lines.indexOf('openai_base_url = "http://127.0.0.1:10100/v1"');
+      expect(routing).toBeGreaterThan(0);
+      expect(lines[routing - 1]).toContain("Auto-injected by opencodex");
+      expect(lines[routing + 1]).toBe('experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"');
+      expect(lines.indexOf("[features]")).toBeGreaterThan(routing + 1);
+      expect(content.match(/Auto-injected by opencodex/g)?.length).toBe(1);
+    });
+
+    test("re-inject is idempotent and follows a port change", () => {
+      const first = setRootRealtimeWsBaseUrl(setRootOpenaiBaseUrl(base, loopback).content, loopback).content;
+      const again = setRootRealtimeWsBaseUrl(first, loopback).content;
+      expect(again).toBe(first);
+      const moved = { ...loopback, baseUrl: "http://127.0.0.1:10190/v1" };
+      const second = setRootRealtimeWsBaseUrl(first, moved).content;
+      expect(second.match(/experimental_realtime_ws_base_url/g)?.length).toBe(1);
+      expect(second).toContain('experimental_realtime_ws_base_url = "http://127.0.0.1:10190/v1"');
+    });
+
+    test("keeps a user's own experimental_realtime_ws_base_url and injects nothing", () => {
+      const original = 'experimental_realtime_ws_base_url = "https://realtime.example/v1"\n\n[features]\n';
+      const { content, keptUserRealtimeWsBaseUrl } = setRootRealtimeWsBaseUrl(original, loopback);
+      expect(keptUserRealtimeWsBaseUrl).toBe(true);
+      expect(content).toBe(original);
+      // A user-owned key elsewhere at the root is also kept when a marker block exists.
+      const routed = setRootOpenaiBaseUrl(`${original}`, loopback).content;
+      const withRouted = setRootRealtimeWsBaseUrl(routed, loopback);
+      expect(withRouted.keptUserRealtimeWsBaseUrl).toBe(true);
+      expect(withRouted.content).toBe(routed);
+    });
+
+    test("without a marker-owned openai_base_url nothing is written", () => {
+      const { content } = setRootRealtimeWsBaseUrl(base, loopback);
+      expect(content).toBe(base);
+    });
+
+    test("strip removes both marker-owned keys and leaves the user's own override", () => {
+      const injected = setRootRealtimeWsBaseUrl(setRootOpenaiBaseUrl(base, loopback).content, loopback).content;
+      const stripped = stripInjectedOpenaiBaseUrl(injected);
+      expect(stripped).not.toContain("openai_base_url");
+      expect(stripped).not.toContain("experimental_realtime_ws_base_url");
+      expect(stripped).not.toContain("Auto-injected by opencodex");
+      expect(stripped).toContain("[features]");
+
+      const userOwned = 'experimental_realtime_ws_base_url = "https://realtime.example/v1"\n\n[features]\n';
+      expect(stripInjectedOpenaiBaseUrl(userOwned)).toBe(userOwned);
+    });
+
+    test("stripOpencodexConfig drops the sideband override together with the routing override", () => {
+      const injected = setRootRealtimeWsBaseUrl(setRootOpenaiBaseUrl(base, loopback).content, loopback).content;
+      const stripped = stripOpencodexConfig(injected);
+      expect(stripped).not.toContain("experimental_realtime_ws_base_url");
+      expect(stripped).not.toContain("openai_base_url");
+      expect(stripped).toContain("[features]");
+    });
+
+    test("an app-reserialized config (comments dropped) is still recognized by journaled value", () => {
+      // #1798: the Codex app rewrites config.toml keeping values and dropping comments.
+      const rewritten = [
+        'openai_base_url = "http://127.0.0.1:10100/v1"',
+        'experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"',
+        'model = "gpt-5.5"',
+        "",
+      ].join("\n");
+      const stripped = stripJournaledOpenaiBaseUrl(rewritten, "http://127.0.0.1:10100/v1", "http://127.0.0.1:10100/v1");
+      expect(stripped).toBe('model = "gpt-5.5"\n');
+      // A different value is not ours and must survive.
+      const foreign = 'experimental_realtime_ws_base_url = "https://realtime.example/v1"\nmodel = "gpt-5.5"\n';
+      expect(stripJournaledOpenaiBaseUrl(foreign, "http://127.0.0.1:10100/v1", "http://127.0.0.1:10100/v1")).toBe(foreign);
+      // A user-owned override that happens to EQUAL the proxy URL is not ours either when the
+      // journal recorded that we preserved it (null) — the realtime key has its own evidence.
+      expect(stripJournaledOpenaiBaseUrl(rewritten, "http://127.0.0.1:10100/v1", null)).toBe(
+        'experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"\nmodel = "gpt-5.5"\n',
+      );
+    });
   });
 
   test("stripOpencodexConfig removes the Design B form including routed root models", () => {

--- a/tests/codex-inject.test.ts
+++ b/tests/codex-inject.test.ts
@@ -383,7 +383,7 @@ describe("Design B openai_base_url injection", () => {
     const loopback = { baseUrl: "http://127.0.0.1:10100/v1", requiresAdmissionToken: false, tokenEnv: "OPENCODEX_API_AUTH_TOKEN" } as const;
     const base = 'model = "gpt-5.5"\n\n[features]\nfast_mode = true\n';
 
-    test("is written directly under the marker-owned openai_base_url with the same value (one marker owns both)", () => {
+    test("is written as its own marker-owned pair directly under the routing pair, with the same value", () => {
       const routed = setRootOpenaiBaseUrl(base, loopback).content;
       const { content, keptUserRealtimeWsBaseUrl } = setRootRealtimeWsBaseUrl(routed, loopback);
       expect(keptUserRealtimeWsBaseUrl).toBe(false);
@@ -391,9 +391,51 @@ describe("Design B openai_base_url injection", () => {
       const routing = lines.indexOf('openai_base_url = "http://127.0.0.1:10100/v1"');
       expect(routing).toBeGreaterThan(0);
       expect(lines[routing - 1]).toContain("Auto-injected by opencodex");
-      expect(lines[routing + 1]).toBe('experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"');
-      expect(lines.indexOf("[features]")).toBeGreaterThan(routing + 1);
-      expect(content.match(/Auto-injected by opencodex/g)?.length).toBe(1);
+      expect(lines[routing + 1]).toContain("Auto-injected by opencodex");
+      expect(lines[routing + 2]).toBe('experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"');
+      expect(lines.indexOf("[features]")).toBeGreaterThan(routing + 2);
+      expect(content.match(/Auto-injected by opencodex/g)?.length).toBe(2);
+    });
+
+    test("a pre-upgrade block where the user's own realtime line sits right under our routing pair is left alone", () => {
+      // Older injections wrote only marker + openai_base_url. A user who added the realtime
+      // key by hand directly beneath must keep it: ownership is per marker, never by adjacency.
+      const original = [
+        "# Auto-injected by opencodex",
+        'openai_base_url = "http://127.0.0.1:10100/v1"',
+        'experimental_realtime_ws_base_url = "https://realtime.example/v1"',
+        "",
+        "[features]",
+        "",
+      ].join("\n");
+      const { content, keptUserRealtimeWsBaseUrl } = setRootRealtimeWsBaseUrl(original, loopback);
+      expect(keptUserRealtimeWsBaseUrl).toBe(true);
+      expect(content).toBe(original);
+      const stripped = stripInjectedOpenaiBaseUrl(original);
+      expect(stripped).not.toContain("openai_base_url");
+      expect(stripped).toContain('experimental_realtime_ws_base_url = "https://realtime.example/v1"');
+    });
+
+    test("an orphaned marker + realtime pair (routing line removed by hand) is stripped, not accumulated", () => {
+      const orphan = [
+        'model = "gpt-5.5"',
+        "# Auto-injected by opencodex",
+        'experimental_realtime_ws_base_url = "http://127.0.0.1:10100/v1"',
+        "",
+        "# Auto-injected by opencodex",
+        "[model_providers.opencodex]",
+        'name = "OpenCodex Proxy"',
+        'base_url = "http://127.0.0.1:10100/v1"',
+        "",
+        "[features]",
+        "fast_mode = true",
+        "",
+      ].join("\n");
+      const stripped = stripOpencodexConfig(orphan);
+      expect(stripped).not.toContain("experimental_realtime_ws_base_url");
+      expect(stripped).not.toContain("opencodex");
+      expect(stripped).toContain('model = "gpt-5.5"');
+      expect(stripped).toContain("fast_mode = true");
     });
 
     test("re-inject is idempotent and follows a port change", () => {

--- a/tests/loopback-listener-integration.test.ts
+++ b/tests/loopback-listener-integration.test.ts
@@ -405,6 +405,12 @@ describe("unauthenticated loopback listener", () => {
       // Plain HTTP on the keyed join paths stays rejected.
       expect((await fetch(`${base}/v1/live/rtc_x`)).status).toBe(404);
       expect((await fetch(`${base}/v1/realtime/calls/rtc_x`)).status).toBe(404);
+      // A malformed escape in the call id is a JSON 404, not a 500.
+      for (const path of ["/v1/live/%ZZ", "/v1/realtime/calls/%ZZ"]) {
+        const res = await fetch(`${base}${path}`, { headers: upgradeHeaders });
+        expect({ path, status: res.status }).toEqual({ path, status: 404 });
+        expect(res.headers.get("content-type")).toContain("application/json");
+      }
     } finally {
       await server.stop(true);
     }

--- a/tests/loopback-listener-integration.test.ts
+++ b/tests/loopback-listener-integration.test.ts
@@ -287,8 +287,11 @@ describe("unauthenticated loopback listener", () => {
         { method: "POST", path: "/v1/messages", body: '{"model":"x","messages":[]}' },
         { method: "POST", path: "/v1/images/generations", body: '{"prompt":"x"}' },
         { method: "GET", path: "/v1/opencodex/artifacts/x" },
-        { method: "POST", path: "/v1/live", body: "{}" },
-        { method: "POST", path: "/v1/realtime/calls", body: "{}" },
+        // Voice call-create is admitted only as POST; the keyed sideband join only as an upgrade.
+        { method: "GET", path: "/v1/live/rtc_x" },
+        { method: "GET", path: "/v1/realtime/calls/rtc_x" },
+        { method: "PUT", path: "/v1/live", body: "{}" },
+        { method: "GET", path: "/v1/realtime/calls" },
         // Allowlisted paths still reject the methods they do not serve.
         { method: "DELETE", path: "/v1/responses" },
         { method: "POST", path: "/v1/models" },
@@ -369,6 +372,39 @@ describe("unauthenticated loopback listener", () => {
       // Plain HTTP on the same paths remains outside the allowlist.
       expect((await fetch(`${base}/v1/realtime?model=m`)).status).toBe(404);
       expect((await fetch(`${base}/v1/live?model=m`)).status).toBe(404);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("admits WebRTC voice call-create POSTs and keyed sideband upgrades (openai/codex #35830)", async () => {
+    const loopbackPort = await freePort();
+    saveConfig(baseConfig(loopbackPort));
+    const server = startServer(0);
+    const base = `http://127.0.0.1:${loopbackPort}`;
+    const upgradeHeaders = {
+      connection: "upgrade",
+      upgrade: "websocket",
+      "sec-websocket-version": "13",
+      "sec-websocket-key": Buffer.from("0123456789abcdef").toString("base64"),
+    };
+    try {
+      // Desktop v3 voice creates the WebRTC call through the provider base (POST /v1/live)
+      // and, with the injected experimental_realtime_ws_base_url, joins the sideband on the
+      // keyed path. Both must clear the allowlist; the relay's own auth answer proves it.
+      for (const path of ["/v1/live", "/v1/realtime/calls"]) {
+        const res = await fetch(`${base}${path}`, {
+          method: "POST", body: "{}", headers: { "content-type": "application/json" },
+        });
+        expect({ path, status: res.status }).not.toEqual({ path, status: 404 });
+      }
+      for (const path of ["/v1/live/rtc_x", "/v1/realtime/calls/rtc_x", "/v1/realtime?call_id=rtc_x"]) {
+        const res = await fetch(`${base}${path}`, { headers: upgradeHeaders });
+        expect({ path, status: res.status }).not.toEqual({ path, status: 404 });
+      }
+      // Plain HTTP on the keyed join paths stays rejected.
+      expect((await fetch(`${base}/v1/live/rtc_x`)).status).toBe(404);
+      expect((await fetch(`${base}/v1/realtime/calls/rtc_x`)).status).toBe(404);
     } finally {
       await server.stop(true);
     }

--- a/tests/server-live.test.ts
+++ b/tests/server-live.test.ts
@@ -492,6 +492,113 @@ test("a routed pool account's token overrides the caller bearer on the live rela
   }
 });
 
+test("call-create and its sideband join bind to the same pool account (openai/codex #35830)", async () => {
+  // Desktop v3 voice: POST /v1/live creates the WebRTC call under the proxy-selected Pool
+  // account; the sideband join must reach OpenAI under that SAME account or the call is not
+  // found (404). Both legs carry codex-rs build_session_headers (session-id + thread-id), so
+  // the pool affinity key is identical — a round-robin pool with two accounts must not hand
+  // the join to the other account.
+  const captured: CapturedRequest[] = [];
+  const upstream = fakeLiveUpstream(captured);
+  const seenUpgradeHeaders: Headers[] = [];
+  const wsUpstream = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+        seenUpgradeHeaders.push(req.headers);
+        if (server.upgrade(req, { data: {} })) return undefined as unknown as Response;
+      }
+      return new Response("not found", { status: 404 });
+    },
+    websocket: { message(ws, message) { ws.send(String(message)); } },
+  });
+  saveConfig({
+    ...forwardConfig(),
+    accountPoolStrategy: "round-robin",
+    providers: {
+      openai: {
+        adapter: "openai-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward",
+        codexAccountMode: "pool",
+      },
+    },
+    codexAccounts: [
+      { id: "pool-a", email: "a@example.test", isMain: false, chatgptAccountId: "acct-pool-a" },
+      { id: "pool-b", email: "b@example.test", isMain: false, chatgptAccountId: "acct-pool-b" },
+    ],
+  } as OcxConfig);
+  for (const [id, acct] of [["pool-a", "acct-pool-a"], ["pool-b", "acct-pool-b"]] as const) {
+    saveCodexAccountCredential(id, {
+      accessToken: fakeChatGptJwt({ chatgpt_account_id: acct, email: `${id}@example.test` }),
+      refreshToken: `${id}-refresh`,
+      expiresAt: Date.now() + 3_600_000,
+      chatgptAccountId: acct,
+    });
+  }
+  const RealWebSocket = globalThis.WebSocket;
+  const wsPort = wsUpstream.port;
+  globalThis.WebSocket = class extends RealWebSocket {
+    constructor(url: string | URL, protocols?: string | string[] | Record<string, unknown>) {
+      const parsed = new URL(String(url));
+      const target = parsed.hostname === "api.openai.com" && parsed.pathname.startsWith("/v1/live/")
+        ? `ws://127.0.0.1:${wsPort}${parsed.pathname}${parsed.search}`
+        : String(url);
+      super(target, protocols as string[]);
+    }
+  } as typeof WebSocket;
+
+  const server = startServer(0);
+  try {
+    const voiceHeaders = {
+      authorization: `Bearer ${DIRECT_CHATGPT_TOKEN}`,
+      "chatgpt-account-id": "acct-123",
+      "session-id": "sess_voice_1",
+      "thread-id": "thread_voice_1",
+    };
+    const { body, contentType } = multipartLiveBody();
+    const created = await fetch(new URL("/v1/live", server.url), {
+      method: "POST",
+      headers: { ...voiceHeaders, "content-type": contentType },
+      body,
+    });
+    expect(created.status).toBe(201);
+    expect(captured).toHaveLength(1);
+    const createAccount = captured[0].headers.get("chatgpt-account-id");
+    expect(["acct-pool-a", "acct-pool-b"]).toContain(createAccount);
+
+    // Unrelated traffic on a different thread advances round-robin in between.
+    const other = await fetch(new URL("/v1/live", server.url), {
+      method: "POST",
+      headers: { ...voiceHeaders, "session-id": "sess_other", "thread-id": "thread_other", "content-type": contentType },
+      body,
+    });
+    expect(other.status).toBe(201);
+    expect(captured[1].headers.get("chatgpt-account-id")).not.toBe(createAccount);
+
+    const wsUrl = new URL("/v1/live/rtc_test", server.url);
+    wsUrl.protocol = "ws:";
+    const client = new RealWebSocket(wsUrl.toString(), { headers: voiceHeaders } as unknown as string[]);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("sideband timeout")), 15_000);
+      client.addEventListener("open", () => client.send("hello"));
+      client.addEventListener("message", () => { clearTimeout(timer); resolve(); });
+      client.addEventListener("error", () => { clearTimeout(timer); reject(new Error("client websocket error")); });
+    });
+    client.close();
+    expect(seenUpgradeHeaders).toHaveLength(1);
+    expect(seenUpgradeHeaders[0].get("chatgpt-account-id")).toBe(createAccount);
+    expect(seenUpgradeHeaders[0].get("authorization")).toBe(captured[0].headers.get("authorization"));
+    expect(seenUpgradeHeaders[0].get("session-id")).toBe("sess_voice_1");
+    expect(seenUpgradeHeaders[0].get("thread-id")).toBe("thread_voice_1");
+  } finally {
+    globalThis.WebSocket = RealWebSocket;
+    await server.stop(true);
+    await upstream.stop(true);
+    await wsUpstream.stop(true);
+  }
+}, { timeout: 20_000 });
+
 test("sideband GET /v1/live/{callId} relays the exact frame ceiling bidirectionally", async () => {
   const seenPaths: string[] = [];
   const seenUpgradeHeaders: Headers[] = [];

--- a/tests/server-live.test.ts
+++ b/tests/server-live.test.ts
@@ -1006,6 +1006,14 @@ test("parseLiveSidebandTarget recognizes standalone realtime sessions", async ()
   ).toBeNull();
   // Bare /v1/realtime/calls is the call-create HTTP path, not a WS target.
   expect(parseLiveSidebandTarget("/v1/realtime/calls", new URLSearchParams(), "")).toBeNull();
+  // A malformed percent escape in a keyed join must read as "no target" (JSON 404), never
+  // let decodeURIComponent throw out of the router as a 500.
+  expect(parseLiveSidebandTarget("/v1/live/%ZZ", new URLSearchParams(), "")).toBeNull();
+  expect(parseLiveSidebandTarget("/v1/realtime/calls/%ZZ", new URLSearchParams(), "")).toBeNull();
+  expect(parseLiveSidebandTarget("/v1/live/rtc%5Fok", new URLSearchParams(), "")).toEqual({
+    style: "frameless-path",
+    callId: "rtc_ok",
+  });
   // Valid join shapes keep working.
   expect(
     parseLiveSidebandTarget("/v1/realtime", new URLSearchParams("call_id=rtc_2"), "call_id=rtc_2"),


### PR DESCRIPTION
## Summary

Codex desktop GPT voice fails through the proxy with `unexpected status 404 Not Found: realtime websocket handshake failed`.

Since openai/codex 438c9e98d (#35830, codex 0.146+, 2026-07-28) the WebRTC voice sideband dials `wss://api.openai.com/v1/live/{callId}` directly with the app's own login, while the call itself was created through the proxy (`POST /v1/live`) under the Pool account opencodex selected. Two accounts, one call: the join is refused upstream. Nothing on the proxy side could fix this because the join never reached the proxy (usage log shows no `gpt-live` 101 upgrade since 2026-07-29).

- `ocx start`/`sync` Design B injection now writes a marker-owned root `experimental_realtime_ws_base_url` with the same loopback value as `openai_base_url`. codex-rs turns that into `ws://127.0.0.1:<port>/v1/live/{callId}`, which the proxy already relays with Pool auth, and the `session-id`/`thread-id` affinity keeps both legs on the same account.
  - The key gets its own marker and its own journal field (`injectedRealtimeWsBaseUrl`): a user-owned override is never overwritten or stripped, even when its value equals the proxy URL, and an app-reserialized config (comments dropped, #1798) is still recognized as ours on re-inject and restore. Journaled-value cleanup now runs before the routing form is chosen, so a Design B → provider-table transition cannot leave our root URLs behind. Provider-table forms (non-loopback admission, authless Desktop) do not get the key.
- The unauthenticated loopback listener admits WebRTC call-create (`POST /v1/live`, `POST /v1/realtime/calls`) and the keyed sideband join upgrades, same trust model as its existing `/v1/responses` allowance; plain HTTP on the join paths stays 404.
- A malformed percent escape in a keyed call id (`/v1/live/%ZZ`) used to escape the router as a 500; it now falls to the JSON 404 guard.
- Docs: Codex integration guide (en/ko), proxy-formats sideband section (en/ko), server.md loopback listener route list. Devlog unit `devlog/_plan/260903_voice_sideband_regression` carries the research, decade docs, audit notes, and the probe transcript.

## Verification

- `bun run typecheck` — exit 0
- `bun test tests/codex-inject.test.ts tests/codex-injected-marker.test.ts tests/codex-journal.test.ts tests/codex-inject-integration.test.ts` — 118 pass, 0 fail
- `bun test tests/server-live.test.ts tests/loopback-listener-integration.test.ts tests/loopback-listener-admission.test.ts` — 88 pass, 0 fail (new: same-account affinity regression across a round-robin advance; loopback voice routes; malformed call-id 404)
- `bun run test:changed` — 10550 pass, 3 skip, 0 fail
- `bun run privacy:scan` — passed
- `cd docs-site && bun run build` — 417 pages built
- Isolated-home / ephemeral-port probe with a fake upstream (`devlog/_plan/260903_voice_sideband_regression/021_wp3_probe_transcript.md`): call-create and the keyed sideband join for the same session/thread both went out under the same Pool account while an unrelated thread advanced round-robin in between.
- Full local suite deliberately not run; relying on CI.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed voice session sideband connections that could fail with a 404 after call creation.
  - Voice call creation and sideband connections now consistently use the same account.
  - Improved handling of malformed call identifiers, returning a safe error instead of failing unexpectedly.
  - Added support for routing voice sideband connections through the local proxy.

- **Documentation**
  - Added setup and troubleshooting guidance for realtime voice routing, sideband connection failures, and account affinity.
  - Clarified which loopback voice and realtime routes are supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->