### PR TITLE
fix: make admin-token prompt password-manager friendly

### DIFF
--- a/gui/src/admin-token-dialog.ts
+++ b/gui/src/admin-token-dialog.ts
@@ -54,7 +54,6 @@ export function promptForAdminToken(
     username.name = "username";
     username.autocomplete = "username";
     username.value = ADMIN_TOKEN_USERNAME;
-    username.readOnly = true;
     accountField.append(accountLabel, username);
 
     const tokenField = document.createElement("div");

--- a/gui/tests/admin-token-dialog.test.ts
+++ b/gui/tests/admin-token-dialog.test.ts
@@ -42,7 +42,7 @@ test("renders stable password-manager-compatible sign-in fields", async () => {
   expect(username?.id).toBe("opencodex-admin-token-dialog-username");
   expect(form?.querySelector(`label[for="${username?.id}"]`)?.textContent).toBe("Account");
   expect(username?.autocomplete).toBe("username");
-  expect(username?.readOnly).toBe(true);
+  expect(username?.readOnly).toBe(false);
   expect(username?.value).toBe("OpenCodex");
   expect(password?.id).toBe("opencodex-admin-token-dialog-password");
   expect(form?.querySelector(`label[for="${password?.id}"]`)?.textContent).toBe("Admin token");


### PR DESCRIPTION
## Summary

- Let password managers treat the OpenCodex admin-token sign-in prompt as a normal username/password form.
- Keep the existing stable account name and standard autocomplete attributes so iPhone Safari PWAs can save and autofill the admin token.

## Verification

- `cd gui; bun test tests/admin-token-dialog.test.ts`
- `git diff --check HEAD^ HEAD`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not needed: this is a standards-compliance fix to an existing prompt).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The username field in the admin token dialog is now editable while remaining pre-filled with “OpenCodex.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
