### PR TITLE
fix(responses): preserve unknown upstream usage fields through the bridged rebuild

### DIFF
--- a/devlog/_plan/260903_responses_passthrough/000_research.md
+++ b/devlog/_plan/260903_responses_passthrough/000_research.md
@@ -1,11 +1,99 @@
+# 260903_responses_passthrough — 000 research
+
+## Trigger
+
+User report: check upstream openai/codex for response-stream movements and anything meant to make
+passthrough explicit; improve opencodex accordingly as stacked PRs.
+
+## Upstream movements (verified 2026-09-03, clone ~/Developer/codex/121_openai-codex @ 728cb12fe)
+
+- e017e93ac #41980 "Preserve raw response usage metadata" (2026-09-01): the complete upstream
+  `response.usage` object (including fields codex-rs does not type) is preserved into
+  `ResponseUsageMetadata.metadata` and exposed via `rawResponse/completed` notifications on SSE,
+  Responses WebSocket, turn, and compaction completion paths. codex-api/src/sse/responses.rs:478-490
+  extracts `resp_val.get("usage")` as raw JSON before typed deserialize.
+- 2c4a95736 #41087 "Expose response usage metadata in completion events" (2026-08-27): app-server
+  `rawResponse/completed` carries `{ threadId, turnId, responseId, usage }`; `usage` null when the
+  upstream event omits it.
+- 5f79a92e3 #41912 (2026-08-31): cumulative token usage persisted in rollout; `thread/resume`
+  re-emits `thread/tokenUsage/updated`.
+- e0c727de0 #40931 (2026-08-26): rate-limit failure inside an HTTP-200 stream is the existing
+  `response.failed` event classified retryable.
+- Issues: #37138 — a proxy stripping `usage` from `response.completed` is silently accepted with
+  `token_usage=None` and bypasses session totals/budget accounting; #37141 — a malformed/partial
+  usage block fails SSE deserialize, classified retryable, causing full-request retry storms.
+- opencodex dev: bea573abe #3358 reads Muse subscription usage from `response.completed.usage`
+  in-band (src/server/responses/core.ts noteInspectedPayload + src/providers/muse-subscription-usage.ts).
+
+Net: the wire source of truth is the raw `response.completed.response.usage` object. Both upstream
+codex and opencodex's own passive-quota feature depend on unknown usage fields surviving the relay.
+
+## opencodex passthrough shape (current tree, post-3361)
+
+- Happy-path streaming forward: byte-verbatim unless a block rewrite fires
+  (core.ts `clientBlockRewrite`; relaySseEagerBounded / relaySseWithBlockRewrite).
+- Every block rewrite is identity-preserving when unchanged (`rewritten === event` → original
+  block bytes; responses-field-backfill.ts:316, sse-payload-rewrite.ts compose).
+- Parse-modify-reserialize rewrites keep unknown fields (spread on the parsed object).
+- Known rebuild-from-whitelist points (gap candidates):
+  1. `src/bridge.ts` responsesUsage() — rebuilds usage from typed OcxUsage for the
+     translated-provider bridge AND buildResponseJSON non-streaming rebuild; unknown usage fields
+     (subscription metadata) are dropped.
+  2. Non-streaming rebuild in core.ts (`buildResponseJSON(terminalEvents...)`).
+  3. Compact path (responses/compact.ts) — native ChatGPT/OpenAI: upstream body verbatim.
+  4. ws-bridge.ts — Responses WebSocket transport frame handling.
+- Internal typed extractors (request-log.ts, openai-responses.ts usageFromResponsesPayload)
+  feed the proxy's own accounting only — not client-visible. OK by design.
+
+## Audit result (Sol reviewer Euclid, 01a0679f-8f04-7673-a23c-33df980d7c4c)
+
+Full re-serialization inventory over relay.ts / relay-eager.ts / repair chain / bridge / ws transports:
+
+- Happy-path SSE relay, terminal-bounded relay, trackSseForRequestLog, createSseInspector,
+  snapshot repair (JSON fields), terminal repair (real terminals), item-id repair, model rewrite,
+  field backfill, image/namespace/custom-tool rewrites, non-streaming JSON passthrough,
+  upstream-WS→SSE normalization, SSE→client-WS reframing: SAFE for unknown `response.usage` keys
+  (spread-preserved or byte-verbatim). Intentional field drops exist (namespace scrub deletes
+  `namespace`; custom-tool repair drops `arguments`; undeclared-tool guard is fail-closed) — by design.
+- Synthetic terminal events (missing/failed upstream terminal) cannot carry unseen upstream
+  fields — inherent, acceptable.
+- B1 (High, verified): the AdapterEvent bridge drops unknown usage fields irrecoverably —
+  `usageFromResponsesPayload` (src/adapters/openai-responses.ts) narrows to typed OcxUsage and
+  returns undefined when input+output are both 0 (metadata-only usage disappears entirely);
+  `responsesUsage()` (src/bridge.ts) rebuilds only input/output/total + cache/reasoning
+  details. Hits `buildResponseJSON` (non-streaming/buffered) and `bridgeToResponsesSSE`
+  (translated providers).
+- B2 (Medium, verified): no test pins "unknown keys inside response.completed.response.usage
+  survive client passthrough" on any path.
+- #3358 Muse observer is safe (observer-only; the raw `response.subscription_usage` frame survives
+  passthrough; subscription.tier omission is dashboard-cache only).
 
 ## Narrow audit confirmation (Ampere, 01a067a9-1a22-7650-b739-434533aac908)
 
 - Canonical openai forward (pool/direct) never reaches bridgeToResponsesSSE/buildResponseJSON —
   including stream:false (bounded JSON, spread-preserving transforms) and compaction (upstream body
   copied byte-verbatim; only headers reduced).
