### PR TITLE
fix(responses): preserve outputs missing call ids

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -919,7 +919,11 @@ function isRepairableToolOutput(output: unknown): output is string | Record<stri
     if (part.type === "refusal") return typeof part.refusal === "string";
     if (part.type === "encrypted_content") return typeof part.encrypted_content === "string";
     if (part.type !== "input_image") return false;
-    const validSource = typeof part.image_url === "string" || typeof part.file_id === "string";
+    const hasImageUrl = typeof part.image_url === "string";
+    const hasFileId = typeof part.file_id === "string";
+    const validSource = (hasImageUrl || hasFileId)
+      && (part.image_url === undefined || hasImageUrl)
+      && (part.file_id === undefined || hasFileId);
     const validDetail = part.detail === undefined
       || (typeof part.detail === "string"
         && ["auto", "low", "high", "original"].includes(part.detail));

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -912,7 +912,8 @@ function isRepairableToolOutput(output: unknown): output is string | Record<stri
   if (!Array.isArray(output)) return false;
   return output.every(part => {
     if (!isPlainObject(part)) return false;
-    if (["output_text", "text", "input_text"].includes(String(part.type))) {
+    if (typeof part.type !== "string") return false;
+    if (["output_text", "text", "input_text"].includes(part.type)) {
       return typeof part.text === "string";
     }
     if (part.type === "refusal") return typeof part.refusal === "string";
@@ -920,7 +921,8 @@ function isRepairableToolOutput(output: unknown): output is string | Record<stri
     if (part.type !== "input_image") return false;
     const validSource = typeof part.image_url === "string" || typeof part.file_id === "string";
     const validDetail = part.detail === undefined
-      || ["auto", "low", "high", "original"].includes(String(part.detail));
+      || (typeof part.detail === "string"
+        && ["auto", "low", "high", "original"].includes(part.detail));
     return validSource && validDetail;
   });
 }

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -919,11 +919,15 @@ function isRepairableToolOutput(output: unknown): output is string | Record<stri
     if (part.type === "refusal") return typeof part.refusal === "string";
     if (part.type === "encrypted_content") return typeof part.encrypted_content === "string";
     if (part.type !== "input_image") return false;
-    const hasImageUrl = typeof part.image_url === "string";
-    const hasFileId = typeof part.file_id === "string";
-    const validSource = (hasImageUrl || hasFileId)
-      && (part.image_url === undefined || hasImageUrl)
-      && (part.file_id === undefined || hasFileId);
+    const imageUrl = part.image_url;
+    const fileId = part.file_id;
+    const imageUrlIsString = typeof imageUrl === "string";
+    const fileIdIsString = typeof fileId === "string";
+    const hasUsableSource = (imageUrlIsString && imageUrl.length > 0)
+      || (fileIdIsString && fileId.length > 0);
+    const validSource = hasUsableSource
+      && (part.image_url === undefined || imageUrlIsString)
+      && (part.file_id === undefined || fileIdIsString);
     const validDetail = part.detail === undefined
       || (typeof part.detail === "string"
         && ["auto", "low", "high", "original"].includes(part.detail));

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -906,9 +906,12 @@ function toolOutputText(output: unknown): string {
   }).filter(Boolean).join("\n");
 }
 
-/** Convert unidentified tool output to user-message content without discarding valid images. */
-function unidentifiedToolOutputContent(output: unknown): Record<string, unknown>[] {
-  const marker = "[tool output for unknown call]";
+/** Convert orphaned tool output to user-message content without discarding valid images. */
+function orphanedToolOutputContent(output: unknown, callId = ""): Record<string, unknown>[] {
+  const marker = `[tool output for ${callId || "unknown call"}]`;
+  if (typeof output !== "string" && !Array.isArray(output)) {
+    return [{ type: "input_text", text: marker }];
+  }
   if (!Array.isArray(output)) {
     return [{ type: "input_text", text: `${marker}\n${toolOutputText(output)}` }];
   }
@@ -976,11 +979,12 @@ function repairUnidentifiedToolOutputItems(body: unknown): unknown {
       || (typeof item.call_id === "string" && item.call_id.length > 0)) {
       return item;
     }
+    if (typeof item.output !== "string" && !Array.isArray(item.output)) return item;
     changed = true;
     return {
       type: "message",
       role: "user",
-      content: unidentifiedToolOutputContent(item.output),
+      content: orphanedToolOutputContent(item.output),
     };
   });
   return changed ? { ...body, input } : body;
