### PR TITLE
docs(devlog): close out the 260904 bug stack train

### DIFF
--- a/devlog/_plan/260904_bug_stack_train/060_closeout.md
+++ b/devlog/_plan/260904_bug_stack_train/060_closeout.md
@@ -1,0 +1,56 @@
+# 060 — Closeout
+
+Six pull requests merged into `dev`, each proven an ancestor of the branch head:
+
+| PR | Merge commit | Content |
+|----|--------------|---------|
+| #3369 | `f825858da` | OpenAI deviceauth grant (#3366 layer 1) |
+| #3385 | `d060f53ab` | deviceauth surface: API, CLI, GUI, poll budgets (layer 2) |
+| #3371 | `53a2adfc4` | Cursor repeated-narration breaker (from #3357) |
+| #3372 | `8a0c10865` | `logs --follow` capability contract (from #3322) |
+| #3373 | `d753fa53b` | Combo strategy selector (from #3335) |
+| #3386 | `a33381182` | Models tab width stability (from #3333) |
+
+Proof form for each: `git fetch origin dev && git merge-base --is-ancestor <sha> FETCH_HEAD`.
+
+## The mistake worth remembering
+
+Two PRs had to be rebuilt mid-train for the same reason, and CI caught both:
+
+- `codex/carry-3333` copied `gui/src/styles.css` wholesale from #3333's head. That PR
+  predates #3367 and #3382, so the copy silently reverted the Logs table clipping fix and
+  the sidebar footer rework. `tests/logs-table-overflow.test.ts` failed on a declaration
+  nothing had intentionally touched.
+- `codex/deviceauth-surface-v2` copied the nine i18n catalogs the same way, reverting every
+  key `dev` had added since — `sidebar.preferences` among them — which broke the GUI build's
+  `TKey` union.
+
+**Carrying another author's work means applying their diff, not taking their files.** A file
+carries its own history with it. Both rebuilds used
+`git diff <pr-merge-base> <pr-head> -- <path>` and applied that.
+
+A third defect surfaced from the same area: `tests/dashboard-tabs.test.ts` located its
+target with `indexOf(".page-tabs {")`, which matches any rule whose selector merely *ends*
+in that string. Adding a scoped `.main-inner--combos > .page-tabs` rule above the base one
+made the guard read the wrong block. It is now anchored to a line-start rule, and removing
+`flex-wrap` from the real base rule still fails it.
+
+## Review value
+
+Eight reviewer rounds across the two deviceauth PRs produced, each with a reproduction:
+a 32-bit timer overflow that turned a hostile `interval` into 34 auth requests in ~50ms; an
+unenforced deadline that accepted a grant arriving after expiry; a cast `access_token` that
+let a 200 with no token resolve a login as successful; a GUI that never actually requested
+device mode, covered by a test that was false-green because its mock answered with a device
+payload regardless of the request; a five-minute modal timer against a fifteen-minute grant;
+budget tests that permitted the exact regression they existed to catch; and a reauth path
+that could not reach the device flow at all.
+
+None of those were visible from the diff alone.
+
+## Still open, deliberately
+
+See 040. #3348 and #3312 (generic 410/413 classified as retryable hops, ~2,000 lines each),
+#3325 (correct, but needs a maintainer sponsorship decision for a restricted workflow
+surface), and all six bug issues (reporter evidence or a product decision; three would
+require weakening an auth or identity boundary to "fix" without a reproduction).