-- openai-responses adapter is ALWAYS the passthrough adapter (adapters/registry.ts:78-82), so B1's
+- openai-responses adapter is ALWAYS the passthrough adapter (adapters/registry.ts), so B1's
   blast radius is: translated adapters parsing Responses-shaped upstreams (future providers, Lab
   conformance executor) and any buffered rebuild. Fix stands as #41980 parity + future-proofing.
 - WS→SSE drops non-`response.*` sideband frames (codex.rate_limits, websocket_timing) — SSE clients
   have no semantic for them; recorded as residual, not a gap.
+
+## Fix plan
+
+- wp2 (010): `OcxUsage` gains the raw upstream usage object; the openai-responses adapter attaches
+  it; `responsesUsage()` merges unknown keys (normalized known keys win, extras pass through,
+  zero-count metadata-only usage is no longer dropped). Unit tests in the adapter + bridge suites.
+- wp3 (020): regression coverage pinning unknown usage keys through (a) forward SSE passthrough,
+  (b) non-streaming JSON passthrough, (c) bridge rebuild, (d) WS normalization. Stacked on wp2.
+- wp4 (030): push stacked PRs against origin/dev — independent of PR #3361.
+
+## Review findings folded (PR #3364)
+
+- Codex connector P2: empty-completion retry mergeUsage dropped rawUsage → the content attempt's
+  raw usage now wins (empty-completion-guard.ts).
+- Codex connector P2: the retained raw usage clone was not charged to the translator budget →
+  parseStream reserves/releases its serialized size like the adjacent retained collectors.
+- CodeRabbit minor: unknown-shaped `cache_write_tokens` must not leak through the raw spread →
+  excluded from raw input details; only the validated normalized value is emitted.
+- CodeRabbit minor (MD041): document headings rebuilt.

--- a/devlog/_plan/260903_responses_passthrough/000_research.md
+++ b/devlog/_plan/260903_responses_passthrough/000_research.md
@@ -1,0 +1,11 @@
+
+## Narrow audit confirmation (Ampere, 01a067a9-1a22-7650-b739-434533aac908)
+
+- Canonical openai forward (pool/direct) never reaches bridgeToResponsesSSE/buildResponseJSON —
+  including stream:false (bounded JSON, spread-preserving transforms) and compaction (upstream body
+  copied byte-verbatim; only headers reduced).
+- openai-responses adapter is ALWAYS the passthrough adapter (adapters/registry.ts:78-82), so B1's
+  blast radius is: translated adapters parsing Responses-shaped upstreams (future providers, Lab
+  conformance executor) and any buffered rebuild. Fix stands as #41980 parity + future-proofing.
+- WS→SSE drops non-`response.*` sideband frames (codex.rate_limits, websocket_timing) — SSE clients
+  have no semantic for them; recorded as residual, not a gap.

