### PR TITLE
docs: add a platform-support reference page

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -148,6 +148,7 @@ export default defineConfig({
             },
             { label: "Adapters", translations: { fr: "Adaptateurs", ko: "어댑터", "zh-CN": "适配器", "zh-TW": "適配器", ru: "Адаптеры", ja: "アダプター", tr: "Adaptörler" }, slug: "reference/adapters" },
             { label: "Architecture", translations: { fr: "Architecture", ko: "아키텍처", "zh-CN": "架构", "zh-TW": "架構", ru: "Архитектура", ja: "アーキテクチャ", tr: "Mimari" }, slug: "reference/architecture" },
+            { label: "Platform Support", translations: { fr: "Prise en charge des plateformes", ko: "플랫폼 지원", "zh-CN": "平台支持", "zh-TW": "平台支援", ru: "Поддержка платформ", ja: "プラットフォーム対応", tr: "Platform Desteği" }, link: `${SITE_URL}/reference/platform-support` },
             { label: "Proxy API Formats", translations: { fr: "Formats de l’API proxy", ko: "프록시 API 형식", "zh-CN": "代理 API 格式", "zh-TW": "代理 API 格式", ru: "Форматы API прокси", ja: "プロキシAPI形式", tr: "Proxy API Formatları" }, slug: "reference/proxy-formats" },
             { label: "Management API", translations: { fr: "API de gestion", ko: "관리 API", "zh-CN": "管理 API", "zh-TW": "管理 API", ru: "API управления", ja: "管理API", tr: "Yönetim API'si" }, slug: "reference/management-api" },
           ],

