### PR TITLE
fix(codex): let the 1M opt-in raise gpt-6-astra to its own ceiling

### DIFF
--- a/src/codex/catalog/metadata.ts
+++ b/src/codex/catalog/metadata.ts
@@ -265,13 +265,36 @@ export function nativeContextLimits(
 }
 
 /** Apply the user levers to an authoritative value. */
+/**
+ * The ceiling a native slug may be RAISED to by a user lever, or undefined when it has no
+ * separate long window.
+ *
+ * This is what makes the dashboard's 1M opt-in work: without an opt-in ceiling a lever can only
+ * ever narrow the advertised window, so the toggle would appear to do nothing. The GPT-5.6 family
+ * shares one measured ceiling; a self-described native carries its own in
+ * `NATIVE_OPENAI_CONTEXT_OVERRIDES.maxContextWindow` (`gpt-6-astra` ships 872,000 against a
+ * 272,000 default), and reading it per-slug is what keeps the toggle honest for a model whose
+ * ceiling is not the family's.
+ */
+function longWindowOptInCeiling(slug: string): number | undefined {
+  if (NATIVE_GPT56_FAMILY.has(slug)) return NATIVE_GPT56_MAX_INPUT_TOKENS;
+  const override = NATIVE_OPENAI_CONTEXT_OVERRIDES[slug];
+  const defaultWindow = positiveInt(override?.contextWindow);
+  const longWindow = positiveInt(override?.maxContextWindow);
+  if (defaultWindow === undefined || longWindow === undefined || longWindow <= defaultWindow) {
+    return undefined;
+  }
+  return longWindow;
+}
+
 function narrowToLimits(raw: number | undefined, slug: string, input: NativeContextLimitsInput): number | undefined {
   if (raw === undefined) return undefined;
   const limits = asLimits(input);
   const overlay = positiveInt(limits.modelWindows?.[slug]) ?? positiveInt(limits.providerWindow);
   const cap = positiveInt(limits.cap);
-  if (NATIVE_GPT56_FAMILY.has(slug)) {
-    const ceiling = NATIVE_GPT56_MAX_INPUT_TOKENS;
+  const optInCeiling = longWindowOptInCeiling(slug);
+  if (optInCeiling !== undefined) {
+    const ceiling = optInCeiling;
     const chosen = overlay ?? cap ?? raw;
     const window = Math.min(chosen, ceiling);
     return overlay !== undefined && cap !== undefined ? Math.min(window, cap) : window;

--- a/tests/native-model-toggle.test.ts
+++ b/tests/native-model-toggle.test.ts
@@ -25,7 +25,7 @@ import {
 } from "../src/codex/catalog";
 import { handleManagementAPI } from "../src/server/management-api";
 import { applyMultiAgentMode, applyNativeOpenAiContextOverride } from "../src/codex/catalog/parsing";
-import { NATIVE_GPT56_CONTEXT_WINDOW, NATIVE_GPT56_OPT_IN_CONTEXT_WINDOW, nativeOpenAiContextWindow } from "../src/codex/catalog";
+import { NATIVE_GPT56_CONTEXT_WINDOW, NATIVE_GPT56_OPT_IN_CONTEXT_WINDOW, nativeOpenAiContextTier, nativeOpenAiContextWindow } from "../src/codex/catalog";
 import type { OcxConfig } from "../src/types";
 import { ACCOUNT_GATED_NATIVE_OPENAI_MODELS } from "../src/codex/catalog/native-models";
 import {
@@ -115,6 +115,25 @@ describe("native GPT model toggles (bare slugs in disabledModels)", () => {
     expect(visibleNativeSlugs({ disabledModels: [] })).toContain("gpt-6-astra");
     // The user visibility lever still owns hiding it; only entitlement gating was removed.
     expect(visibleNativeSlugs({ disabledModels: ["gpt-6-astra"] })).not.toContain("gpt-6-astra");
+  });
+
+  test("the 1M opt-in raises gpt-6-astra to its own 872k ceiling, not the family's 922k", () => {
+    // The dashboard's native 1M toggle writes providerContextCaps.openai = 922_000 for the whole
+    // group. Raising a window only happens for slugs that HAVE an opt-in ceiling, which used to
+    // mean "member of NATIVE_GPT56_FAMILY". Astra ships its own 272k/872k pair and is not in that
+    // family, so the toggle moved every other native and left this one pinned at 272k.
+    const optIn = { cap: NATIVE_GPT56_OPT_IN_CONTEXT_WINDOW } as const;
+
+    expect(nativeOpenAiContextWindow("gpt-6-astra")).toBe(272_000);
+    // Raised to the model's OWN ceiling: the 922k lever must not advertise 922k on a 872k model.
+    expect(nativeOpenAiContextWindow("gpt-6-astra", optIn)).toBe(872_000);
+    // The family keeps its measured ceiling, so the shared lever is not degraded for anyone else.
+    expect(nativeOpenAiContextWindow("gpt-5.6-sol", optIn)).toBe(922_000);
+
+    // The tier pair is availability metadata and stays put either way — it is what told us the
+    // window SHOULD have moved while the window itself did not.
+    expect(nativeOpenAiContextTier("gpt-6-astra", optIn))
+      .toEqual({ defaultWindow: 272_000, longWindow: 872_000 });
   });
 
   test("Direct bare rows use only main entitlement while Pool may use any eligible account", () => {


### PR DESCRIPTION
## Summary

The dashboard's native 1M opt-in had no effect on `gpt-6-astra`: the toggle raised every other native model's window and left Astra pinned at 272k.

The toggle writes `providerContextCaps.openai = 922_000` for the whole native group. `narrowToLimits` only ever *raised* a window for members of `NATIVE_GPT56_FAMILY` — for everything else a cap can only narrow. Astra was removed from that family so it would stop inheriting the measured 922k clamp (its real ceiling is 872k), and that removal silently took the opt-in path with it.

The fix reads the opt-in ceiling per slug rather than keying it on family membership. The GPT-5.6 family keeps its measured 922k; a self-described native uses its own `maxContextWindow`. So the shared 922k lever raises Astra to **872k** — its actual ceiling — instead of advertising a window the model does not have.

## Verification

- Live with the toggle on (`providerContextCaps.openai = 922000`), `/v1/models` reports `922000` for `gpt-5.6-sol` and `872000` for `gpt-6-astra`. Before the fix Astra reported `272000`.
- The on-disk Codex catalog agrees: `gpt-6-astra` writes `context_window: 872000`.
- New regression test asserts the raise, that the family ceiling is undisturbed, and that the tier pair stays `{272000, 872000}`.
- `bun test` on the catalog, toggle and desktop-context suites — 306 pass / 0 fail.
- `bun run test:changed` — 10430 pass / 0 fail across 556 files.
- `bun run typecheck` — exit 0.

No GUI change: the toggle already sent the right lever, the server-side resolver ignored it.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved long-context opt-in handling for supported native models.
  - Models with model-specific context limits now use their correct maximum window instead of sharing another model family’s limit.
  - Updated context-window tier information to accurately reflect default and expanded limits.

- **Bug Fixes**
  - Corrected expanded context behavior for `gpt-6-astra`, increasing its opt-in limit to 872,000 tokens rather than applying an unrelated 922,000-token ceiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->