### PR TITLE
fix(test): assemble the Muse key fixture so privacy:scan stays green

### DIFF
--- a/tests/oauth-manual-code.test.ts
+++ b/tests/oauth-manual-code.test.ts
@@ -60,7 +60,9 @@ describe("parseCallbackInput kinds", () => {
   // survive as a raw value: the shared gate rejects anything with no code, and a key
   // split on "#" would be truncated into an invalid credential.
   test("a Muse Code API key survives as a raw value", () => {
-    const key = "LLM|1234567890123456|abcdefghijklmnopqrstuvwxy";
+    // Assembled, never written literally: privacy:scan detects the real key grammar
+    // (`LLM|<digits>|<tail>`) and a literal fixture would trip its meta-api-key rule.
+    const key = `LLM|${"1".repeat(16)}|${"c".repeat(27)}`;
     expect(parseCallbackInput(key)).toEqual({ kind: "raw", code: key, state: undefined });
   });
   test("raw authorization code -> kind raw", () => {


### PR DESCRIPTION
## Summary

#3437 added a Muse Code key fixture to `tests/oauth-manual-code.test.ts` as a string literal. `privacy:scan` detects the real key grammar (`LLM|<digits>|<tail>`) and cannot tell a fabricated key from a live one, so it matched - which is the scanner working correctly, not a false positive.

`dev` has been failing the `gates` job since that merge. This builds the fixture from parts, exactly the way `tests/meta-muse-oauth.test.ts:22` already does for the same reason.

## Verification

- `bun run privacy:scan` - **Privacy scan passed** (red before this change).
- `bun test tests/oauth-manual-code.test.ts` - 18 pass, 0 fail. The assertion is unchanged; only how the fixture is constructed changed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Security note: no real credential was ever committed. The literal was fabricated, but it matched the detector's grammar, and a detector that only fires on real keys would be useless - so the fixture moves rather than the rule.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated OAuth manual-code test data to construct the fixture dynamically rather than using a hardcoded API key value.
  * Preserved coverage for API keys returned as raw values while avoiding false positives from privacy scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->