### PR TITLE
fix(cli): heal deleted cwd at launch and avoid stream init in TTY guard

### DIFF
--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -38,7 +38,9 @@ try {
 } catch {
   try {
     process.chdir(homedir());
-  } catch {}
+  } catch {
+    /* best-effort */
+  }
 }
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));

--- a/bin/ocx.mjs
+++ b/bin/ocx.mjs
@@ -33,6 +33,13 @@ import {
 } from "../src/update/codex-cli-update-launch-policy.mjs";
 
 const PKG = "@bitkyc08/opencodex";
+try {
+  process.cwd();
+} catch {
+  try {
+    process.chdir(homedir());
+  } catch {}
+}
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 const cliPath = join(here, "..", "src", "cli", "index.ts");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,8 @@
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 
+// Best-effort recovery for runtime execution and spawned children if launched
+// from an unlinked/deleted working directory (runs after hoisted ESM module imports).
 try {
   process.cwd();
 } catch {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,16 @@
 #!/usr/bin/env bun
 import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+
+try {
+  process.cwd();
+} catch {
+  try {
+    process.chdir(homedir());
+  } catch {
+    /* best-effort */
+  }
+}
 import { currentExternalCodexModelProvider, restoreNativeCodex, restoreNativeCodexAsync, shouldInjectApiAuthHeader } from "../codex/inject";
 import { stripGrokConfig } from "../grok/inject";
 import { STOP_HISTORY_INCOMPLETE_EXIT_CODE } from "../update/stop-contract.mjs";

--- a/src/cli/star-prompt.ts
+++ b/src/cli/star-prompt.ts
@@ -168,7 +168,13 @@ function printAgentDeferral(): void {
  */
 export async function maybeShowStarPrompt(): Promise<void> {
   try {
-    if (process.env.OCX_SERVICE || !isatty(0) || !isatty(1)) return;
+    let isTty = false;
+    try {
+      isTty = isatty(0) && isatty(1);
+    } catch {
+      /* best-effort */
+    }
+    if (process.env.OCX_SERVICE || !isTty) return;
     const dir = getConfigDir();
     const marker = join(dir, MARKER);
     if (existsSync(marker)) return;

--- a/src/cli/star-prompt.ts
+++ b/src/cli/star-prompt.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { isatty } from "node:tty";
 import { spawnSync } from "node:child_process";
 import { getConfigDir } from "../config";
 import { recordOwnedConfigPath } from "../lib/config-ownership";
@@ -167,7 +168,7 @@ function printAgentDeferral(): void {
  */
 export async function maybeShowStarPrompt(): Promise<void> {
   try {
-    if (process.env.OCX_SERVICE || !process.stdin.isTTY || !process.stdout.isTTY) return;
+    if (process.env.OCX_SERVICE || !isatty(0) || !isatty(1)) return;
     const dir = getConfigDir();
     const marker = join(dir, MARKER);
     if (existsSync(marker)) return;

--- a/src/update/notify.ts
+++ b/src/update/notify.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { isatty } from "node:tty";
 import { createInterface } from "node:readline/promises";
 import { atomicWriteFile, getConfigDir } from "../config";
 import { hasStarPromptRun } from "../cli/star-prompt";
@@ -123,7 +124,11 @@ export function isSourceBuildVersion(v: string): boolean {
 
 /** The interactive/TTY + install-method gate shared with the star prompt. */
 function interactiveGuardOk(): boolean {
-  return !(process.env.OCX_SERVICE || !process.stdin.isTTY || !process.stdout.isTTY);
+  try {
+    return !(process.env.OCX_SERVICE || !isatty(0) || !isatty(1));
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/update/notify.ts
+++ b/src/update/notify.ts
@@ -123,10 +123,11 @@ export function isSourceBuildVersion(v: string): boolean {
 }
 
 /** The interactive/TTY + install-method gate shared with the star prompt. */
-function interactiveGuardOk(): boolean {
+export function interactiveGuardOk(): boolean {
   try {
     return !(process.env.OCX_SERVICE || !isatty(0) || !isatty(1));
   } catch {
+    /* best-effort */
     return false;
   }
 }

--- a/tests/update-notify.test.ts
+++ b/tests/update-notify.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   getUpgradeVersionForPopup,
+  interactiveGuardOk,
   isNewer,
   isSourceBuildVersion,
   readVersionCache,
@@ -133,6 +134,18 @@ describe("cli wiring", () => {
     expect(portIndex).toBeGreaterThan(-1);
     expect(promptIndex).toBeLessThan(portIndex);
     expect(promptIndex).toBeLessThan(serverIndex);
+  });
+
+  test("interactiveGuardOk safely evaluates without throwing when cwd is unlinked", () => {
+    const origCwd = process.cwd();
+    const tempDir = mkdtempSync(join(tmpdir(), "ocx-unlinked-cwd-"));
+    process.chdir(tempDir);
+    removeTreeWithRetry(tempDir);
+    try {
+      expect(typeof interactiveGuardOk()).toBe("boolean");
+    } finally {
+      try { process.chdir(origCwd); } catch { /* best-effort */ }
+    }
   });
 
   test("hidden __refresh-version subcommand is wired", async () => {


### PR DESCRIPTION
## Summary

- Heal stale/unlinked working directory at launch in `bin/ocx.mjs` and `src/cli/index.ts` by catching broken `process.cwd()` and falling back to `homedir()`.
- Avoid initializing `process.stdin` / `process.stdout` stream objects during TTY guard checks in `src/update/notify.ts` and `src/cli/star-prompt.ts` by using `isatty(0)` and `isatty(1)` from `node:tty`.

Closes #3400

### Problem
When `ocx` is launched from a working directory that has been deleted:
1. In Bun, accessing `process.stdin.isTTY` lazily initializes `new tty.ReadStream(0)`, which calls `fs.ReadStream("", { fd: 0 })`.
2. Bun's internal stream path validation tries to resolve `""` against `process.cwd()`.
3. Libuv's `uv_cwd` fails with `ENOENT: process.cwd failed with error no such file or directory, the current working directory was likely removed without changing the working directory, uv_cwd`.
4. Bun outputs an error dump to stderr before the caller's catch block can intercept it.
5. In addition, the proxy remains running with a deleted working directory. When the dashboard queries `GET /api/update/check?tag=latest`, `spawnSync` for `npm view` fails because the child cannot inherit the deleted cwd, causing the GUI to report `latest_unavailable` ("Could not read the latest version from npm").

### Solution
1. Use `node:tty`'s `isatty(0)` and `isatty(1)` directly, avoiding allocating stream objects or touching `process.cwd()`.
2. At the earliest entry points (`bin/ocx.mjs` and `src/cli/index.ts`), catch broken `process.cwd()` and switch to `homedir()`, restoring a valid working directory for the process and all child processes.

## Verification

- Tested with PTY in an unlinked working directory: confirmed no `ENOENT (uv_cwd)` error occurs on startup.
- Verified `/api/update/check?tag=latest` correctly queries `npm view` and reports `already_latest` without `latest_unavailable`.
- Ran `bun test tests/update-notify.test.ts` (21 passed).
- Ran `bun test tests/startup-prompt.test.ts` (14 passed).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now starts more reliably when the current working directory is unavailable by falling back to the user’s home directory.
  * Interactive prompts and update notifications now appear only in supported terminal sessions, preventing unexpected output in non-interactive environments.
  * Terminal checks safely handle detection errors without interrupting startup or command execution.
* **Tests**
  * Added coverage for running update checks when the working directory no longer exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->