--- a/devlog/_plan/260904_bug_stack_train/070_issue_dispositions.md
+++ b/devlog/_plan/260904_bug_stack_train/070_issue_dispositions.md
@@ -1,0 +1,24 @@
+# 070 — Bug-issue dispositions
+
+Six open bug-labelled issues, each root-caused against the current tree. None is
+safely fixable from the evidence attached today. Deferring is the disposition, not
+an absence of one.
+
+| Issue | Disposition | Why |
+|-------|-------------|-----|
+| #3352 | NEEDS_REPORTER_EVIDENCE | Mechanism is fully traced, cause is not. Letting `unknown` entitlement through would be a security-policy change, not a bug fix. |
+| #3320 | NEEDS_REPORTER_EVIDENCE | Production XML writes a locale-independent SID; exact `<UserId>` matching is deliberate. Needs redacted live XML. |
+| #3279 | NEEDS_REPORTER_EVIDENCE | Each page load mints a session from its own Host-derived origin; the exact origin check IS the admission boundary. |
+| #3255 | PRODUCT_DECISION | Reasoning and speed are already independent dimensions; there is no Ultra-fast wire tier to pass through. |
+| #3245 | NEEDS_REPORTER_EVIDENCE | The reporter saw no POST after the 426, which puts the failure before the Responses bridge. |
+| #1527 | NEEDS_REPORTER_EVIDENCE | Every known defect in this path is already fixed; needs a matched current-dev trace. |
+
+## The pattern worth naming
+
+Three of these (#3352, #3320, #3279) have an obvious-looking fix that is the wrong
+trade: allow the unconfirmed entitlement, fold non-ASCII identities together, treat
+localhost/IPv4/IPv6 as one origin. Each would make the symptom go away by widening a
+trust boundary, without a reproduction proving that boundary is what failed. A bug
+report is not evidence that the check causing the symptom is the wrong check.
+
+Full mechanism traces with file:line are in `000_research.md`.

--- a/devlog/_plan/260904_bug_stack_train/080_merge_ledger.md
+++ b/devlog/_plan/260904_bug_stack_train/080_merge_ledger.md
@@ -1,0 +1,35 @@
+# 080 — Merge ledger
+
+Every merge, with the proof form used for each:
+
+```
+git fetch origin dev && git merge-base --is-ancestor <merge-sha> FETCH_HEAD
+```
+
+| Order | PR | Merge commit | Ancestor of dev |
+|-------|----|--------------|-----------------|
+| 1 | #3369 | `f825858da5b2e8dc5c949cc9f17b5111bf07bda4` | ok |
+| 2 | #3372 | `8a0c1086539b82648984e0a1c3546d9d493d5fd9` | ok |
+| 3 | #3371 | `53a2adfc45ed18a980355abe353ec02f06f3f39e` | ok |
+| 4 | #3373 | `d753fa53bec651c90e538602a56d1a1cddf56589` | ok |
+| 5 | #3385 | `d060f53abe255b28f8c36330ddd0c4e39fd9b6a2` | ok |
+| 6 | #3386 | `a33381182b144bfccb61269f4dfbc73057eacae2` | ok |
+
+Each merge was gated on the check-run rollup for that PR's exact `headRefOid`, not on
+`gh pr checks` output alone — a cancelled superseded run renders as a failure there, and
+an empty required-check list is not evidence of green.
+
+## Two rebuilds, and one flake that was not one
+
+#3370 could not be rebased after its parent #3369 squash-merged: the branch still carried
+the core commits, and the rebase conflicted against content that had already landed in
+squashed form. Rebuilt as #3385 from the surface file set on current `dev`.
+
+#3374 was rebuilt as #3386 after CI exposed the `styles.css` revert.
+
+One genuine flake: `test 4/4` failed on
+`update stops the running proxy before replacing files > npm launcher restarts the stopped
+runtime after a staged update failure` — a 91-second timing-sensitive test in
+`tests/update-stop-first.test.ts`, which reads nothing from `gui/` while that PR changed
+only stylesheets. It passed locally (15 pass / 0 fail) and passed on re-run. Distinguishing
+that from a real failure required reading the shard log, not assuming.


### PR DESCRIPTION
## Summary

Closes out the 260904 bug stack train devlog unit with three records: the campaign outcome, the six bug-issue dispositions, and the merge ledger.

Docs only — nothing in the build, typecheck, or test path reads \`devlog/\`.

Three things worth having on the record rather than in a chat log:

**Carrying another author's work means applying their diff, not taking their files.** Two PRs in this train had to be rebuilt because a whole-file copy silently reverted work that had landed since the source PR was written — \`gui/src/styles.css\` reverted #3367 and #3382, and the nine i18n catalogs reverted \`sidebar.preferences\` and broke the GUI build's TKey union. CI caught both, which is the system working, but the mistake is cheap to avoid.

**A guard test that locates its target by substring is a guard against nothing.** \`tests/dashboard-tabs.test.ts\` used \`indexOf(".page-tabs {")\`, which matches any rule whose selector merely ends in that string.

**Three of the six bug issues have an obvious-looking fix that widens a trust boundary.** Allowing an unconfirmed entitlement, folding non-ASCII identities together, treating localhost/IPv4/IPv6 as one origin. A bug report is not evidence that the check causing the symptom is the wrong check.

## Verification

\`\`\`
bun run privacy:scan    Privacy scan passed
\`\`\`

That is the gate that applies: \`privacy:scan\` is the one CI check that reads \`devlog/\`, which is what makes a public devlog safe rather than merely visible.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. *(No security material: every item recorded here is already public in a merged diff.)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added closeout documentation for a completed bug-fix train, including merged changes, verification records, review findings, and deferred issues.
  * Documented issue dispositions and the rationale for deferring unresolved reports.
  * Added a merge ledger detailing integration history, verification checks, rebuilt changes, and a flaky test rerun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->