### PR TITLE
fix(lab): reject file URI privacy bypasses

### DIFF
--- a/src/lab/events/limits.ts
+++ b/src/lab/events/limits.ts
@@ -33,7 +33,7 @@ const FORBIDDEN_EXACT_KEYS = new Set([
 
 const RAW_POSIX_PATH_RE =
   /(?:^|[^A-Za-z0-9._~/])\/(?:(?=$|[^A-Za-z0-9._~/])|(?!\/)(?![ \t\r\n])(?:\/|[^/\0\r\n]+)+\/?(?=$|[^A-Za-z0-9._~/]))/u;
-const FILE_URI_RE = /(?:^|[^A-Za-z0-9+.-])file:\/\//i;
+const FILE_URI_RE = /(?:^|[^A-Za-z0-9+.-])file:[\\/]+/i;
 
 function fieldPath(base: string, key: string | number): string {
   return base ? `${base}.${String(key)}` : String(key);

--- a/src/lab/events/limits.ts
+++ b/src/lab/events/limits.ts
@@ -33,6 +33,7 @@ const FORBIDDEN_EXACT_KEYS = new Set([
 
 const RAW_POSIX_PATH_RE =
   /(?:^|[^A-Za-z0-9._~/])\/(?:(?=$|[^A-Za-z0-9._~/])|(?!\/)(?![ \t\r\n])(?:\/|[^/\0\r\n]+)+\/?(?=$|[^A-Za-z0-9._~/]))/u;
+const ASCII_URL_WHITESPACE_RE = /[\t\r\n]/g;
 const FILE_URI_RE = /(?:^|[^A-Za-z0-9+.-])file:/i;
 
 function fieldPath(base: string, key: string | number): string {
@@ -82,6 +83,7 @@ export function enforceEventStructureLimits(
     if (
       /^[A-Za-z]:\\/.test(value) ||
       FILE_URI_RE.test(value) ||
+      FILE_URI_RE.test(value.replace(ASCII_URL_WHITESPACE_RE, "")) ||
       RAW_POSIX_PATH_RE.test(value) ||
       value.includes("\\Users\\")
     ) {

--- a/src/lab/events/limits.ts
+++ b/src/lab/events/limits.ts
@@ -33,7 +33,7 @@ const FORBIDDEN_EXACT_KEYS = new Set([
 
 const RAW_POSIX_PATH_RE =
   /(?:^|[^A-Za-z0-9._~/])\/(?:(?=$|[^A-Za-z0-9._~/])|(?!\/)(?![ \t\r\n])(?:\/|[^/\0\r\n]+)+\/?(?=$|[^A-Za-z0-9._~/]))/u;
-const FILE_URI_RE = /(?:^|[^A-Za-z0-9+.-])file:[\\/]+/i;
+const FILE_URI_RE = /(?:^|[^A-Za-z0-9+.-])file:/i;
 
 function fieldPath(base: string, key: string | number): string {
   return base ? `${base}.${String(key)}` : String(key);

--- a/src/lab/events/limits.ts
+++ b/src/lab/events/limits.ts
@@ -33,6 +33,7 @@ const FORBIDDEN_EXACT_KEYS = new Set([
 
 const RAW_POSIX_PATH_RE =
   /(?:^|[^A-Za-z0-9._~/])\/(?:(?=$|[^A-Za-z0-9._~/])|(?!\/)(?![ \t\r\n])(?:\/|[^/\0\r\n]+)+\/?(?=$|[^A-Za-z0-9._~/]))/u;
+const FILE_URI_RE = /(?:^|[^A-Za-z0-9+.-])file:\/\//i;
 
 function fieldPath(base: string, key: string | number): string {
   return base ? `${base}.${String(key)}` : String(key);
@@ -80,6 +81,7 @@ export function enforceEventStructureLimits(
     }
     if (
       /^[A-Za-z]:\\/.test(value) ||
+      FILE_URI_RE.test(value) ||
       RAW_POSIX_PATH_RE.test(value) ||
       value.includes("\\Users\\")
     ) {

--- a/tests/lab-post-merge-hardening.test.ts
+++ b/tests/lab-post-merge-hardening.test.ts
@@ -197,6 +197,8 @@ test("event privacy admission rejects raw filesystem path bypass forms", () => {
     "file://localhost/home/alice/secret.txt",
     "detail_file:///etc/passwd",
     "file://server/share/secret",
+    String.raw`file:\\server\share\secret`,
+    String.raw`file:\C:\secret\data`,
   ]) {
     try {
       enforceEventStructureLimits({ detail });

--- a/tests/lab-post-merge-hardening.test.ts
+++ b/tests/lab-post-merge-hardening.test.ts
@@ -180,7 +180,7 @@ test("replay discards an oversized unterminated line after reporting it once", (
   expect(replay.corruptions[0]?.kind).toBe("malformed_line");
 });
 
-test("event privacy admission rejects raw POSIX path bypass forms", () => {
+test("event privacy admission rejects raw filesystem path bypass forms", () => {
   for (const detail of [
     "config=/home/alice/work/repo",
     "cwd=/usr/local/bin",
@@ -192,6 +192,11 @@ test("event privacy admission rejects raw POSIX path bypass forms", () => {
     "cwd=/home/@alice",
     "cwd=/home/josé/work",
     "x-/home/alice",
+    "file:///etc/passwd",
+    "FiLe:///home/alice/secret.txt",
+    "file://localhost/home/alice/secret.txt",
+    "detail_file:///etc/passwd",
+    "file://server/share/secret",
   ]) {
     try {
       enforceEventStructureLimits({ detail });
@@ -199,6 +204,10 @@ test("event privacy admission rejects raw POSIX path bypass forms", () => {
     } catch (err) {
       expect((err as { code?: string }).code).toBe("raw_path");
     }
+  }
+
+  for (const detail of ["https://example.com/path", "profile:///etc/passwd"]) {
+    expect(() => enforceEventStructureLimits({ detail })).not.toThrow();
   }
 });
 

--- a/tests/lab-post-merge-hardening.test.ts
+++ b/tests/lab-post-merge-hardening.test.ts
@@ -199,6 +199,8 @@ test("event privacy admission rejects raw filesystem path bypass forms", () => {
     "file://server/share/secret",
     String.raw`file:\\server\share\secret`,
     String.raw`file:\C:\secret\data`,
+    String.raw`file:C:\private\secret`,
+    "file:etc/passwd",
   ]) {
     try {
       enforceEventStructureLimits({ detail });

--- a/tests/lab-post-merge-hardening.test.ts
+++ b/tests/lab-post-merge-hardening.test.ts
@@ -201,6 +201,13 @@ test("event privacy admission rejects raw filesystem path bypass forms", () => {
     String.raw`file:\C:\secret\data`,
     String.raw`file:C:\private\secret`,
     "file:etc/passwd",
+    "fi\nle:///etc/passwd",
+    "fil\te:///etc/passwd",
+    "file\r:///etc/passwd",
+    "file\n:///etc/passwd",
+    "detail\nfile:///etc/passwd",
+    "detail\rfile:etc/passwd",
+    "detail\tfile:C:\\private\\secret",
   ]) {
     try {
       enforceEventStructureLimits({ detail });


### PR DESCRIPTION
## Summary

- reject any standalone case-insensitive `file:` scheme, including separator-less, forward-slash, backslash, and mixed-separator forms, before Compatibility Lab event data is admitted
- normalize ASCII URL whitespace (tab, CR, LF) before the scheme test, so `fi\nle:///etc/passwd` and `fil\te:///etc/passwd` can no longer slide past admission and become valid `file:///` URLs downstream
- cover empty, relative, localhost, remote, UNC-style, and drive-qualified forms while preserving non-file schemes such as `profile://`
- keep the change limited to the existing privacy admission helper and its focused regression test

## Motivation

The existing raw path detectors did not recognize every URI-encoded or Windows-style `file:` path. Values such as `file:///etc/passwd`, `file://server/share/secret`, and `file:\\server\share\secret` could therefore pass event privacy admission and enter retained lab evidence.

Per [maintainer review](https://github.com/lidge-jun/opencodex/pull/3432#issuecomment-5537004080), the same bypass class was still reachable through whitespace inside the scheme: WHATWG URL parsing strips tabs, CRs, and LFs, so `"fi\nle:///etc/passwd"` normalized into a valid `file:///` URL while the raw string missed `FILE_URI_RE`. The admission test now runs against both the original value and its whitespace-stripped form, which keeps delimiter-prefixed detection intact while closing the split-scheme forms.

## Validation

All commands were run in an isolated worktree on the rebased head `2b0653f4a3297353ef45ebdb3404259fda838230`, whose base is current `dev` `5364ce01d2156e8784bf2be42944ef983aa27b33`.

- `bun test --isolate ./tests/lab-post-merge-hardening.test.ts` — 8 pass, 0 fail, 48 expect() calls (includes the 7 new tab/CR/LF regressions)
- `bun run typecheck` — passed
- `git diff --check 5364ce01d2..HEAD` — passed
- `git diff --stat 5364ce01d2..HEAD` — 2 files changed, 25 insertions(+), 1 deletion(-), limited to `src/lab/events/limits.ts` and `tests/lab-post-merge-hardening.test.ts`
- the pre-rebase and post-rebase diffs hash identically (SHA-256 `20C045BF054DACA4DD9E7931A7D590E76DE6EA90F1FFB8E4280D7586E0FE9312`), so the rebase carried no content change
- two independent reviews — no remaining actionable findings

`bun run privacy:scan` currently fails on this branch, but the failure is not from this PR. A clean checkout of `dev` at `5364ce01d2` reproduces the identical failure:

```
Privacy scan failed:
tests/oauth-manual-code.test.ts:63 meta-api-key: <redacted>
```

That file and line come from #3437, not from either file changed here. On the previous base `20011a1c48` the same scan passed against this change set.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy validation to reject file URL variants and filesystem path bypasses, including mixed-case, control-character, Windows, and network-share forms.
  * Continued allowing non-file URI schemes, such as HTTPS and profile URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->