### PR TITLE
fix(proxy): accept dotted ns.name tool echo alongside ns__name

### DIFF
--- a/src/server/responses-undeclared-tool-guard.ts
+++ b/src/server/responses-undeclared-tool-guard.ts
@@ -1,5 +1,6 @@
 import {
   CODE_MODE_EXEC_TOOL_NAME,
+  dottedToolName,
   namespacedToolName,
   normalizeDeclaredToolName,
 } from "../types";
@@ -93,6 +94,10 @@ function addWireToolName(names: Set<string>, tool: unknown, namespace?: string):
     return;
   }
   names.add(namespacedToolName(namespace, name));
+  // Some routed providers echo the flattened wire name with a dot (`ns.name`, observed with
+  // muse-spark via opencode-go) instead of `ns__name`. It is the same tool identity, so register
+  // the dotted spelling too �w^~)�t mirroring `toolChoiceAliases` (#3402).
+  names.add(dottedToolName(namespace, name));
   // `exec` is the one name that also switches on nested-helper normalization, so a bare alias
   // for a namespaced MCP tool would silently authorize `exec_command`/`shell_command`/
   // `apply_patch` the request never declared. Every other inner name keeps the bare alias.
@@ -293,7 +298,10 @@ function undeclaredNameInItem(
   if (typeof item.namespace === "string") {
     // Namespaced calls are matched by their full wire name only — never legacy-normalize
     // them, or an undeclared namespaced `exec_command` could slip through as bare `exec`.
+    // Both flattened spellings (`ns__name` and the dotted `ns.name` some providers echo,
+    // #3402) name the same tool identity.
     if (declared.has(namespacedToolName(item.namespace, name))) return undefined;
+    if (declared.has(dottedToolName(item.namespace, name))) return undefined;
     return name;
   }
   const effectiveName = normalizeDeclaredToolName(name, declared);

--- a/src/server/responses-undeclared-tool-guard.ts
+++ b/src/server/responses-undeclared-tool-guard.ts
@@ -75,16 +75,40 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function addWireToolName(names: Set<string>, tool: unknown, namespace?: string): void {
-  if (!isPlainObject(tool)) return;
+/**
+ * A dotted spelling is a safe alias only when it cannot ALSO be read as some other identity's
+ * canonical `ns__name`.
+ *
+ * `{namespace: "x__y", name: "z"}` produces the dotted spelling "x__y.z", which is exactly the
+ * canonical wire name of `{namespace: "x", name: "y.z"}`. If only the latter is declared, an
+ * echoed call for the former would still find "x__y.z" in the declared set and be authorized as
+ * a tool the caller never granted. Requiring both halves to be free of the `__` separator keeps
+ * a dotted alias from ever impersonating a canonical name.
+ */
+function dottedAliasIsUnambiguous(namespace: string, name: string): boolean {
+  return !namespace.includes("__") && !name.includes("__");
+}
+
+function wireToolInnerName(tool: unknown): string | undefined {
+  if (!isPlainObject(tool)) return undefined;
   const nestedFunction = tool.type === "function" && isPlainObject(tool.function)
     ? tool.function
     : undefined;
-  const name = typeof tool.name === "string" && tool.name.length > 0
+  return typeof tool.name === "string" && tool.name.length > 0
     ? tool.name
     : typeof nestedFunction?.name === "string" && nestedFunction.name.length > 0
       ? nestedFunction.name
       : undefined;
+}
+
+function addWireToolName(
+  names: Set<string>,
+  tool: unknown,
+  namespace?: string,
+  ambiguousDottedAliases?: ReadonlySet<string>,
+): void {
+  if (!isPlainObject(tool)) return;
+  const name = wireToolInnerName(tool);
   if (!name) return;
   // Codex routes MCP calls by an explicit `namespace` field, so the same tool is reachable
   // as a bare inner name or as the flattened form; accept both rather than guess which
@@ -96,8 +120,15 @@ function addWireToolName(names: Set<string>, tool: unknown, namespace?: string):
   names.add(namespacedToolName(namespace, name));
   // Some routed providers echo the flattened wire name with a dot (`ns.name`, observed with
   // muse-spark via opencode-go) instead of `ns__name`. It is the same tool identity, so register
-  // the dotted spelling too �w^~)�t mirroring `toolChoiceAliases` (#3402).
-  names.add(dottedToolName(namespace, name));
+  // the dotted spelling too, mirroring `toolChoiceAliases` (#3402) -- but only while that
+  // spelling names exactly one declared tool. Dots are legal inside both a namespace and a
+  // name, so two distinct identities can flatten onto one dotted alias; accepting it then would
+  // authorize a call the caller never declared under that identity. Ambiguous aliases fall back
+  // to the unambiguous `ns__name` form.
+  const dotted = dottedToolName(namespace, name);
+  if (dottedAliasIsUnambiguous(namespace, name) && !ambiguousDottedAliases?.has(dotted)) {
+    names.add(dotted);
+  }
   // `exec` is the one name that also switches on nested-helper normalization, so a bare alias
   // for a namespaced MCP tool would silently authorize `exec_command`/`shell_command`/
   // `apply_patch` the request never declared. Every other inner name keeps the bare alias.
@@ -123,17 +154,63 @@ export function currentTurnWireToolCatalogBody(
   return { ...body, input: body.input.slice(start) };
 }
 
-function addWireToolSpecs(names: Set<string>, specs: unknown): void {
+function addWireToolSpecs(
+  names: Set<string>,
+  specs: unknown,
+  ambiguousDottedAliases?: ReadonlySet<string>,
+): void {
   if (!Array.isArray(specs)) return;
   for (const spec of specs) {
     if (!isPlainObject(spec)) continue;
     if (spec.type === "namespace" && Array.isArray(spec.tools)) {
       const namespace = typeof spec.name === "string" ? spec.name : undefined;
-      for (const inner of spec.tools) addWireToolName(names, inner, namespace);
+      for (const inner of spec.tools) addWireToolName(names, inner, namespace, ambiguousDottedAliases);
       continue;
     }
-    addWireToolName(names, spec);
+    addWireToolName(names, spec, undefined, ambiguousDottedAliases);
   }
+}
+
+/**
+ * Dotted aliases that more than one declared identity would claim, plus dotted aliases that
+ * collide with a canonical or bare declared name.
+ *
+ * Resolved over the WHOLE catalog before any name is registered, so which identity "wins" can
+ * never depend on declaration order -- an order the caller controls.
+ */
+function collectAmbiguousDottedAliases(specGroups: readonly unknown[]): Set<string> {
+  const owners = new Map<string, string | null>();
+  const claim = (alias: string, identity: string): void => {
+    const owner = owners.get(alias);
+    if (owner === undefined) owners.set(alias, identity);
+    else if (owner !== identity) owners.set(alias, null);
+  };
+  for (const specs of specGroups) {
+    if (!Array.isArray(specs)) continue;
+    for (const spec of specs) {
+      if (!isPlainObject(spec)) continue;
+      if (spec.type === "namespace" && Array.isArray(spec.tools)) {
+        const namespace = typeof spec.name === "string" ? spec.name : undefined;
+        if (!namespace || namespace === BUILTIN_FUNCTIONS_NAMESPACE) continue;
+        for (const inner of spec.tools) {
+          const name = wireToolInnerName(inner);
+          if (!name) continue;
+          const identity = JSON.stringify([namespace, name]);
+          claim(dottedToolName(namespace, name), identity);
+          // A canonical or bare name already owned by a different identity poisons the dotted
+          // alias that would shadow it.
+          claim(namespacedToolName(namespace, name), identity);
+          claim(name, identity);
+        }
+        continue;
+      }
+      const name = wireToolInnerName(spec);
+      if (name) claim(name, JSON.stringify([undefined, name]));
+    }
+  }
+  const ambiguous = new Set<string>();
+  for (const [alias, owner] of owners) if (owner === null) ambiguous.add(alias);
+  return ambiguous;
 }
 
 /**
@@ -147,15 +224,17 @@ function addWireToolSpecs(names: Set<string>, specs: unknown): void {
 export function collectDeclaredWireToolNames(body: unknown): Set<string> {
   const names = new Set<string>();
   if (!isPlainObject(body)) return names;
-  addWireToolSpecs(names, body.tools);
+  const specGroups: unknown[] = [body.tools];
   if (Array.isArray(body.input)) {
     for (const item of body.input) {
       if (
         isPlainObject(item)
         && (item.type === "additional_tools" || item.type === "tool_search_output")
-      ) addWireToolSpecs(names, item.tools);
+      ) specGroups.push(item.tools);
     }
   }
+  const ambiguousDottedAliases = collectAmbiguousDottedAliases(specGroups);
+  for (const specs of specGroups) addWireToolSpecs(names, specs, ambiguousDottedAliases);
   return names;
 }
 
@@ -301,7 +380,12 @@ function undeclaredNameInItem(
     // Both flattened spellings (`ns__name` and the dotted `ns.name` some providers echo,
     // #3402) name the same tool identity.
     if (declared.has(namespacedToolName(item.namespace, name))) return undefined;
-    if (declared.has(dottedToolName(item.namespace, name))) return undefined;
+    // Only consult the dotted spelling when it cannot double as another identity's canonical
+    // name; otherwise a stranger's `ns__name` would authorize this call.
+    if (
+      dottedAliasIsUnambiguous(item.namespace, name)
+      && declared.has(dottedToolName(item.namespace, name))
+    ) return undefined;
     return name;
   }
   const effectiveName = normalizeDeclaredToolName(name, declared);

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -28,7 +28,7 @@ import {
 } from "../../combos";
 import { isInjectionDebugEnabled } from "../../lib/debug-settings";
 import { injectionDebugLog } from "../../lib/injection-debug-log";
-import { modelInList, namespacedToolName, toolChoiceToolPredicate } from "../../types";
+import { dottedToolName, modelInList, namespacedToolName, toolChoiceToolPredicate } from "../../types";
 import type { AdapterEvent, OcxConfig, OcxParsedRequest, OcxProviderConfig, OcxProviderContinuationState, OcxUsage } from "../../types";
 import {
   forceRefreshOAuthAccessSnapshot,
@@ -133,6 +133,14 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
     if (t.namespace) {
       budget?.chargeRetained(new TextEncoder().encode(JSON.stringify([wireName, t.namespace, t.name])).byteLength, { kind: "retained_collectors" });
       toolNsMap.set(wireName, { namespace: t.namespace, name: t.name, ...(t.freeform ? { freeform: true } : {}) });
+      // Dotted echo alias (`ns.name`, #3402): same tool identity as the flattened wire name,
+      // so a provider that echoes the dotted spelling still restores against this entry.
+      const dottedName = dottedToolName(t.namespace, t.name);
+      budget?.chargeRetained(new TextEncoder().encode(dottedName).byteLength, { kind: "retained_collectors" });
+      declaredToolNames.add(dottedName);
+      budget?.chargeRetained(new TextEncoder().encode(JSON.stringify([dottedName, t.namespace, t.name])).byteLength, { kind: "retained_collectors" });
+      toolNsMap.set(dottedName, { namespace: t.namespace, name: t.name, ...(t.freeform ? { freeform: true } : {}) });
+      if (t.parameters && typeof t.parameters === "object") toolParameterSchemas.set(dottedName, t.parameters);
     }
     if (t.freeform) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });

--- a/src/server/responses/collaboration.ts
+++ b/src/server/responses/collaboration.ts
@@ -122,6 +122,34 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
   const requestedTools = parsed.context.tools ?? [];
   const toolAllowed = toolChoiceToolPredicate(parsed.options.toolChoice, requestedTools);
   const authorizedTools = requestedTools.filter(toolAllowed);
+  // A dotted alias is only safe while it names ONE tool. Namespaces and names both come from
+  // the caller's tool catalog and may contain dots, so `{ns: "a", name: "b.c"}` and
+  // `{ns: "a.b", name: "c"}` flatten to the same "a.b.c". Registering both would let a dotted
+  // provider echo restore against whichever was inserted last, which is a dispatch decision made
+  // by declaration order. Resolve ownership across the whole catalog FIRST so the outcome does
+  // not depend on that order, then register only the aliases that stayed unambiguous.
+  const dottedAliasOwners = new Map<string, string | null>();
+  for (const t of authorizedTools) {
+    if (!t.namespace) continue;
+    const alias = dottedToolName(t.namespace, t.name);
+    const identity = JSON.stringify([t.namespace, t.name]);
+    const owner = dottedAliasOwners.get(alias);
+    if (owner === undefined) dottedAliasOwners.set(alias, identity);
+    else if (owner !== identity) dottedAliasOwners.set(alias, null);
+  }
+  // A dotted alias that shadows a canonical `ns__name` or a bare declaration is the same
+  // confusion wearing a different spelling, so those lose the alias too.
+  for (const t of authorizedTools) {
+    const canonical = namespacedToolName(t.namespace, t.name);
+    const owner = dottedAliasOwners.get(canonical);
+    if (owner !== undefined && owner !== JSON.stringify([t.namespace, t.name])) {
+      dottedAliasOwners.set(canonical, null);
+    }
+    const bare = dottedAliasOwners.get(t.name);
+    if (bare !== undefined && bare !== JSON.stringify([t.namespace, t.name])) {
+      dottedAliasOwners.set(t.name, null);
+    }
+  }
   for (const t of authorizedTools) {
     // Upstream output is untrusted: only restore calls for tools the caller authorized.
     const wireName = namespacedToolName(t.namespace, t.name);
@@ -136,11 +164,15 @@ export function buildToolBridgeMaps(parsed: OcxParsedRequest, budget?: Translato
       // Dotted echo alias (`ns.name`, #3402): same tool identity as the flattened wire name,
       // so a provider that echoes the dotted spelling still restores against this entry.
       const dottedName = dottedToolName(t.namespace, t.name);
-      budget?.chargeRetained(new TextEncoder().encode(dottedName).byteLength, { kind: "retained_collectors" });
-      declaredToolNames.add(dottedName);
-      budget?.chargeRetained(new TextEncoder().encode(JSON.stringify([dottedName, t.namespace, t.name])).byteLength, { kind: "retained_collectors" });
-      toolNsMap.set(dottedName, { namespace: t.namespace, name: t.name, ...(t.freeform ? { freeform: true } : {}) });
-      if (t.parameters && typeof t.parameters === "object") toolParameterSchemas.set(dottedName, t.parameters);
+      // Ambiguous aliases were resolved to null above; skipping them falls back to the
+      // unambiguous `ns__name` form, which every provider can still echo.
+      if (dottedAliasOwners.get(dottedName) !== null && dottedName !== wireName) {
+        budget?.chargeRetained(new TextEncoder().encode(dottedName).byteLength, { kind: "retained_collectors" });
+        declaredToolNames.add(dottedName);
+        budget?.chargeRetained(new TextEncoder().encode(JSON.stringify([dottedName, t.namespace, t.name])).byteLength, { kind: "retained_collectors" });
+        toolNsMap.set(dottedName, { namespace: t.namespace, name: t.name, ...(t.freeform ? { freeform: true } : {}) });
+        if (t.parameters && typeof t.parameters === "object") toolParameterSchemas.set(dottedName, t.parameters);
+      }
     }
     if (t.freeform) {
       budget?.chargeRetained(new TextEncoder().encode(t.name).byteLength, { kind: "retained_collectors" });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@
 export type { OcxTool, OcxToolChoice } from "./types/tools";
 export {
   CODE_MODE_EXEC_TOOL_NAME,
+  dottedToolName,
   namespacedToolName,
   normalizeDeclaredToolName,
   toolChoiceAliases,

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -32,6 +32,17 @@ export function namespacedToolName(namespace: string | undefined, name: string):
 }
 
 /**
+ * Dotted alias of a namespaced tool's wire name. Some routed providers (observed: muse-spark
+ * via opencode-go) echo a namespaced tool call as "<namespace>.<name>" instead of the flattened
+ * "<namespace>__<name>" form. It names the same tool identity+�u���T never a new grant"��y��y� so the
+ * undeclared-tool guard and the tool bridge maps accept it wherever the wire name is accepted
+ * (mirroring the second entry of `toolChoiceAliases`). See #3402.
+ */
+export function dottedToolName(namespace: string | undefined, name: string): string {
+  return namespace ? `${namespace}.${name}` : name;
+}
+
+/**
  * Codex unified-exec name normalization.
  *
  * Codex's code-mode shell tool is declared as `exec` (a freeform custom tool whose own
@@ -75,7 +86,7 @@ export function normalizeDeclaredToolName(
 
 export function toolChoiceAliases(tool: Pick<OcxTool, "namespace" | "name">): string[] {
   const wireName = namespacedToolName(tool.namespace, tool.name);
-  return tool.namespace ? [wireName, `${tool.namespace}.${tool.name}`] : [wireName];
+  return tool.namespace ? [wireName, dottedToolName(tool.namespace, tool.name)] : [wireName];
 }
 
 function sameToolIdentity(

--- a/tests/responses-parser.test.ts
+++ b/tests/responses-parser.test.ts
@@ -187,15 +187,16 @@ describe("Responses parser", () => {
     let maps = buildToolBridgeMaps(parsed);
     expect([...maps.toolNsMap]).toEqual([
       ["mcp__tools__safe", { namespace: "mcp__tools", name: "safe" }],
+      ["mcp__tools.safe", { namespace: "mcp__tools", name: "safe" }],
     ]);
-    expect([...maps.declaredToolNames]).toEqual(["mcp__tools__safe", "apply_patch"]);
+    expect([...maps.declaredToolNames]).toEqual(["mcp__tools__safe", "mcp__tools.safe", "apply_patch"]);
     expect([...maps.freeformToolNames]).toEqual(["apply_patch"]);
     expect([...maps.toolSearchToolNames]).toEqual([]);
 
     parsed.options.toolChoice = { allowedTools: ["mcp__tools__safe"], mode: "required" };
     maps = buildToolBridgeMaps(parsed);
-    expect([...maps.toolNsMap.keys()]).toEqual(["mcp__tools__safe"]);
-    expect([...maps.declaredToolNames]).toEqual(["mcp__tools__safe"]);
+    expect([...maps.toolNsMap.keys()]).toEqual(["mcp__tools__safe", "mcp__tools.safe"]);
+    expect([...maps.declaredToolNames]).toEqual(["mcp__tools__safe", "mcp__tools.safe"]);
     expect([...maps.freeformToolNames]).toEqual([]);
 
     parsed.options.toolChoice = { name: "tool_search" };
@@ -232,9 +233,10 @@ describe("Responses parser", () => {
     let maps = buildToolBridgeMaps(parsed);
     expect([...maps.toolNsMap]).toEqual([
       ["mcp__functions__exec", { namespace: "mcp__functions", name: "exec", freeform: true }],
+      ["mcp__functions.exec", { namespace: "mcp__functions", name: "exec", freeform: true }],
       ["exec", { namespace: "mcp__functions", name: "exec", freeform: true }],
     ]);
-    expect([...maps.declaredToolNames]).toEqual(["mcp__functions__exec", "exec"]);
+    expect([...maps.declaredToolNames]).toEqual(["mcp__functions__exec", "mcp__functions.exec", "exec"]);
     expect([...maps.freeformToolNames]).toEqual(["exec"]);
 
     const bridged = buildResponseJSON([
@@ -254,7 +256,7 @@ describe("Responses parser", () => {
 
     parsed.options.toolChoice = { name: "exec" };
     maps = buildToolBridgeMaps(parsed);
-    expect([...maps.toolNsMap.keys()]).toEqual(["mcp__functions__exec", "exec"]);
+    expect([...maps.toolNsMap.keys()]).toEqual(["mcp__functions__exec", "mcp__functions.exec", "exec"]);
 
     expect(() => parseRequest({
       model: "claude-opus-5",

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -108,6 +108,77 @@ describe("collectDeclaredWireToolNames", () => {
     expect([...names]).toEqual(["mcp__exec", "mcp.exec"]);
   });
 
+  test("withholds a dotted alias two declared identities would both claim", () => {
+    // Dots are legal in a namespace and in a name, so `{a, b.c}` and `{a.b, c}` flatten onto
+    // the same "a.b.c". Accepting it would authorize whichever identity happened to be
+    // registered last, so neither gets the alias and both keep their unambiguous `ns__name`.
+    const names = collectDeclaredWireToolNames({
+      tools: [
+        { type: "namespace", name: "a", tools: [{ type: "function", name: "b.c" }] },
+        { type: "namespace", name: "a.b", tools: [{ type: "function", name: "c" }] },
+      ],
+    });
+
+    expect(names.has("a.b.c")).toBe(false);
+    expect(names.has("a__b.c")).toBe(true);
+    expect(names.has("a.b__c")).toBe(true);
+  });
+
+  test("suppresses the ambiguous dotted alias in either declaration order", () => {
+    // The caller controls declaration order, so the outcome must not: resolve ownership across
+    // the whole catalog before registering, or the "winner" is attacker-chosen.
+    const forward = collectDeclaredWireToolNames({
+      tools: [
+        { type: "namespace", name: "a", tools: [{ type: "function", name: "b.c" }] },
+        { type: "namespace", name: "a.b", tools: [{ type: "function", name: "c" }] },
+      ],
+    });
+    const reverse = collectDeclaredWireToolNames({
+      tools: [
+        { type: "namespace", name: "a.b", tools: [{ type: "function", name: "c" }] },
+        { type: "namespace", name: "a", tools: [{ type: "function", name: "b.c" }] },
+      ],
+    });
+
+    expect([...forward].sort()).toEqual([...reverse].sort());
+    expect(forward.has("a.b.c")).toBe(false);
+  });
+
+  test("a dotted spelling never authorizes another identity's canonical wire name", () => {
+    // "x__y.z" is the canonical name of {x, "y.z"} AND the dotted spelling of {"x__y", z}.
+    // Only the first is declared, so a call for the second must still be refused: otherwise a
+    // stranger's canonical name silently grants a tool the caller never declared.
+    const declared = collectDeclaredWireToolNames({
+      tools: [{ type: "namespace", name: "x", tools: [{ type: "function", name: "y.z" }] }],
+    });
+
+    expect(declared.has("x__y.z")).toBe(true);
+    expect(
+      undeclaredToolCallNameInResponse({
+        output: [{ type: "function_call", namespace: "x__y", name: "z", call_id: "c1" }],
+      }, declared),
+    ).toBe("z");
+    // The identity that really owns that canonical name is still accepted.
+    expect(
+      undeclaredToolCallNameInResponse({
+        output: [{ type: "function_call", namespace: "x", name: "y.z", call_id: "c2" }],
+      }, declared),
+    ).toBeUndefined();
+  });
+
+  test("keeps a uniquely owned dotted alias, which is the echo #3402 reported", () => {
+    // The fix is scoped to ambiguity: an unambiguous dotted echo must still be restored, or the
+    // defect this PR exists to fix comes back.
+    const names = collectDeclaredWireToolNames({
+      tools: [
+        { type: "namespace", name: "default", tools: [{ type: "custom", name: "apply_patch" }] },
+      ],
+    });
+
+    expect(names.has("default.apply_patch")).toBe(true);
+    expect(names.has("default__apply_patch")).toBe(true);
+  });
+
   test("keeps exec bare in Codex's reserved functions namespace", () => {
     // Codex groups ordinary top-level tools here; this is not an MCP namespace and the parser
     // deliberately lowers its children without a namespace.

--- a/tests/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses-undeclared-tool-guard.test.ts
@@ -90,9 +90,10 @@ describe("collectDeclaredWireToolNames", () => {
       ],
     });
 
-    // Namespaced MCP tools are reachable under either coordinate system, so both are accepted.
+    // Namespaced MCP tools are reachable under every coordinate system (`ns__name`, the bare
+    // name, and the dotted `ns.name` some providers echo), so all are accepted.
     expect([...names].sort()).toEqual(
-      ["apply_patch", "create_issue", "exec", "linear__create_issue"],
+      ["apply_patch", "create_issue", "exec", "linear.create_issue", "linear__create_issue"],
     );
   });
 
@@ -104,7 +105,7 @@ describe("collectDeclaredWireToolNames", () => {
       tools: [{ type: "namespace", name: "mcp", tools: [{ type: "function", name: "exec" }] }],
     });
 
-    expect([...names]).toEqual(["mcp__exec"]);
+    expect([...names]).toEqual(["mcp__exec", "mcp.exec"]);
   });
 
   test("keeps exec bare in Codex's reserved functions namespace", () => {
@@ -129,7 +130,7 @@ describe("collectDeclaredWireToolNames", () => {
       ],
     });
 
-    expect([...names].sort()).toEqual(["exec", "mcp__exec"]);
+    expect([...names].sort()).toEqual(["exec", "mcp.exec", "mcp__exec"]);
   });
 
   test("reads tools carried inside input as an additional_tools item", () => {
@@ -332,6 +333,36 @@ describe("undeclared tool call guard", () => {
     });
 
     expect(await relay(upstream, ["linear__create_issue"])).toBe(upstream);
+  });
+
+  test("accepts a namespaced call echoed in dotted form", async () => {
+    // muse-spark via opencode-go echoes `default.apply_patch` for the declared
+    // `default__apply_patch` tool (#3402). The dotted spelling is the same tool identity.
+    const outbound = {
+      tools: [{ type: "namespace", name: "default", tools: [{ type: "custom", name: "apply_patch" }] }],
+    };
+    const upstream = sse("response.output_item.added", {
+      output_index: 0,
+      item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", name: "default.apply_patch", input: "" },
+    });
+
+    expect(await relay(upstream, collectDeclaredWireToolNames(outbound))).toBe(upstream);
+  });
+
+  test("accepts an explicit-namespace call when only the dotted spelling was declared", async () => {
+    const upstream = sse("response.output_item.added", {
+      output_index: 0,
+      item: {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_1",
+        name: "create_issue",
+        namespace: "linear",
+        arguments: "{}",
+      },
+    });
+
+    expect(await relay(upstream, ["linear.create_issue"])).toBe(upstream);
   });
 
   test("never blocks apply_patch when the request really declared it", async () => {


### PR DESCRIPTION
Closes #3402.

## Summary

A Codex subagent on `opencode-go/muse-spark-1.3-contributor` dies on any file-write turn with `routed provider emitted undeclared client tool "default.apply_patch"`. muse-spark echoes a namespaced tool call in dotted form (`default.apply_patch`) while the proxy guard/bridge only recognize the flattened form (`default__apply_patch`), so a legitimate declared call is fail-closed. Deterministic; retry does not help.

## Changes

- `src/types/tools.ts`: new `dottedToolName()` helper (dotted spelling of `namespacedToolName`); `toolChoiceAliases()` now uses it so there is a single alias rule.
- `src/types.ts`: re-export `dottedToolName` from the barrel.
- `src/server/responses-undeclared-tool-guard.ts`: `addWireToolName()` registers the dotted alias alongside `ns__name`; the explicit-namespace check in `undeclaredNameInItem()` accepts both spellings.
- `src/server/responses/collaboration.ts`: `buildToolBridgeMaps()` registers the dotted key in `declaredToolNames`/`toolNsMap` (+ parameter schema) so a dotted echo restores against the same entry.
- Tests: 2 new regression tests in `tests/responses-undeclared-tool-guard.test.ts` (dotted echo end-to-end over `collectDeclaredWireToolNames`; explicit-namespace call against a dotted-only declaration); updated exact-set expectations in the guard + parser tests.

## Safety note

The dotted spelling names the same tool identity+�u���T never a new grant. `normalizeDeclaredToolName()` is untouched: the bare-`exec` withholding for namespaced `exec` (and the no-legacy-normalize rule for namespaced calls) behaves exactly as before; only the additional same-identity spelling is accepted. This mirrors the pre-existing second entry of `toolChoiceAliases`.

## Evidence

- `bun test tests/responses-undeclared-tool-guard.test.ts` �w^~)�t 78 pass, 0 fail (incl. the 2 new tests).
- `bun test tests/responses-parser.test.ts tests/bridge-legacy-shell-normalization.test.ts tests/codex-tool-mode.test.ts tests/responses-undeclared-tool-guard.test.ts`"��y��y� 138 pass, 0 fail.
- `bun run typecheck` (`tsc --noEmit`) �w^~)�t clean.
- `bun run privacy:scan`"��y��y� passed.
- Full `bun test` was still running locally when this PR was opened (integration tests are slow on this machine); deferring to CI for the full gate.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with routed tool providers that return namespaced tools using dotted names, such as `namespace.tool`.
  - Namespaced tools now resolve consistently whether represented with dotted or double-underscore notation.
  - Tool selection and validation recognize both naming formats while avoiding ambiguous or conflicting aliases.

- **Tests**
  - Added coverage for dotted names in tool registration, selection, ambiguity handling, and relay validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