@@ -1106,12 +1110,16 @@ function repairOrphanedInputItems(body: unknown, dropReasoning: boolean, synthes
       flushPendingSyntheticOutputs();
       const callId = typeof item.call_id === "string" ? item.call_id : "";
       const paired = isFnOutput ? functionCallIds.has(callId) : customCallIds.has(callId);
-      if (!paired) {
+      const usableOutput = typeof item.output === "string" || Array.isArray(item.output);
+      // A known orphan call is still useful as a labeled user message even when its output is
+      // incomplete. With no call id and no output, preserve the invalid item so validation fails
+      // closed rather than pretending any tool result exists.
+      if (!paired && (callId.length > 0 || usableOutput)) {
         changed = true;
         repaired.push({
           type: "message",
           role: "user",
-          content: [{ type: "input_text", text: `[tool output for ${callId || "unknown call"}]\n${toolOutputText(item.output)}` }],
+          content: orphanedToolOutputContent(item.output, callId),
         });
         continue;
       }

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -921,6 +921,8 @@ function orphanedToolOutputContent(output: unknown, callId = ""): Record<string,
     if (!isPlainObject(part)) continue;
     if (part.type === "input_image") {
       content.push(part);
+    } else if (part.type === "encrypted_content" && typeof part.encrypted_content === "string") {
+      content.push({ type: "input_text", text: "[encrypted content omitted]" });
     } else if (typeof part.text === "string") {
       content.push({ type: "input_text", text: part.text });
     } else if (part.type === "refusal" && typeof part.refusal === "string") {

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -906,6 +906,27 @@ function toolOutputText(output: unknown): string {
   }).filter(Boolean).join("\n");
 }
 
+/** Convert unidentified tool output to user-message content without discarding valid images. */
+function unidentifiedToolOutputContent(output: unknown): Record<string, unknown>[] {
+  const marker = "[tool output for unknown call]";
+  if (!Array.isArray(output)) {
+    return [{ type: "input_text", text: `${marker}\n${toolOutputText(output)}` }];
+  }
+
+  const content: Record<string, unknown>[] = [{ type: "input_text", text: marker }];
+  for (const part of output) {
+    if (!isPlainObject(part)) continue;
+    if (part.type === "input_image") {
+      content.push(part);
+    } else if (typeof part.text === "string") {
+      content.push({ type: "input_text", text: part.text });
+    } else if (part.type === "refusal" && typeof part.refusal === "string") {
+      content.push({ type: "input_text", text: `[refusal] ${part.refusal}` });
+    }
+  }
+  return content;
+}
+
 /** True when a Responses tool output item is present but carries no usable content. */
 function isToolOutputEmpty(output: unknown): boolean {
   if (typeof output === "string") return output.trim() === "";
@@ -959,10 +980,7 @@ function repairUnidentifiedToolOutputItems(body: unknown): unknown {
     return {
       type: "message",
       role: "user",
-      content: [{
-        type: "input_text",
-        text: `[tool output for unknown call]\n${toolOutputText(item.output)}`,
-      }],
+      content: unidentifiedToolOutputContent(item.output),
     };
   });
   return changed ? { ...body, input } : body;

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -941,6 +941,34 @@ function annotateEmptyResponsesToolOutputs(body: unknown, enabled: boolean): unk
 }
 
 /**
+ * Preserve the text of structurally invalid tool-output items before they reach a strict
+ * Responses parser. Stateful destinations may legitimately receive an output whose matching
+ * call lives behind `previous_response_id`, so ordinary orphan repair cannot run universally.
+ * A missing or empty `call_id`, however, cannot identify stored state on any destination.
+ */
+function repairUnidentifiedToolOutputItems(body: unknown): unknown {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return body;
+  let changed = false;
+  const input = body.input.map(item => {
+    if (!isPlainObject(item)
+      || (item.type !== "function_call_output" && item.type !== "custom_tool_call_output")
+      || (typeof item.call_id === "string" && item.call_id.length > 0)) {
+      return item;
+    }
+    changed = true;
+    return {
+      type: "message",
+      role: "user",
+      content: [{
+        type: "input_text",
+        text: `[tool output for unknown call]\n${toolOutputText(item.output)}`,
+      }],
+    };
+  });
+  return changed ? { ...body, input } : body;
+}
+
+/**
  * Repair a forward-mode input array whose continuation context was lost. When the replay
  * expansion misses (proxy restart, unrecorded prior turn), previous_response_id is stripped
  * (the ChatGPT backend rejects it), so the delta may carry items that reference now-absent
@@ -2272,11 +2300,14 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
       // Same predicate as the routedCompaction gate in handleResponses(): an authMode check would
       // let a noncanonical custom forward provider skip this rewrite while the server still routes
       // it as a summarizer turn (#422). The compaction body build removes the tool surface and must
-      // therefore be the last routed transform: anything before it may depend on the declarations;
-      // anything after it cannot.
+      // therefore be the last routed transform that may depend on those declarations. Structural
+      // sanitizers below can still run after it.
       if (parsed._compactionRequest === true && !isCanonicalOpenAiForwardProvider(provider)) {
         outBody = buildRoutedCompactionBody(outBody);
       }
+      // Run after routed compaction so nested input_image parts are replaced before a malformed
+      // tool output is flattened to text and can no longer be inspected structurally.
+      outBody = repairUnidentifiedToolOutputItems(outBody);
       const threadServingIdentityChanged = parsed._stripReasoningEncryptedContent === true;
       const sanitizedBody = normalizeToolSchemas(
         stripSparkCompatibility(

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -906,6 +906,25 @@ function toolOutputText(output: unknown): string {
   }).filter(Boolean).join("\n");
 }
 
+/** True when an output can be losslessly represented as user-message content. */
+function isRepairableToolOutput(output: unknown): output is string | Record<string, unknown>[] {
+  if (typeof output === "string") return true;
+  if (!Array.isArray(output)) return false;
+  return output.every(part => {
+    if (!isPlainObject(part)) return false;
+    if (["output_text", "text", "input_text"].includes(String(part.type))) {
+      return typeof part.text === "string";
+    }
+    if (part.type === "refusal") return typeof part.refusal === "string";
+    if (part.type === "encrypted_content") return typeof part.encrypted_content === "string";
+    if (part.type !== "input_image") return false;
+    const validSource = typeof part.image_url === "string" || typeof part.file_id === "string";
+    const validDetail = part.detail === undefined
+      || ["auto", "low", "high", "original"].includes(String(part.detail));
+    return validSource && validDetail;
+  });
+}
+
 /** Convert orphaned tool output to user-message content without discarding valid images. */
 function orphanedToolOutputContent(output: unknown, callId = ""): Record<string, unknown>[] {
   const marker = `[tool output for ${callId || "unknown call"}]`;
@@ -981,7 +1000,7 @@ function repairUnidentifiedToolOutputItems(body: unknown): unknown {
       || (typeof item.call_id === "string" && item.call_id.length > 0)) {
       return item;
     }
-    if (typeof item.output !== "string" && !Array.isArray(item.output)) return item;
+    if (!isRepairableToolOutput(item.output)) return item;
     changed = true;
     return {
       type: "message",
@@ -1112,11 +1131,12 @@ function repairOrphanedInputItems(body: unknown, dropReasoning: boolean, synthes
       flushPendingSyntheticOutputs();
       const callId = typeof item.call_id === "string" ? item.call_id : "";
       const paired = isFnOutput ? functionCallIds.has(callId) : customCallIds.has(callId);
-      const usableOutput = typeof item.output === "string" || Array.isArray(item.output);
+      const usableOutput = isRepairableToolOutput(item.output);
       // A known orphan call is still useful as a labeled user message even when its output is
       // incomplete. With no call id and no output, preserve the invalid item so validation fails
       // closed rather than pretending any tool result exists.
-      if (!paired && (callId.length > 0 || usableOutput)) {
+      const knownNullOutput = callId.length > 0 && item.output == null;
+      if (!paired && (knownNullOutput || usableOutput)) {
         changed = true;
         repaired.push({
           type: "message",

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2358,6 +2358,7 @@ describe("OpenAI Responses passthrough sanitization", () => {
         type: "function_call_output",
         output: [{ type: "input_image", image_url: 42, file_id: "file_1" }],
       },
+      { type: "function_call_output", output: [{ type: "input_image", image_url: "" }] },
       {
         type: "function_call_output",
         output: [{ type: { toString: null, valueOf: null }, text: "must not coerce" }],

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2245,6 +2245,65 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(rawDeltaBody.input).toHaveLength(1);
   });
 
+  test("api-key mode preserves delegated tool output text when call_id is missing", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "key" as const,
+      apiKey: "xai-test",
+    });
+
+    const body = JSON.parse(adapter.buildRequest({
+      ...parsedBase,
+      previousResponseId: undefined,
+      _rawBody: {
+        model: "grok-4.6",
+        input: [
+          {
+            type: "function_call_output",
+            id: "fco_delegation",
+            output: "<codex_delegation>Inspect the adapter.</codex_delegation>",
+          },
+        ],
+      },
+    }, meta).body) as { input: Record<string, unknown>[] };
+
+    expect(body.input).toEqual([{
+      type: "message",
+      role: "user",
+      content: [{
+        type: "input_text",
+        text: "[tool output for unknown call]\n<codex_delegation>Inspect the adapter.</codex_delegation>",
+      }],
+    }]);
+  });
+
+  test("api-key mode keeps stateful tool outputs with call_id intact", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "key" as const,
+      apiKey: "xai-test",
+    });
+    const statefulOutput = {
+      type: "function_call_output",
+      call_id: "call_from_previous_response",
+      output: "tool result",
+    };
+
+    const body = JSON.parse(adapter.buildRequest({
+      ...parsedBase,
+      _rawBody: {
+        model: "grok-4.6",
+        previous_response_id: "resp_stateful",
+        input: [statefulOutput],
+      },
+    }, meta).body) as { previous_response_id?: string; input: Record<string, unknown>[] };
+
+    expect(body.previous_response_id).toBe("resp_stateful");
+    expect(body.input).toEqual([statefulOutput]);
+  });
+
   test("forward unexpanded miss converts orphan tool outputs and drops reasoning", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const body = JSON.parse(adapter.buildRequest({

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2350,6 +2350,14 @@ describe("OpenAI Responses passthrough sanitization", () => {
     const invalidOutputs = [
       { type: "custom_tool_call_output" },
       { type: "function_call_output", output: [{ type: "bogus", value: "not a tool-output part" }] },
+      {
+        type: "function_call_output",
+        output: [{ type: "input_image", image_url: "data:image/png;base64,AAAA", detail: ["high"] }],
+      },
+      {
+        type: "function_call_output",
+        output: [{ type: { toString: null, valueOf: null }, text: "must not coerce" }],
+      },
     ];
 
     const body = JSON.parse(adapter.buildRequest({

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2340,21 +2340,24 @@ describe("OpenAI Responses passthrough sanitization", () => {
     ]);
   });
 
-  test("api-key mode leaves incomplete output without call_id fail-closed", () => {
+  test("api-key mode leaves invalid output without call_id fail-closed", () => {
     const adapter = createResponsesPassthroughAdapter({
       adapter: "openai-responses",
       baseUrl: "https://api.x.ai/v1",
       authMode: "key" as const,
       apiKey: "xai-test",
     });
-    const incompleteOutput = { type: "custom_tool_call_output" };
+    const invalidOutputs = [
+      { type: "custom_tool_call_output" },
+      { type: "function_call_output", output: [{ type: "bogus", value: "not a tool-output part" }] },
+    ];
 
     const body = JSON.parse(adapter.buildRequest({
       ...parsedBase,
-      _rawBody: { model: "grok-4.6", input: [incompleteOutput] },
+      _rawBody: { model: "grok-4.6", input: invalidOutputs },
     }, meta).body) as { input: Record<string, unknown>[] };
 
-    expect(body.input).toEqual([incompleteOutput]);
+    expect(body.input).toEqual(invalidOutputs);
   });
 
   test("forward unexpanded miss converts orphan tool outputs and drops reasoning", () => {

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2304,6 +2304,37 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.input).toEqual([statefulOutput]);
   });
 
+  test("api-key mode preserves images when repairing output without call_id", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "key" as const,
+      apiKey: "xai-test",
+    });
+    const image = {
+      type: "input_image",
+      image_url: "data:image/png;base64,AAAA",
+      detail: "high",
+    };
+
+    const body = JSON.parse(adapter.buildRequest({
+      ...parsedBase,
+      _rawBody: {
+        model: "grok-4.6",
+        input: [{
+          type: "function_call_output",
+          output: [{ type: "input_text", text: "screenshot" }, image],
+        }],
+      },
+    }, meta).body) as { input: Array<{ content: Record<string, unknown>[] }> };
+
+    expect(body.input[0]?.content).toEqual([
+      { type: "input_text", text: "[tool output for unknown call]" },
+      { type: "input_text", text: "screenshot" },
+      image,
+    ]);
+  });
+
   test("forward unexpanded miss converts orphan tool outputs and drops reasoning", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
     const body = JSON.parse(adapter.buildRequest({

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2356,6 +2356,10 @@ describe("OpenAI Responses passthrough sanitization", () => {
       },
       {
         type: "function_call_output",
+        output: [{ type: "input_image", image_url: 42, file_id: "file_1" }],
+      },
+      {
+        type: "function_call_output",
         output: [{ type: { toString: null, valueOf: null }, text: "must not coerce" }],
       },
     ];

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2335,8 +2335,26 @@ describe("OpenAI Responses passthrough sanitization", () => {
     ]);
   });
 
+  test("api-key mode leaves incomplete output without call_id fail-closed", () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses",
+      baseUrl: "https://api.x.ai/v1",
+      authMode: "key" as const,
+      apiKey: "xai-test",
+    });
+    const incompleteOutput = { type: "custom_tool_call_output" };
+
+    const body = JSON.parse(adapter.buildRequest({
+      ...parsedBase,
+      _rawBody: { model: "grok-4.6", input: [incompleteOutput] },
+    }, meta).body) as { input: Record<string, unknown>[] };
+
+    expect(body.input).toEqual([incompleteOutput]);
+  });
+
   test("forward unexpanded miss converts orphan tool outputs and drops reasoning", () => {
     const adapter = createResponsesPassthroughAdapter(provider);
+    const image = { type: "input_image", image_url: "data:image/png;base64,AAAA" };
     const body = JSON.parse(adapter.buildRequest({
       ...parsedBase,
       _rawBody: {
@@ -2345,7 +2363,11 @@ describe("OpenAI Responses passthrough sanitization", () => {
         input: [
           { type: "reasoning", id: "rs_1", summary: [] },
           { type: "function_call_output", call_id: "call_orphan", output: "tool said hi" },
-          { type: "custom_tool_call_output", call_id: "call_custom", output: [{ type: "output_text", text: "custom out" }] },
+          {
+            type: "custom_tool_call_output",
+            call_id: "call_custom",
+            output: [{ type: "output_text", text: "custom out" }, image],
+          },
           { role: "user", content: "next question" },
         ],
       },
@@ -2362,7 +2384,11 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.input[1]).toMatchObject({
       type: "message",
       role: "user",
-      content: [{ type: "input_text", text: "[tool output for call_custom]\ncustom out" }],
+      content: [
+        { type: "input_text", text: "[tool output for call_custom]" },
+        { type: "input_text", text: "custom out" },
+        image,
+      ],
     });
     expect(body.input[2]).toMatchObject({ role: "user", content: "next question" });
   });

--- a/tests/openai-responses-passthrough.test.ts
+++ b/tests/openai-responses-passthrough.test.ts
@@ -2323,7 +2323,11 @@ describe("OpenAI Responses passthrough sanitization", () => {
         model: "grok-4.6",
         input: [{
           type: "function_call_output",
-          output: [{ type: "input_text", text: "screenshot" }, image],
+          output: [
+            { type: "input_text", text: "screenshot" },
+            image,
+            { type: "encrypted_content", encrypted_content: "opaque-tool-state" },
+          ],
         }],
       },
     }, meta).body) as { input: Array<{ content: Record<string, unknown>[] }> };
@@ -2332,6 +2336,7 @@ describe("OpenAI Responses passthrough sanitization", () => {
       { type: "input_text", text: "[tool output for unknown call]" },
       { type: "input_text", text: "screenshot" },
       image,
+      { type: "input_text", text: "[encrypted content omitted]" },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Preserve delegated/tool-output text when a Responses request contains a `function_call_output` or `custom_tool_call_output` without a usable `call_id`.
- Convert only that structurally invalid item into an ordinary user message before a strict upstream parser sees it.
- Preserve valid `input_image` parts alongside the recovered text.
- Represent opaque `encrypted_content` parts with the existing `[encrypted content omitted]` marker instead of silently dropping them.
- Keep valid stateful tool outputs unchanged, because their matching call may legitimately live behind `previous_response_id`.
- Leave items with neither a usable `call_id` nor a valid `output` untouched so schema validation still fails closed.

### What fails today

```json
{
  "model": "grok-4.6",
  "input": [{
    "type": "function_call_output",
    "output": "<codex_delegation>Inspect the adapter.</codex_delegation>"
  }]
}
```

A strict Responses endpoint rejects that request before model execution:

```text
422 Unprocessable Entity: invalid function_call_output item: missing field call_id
```

```mermaid
flowchart LR
  A["Codex creates a delegated task"] --> B["function_call_output<br/>has text but no call_id"]
  B --> C["OpenCodex stateful<br/>Responses path"]
  C --> D["Strict provider parser"]
  D --> E["HTTP 422<br/>model never runs"]
```

### Behavior after this change

The malformed item becomes a schema-valid message while preserving the useful payload:

```json
{
  "type": "message",
  "role": "user",
  "content": [{
    "type": "input_text",
    "text": "[tool output for unknown call]\n<codex_delegation>Inspect the adapter.</codex_delegation>"
  }]
}
```

```mermaid
flowchart LR
  A["Tool output has call_id"] --> B["Pass through unchanged"]
  C["Tool output has no call_id"] --> D["Preserve output as<br/>a user text message"]
  B --> E["Provider accepts request"]
  D --> E
```

The repair runs after routed compaction so nested image parts can still be sanitized structurally before any malformed output is flattened to text. Forward/stateless orphan repair uses the same lossless conversion so both paths preserve valid multimodal output.

## Verification

- Added the missing-`call_id` regression first and confirmed it failed against the previous implementation.
- `bun test tests/openai-responses-passthrough.test.ts tests/responses-compaction-routing.test.ts tests/responses-stateless-dangling-call-repair.test.ts --timeout 30000` — 190 pass, 0 fail.
- `bun run typecheck` — passed.
- `bun run test -- --parallel=4 --timeout 30000` — 17,734 pass, 0 fail across the full suite.
- `bun run privacy:scan` — passed.
- `bun run doctor:gui:if-changed` — no issues found.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing configuration or API contract changed.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
