### PR TITLE
fix(cursor): break repeated narration across tool cycles

### DIFF
--- a/src/adapters/cursor/protobuf-request.ts
+++ b/src/adapters/cursor/protobuf-request.ts
@@ -298,38 +298,40 @@ function rootPromptMessages(
   // Repetition breaker (devlog 260826 gap-9): external full-replay flattens history to text,
   // so N identical assistant/tool-result rounds replay as N identical lines and PRIME the model
   // to emit the same line again (self-reinforcing loop: S2a 180x, identical-probe repetition).
-  // Collapse consecutive duplicates into one entry + a count marker, and count collapses so a
-  // strategy-change note can be appended when the pattern is severe.
-  let lastReplayText: string | undefined;
-  let lastReplayEntry: RootBlobCandidate | undefined;
-  let collapsedRepeats = 0;
+  // Collapse consecutive same-role duplicates within one user turn into one entry + a count marker.
+  // Track assistant narration separately from tool results so a real narration→tool→result cycle
+  // cannot reset the breaker before the next identical narration arrives.
+  const replayRuns = new Map<RootBlobCandidate["role"], {
+    text: string;
+    entry: RootBlobCandidate;
+    length: number;
+  }>();
+  const toolCallCounts = new Map<string, number>();
   let maxRunLength = 1;
-  let currentRun = 1;
+  let maxToolCallCount = 1;
   const pushDeduped = (
     payload: { role: string; content: [{ type: "text"; text: string }] },
     role: RootBlobCandidate["role"],
     opts: { messageIndex: number; text?: string },
     normalized: string,
   ): void => {
-    if (externalModel && lastReplayText !== undefined && normalized === lastReplayText && lastReplayEntry) {
-      collapsedRepeats++;
-      currentRun++;
-      if (currentRun > maxRunLength) maxRunLength = currentRun;
-      const marked = `${normalized}\n[note: this exact output was produced ${currentRun} times in a row]`;
+    const previous = replayRuns.get(role);
+    if (externalModel && previous?.text === normalized) {
+      const runLength = previous.length + 1;
+      if (runLength > maxRunLength) maxRunLength = runLength;
+      const marked = `${normalized}\n[note: this exact output was produced ${runLength} times in a row]`;
       const replacement = rootBlobCandidate(
         { role: payload.role, content: [{ type: "text", text: marked }] },
         role,
-        opts,
+        { ...opts, messageIndex: previous.entry.messageIndex ?? opts.messageIndex },
       );
-      entries[entries.indexOf(lastReplayEntry)] = replacement;
-      lastReplayEntry = replacement;
+      entries[entries.indexOf(previous.entry)] = replacement;
+      replayRuns.set(role, { text: normalized, entry: replacement, length: runLength });
       return;
     }
-    currentRun = 1;
     const entry = rootBlobCandidate(payload, role, opts);
     entries.push(entry);
-    lastReplayText = normalized;
-    lastReplayEntry = entry;
+    replayRuns.set(role, { text: normalized, entry, length: 1 });
   };
 
   for (let i = 0; i < messages.length; i++) {
@@ -337,14 +339,13 @@ function rootPromptMessages(
     const message = messages[i];
     if (!message) continue;
     if (message.role === "user" || message.role === "developer") {
+      replayRuns.clear();
+      toolCallCounts.clear();
       const text = historyContentText(message).trim();
       // Cursor root replay expects OpenAI-style content parts for historical user messages.
       // A bare string survives blob hydration but external workers reject the completed replay
       // before tokenization (`usedTokens: 0`, then invalid_argument).
       if (text.length > 0) {
-        lastReplayText = undefined;
-        lastReplayEntry = undefined;
-        currentRun = 1;
         entries.push(rootBlobCandidate({
           role: "user",
           content: [{ type: "text", text }],
@@ -361,6 +362,20 @@ function rootPromptMessages(
           { messageIndex: i },
           text,
         );
+      }
+      if (externalModel && Array.isArray(message.content)) {
+        const callsInMessage = new Set<string>();
+        for (const part of message.content) {
+          if (part.type !== "toolCall") continue;
+          const args = serializeToolCallArguments(part.arguments);
+          if (args === undefined) continue;
+          callsInMessage.add(JSON.stringify([namespacedToolName(part.namespace, part.name), args]));
+        }
+        for (const call of callsInMessage) {
+          const count = (toolCallCounts.get(call) ?? 0) + 1;
+          toolCallCounts.set(call, count);
+          if (count > maxToolCallCount) maxToolCallCount = count;
+        }
       }
       // Assistant tool CALLS are NOT replayed as a separate visible "[Tool Call]" entry: a model
        // few-shot-mimics that marker and emits later tool calls as inert text (363-B guard in
@@ -382,7 +397,12 @@ function rootPromptMessages(
     }
   }
   // Severe repetition: tell the model ONCE, imperatively, to change strategy.
-  if (externalModel && maxRunLength >= 3) {
+  if (externalModel && maxToolCallCount >= 3) {
+    entries.push(rootBlobCandidate({
+      role: "user",
+      content: [{ type: "text", text: `[context note] The transcript above contains the same tool call repeated ${maxToolCallCount} times in this user turn. Repeating it again is a failure. Take a DIFFERENT action now, or state plainly what is blocking progress.` }],
+    }, "user", {}));
+  } else if (externalModel && maxRunLength >= 3) {
     entries.push(rootBlobCandidate({
       role: "user",
       content: [{ type: "text", text: `[context note] The transcript above contains the same output repeated ${maxRunLength} times in a row. Repeating it again is a failure. Take a DIFFERENT action now, or state plainly what is blocking progress.` }],

--- a/tests/cursor-repetition-breaker.test.ts
+++ b/tests/cursor-repetition-breaker.test.ts
@@ -41,6 +41,30 @@ function repeatedHistory(times: number): OcxMessage[] {
   return messages;
 }
 
+function repeatedToolHistory(times: number): OcxMessage[] {
+  const messages: OcxMessage[] = [{ role: "user", content: "熟悉一下当前项目", timestamp: 1 }];
+  for (let i = 0; i < times; i++) {
+    const callId = `call_${i}`;
+    messages.push({
+      role: "assistant",
+      content: [
+        { type: "text", text: REPEAT },
+        { type: "toolCall", id: callId, name: "exec_command", arguments: { cmd: `echo ${i}` } },
+      ],
+      timestamp: 2 + i * 2,
+    });
+    messages.push({
+      role: "toolResult",
+      toolCallId: callId,
+      toolName: "exec_command",
+      content: `result ${i}`,
+      isError: false,
+      timestamp: 3 + i * 2,
+    });
+  }
+  return messages;
+}
+
 function encode(messages: OcxMessage[], modelId = "grok-4.6-high") {
   return encodeCursorRunRequest({
     modelId,
@@ -71,6 +95,16 @@ describe("cursor external-replay repetition breaker (devlog 260826 gap-9)", () =
     expect(texts.filter(text => text.includes("Take a DIFFERENT action now"))).toHaveLength(0);
   });
 
+  test("repeated assistant narration across tool-result cycles still trips the breaker", () => {
+    const bytes = encode(repeatedToolHistory(4));
+    const texts = rootTexts(bytes);
+    const repeats = texts.filter(text => text.startsWith(REPEAT));
+    expect(repeats).toHaveLength(1);
+    expect(repeats[0]).toContain("4 times in a row");
+    expect(texts.filter(text => text.startsWith("[Tool Result]"))).toHaveLength(4);
+    expect(texts.filter(text => text.includes("Take a DIFFERENT action now"))).toHaveLength(1);
+  });
+
   test("distinct assistant entries stay untouched", () => {
     const messages: OcxMessage[] = [
       { role: "user", content: "hi", timestamp: 1 },
@@ -94,5 +128,45 @@ describe("cursor external-replay repetition breaker (devlog 260826 gap-9)", () =
     ] as OcxMessage[];
     const texts = rootTexts(encode(messages));
     expect(texts.filter(text => text === REPEAT)).toHaveLength(2);
+  });
+
+  test("empty user boundaries still reset repetition tracking", () => {
+    const messages: OcxMessage[] = [
+      { role: "user", content: "go", timestamp: 1 },
+      { role: "assistant", content: REPEAT, timestamp: 2 },
+      { role: "user", content: "   ", timestamp: 3 },
+      { role: "assistant", content: REPEAT, timestamp: 4 },
+      { role: "user", content: "final", timestamp: 5 },
+    ] as OcxMessage[];
+    const texts = rootTexts(encode(messages));
+    expect(texts.filter(text => text === REPEAT)).toHaveLength(2);
+  });
+
+  test("three identical tool calls with changing narration trigger a strategy change", () => {
+    const messages: OcxMessage[] = [{ role: "user", content: "find the i18n bug", timestamp: 1 }];
+    for (let i = 0; i < 3; i++) {
+      const callId = `view_${i}`;
+      messages.push({
+        role: "assistant",
+        content: [
+          { type: "text", text: `investigation step ${i}` },
+          { type: "toolCall", id: callId, name: "view_image", arguments: { path: "C:\\tmp\\same.png" } },
+        ],
+        timestamp: 2 + i * 2,
+      });
+      messages.push({
+        role: "toolResult",
+        toolCallId: callId,
+        toolName: "view_image",
+        content: `viewed image ${i}`,
+        isError: false,
+        timestamp: 3 + i * 2,
+      });
+    }
+
+    const texts = rootTexts(encode(messages));
+    expect(texts.filter(text => text.startsWith("investigation step"))).toHaveLength(3);
+    expect(texts.filter(text => text.startsWith("[Tool Result]"))).toHaveLength(3);
+    expect(texts.filter(text => text.includes("same tool call repeated 3 times"))).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Carried from #3357 by @huaiqing-afk onto current `dev`, with the author's `Co-authored-by` trailer on the commit.

Cursor turns repeated the same narration across tool cycles. The cause is a single global previous-text slot in `src/adapters/cursor/protobuf-request.ts`: every intervening tool result overwrote it, so the repetition check never saw the assistant's own prior narration and could not collapse it.

The fix tracks narration and tool results independently by role, and resets both trackers at each user/developer boundary — including whitespace-only messages, which is what an earlier review flagged as an empty-boundary hole. It also detects repeated identical tool invocations and emits one strategy-change note instead of silently looping.

The original PR is a draft, and drafts do not merge; the fix itself was judged root-correct with a strong regression, so it is carried here rather than left waiting.

Closes #3357

## Verification

```
bun test tests/cursor-repetition-breaker.test.ts    8 pass, 0 fail
bun run typecheck                                  exit 0
```

The carried test is RED without the fix: it asserts collapsed narration across four retained tool results, whitespace-boundary reset, and repeated calls with changing narration.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. *(Internal adapter behavior; no user-facing surface changed.)*
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: huaiqing-afk <huaiqing-afk@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cursor history replay by collapsing repeated assistant narration and tool results while preserving message context.
  * Repetition tracking now resets after each user turn, including whitespace-only messages.
  * Repeated tool calls are identified separately, with a strategy-change note shown after three identical calls.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->