### PR TITLE
fix(codex): list gpt-6-astra unconditionally so the request reaches upstream

### DIFF
--- a/src/codex/catalog/metadata.ts
+++ b/src/codex/catalog/metadata.ts
@@ -66,6 +66,11 @@ export {
 export const DOCUMENTED_NATIVE_OPENAI_ADDITIONS = [
   "gpt-5.3-codex-spark",
   "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+  // Preemptive leak-based registration: no shipped codex-rs catalog carries it, so without this
+  // entry an install WITH a live catalog would drop the row that native-models.ts deliberately
+  // ungated. Listing it here keeps the bare slug reachable so a request actually dispatches and
+  // reports the upstream status.
+  NATIVE_GPT6_ASTRA_MODEL,
 ];
 
 export function configuredNativeAliasSlugs(

--- a/src/codex/catalog/native-models.ts
+++ b/src/codex/catalog/native-models.ts
@@ -8,6 +8,14 @@ export const NATIVE_DAYBREAK_BLUE_MODEL = "gpt-daybreak-blue-latest";
  * Registered preemptively so an entitled account can route it the moment it ships, before any
  * codex-rs catalog carries it. Unlike Daybreak it is NOT wire-normalized to a serving id —
  * the leaked slug IS the wire id.
+ *
+ * Deliberately NOT account-gated (owner decision, 2026-09-04). Entitlement gating hides a slug
+ * until an authenticated `/models` roster carries it, and no roster carries this one yet, so
+ * gating made the row invisible on every install — including the accounts meant to try it. The
+ * row is listed unconditionally instead: selecting it dispatches `gpt-6-astra` upstream and
+ * surfaces the real upstream status (404 while the slug is unreleased) rather than silently
+ * omitting the model. Add it back to `ACCOUNT_GATED_NATIVE_OPENAI_MODELS` once an entitled
+ * roster actually reports it and per-account availability becomes the honest answer.
  */
 export const NATIVE_GPT6_ASTRA_MODEL = "gpt-6-astra";
 
@@ -17,7 +25,6 @@ export const ACCOUNT_GATED_NATIVE_OPENAI_MODELS: ReadonlySet<string> = new Set([
   "gpt-5.6-terra",
   "gpt-5.6-luna",
   NATIVE_DAYBREAK_BLUE_MODEL,
-  NATIVE_GPT6_ASTRA_MODEL,
 ]);
 
 /**

--- a/tests/codex-catalog.test.ts
+++ b/tests/codex-catalog.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { codexAccountGatedCanonicalWireModel } from "../src/server/responses/core";
+import { ACCOUNT_GATED_NATIVE_OPENAI_MODELS } from "../src/codex/catalog/native-models";
 import { applyNativeVisibility, augmentRoutedModelsWithMetadata, augmentRoutedModelsWithRegistryOpenAiApiRows, buildCatalogEntries, buildComboCatalogOmission, catalogModelSlug, clampCatalogModelsToCodexSupport, clampEntryToCodexSupportedEfforts, clampedDefaultEffort, CODEX_ACCOUNT_BOUND_CATALOG_KIND, CODEX_NATIVE_ALIAS_CATALOG_KIND, comboCatalogOmissionReason, deriveComboCatalogModel, exactComboCatalogSlugs, filterCatalogVisibleModels, filterSupportedNativeSlugs, gatherRoutedModels as gatherRoutedModelsDirect, isDatedVariantId, isMediaGenerationModelId, loadBundledCodexCatalog, materializeBundledCodexCatalog, mergeCatalogEntriesForSync, NATIVE_DAYBREAK_BLUE_MODEL, NATIVE_GPT6_ASTRA_MODEL, NATIVE_OPENAI_MODELS, nativeDefaultReasoningEffort, nativeInputModalities, nativeOpenAiCapabilitySourceSlug, nativeOpenAiContextWindow, nativeReasoningEfforts, normalizeRoutedCatalogEntry, resetCatalogRuntimeStateForTests, resetOpenAiApiCatalogWarningStateForTests, resolveComboCatalogMember, shouldExposeRoutedModel, upstreamNativeEntry } from "../src/codex/catalog";
 import { applyProviderConfigHints, mergeConfiguredModelsIntoLiveCatalog } from "../src/codex/catalog/provider-fetch";
 import {
@@ -3354,11 +3355,13 @@ describe("Codex catalog routed normalization", () => {
     expect(projected.some(entry => entry.slug === "daybreak-blue-latest")).toBe(false);
   });
 
-  test("gpt-6-astra is registered gated with Sol capabilities and no wire normalization", () => {
-    // Leak-based preemptive registration (2026-09-03): the slug must be a gated native with
-    // Sol's capability shape so an entitled account routes it the moment it ships, and it must
-    // go to the wire AS gpt-6-astra (it is NOT a Daybreak-style serving alias).
+  test("gpt-6-astra is registered ungated with Sol capabilities and no wire normalization", () => {
+    // Leak-based preemptive registration (2026-09-03), ungated 2026-09-04: the slug carries
+    // Sol's capability shape, is NOT entitlement-gated (no roster reports it yet, and gating
+    // therefore hid it everywhere), and goes to the wire AS gpt-6-astra (it is NOT a
+    // Daybreak-style serving alias), so a selection surfaces the real upstream status.
     expect(NATIVE_GPT6_ASTRA_MODEL).toBe("gpt-6-astra");
+    expect(ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has(NATIVE_GPT6_ASTRA_MODEL)).toBe(false);
     expect(nativeOpenAiCapabilitySourceSlug(NATIVE_GPT6_ASTRA_MODEL)).toBe("gpt-5.6-sol");
     expect(nativeOpenAiContextWindow(NATIVE_GPT6_ASTRA_MODEL)).toBe(272_000);
     expect(nativeReasoningEfforts(NATIVE_GPT6_ASTRA_MODEL))

--- a/tests/native-model-toggle.test.ts
+++ b/tests/native-model-toggle.test.ts
@@ -105,6 +105,18 @@ describe("native GPT model toggles (bare slugs in disabledModels)", () => {
       .toContain("gpt-daybreak-blue-latest");
   });
 
+  test("gpt-6-astra lists without any roster so the request reaches upstream", () => {
+    // Owner decision (2026-09-04): the leaked slug appears on every install rather than waiting
+    // for an entitlement roster that does not carry it yet. With the cache reset there is no
+    // confirmed account at all, and the row must still be present and selectable.
+    resetCodexModelEntitlementCacheForTests();
+    expect(ACCOUNT_GATED_NATIVE_OPENAI_MODELS.has("gpt-6-astra")).toBe(false);
+    expect(nativeModelRows({ disabledModels: [] }).map(row => row.slug)).toContain("gpt-6-astra");
+    expect(visibleNativeSlugs({ disabledModels: [] })).toContain("gpt-6-astra");
+    // The user visibility lever still owns hiding it; only entitlement gating was removed.
+    expect(visibleNativeSlugs({ disabledModels: ["gpt-6-astra"] })).not.toContain("gpt-6-astra");
+  });
+
   test("Direct bare rows use only main entitlement while Pool may use any eligible account", () => {
     seedCodexModelEntitlementsForTests("pool-a", ["gpt-daybreak-blue-latest"]);
     const direct = makeConfig({


### PR DESCRIPTION
## Summary

- List `gpt-6-astra` unconditionally instead of hiding it behind account entitlement.
- The slug is a preemptive leak-based registration, so no authenticated `/models` roster reports it yet. Entitlement gating therefore filtered it out of the Codex catalog, `/v1/models`, the dashboard rows and the desktop projection on every install, including the accounts meant to try it.
- Remove it from `ACCOUNT_GATED_NATIVE_OPENAI_MODELS` and add it to `DOCUMENTED_NATIVE_OPENAI_ADDITIONS` so installs that do have a live codex-rs catalog keep the row as well.
- Selecting it now dispatches `gpt-6-astra` upstream and surfaces the real upstream status rather than silently omitting the model. `disabledModels` remains the user visibility lever.

## Verification

- `bun test tests/native-model-toggle.test.ts tests/codex-catalog.test.ts` — 303 pass, 0 fail.
- `bun test tests/codex-catalog-sync-hardening.test.ts tests/codex-model-entitlements.test.ts tests/model-visibility-management-api.test.ts tests/vision-reasoning-contract.test.ts tests/claude-desktop-native-context.test.ts` — 90 pass, 0 fail.
- `bun run typecheck` — clean.
- Live proxy on port 10100 after `ocx service`: `/v1/models` now lists `gpt-6-astra`, and a chat completion against it reaches the Codex credential path instead of being filtered out of the catalog.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-6 Astra to the available native model catalog.
  * GPT-6 Astra is now listed without account entitlement gating and can be dispatched using its native model identifier.
  * Existing disabled-model settings continue to hide GPT-6 Astra when configured.

* **Tests**
  * Added coverage verifying GPT-6 Astra visibility, native capabilities, identifier handling, and disabled-model behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->