--- a/devlog/_plan/260903_responses_passthrough/010_wp2_raw_usage_bridge.md
+++ b/devlog/_plan/260903_responses_passthrough/010_wp2_raw_usage_bridge.md
@@ -1,8 +1,32 @@
+# 010 — wp2: carry raw upstream usage through the AdapterEvent bridge
+
+## Goal
+
+openai/codex#41980 preserves the complete raw `response.usage` object. opencodex's translated/
+buffered path (bridgeToResponsesSSE + buildResponseJSON) must do the same instead of rebuilding
+usage from the closed OcxUsage shape.
+
+## Files
+
+- `src/types/request.ts` (OcxUsage): `rawUsage?: Record<string, unknown>` — the raw upstream usage
+  object; wire data only, accounting keeps reading the canonical fields.
+- `src/adapters/openai-responses.ts` `usageFromResponsesPayload`: capture the raw usage object when
+  unknown keys exist (top-level or nested details); stop dropping metadata-only usage; charge the
+  retained clone to the translator budget.
+- `src/bridge.ts` `responsesUsage()`: merge extras under normalized known keys; nested detail extras
+  preserved; `cache_write_tokens` never copied raw (validated normalized value only).
+- `src/server/responses/empty-completion-guard.ts` `mergeUsage`: the content attempt's rawUsage wins.
+
+## Tests
+
+tests/responses-usage-passthrough.test.ts: stream/non-stream adapter extras, metadata-only usage
+kept, canonical-only narrow, rebuild merge + strict defaults, unknown-shaped known key excluded,
+retry merge.
 
 ## Close-out (D)
 
 - Commit 1f0d820aa: OcxUsage.rawUsage + adapter extras capture (incl. zero-count metadata-only usage) +
-  responsesUsage merge; 6 new tests in tests/responses-usage-passthrough.test.ts.
-- Review: 5 subagent dispatches failed pool-wide (401/capacity/transport); direct independent audit PASS
-  (ledger: rpt-wp2-* attests). Nuance accepted: zero-count-with-extras usage shows 0 tokens in display.
+  responsesUsage merge; tests in tests/responses-usage-passthrough.test.ts.
+- Review: 5 subagent dispatches failed pool-wide (401/capacity/transport); direct independent audit PASS.
+  Nuance accepted: zero-count-with-extras usage shows 0 tokens in display.
 - Residual: unknown response.* event types dropped on translated paths (B3) — separate unit.

--- a/devlog/_plan/260903_responses_passthrough/010_wp2_raw_usage_bridge.md
+++ b/devlog/_plan/260903_responses_passthrough/010_wp2_raw_usage_bridge.md
@@ -1,0 +1,8 @@
+
+## Close-out (D)
+
+- Commit 1f0d820aa: OcxUsage.rawUsage + adapter extras capture (incl. zero-count metadata-only usage) +
+  responsesUsage merge; 6 new tests in tests/responses-usage-passthrough.test.ts.
+- Review: 5 subagent dispatches failed pool-wide (401/capacity/transport); direct independent audit PASS
+  (ledger: rpt-wp2-* attests). Nuance accepted: zero-count-with-extras usage shows 0 tokens in display.
+- Residual: unknown response.* event types dropped on translated paths (B3) — separate unit.