--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -467,7 +467,8 @@ Elsewhere it asks you to paste the key. Meta ships no native Windows CLI, and on
 CLI exists but where it stores its credential has not been verified, so OpenCodex refuses
 to guess at a credential store and points you at [dev.meta.ai](https://dev.meta.ai)
 instead, where the same key is visible. A pasted key faces the same format check and the
-same live validation against the Model API as an imported one.
+same live validation against the Model API as an imported one. See
+[Platform support](/reference/platform-support/) for the full per-platform picture.
 
 **Read this before enabling it.** Meta scopes that credential to the Muse Code CLI, so
 using it here is an *unsupported* path. Meta does not authorize subscription coverage

--- a/docs-site/src/content/docs/reference/platform-support.md
+++ b/docs-site/src/content/docs/reference/platform-support.md
@@ -1,0 +1,81 @@
+---
+title: Platform support
+description: What OpenCodex can do on macOS, Windows and Linux, and why a few capabilities stay platform-specific.
+---
+
+OpenCodex runs on macOS, Windows and Linux. Most of it behaves identically on all
+three; a few capabilities depend on something the operating system provides, and
+this page says which, and why.
+
+## Everywhere
+
+| Capability | Notes |
+| --- | --- |
+| Proxy, routing, provider adapters | The core runtime is platform-neutral. |
+| Background service | Three native backends: launchd on macOS, Task Scheduler **or** WinSW on Windows, a systemd user unit on Linux. |
+| Browser login | Opens through the platform's own handler. |
+| Client detection | Cursor, Claude Desktop, Kiro and Codex installs are located per platform. |
+
+### Provider keys in the OS credential store
+
+Supported on all three platforms, **when an unlocked OS credential service is
+available**: Keychain on macOS, Credential Manager on Windows, libsecret on
+Linux. A locked keyring or a headless session has no unlocked service, so the
+store is unavailable and OpenCodex says so rather than silently falling back.
+See [Providers](/reference/configuration/providers/) for the storage rules.
+
+## macOS only
+
+### Claude Code auto-connect
+
+Injecting `ANTHROPIC_BASE_URL` and the Claude Code levers into your session
+happens through the launchd user domain, which has no single equivalent
+elsewhere.
+
+On Linux the three plausible mechanisms each reach a different set of processes:
+`systemctl --user set-environment` reaches only systemd-spawned units,
+`~/.profile` only login shells, and `~/.bashrc` only interactive non-login
+shells. There is no one place that covers a user's whole session.
+
+On Windows the equivalent is `HKCU\Environment`, which is genuinely persistent
+rather than per-boot. That is the problem: it would move a bearer token from a
+domain that empties at reboot into a registry hive that does not, which is a
+change in how long the credential sits on disk and who can read it. That
+decision needs a security review rather than a port.
+
+Everything else Claude Code needs works on all platforms. You can set the same
+variables yourself, or run `ocx claude`, which passes them to the child process
+directly.
+
+## Import versus paste
+
+### Meta Muse Code
+
+On macOS, OpenCodex imports the API key the Muse Code CLI already stored after
+`muse login`, so you are not asked to provision a second one.
+
+Elsewhere it asks you to paste the key instead. Meta ships no native Windows
+CLI, and on Linux the CLI exists but where it keeps its credential has not been
+verified, so OpenCodex declines to guess at a credential store. The same key is
+visible in [Meta's developer console](https://dev.meta.ai), and a pasted key
+faces the same format check and the same live validation against the Model API
+as an imported one.
+
+## Windows notes
+
+The Windows service can run under Task Scheduler or as a native WinSW service,
+and those are mutually exclusive. `ocx service repair` refuses to proceed when
+it finds state for both, because guessing which one you meant is how a machine
+ends up with two proxies fighting over a port.
+
+Console output on a non-English Windows install arrives in the system code page
+rather than UTF-8. OpenCodex decodes it accordingly, so an account name with
+non-ASCII characters resolves correctly.
+
+## When something is unavailable
+
+OpenCodex states the actual reason rather than disabling a control silently. If
+a capability is unavailable on your platform, the error or the dashboard says
+which mechanism is missing and what the supported alternative is. If you hit one
+that does not, that is a bug worth reporting.
+


### PR DESCRIPTION
## Summary

A user who hit a disabled control or a platform refusal had nowhere to read what OpenCodex can actually do on their OS. This adds `reference/platform-support`, stating the answer per platform with the reason attached wherever something is unavailable.

Most capabilities are on all three platforms, including the background service and OS credential storage. The page is deliberately careful about two things that would be easy to overstate:

- **Keyring support is conditional.** All three platforms work *when an unlocked OS credential service is available*; a locked keyring or headless session has none. This matches `src/providers/key-store.ts:95-107` and does not contradict `reference/configuration/providers`.
- **The two Windows service backends are mutually exclusive**, not combined. `ServiceBackend` is `"scheduler" | "native"` (`src/service.ts:64`), and repair refuses when it finds state for both (`:417-420`).

Claude Code auto-connect is documented as macOS-only *with the mechanism*: the launchd user domain has no single equivalent, Linux has three mechanisms that each reach a different set of processes, and the Windows equivalent would move a bearer token from a per-boot domain into a persistent registry hive - a security decision rather than a port.

### The sidebar entry is a link, not a slug

`docs-site/astro.config.mjs` enumerates the Reference group manually. The entry uses a manual **absolute** link built from the existing `SITE_URL` constant (`astro.config.mjs:7`).

That form is load-bearing. Starlight treats only `http://` and `https://` as absolute (`utils/url.ts`), and `linkFromSidebarLinkItem` (`utils/navigation.ts:121-127`) prefixes anything else with the active locale. A `slug`, or a site-relative `/reference/platform-support`, would send all seven localized sidebars to a route that does not exist - and unlike a slug, a broken `link` is not build-validated, so the build would have passed anyway.

No runtime source, no GUI, no test behavior changed.

Stacked on #3437. Retarget to `dev` once the parents land.

## Verification

- `bun install --frozen-lockfile` then `bun run build` in `docs-site/` - complete, 425 pages built, exit 0.
- **Verified by hand in the built output**, because the build cannot validate a manual link: `dist/ko/reference/adapters/index.html` renders the sidebar href as `https://opencodex.me/reference/platform-support`, not `/ko/reference/...`.
- `dist/reference/platform-support/index.html` and the localized routes exist.
- Full suite not run locally by request; CI is the authority.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Security note: documentation only. The page describes the credential-storage boundary rather than changing it, and states the token-exposure reason auto-connect stays macOS-only.




---

**CI status (updated after rebase).** The stack was rebased onto current `dev`: it branched when `dev` was at 2.42.0, that version then shipped, and `release version line` correctly refused a tree claiming an already-published version. That failure was ours and is fixed.

Two failures remain and are **inherited, not introduced**. Both were reproduced on clean `origin/dev` in a scratch worktree rather than assumed:

- `tests/loopback-listener-integration.test.ts:366` (image routes on the loopback listener, arrived with #3430) - 30 pass / 1 fail on clean `dev`, identical here.
- `tests/star-deferral.test.ts:102` - 6 pass / 1 fail on clean `dev`, identical here.

Neither is in this stack's blast radius. Full triage: `devlog/_plan/260904_cross_platform_parity/041_ci_triage.md`. This means the honest claim is **no new failures**, not "all checks pass" - the stack cannot go fully green until `dev` does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Platform Support reference page covering macOS, Windows, and Linux capabilities and differences.
  - Added the Platform Support page to the documentation sidebar.
  - Added a link from the API-key catalog guide to the new platform-specific support details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->