### PR TITLE
fix: prevent Windows config writes from failing with ENOENT

### DIFF
--- a/src/config/atomic-write.ts
+++ b/src/config/atomic-write.ts
@@ -1,7 +1,6 @@
 import {
   chmodSync,
   closeSync,
-  constants,
   fchmodSync,
   fstatSync,
   lstatSync,
@@ -121,7 +120,7 @@ function writePrivateTempFile(
   timeoutMemoKey: string,
   onCreated: () => void,
 ): void {
-  const descriptor = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+  const descriptor = openSync(path, "wx", 0o600);
   onCreated();
   try {
     if (process.platform === "win32") {
@@ -142,7 +141,7 @@ async function writePrivateTempFileAsync(
   timeoutMemoKey: string,
   onCreated: () => void,
 ): Promise<void> {
-  const descriptor = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+  const descriptor = openSync(path, "wx", 0o600);
   onCreated();
   try {
     if (process.platform === "win32") {


### PR DESCRIPTION
## Summary

- Use Node's portable exclusive-write flag for OpenCodex atomic temp files instead of numeric open flags that Bun on Windows can misreport as ENOENT even when the config directory exists.
- Covers both synchronous startup/config writes and asynchronous state writes while preserving exclusive creation, 0600 permissions, and Windows ACL hardening.

## Verification

- un test tests/config.test.ts (169 pass)
- un run typecheck 
- un run test 
- un run privacy:scan 

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (not needed; no user-facing configuration change).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; exclusive creation and existing file hardening remain intact.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized temporary-file creation across synchronous and asynchronous operations while preserving existing file permissions and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->