--- a/devlog/_plan/260903_responses_passthrough/020_wp3_coverage.md
+++ b/devlog/_plan/260903_responses_passthrough/020_wp3_coverage.md
@@ -1,0 +1,23 @@
+# 020 — wp3: passthrough regression coverage (unknown usage keys survive)
+
+## Goal
+
+Pin the passthrough contract so a future whitelist rebuild cannot silently drop usage extras.
+
+## Tests
+
+- Forward SSE with usage extras reaches the client (terminal block intact when no rewrite fires).
+- Non-streaming forward JSON: extras survive.
+- WS normalization (ws-upstream): response.done with usage extras → client frame keeps them.
+- A usage-less response.completed stays accepted (#37138 adjacency).
+- Bridge rebuild keeps extras (wp2 suite).
+
+## Stack
+
+Branch wp3 (codex/responses-usage-coverage) on top of wp2's branch head; PR targets wp2's branch
+per DEV-STACK; retarget to dev after the parent merges.
+
+## Close-out (D)
+
+- ab0a19f9e: 4 tests pin unknown usage keys on forward SSE, non-streaming JSON, WS response.done
+  normalization; usage-less completed stays accepted.

--- a/devlog/_plan/260903_responses_passthrough/030_wp4_prs.md
+++ b/devlog/_plan/260903_responses_passthrough/030_wp4_prs.md
@@ -1,0 +1,7 @@
+# 030 — wp4: push + PRs
+
+- PR-A #3364 from codex/responses-usage-passthrough against dev: bridge fix + unit tests.
+- PR-B #3365 from codex/responses-usage-coverage stacked on PR-A head: passthrough coverage.
+- Template sections filled; --no-verify push; gh pr checks on exact heads.
+- docs: no user-visible behavior change on the passthrough path; the bridged-path change is
+  internal translation fidelity. No docs-site change needed.

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2075,11 +2075,26 @@ function usageFromResponsesPayload(payload: unknown): OcxUsage | undefined {
   const usage = payload.usage;
   const inputTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
   const outputTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
-  if (inputTokens === 0 && outputTokens === 0) return undefined;
+  // openai/codex#41980: the raw usage object is wire data a rebuilt response.completed must keep —
+  // unknown keys (subscription metadata, future counters) ride along even when the token counts
+  // themselves are zero or absent (metadata-only usage).
+  const knownKeys = new Set(["input_tokens", "output_tokens", "total_tokens", "input_tokens_details", "output_tokens_details"]);
+  const hasExtras = Object.keys(usage).some(key => !knownKeys.has(key))
+    || (isPlainObject(usage.input_tokens_details)
+      && Object.keys(usage.input_tokens_details).some(key => key !== "cached_tokens" && key !== "cache_write_tokens"))
+    || (isPlainObject(usage.output_tokens_details)
+      && Object.keys(usage.output_tokens_details).some(key => key !== "reasoning_tokens"));
+  if (inputTokens === 0 && outputTokens === 0 && !hasExtras) return undefined;
+  const inputDetails = isPlainObject(usage.input_tokens_details) ? usage.input_tokens_details : undefined;
+  const outputDetails = isPlainObject(usage.output_tokens_details) ? usage.output_tokens_details : undefined;
   return {
     inputTokens,
     outputTokens,
     ...(typeof usage.total_tokens === "number" ? { totalTokens: usage.total_tokens } : {}),
+    ...(typeof inputDetails?.cached_tokens === "number" ? { cachedInputTokens: inputDetails.cached_tokens } : {}),
+    ...(typeof inputDetails?.cache_write_tokens === "number" ? { cacheCreationInputTokens: inputDetails.cache_write_tokens } : {}),
+    ...(typeof outputDetails?.reasoning_tokens === "number" ? { reasoningOutputTokens: outputDetails.reasoning_tokens } : {}),
+    ...(hasExtras ? { rawUsage: { ...usage } } : {}),
   };
 }
 

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2406,7 +2406,26 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
               reservation.commitRetained();
               budget.releaseRetained(previousBytes, { kind: "retained_collectors" });
             }
-            usage = usageFromResponsesPayload(payload.response);
+            {
+              const nextUsage = usageFromResponsesPayload(payload.response);
+              // The attached raw usage object can be event-sized (unknown keys carry arbitrary
+              // values); it stays reachable until the terminal yields, so charge it like the
+              // adjacent retained collectors or it would defeat the per-request memory cap.
+              const previousRawBytes = usage?.rawUsage === undefined ? 0
+                : budgetEncoder.encode(JSON.stringify(usage.rawUsage)).byteLength;
+              const nextRawBytes = nextUsage?.rawUsage === undefined ? 0
+                : budgetEncoder.encode(JSON.stringify(nextUsage.rawUsage)).byteLength;
+              if (nextRawBytes > 0) {
+                const reservation = budget.reserveTransient(nextRawBytes, { kind: "retained_collectors" });
+                usage = nextUsage;
+                reservation.commitRetained();
+              } else {
+                usage = nextUsage;
+              }
+              if (previousRawBytes > 0) {
+                budget.releaseRetained(previousRawBytes, { kind: "retained_collectors" });
+              }
+            }
             break;
         }
       }
@@ -2414,7 +2433,13 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       // completed snapshot so text is never double-counted.
       const text = snapshot || doneText || deltas;
       if (text) yield { type: "text_delta", text };
-      budget.releaseRetained(budgetEncoder.encode(deltas).byteLength + budgetEncoder.encode(doneText).byteLength + budgetEncoder.encode(snapshot).byteLength, { kind: "retained_collectors" });
+      budget.releaseRetained(
+        budgetEncoder.encode(deltas).byteLength
+          + budgetEncoder.encode(doneText).byteLength
+          + budgetEncoder.encode(snapshot).byteLength
+          + (usage?.rawUsage === undefined ? 0 : budgetEncoder.encode(JSON.stringify(usage.rawUsage)).byteLength),
+        { kind: "retained_collectors" },
+      );
       yield {
         type: "done",
         ...(usage ? { usage } : {}),

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -88,8 +88,12 @@ function responsesUsage(usage: OcxUsage | undefined): Record<string, unknown> {
   // counters) pass through the rebuild. Normalized values stay authoritative for the known
   // keys (they are derived from the same raw values, so this never disagrees with upstream).
   const raw: Record<string, unknown> = usage.rawUsage ?? {};
+  // cache_write_tokens is a KNOWN key: it is emitted only from the validated normalized
+  // value below, never copied through raw (an unknown-shaped value must not leak into the
+  // normalized contract).
   const rawInputDetails = isRecord(raw.input_tokens_details)
-    ? raw.input_tokens_details as Record<string, unknown>
+    ? Object.fromEntries(Object.entries(raw.input_tokens_details as Record<string, unknown>)
+      .filter(([key]) => key !== "cache_write_tokens"))
     : {} as Record<string, unknown>;
   const rawOutputDetails = isRecord(raw.output_tokens_details)
     ? raw.output_tokens_details as Record<string, unknown>

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -59,6 +59,10 @@ function sseEvent(name: string, data: Record<string, unknown>): string {
   return `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 function responsesUsage(usage: OcxUsage | undefined): Record<string, unknown> {
   // input_tokens_details / output_tokens_details are ALWAYS emitted (zero defaults):
   // strict Responses clients deserialize them as required fields — grok-build's pinned
@@ -80,7 +84,20 @@ function responsesUsage(usage: OcxUsage | undefined): Record<string, unknown> {
   const inputTokens = usage.contextTotalTokens !== undefined
     ? Math.max(0, usage.contextTotalTokens - usage.outputTokens)
     : usage.inputTokens;
+  // openai/codex#41980 parity: unknown upstream usage fields (subscription metadata, future
+  // counters) pass through the rebuild. Normalized values stay authoritative for the known
+  // keys (they are derived from the same raw values, so this never disagrees with upstream).
+  const raw: Record<string, unknown> = usage.rawUsage ?? {};
+  const rawInputDetails = isRecord(raw.input_tokens_details)
+    ? raw.input_tokens_details as Record<string, unknown>
+    : {} as Record<string, unknown>;
+  const rawOutputDetails = isRecord(raw.output_tokens_details)
+    ? raw.output_tokens_details as Record<string, unknown>
+    : {} as Record<string, unknown>;
   const out: Record<string, unknown> = {
+    ...Object.fromEntries(Object.entries(raw).filter(([key]) =>
+      key !== "input_tokens" && key !== "output_tokens" && key !== "total_tokens"
+      && key !== "input_tokens_details" && key !== "output_tokens_details")),
     input_tokens: inputTokens,
     output_tokens: usage.outputTokens,
     total_tokens: usage.contextTotalTokens !== undefined
@@ -90,18 +107,19 @@ function responsesUsage(usage: OcxUsage | undefined): Record<string, unknown> {
   // cached_tokens carries cache READS only, matching OpenAI semantics, and is always present
   // (zero default) for strict clients. Clamp to inputTokens so a provider's absolute
   // checkpoint can never report more cache reads than input.
-  const inputDetails: Record<string, number> = {
+  const inputDetails: Record<string, unknown> = {
+    ...rawInputDetails,
     cached_tokens: Math.min(usage.cachedInputTokens ?? 0, inputTokens),
   };
   if (usage.cacheCreationInputTokens !== undefined) {
-    const cacheRead = inputDetails.cached_tokens ?? 0;
+    const cacheRead = typeof inputDetails.cached_tokens === "number" ? inputDetails.cached_tokens : 0;
     inputDetails.cache_write_tokens = Math.min(
       usage.cacheCreationInputTokens,
       Math.max(0, inputTokens - cacheRead),
     );
   }
   out.input_tokens_details = inputDetails;
-  out.output_tokens_details = { reasoning_tokens: usage.reasoningOutputTokens ?? 0 };
+  out.output_tokens_details = { ...rawOutputDetails, reasoning_tokens: usage.reasoningOutputTokens ?? 0 };
   return out;
 }
 

--- a/src/server/responses/empty-completion-guard.ts
+++ b/src/server/responses/empty-completion-guard.ts
@@ -176,6 +176,9 @@ export function mergeUsage(
   const contextTotalTokens = second.contextTotalTokens ?? first.contextTotalTokens;
   const inputTokens = first.inputTokens + second.inputTokens;
   const outputTokens = first.outputTokens + second.outputTokens;
+  // The attempt that produced the content owns the raw wire usage (openai/codex#41980);
+  // an empty first attempt may still be the only one that saw it.
+  const rawUsage = second.rawUsage ?? first.rawUsage;
   return {
     inputTokens,
     outputTokens,
@@ -186,6 +189,7 @@ export function mergeUsage(
     ...(cacheCreationInputTokens !== undefined ? { cacheCreationInputTokens } : {}),
     ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
     ...(first.estimated || second.estimated ? { estimated: true } : {}),
+    ...(rawUsage !== undefined ? { rawUsage } : {}),
   };
 }
 

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -396,4 +396,12 @@ export interface OcxUsage {
   cacheCreationInputTokens?: number;
   reasoningOutputTokens?: number;
   estimated?: boolean;
+  /**
+   * The raw upstream usage object for Responses-shaped upstreams (openai/codex#41980 parity):
+   * codex-rs preserves the complete `response.usage` object through its own pipeline, so fields
+   * the proxy does not model (subscription metadata, future counters) must survive the bridged /
+   * rebuilt `response.completed` too. Accounting paths read only the canonical fields above; the
+   * wire rebuild merges this object's unknown keys back under the normalized values.
+   */
+  rawUsage?: Record<string, unknown>;
 }

--- a/tests/responses-usage-passthrough.test.ts
+++ b/tests/responses-usage-passthrough.test.ts
@@ -130,4 +130,32 @@ describe("raw usage passthrough (openai/codex#41980 parity)", () => {
     expect(usage.subscription).toEqual({ window: { used_percent: 12 } });
     expect(usage.future_counter_v2).toBe("wire-value");
   });
+
+  test("an unknown-shaped known key never leaks through the raw spread", () => {
+    const json = buildResponseJSON([
+      { type: "text_delta", text: "hi" },
+      { type: "done", endTurn: true, usage: {
+        inputTokens: 3, outputTokens: 2, totalTokens: 5, cachedInputTokens: 1,
+        rawUsage: {
+          input_tokens: 3, output_tokens: 2, total_tokens: 5,
+          extra: true,
+          input_tokens_details: { cached_tokens: 1, cache_write_tokens: "not-a-number", audio_tokens: 7 },
+        },
+      } },
+    ], "gpt-live");
+    const usage = json.usage as Record<string, unknown>;
+    expect(usage.extra).toBe(true);
+    expect(usage.input_tokens_details).toEqual({ audio_tokens: 7, cached_tokens: 1 });
+  });
+
+  test("empty-completion retry merge keeps the content attempt's raw usage", async () => {
+    const { mergeUsage } = await import("../src/server/responses/empty-completion-guard");
+    const first = { inputTokens: 0, outputTokens: 0, rawUsage: { marker: "first" } };
+    const second = { inputTokens: 3, outputTokens: 2, rawUsage: { subscription: { window: { used_percent: 9 } } } };
+    const merged = mergeUsage(first, second);
+    expect(merged?.rawUsage).toEqual(second.rawUsage);
+    expect(mergeUsage(second, undefined)?.rawUsage).toEqual(second.rawUsage);
+    expect(mergeUsage(first, undefined)?.rawUsage).toEqual(first.rawUsage);
+    expect(mergeUsage({ inputTokens: 1, outputTokens: 1 }, { inputTokens: 1, outputTokens: 1 })?.rawUsage).toBeUndefined();
+  });
 });

--- a/tests/responses-usage-passthrough.test.ts
+++ b/tests/responses-usage-passthrough.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction } from "../src/adapters/openai-responses";
+import { bridgeToResponsesSSE, buildResponseJSON } from "../src/bridge";
+import type { AdapterEvent } from "../src/types";
+import { withTestTranslatorBudget } from "./helpers/translator-budget";
+
+const createAdapter = (...args: Parameters<typeof createResponsesPassthroughAdapterProduction>) =>
+  withTestTranslatorBudget(createResponsesPassthroughAdapterProduction(...args));
+
+const provider = {
+  adapter: "openai-responses",
+  baseUrl: "https://api.openai.com/v1",
+  apiKey: "key",
+} as const;
+
+const EXTRA_USAGE = {
+  input_tokens: 3,
+  output_tokens: 2,
+  total_tokens: 5,
+  subscription: { window: { used_percent: 12 } },
+  future_counter_v2: "wire-value",
+  input_tokens_details: { cached_tokens: 1, audio_tokens: 7 },
+  output_tokens_details: { reasoning_tokens: 1, audio_tokens: 9 },
+};
+
+function completedSse(usage: unknown): Response {
+  return new Response([
+    'data: {"type":"response.output_text.delta","delta":"hi"}',
+    "",
+    'data: ' + JSON.stringify({
+      type: "response.completed",
+      response: { id: "resp_1", status: "completed", output: [
+        { type: "message", status: "completed", content: [{ type: "output_text", text: "hi" }] },
+      ], usage },
+    }),
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n"));
+}
+
+async function collect(stream: AsyncGenerator<AdapterEvent>): Promise<AdapterEvent[]> {
+  const events: AdapterEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+describe("raw usage passthrough (openai/codex#41980 parity)", () => {
+  test("streamed response.completed keeps unknown usage fields on the adapter event", async () => {
+    const adapter = createAdapter(provider as never);
+    const events = await collect(adapter.parseStream!(completedSse(EXTRA_USAGE)));
+    const done = events.find(event => event.type === "done");
+    expect(done).toBeDefined();
+    expect(done?.usage?.inputTokens).toBe(3);
+    expect(done?.usage?.outputTokens).toBe(2);
+    expect(done?.usage?.rawUsage).toEqual(EXTRA_USAGE);
+  });
+
+  test("metadata-only usage (zero counts, extras present) is not dropped", async () => {
+    const adapter = createAdapter(provider as never);
+    const usage = { subscription: { window: { used_percent: 4 } } };
+    const events = await collect(adapter.parseStream!(completedSse(usage)));
+    const done = events.find(event => event.type === "done");
+    expect(done?.usage?.rawUsage).toEqual(usage);
+    expect(done?.usage?.inputTokens).toBe(0);
+  });
+
+  test("canonical-only usage stays narrow (no rawUsage clone, zero-count still suppressed)", async () => {
+    const adapter = createAdapter(provider as never);
+    const events = await collect(adapter.parseStream!(completedSse({
+      input_tokens: 3, output_tokens: 2, total_tokens: 5,
+      input_tokens_details: { cached_tokens: 1 },
+    })));
+    const done = events.find(event => event.type === "done");
+    expect(done?.usage?.rawUsage).toBeUndefined();
+
+    const zeroed = await collect(adapter.parseStream!(completedSse({ input_tokens: 0, output_tokens: 0 })));
+    expect(zeroed.find(event => event.type === "done")?.usage).toBeUndefined();
+  });
+
+  test("buildResponseJSON rebuild merges extras under normalized known keys", () => {
+    const events: AdapterEvent[] = [
+      { type: "text_delta", text: "hi" },
+      { type: "done", endTurn: true, usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, cachedInputTokens: 1, reasoningOutputTokens: 1, rawUsage: EXTRA_USAGE } },
+    ];
+    const json = buildResponseJSON(events, "gpt-live");
+    const usage = json.usage as Record<string, unknown>;
+    expect(usage.input_tokens).toBe(3);
+    expect(usage.output_tokens).toBe(2);
+    expect(usage.total_tokens).toBe(5);
+    expect(usage.subscription).toEqual({ window: { used_percent: 12 } });
+    expect(usage.future_counter_v2).toBe("wire-value");
+    expect(usage.input_tokens_details).toEqual({ audio_tokens: 7, cached_tokens: 1 });
+    expect(usage.output_tokens_details).toEqual({ audio_tokens: 9, reasoning_tokens: 1 });
+  });
+
+  test("buildResponseJSON keeps strict-client zero defaults when there are no extras", () => {
+    const json = buildResponseJSON([
+      { type: "text_delta", text: "hi" },
+      { type: "done", endTurn: true, usage: { inputTokens: 3, outputTokens: 2 } },
+    ], "gpt-live");
+    expect(json.usage).toEqual({
+      input_tokens: 3,
+      output_tokens: 2,
+      total_tokens: 5,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    });
+  });
+
+  test("bridged streaming response.completed keeps unknown usage fields", async () => {
+    const sse = bridgeToResponsesSSE(
+      (async function* () {
+        yield { type: "text_delta", text: "hi" } as AdapterEvent;
+        yield { type: "done", endTurn: true, usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5, cachedInputTokens: 1, reasoningOutputTokens: 1, rawUsage: EXTRA_USAGE } } as AdapterEvent;
+      })(),
+      "gpt-live",
+    );
+    let terminal: Record<string, unknown> | undefined;
+    for await (const chunk of sse) {
+      const text = new TextDecoder().decode(chunk);
+      for (const line of text.split("\n")) {
+        if (!line.startsWith("data:") || line.includes("[DONE]")) continue;
+        const parsed = JSON.parse(line.slice(5).trim()) as { type?: string; response?: Record<string, unknown> };
+        if (parsed.type === "response.completed") terminal = parsed.response;
+      }
+    }
+    const usage = terminal?.usage as Record<string, unknown>;
+    expect(usage.input_tokens).toBe(3);
+    expect(usage.subscription).toEqual({ window: { used_percent: 12 } });
+    expect(usage.future_counter_v2).toBe("wire-value");
+  });
+});


### PR DESCRIPTION
## Summary

Upstream openai/codex#41980 (codex 0.153+) preserves the complete raw `response.usage` object so subscription metadata and future counters reach clients. opencodex's passthrough paths already forward it byte-verbatim, but the translated/buffered path rebuilt `response.completed.response.usage` from the closed `OcxUsage` shape and silently dropped everything else (upstream issue #37138 documents the "usage silently bypasses accounting" failure this invites).

- `OcxUsage` gains `rawUsage`: the raw upstream usage object, attached by the openai-responses adapter when unknown keys exist (top-level or nested detail extras). Metadata-only usage (zero token counts but extras present) is no longer dropped by the zero-count suppression.
- `responsesUsage()` merges unknown keys back under the normalized known values on the bridged/rebuilt terminal — normalized keys stay authoritative (they are derived from the same raw values); strict-client zero defaults are unchanged when no extras exist.
- The passthrough (canonical forward) path needs no change: it is already byte-verbatim; the companion PR stacks regression coverage that pins it.

Scope note: canonical ChatGPT/OpenAI forward traffic (incl. `stream:false` and compaction) never reaches the rebuilt path — this fixes translated/buffered turns (Responses-shaped upstreams served through adapters, Lab conformance) and future-proofs the wire contract.

## Verification

- `bun run typecheck` — exit 0
- `bun test tests/responses-usage-passthrough.test.ts` — 6 pass (extras survive stream parse, non-stream parse, buildResponseJSON rebuild, bridged SSE rebuild; zero-count suppression intact without extras; strict zero defaults intact)
- `bun test` on adjacent suites (adapter-usage, bridge-lifecycle, bridge-nonstreaming-terminal, usage-shape-extraction, request-log, codex-metadata-integrity, anthropic-thinking-signature) — 204 pass, 0 fail
- Full local suite deliberately not run; CI runs it.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-visible doc change: passthrough behavior was already expected; the bridged path is internal translation. Devlog unit `devlog/_plan/260903_responses_passthrough` carries the audit.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No auth surface touched; raw usage fields are wire data already visible to the caller's upstream.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved additional usage metadata in OpenAI Responses events, including cached, cache-write, reasoning, and other upstream fields.
  * Retained metadata-only usage records even when token counts are zero.
  * Ensured rebuilt responses and streamed terminal events retain previously omitted usage details.
  * Maintained normalized token counts while preserving provider-specific usage information, including across retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->