### PR TITLE
fix(providers): advertise the reasoning-effort ladder for native Anthropic models

### DIFF
--- a/devlog/_plan/260904_anthropic_effort_ladder/000_research.md
+++ b/devlog/_plan/260904_anthropic_effort_ladder/000_research.md
@@ -1,0 +1,179 @@
+# 000 — Research: native Anthropic models advertise no reasoning-effort ladder
+
+## Reported symptom
+
+Connecting opencodex to Aside shows a reasoning-effort control for every routed
+model EXCEPT the Claude ones. The user's phrasing — "claude 모델들만 추론강도
+조절이 나타나지 않는다" — is precise but the word "Claude" is a red herring, and
+that matters for the fix: Claude models routed through OTHER providers are fine.
+
+## Evidence
+
+`~/.aside/u/0/models.json`, the file Aside actually reads, on 2026-09-04:
+
+```
+anthropic/claude-fable-5-1                    reasoning=None  thinkingLevelMap=-
+anthropic/claude-opus-4-6                     reasoning=None  thinkingLevelMap=-
+anthropic/claude-opus-5                       reasoning=None  thinkingLevelMap=-
+cursor/claude-fable-5-1                       reasoning=True  thinkingLevelMap=yes
+google-antigravity/claude-opus-4-6-thinking   reasoning=True  thinkingLevelMap=yes
+```
+
+`cursor/claude-fable-5-1` and `anthropic/claude-fable-5-1` are the SAME model.
+One has an effort control and the other does not, so nothing about Claude itself
+can explain it. The discriminator is the provider entry.
+
+`GET http://127.0.0.1:10100/v1/models` on the live proxy agrees, which locates
+the defect upstream of Aside and upstream of the exporter:
+
+```
+anthropic/claude-fable-5-1                   supports_reasoning_effort=absent  reasoning_efforts=[]
+cursor/claude-fable-5-1                      supports_reasoning_effort=True    reasoning_efforts=[low,medium,high,xhigh,max]
+google-antigravity/claude-opus-4-6-thinking  supports_reasoning_effort=True    reasoning_efforts=[low,medium,high,max]
+```
+
+## Causal chain
+
+Corrected after audit. An earlier draft of this document routed the export
+through `src/routing/capability.ts:216`; that function
+(`candidateCapabilityEvidence`) feeds POLICY ROUTING and never reaches the
+catalog or `ExportModel`. Naming the wrong hop would have produced a test that
+guards a seam the bug does not live in, so the real chain is recorded here:
+
+1. `src/providers/registry.ts` — the `anthropic` entry (line ~1330) and
+   `anthropic-apikey` entry (line ~1346) declare `models`,
+   `modelContextWindows` and `defaultModel`, but no `modelReasoningEfforts`.
+   Every peer provider that shows effort declares one: `cursor` line 1162,
+   `google-antigravity` line 1861, `xai` line 1281, `kimi` line 1384.
+2. `captureProviderGather` clones the configured provider and calls
+   `enrichProviderFromRegistry` — `src/codex/catalog/provider-fetch.ts:411-420`.
+   This is where a registry ladder would be merged into the live provider.
+3. `configuredReasoningEfforts(prov, model.id)` —
+   `src/reasoning-effort.ts:148-153`. It returns `[]` for a
+   `noReasoningModels` member, the per-model map when present, the
+   provider-wide ladder next, and `undefined` when nothing is declared.
+   Anthropic hits the last arm.
+4. `src/codex/catalog/provider-fetch.ts:749-772` spreads
+   `reasoningEfforts` onto the `CatalogModel` only when it is not
+   `undefined`, so the catalog row carries no ladder.
+5. `src/server/management/model-rows.ts:150-165` builds the
+   `ManagementModelRow` from that catalog row, and `toExportModel`
+   (`model-rows.ts:170-182`) copies `reasoningEfforts` only when present.
+6. `normalizeExportModels` (`src/clients/config-export.ts:934-942`) preserves
+   the object as-is.
+7. `buildPiClientConfig` (`config-export.ts:1229-1258`) emits `reasoning: true`
+   plus `thinkingLevelMap` ONLY when
+   `Array.isArray(model.reasoningEfforts) && model.reasoningEfforts.length > 0`.
+   Aside reuses that builder through `buildAsideContribution`
+   (`config-export.ts:1778-1780`), so the Claude rows are written with no
+   effort control.
+
+Every step is behaving as designed. The only missing fact is the ladder itself,
+which was never declared for the native Anthropic providers.
+
+`candidateCapabilityEvidence` still matters, but as BLAST RADIUS rather than as
+the defect path — see 010.
+
+## The adapter already supports effort
+
+This is the fact that makes the fix a one-place change rather than a feature.
+`src/adapters/anthropic.ts` has honored effort for a long time (line ~922):
+
+- Adaptive families send `thinking: {type:"adaptive"}` plus
+  `output_config: {effort}`. `adaptiveEffort()` (line 553) maps `minimal` to
+  `low` because the wire rejects `minimal` with a 400, and accepts
+  `low|medium|high|xhigh|max`.
+- Older families send `thinking: {type:"enabled", budget_tokens}` sized by
+  `reasoningBudget()` (line 463), which has a distinct budget for every rung:
+  minimal 1024, low 4096, medium 8192, high 16384, xhigh 24576, max 32000.
+
+So the proxy has always been willing to send effort for these models; it simply
+never told any client the knob existed. A user could reach it by hand-editing
+`thinkingLevelMap`, which is exactly the workaround shape that indicates a
+missing advertisement rather than a missing capability.
+
+## Which ladder is correct per family
+
+`ADAPTIVE_THINKING_FAMILY_MINIMUMS` (line 483) splits the wire shapes, and its
+comment records vendor verification against api.anthropic.com: sonnet>=5,
+fable (any), opus>=4.7 require adaptive; haiku-4-5 and sonnet-4-5 reject it;
+opus-4-6 and sonnet-4-6 accept both.
+
+`ANTHROPIC_MODELS` (registry line 350) is: claude-fable-5-1, claude-fable-5,
+claude-sonnet-5, claude-opus-5, claude-opus-4-8, claude-opus-4-7,
+claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5.
+
+Both wire shapes cover the same five rungs, so the honest ladder is the same for
+every model in the list: `low, medium, high, xhigh, max`.
+
+- `minimal` is deliberately EXCLUDED. Adaptive models 400 on it, and the
+  adapter only survives it by silently rewriting it to `low`. Advertising a rung
+  that collapses into another rung invites a user to pick a setting that does
+  nothing.
+- `none` is deliberately EXCLUDED. `supportsExplicitThinkingDisable` is seeded
+  with sonnet>=5 ONLY, and its comment warns that a wrong entry turns a silent
+  truncation into a 400. Fable in particular always thinks and rejects an
+  explicit disable. A ladder-wide `none` would advertise an off switch that does
+  not exist for most of the list.
+- `ultra` is not an Anthropic concept; `reasoningBudget` has no case for it and
+  it would fall through to the medium default.
+
+## Blast radius of adding the ladder
+
+`modelReasoningEfforts` is read by more than the catalog, so the change is
+checked against each consumer. Two of these turned into required correctness
+work rather than mere acknowledgement (010 phases 2 and 3).
+
+- `src/clients/config-export.ts` — every exporter with an effort concept (pi,
+  aside, prime, omp, dsh, hermes, openclaw, kimi, zcode) starts emitting the
+  control. This is the user-visible fix.
+- `src/providers/derive.ts:493` — enrichment copies the registry map only when
+  the persisted provider has NO map
+  (`if (!prov.modelReasoningEfforts && seed.modelReasoningEfforts)`). One
+  customized Anthropic model would therefore suppress the registry ladder for
+  all eight others. The neighbouring `modelInputModalities` line already uses
+  the per-key `fillRecordOfArrays` for exactly this reason, and its comment
+  documents the same class of bug. Requests are unaffected because
+  `routedProviderConfig` merges per key (`src/router.ts:181-189`), so the
+  symptom would be split-brain: correct on the wire, missing in the catalog.
+- `src/routing/capability.ts:216-239` — `candidateCapabilityEvidence` reads the
+  registry map directly and, unlike `configuredReasoningEfforts`
+  (`reasoning-effort.ts:148`) and `supportedLadderFor`
+  (`effort-policy.ts:119-127`), never consults `noReasoningModels`. Today that
+  is harmless for Anthropic because there is no ladder to report; once one
+  exists, a model the user explicitly disabled reasoning for would still present
+  five supported rungs to `src/routing/evaluator.ts:141,218`.
+- `src/server/effort-policy.ts:122` — supplies the ladder to the effort CAP.
+  Note this is not a general per-request clamp: `effortCapAppliesTo` gates it
+  (`src/server/responses/core.ts:2159-2163`), so it only engages when the user
+  configured `effortCap`/`subagentEffortCap`.
+- `src/routing/compatibility/behavior.ts:194-200` — `reasoning.supported` flips
+  false to true and `reasoning.efforts` gains five rungs, which changes the
+  Compatibility Lab behavior fingerprint for Anthropic. That invalidation is
+  intended: the previous fingerprint recorded a capability the proxy really has.
+
+### What does NOT change
+
+`ultra` handling. `src/responses/parser.ts:814-820` already degrades `ultra` to
+`max` at parse time, and `mapReasoningEffort` applies the same boundary
+(`src/reasoning-effort.ts:209-225`). An earlier draft claimed the new ladder
+would newly clamp `ultra`; that assertion is already green today and cannot
+demonstrate activation.
+
+The Codex catalog surface also already synthesizes `max`/`ultra` rungs for any
+reasoning-capable routed row (`src/codex/catalog/effort.ts:225-237`), so this
+change does not introduce `ultra` there either.
+
+## Related defects found in the same evidence chain
+
+Two more rows in the live catalog advertise no ladder. Recorded here and
+investigated in 030 rather than silently bundled into this fix:
+
+- `lidge/qwen3.8-27b-nvfp4` — the provider block has no `models` key at all and
+  no `modelReasoningEfforts`.
+- `opencode-free/muse-spark-1.2-contributor-free` — the provider declares
+  `modelReasoningEfforts` for `deepseek-v4-flash-free` only, so the muse row
+  falls through.
+
+Neither is the reported bug, and each needs its own capability evidence before a
+ladder can be asserted honestly.

--- a/devlog/_plan/260904_anthropic_effort_ladder/010_registry_ladder.md
+++ b/devlog/_plan/260904_anthropic_effort_ladder/010_registry_ladder.md
@@ -1,0 +1,254 @@
+# 010 — Declare the reasoning-effort ladder on the native Anthropic providers
+
+Work phase: wp2. Consumes 000.
+
+Scope was one production file in the first draft. The audit disproved that:
+declaring the ladder is necessary but not sufficient, because enrichment can
+drop it and routing evidence can contradict it. Three production files.
+
+## Phase 1 — `src/providers/registry.ts` (the advertisement)
+
+Add one shared constant beside the existing Anthropic constants (after
+`ANTHROPIC_MODEL_CONTEXT_WINDOWS`, line ~351):
+
+```ts
+/**
+ * Every model in ANTHROPIC_MODELS accepts the same five rungs, because both wire
+ * shapes the adapter emits cover the same range: adaptive families take
+ * output_config.effort (low|medium|high|xhigh|max) and older families take a
+ * thinking budget, which reasoningBudget() sizes distinctly for each of those
+ * five. Deliberately excluded: minimal (adaptive 400s on it and the adapter
+ * rewrites it to low, so it is not a distinct setting), none (only sonnet>=5
+ * accepts an explicit thinking disable; Fable rejects one outright), and ultra
+ * (not an Anthropic concept; reasoningBudget has no case for it).
+ */
+const ANTHROPIC_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
+const ANTHROPIC_MODEL_REASONING_EFFORTS: Record<string, string[]> = Object.fromEntries(
+  ANTHROPIC_MODELS.map(id => [id, [...ANTHROPIC_REASONING_EFFORTS]]),
+);
+```
+
+Then add `modelReasoningEfforts` to BOTH provider entries, next to the existing
+`modelContextWindows` line so the metadata stays visually grouped:
+
+- `anthropic` (line ~1341): `modelReasoningEfforts: { ...ANTHROPIC_MODEL_REASONING_EFFORTS },`
+- `anthropic-apikey` (line ~1356): the same spread.
+
+Both entries get it. They share `ANTHROPIC_MODELS` and the same adapter, so a
+ladder on only one would make the effort control depend on whether the user
+signed in with OAuth or an API key — the exact class of inconsistency this unit
+is fixing. `tests/provider-registry-parity.test.ts:450-451` already asserts the
+two entries agree on `models` and `modelContextWindows`; extend it to the ladder.
+
+### What the ladder means
+
+It is an OPENCODEX ladder, not a claim that every model takes
+`output_config.effort`. Fable 5/5.1, Sonnet 5, Opus 5 and Opus 4.7/4.8 send the
+five values directly; Opus 4.6, Sonnet 4.6 and Haiku 4.5 take the legacy budget
+path where the adapter TRANSLATES each rung into `thinking.budget_tokens`. Per
+Anthropic's effort documentation the 4.6 models expose `low|medium|high|max`
+natively and Haiku 4.5 has no effort parameter at all — the adapter's budget
+translation is what makes five rungs meaningful there. That is why the ladder is
+uniform: the proxy, not the vendor, defines it, and the adapter honors all five
+for every family without a 400 (budgets are clamped below `max_tokens` at
+`src/adapters/anthropic.ts:947-956`).
+
+## Phase 2 — `src/providers/derive.ts` (make enrichment per-model)
+
+Line 493 today:
+
+```ts
+if (!prov.modelReasoningEfforts && seed.modelReasoningEfforts) prov.modelReasoningEfforts = cloneRecordOfArrays(seed.modelReasoningEfforts);
+```
+
+becomes the per-key fill already used one line above it for modalities:
+
+```ts
+if (seed.modelReasoningEfforts) {
+  prov.modelReasoningEfforts = fillRecordOfArrays(seed.modelReasoningEfforts, prov.modelReasoningEfforts);
+}
+```
+
+`fillRecordOfArrays` (line 111) spreads the seed first and the user's map second,
+so per-model user entries stay authoritative while untouched models inherit the
+registry. Without this, any user who customized ONE Anthropic model keeps the bug
+for the other eight, and in a particularly confusing shape: routing merges these
+maps per key already (`src/router.ts:181-189`), so the wire would honor the
+effort while `/v1/models` and Aside still showed no control.
+
+Precisely: authoritative for the SAME EXACT KEY. A differently-cased user key can
+coexist with the canonical registry key, and `modelRecordValue`
+(`src/reasoning-effort.ts:115-126`) resolves an exact match before its
+case-folded fallback, so the canonical entry wins the lookup. The direct-contract
+pass (`derive.ts:130-147,158-205,562`) then removes folded duplicates and
+restores the explicit spelling, which is why
+`tests/alibaba-intl-token-plan.test.ts:102-121` stays green.
+
+This is a general fix, not an Anthropic one — it repairs the same latent bug for
+every provider with a registry ladder. Its comment at line 100-107 documents the
+identical reasoning for `modelInputModalities`; that precedent is why this rides
+in the same PR rather than becoming a separate unit.
+
+## Phase 3 — `src/routing/capability.ts` (do not contradict `noReasoningModels`)
+
+Two edits in one file: the guard, and the line-239 spread that would otherwise
+discard its result.
+
+`candidateCapabilityEvidence` (line 216) reads the registry map directly and
+never consults `noReasoningModels`, unlike `configuredReasoningEfforts`
+(`src/reasoning-effort.ts:148`), `supportedLadderFor`
+(`src/server/effort-policy.ts:119-127`) and the compatibility fingerprint
+(`src/routing/compatibility/behavior.ts:194-196`). Add the same guard first:
+
+```ts
+const reasoningEfforts = modelInList(provider?.noReasoningModels, modelId)
+  ? []
+  : modelRecordValue(provider?.modelReasoningEfforts, modelId)
+    ?? modelRecordValue(registryEntry?.modelReasoningEfforts, modelId)
+    ?? (isNative ? nativeReasoningEfforts(modelId) : undefined);
+```
+
+The `[]` must SURVIVE into the returned evidence, which the current line 239
+prevents:
+
+```ts
+...(reasoningEfforts !== undefined && reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+```
+
+An empty ladder is dropped, the property is absent, and
+`src/routing/evaluator.ts:141-150` and `:218-227` take their
+`Array.isArray(ladder)` false branch and record `unknown`. Unknown is
+permissive — it is "we could not tell", not "this model has no effort control".
+So returning `[]` alone would leave the original defect intact behind a
+different code path.
+
+Change line 239 to preserve a DEFINED ladder, empty or not:
+
+```ts
+...(reasoningEfforts !== undefined ? { reasoningEfforts } : {}),
+```
+
+Blast radius of that widening, since it affects every provider and not just
+Anthropic: a defined-but-empty ladder today comes from an explicit per-model
+`[]` in config or registry, which `src/types/provider.ts:465-467` documents as
+"intentionally expose no effort control". Every other consumer already reads
+`[]` as a known negative — `configuredReasoningEfforts`
+(`reasoning-effort.ts:148`) returns `[]` for `noReasoningModels`,
+`supportedLadderFor` (`effort-policy.ts:119-127`) does the same, and
+`behavior.ts:194-196` reports `reasoning.supported: false`. Routing evidence is
+the one surface that silently downgraded that to unknown. Making it agree is the
+intent, and the evaluator change is the observable effect: a candidate with an
+explicit empty ladder now returns `unsatisfied` for a reasoning-effort
+requirement instead of `unknown`.
+
+Today this cannot misfire for Anthropic because there is no ladder to report.
+Phase 1 is exactly what makes it reachable, which is why it belongs in this PR.
+
+The spread (rather than sharing one object reference) matches how
+`modelContextWindows` is already written on these two entries and keeps a
+later mutation of one provider from reaching the other.
+
+## Why no `modelDefaultReasoningEfforts`
+
+Considered and rejected. Setting a default would change what the proxy SENDS for
+callers who specify nothing, which is a behavior change for existing users beyond
+the reported bug. The reported bug is that the control is absent, not that its
+default is wrong. Anthropic's own defaults stay in force: adaptive models decide
+for themselves, and `defaultReasoningEffort()` returns undefined so the adapter
+omits the field exactly as it does today.
+
+Consequence to keep in mind while reading the export: `buildPiClientConfig`
+emits no per-model default either (config-export.ts line ~823 documents that the
+proxy owns the default), so the client shows a ladder with no preselected rung.
+That is the same shape every other routed provider already has.
+
+## Scope boundary
+
+IN: the two registry entries plus constants, the `derive.ts` per-model fill, and
+the `capability.ts` `noReasoningModels` guard.
+
+OUT: `src/adapters/anthropic.ts` (already correct — see 000), the exporters in
+`src/clients/config-export.ts` (they key off the ladder and need no edit),
+`effort-policy.ts` (already correct), and the unrelated empty-ladder providers
+in 030 — that investigation ships in its own change, never in this PR.
+
+## Accept criteria
+
+1. `GET /v1/models` returns `supports_reasoning_effort: true` and
+   `reasoning_efforts` of low..max for every `anthropic/claude-*` row, and the
+   same for `anthropic-apikey` when configured.
+2. The Aside export document emits `reasoning: true` and a `thinkingLevelMap`
+   for those rows, with `off` and `minimal` mapped to `null` (the ladder
+   declares neither) and `max` mapped to `max`.
+3. A provider carrying a PARTIAL persisted `modelReasoningEfforts` still
+   receives the registry ladder for its untouched models, and the customized
+   model keeps the user's value.
+4. A model listed in `noReasoningModels` reports no effort evidence to routing
+   even though the registry now declares a ladder.
+5. `bun run typecheck` passes.
+
+The earlier `ultra` criterion is deleted, not weakened: `parser.ts:814-820`
+already degrades `ultra` to `max`, so that assertion passes before the change
+and proves nothing.
+
+### Activation scenarios (C-ACTIVATION-GROUNDING-01)
+
+Both new conditional paths must be shown to fire:
+
+- Phase 2's per-key fill activates when the persisted provider has a non-empty
+  `modelReasoningEfforts` missing some registry keys. C constructs exactly that
+  config; the observable effect is the untouched model's ladder in the enriched
+  provider. Under the old line the map is returned unchanged, so this assertion
+  is red before the change.
+- Phase 3's guard activates when `noReasoningModels` names a model the registry
+  gives a ladder. The observable effect is `reasoningEfforts: []` in the
+  capability evidence AND an `unsatisfied` (not `unknown`) evaluator outcome for
+  a reasoning-effort requirement. Asserting mere ABSENCE would be a green
+  no-op — absence is exactly the buggy state — so the assertion is on the
+  present-and-empty value and the downstream outcome. This is red after phase 1
+  alone, which is the point: phase 1 is what makes it reachable.
+
+## Test plan
+
+Rewritten after audit. The first draft built an `ExportModel` that already
+carried the ladder, which tests the serializer and skips every hop where the bug
+actually lives. Tests attach to the subsystem they cover:
+
+1. `tests/provider-registry-parity.test.ts` — extend the existing anthropic
+   parity block (line ~440-451): both entries declare a ladder for every id in
+   `ANTHROPIC_MODELS`, the two agree, and the ladder excludes `minimal`,
+   `none` and `ultra`. Asserting the exclusions is the point: a future widening
+   to `minimal` would be collapsed to `low` by `adaptiveEffort`.
+2. `tests/aside-client.test.ts` — the anthropic fixture at line 38 currently
+   carries no ladder and asserts nothing about it. Give it the ladder and assert
+   `buildClientConfig("aside", ctx)` emits `reasoning: true` with `off` and
+   `minimal` null. Use the PUBLIC `buildClientConfig` entry point
+   (`config-export.ts:1963`) — `buildPiClientConfig` and
+   `buildAsideContribution` are private. Keep a no-ladder row in the same
+   document asserting neither field appears, so the test fails if someone makes
+   `reasoning: true` unconditional.
+3. Enrichment: a focused test over `enrichProviderFromRegistry` with a partial
+   persisted `modelReasoningEfforts`, asserting registry fill for untouched
+   models and user precedence for the customized one.
+4. `tests/routing-capability-model-matching.test.ts` — a `noReasoningModels`
+   case asserting `evidence.reasoningEfforts` EQUALS `[]` (not merely absent),
+   fed through the evaluator to assert `outcome: "unsatisfied"`, plus a control
+   case that still reports the five-rung ladder and `satisfied`.
+5. `tests/management-client-config-route.test.ts` — the INTEGRATION regression,
+   and the only test here that covers the seam the bug actually lives in. Items
+   1-4 and the aside-client serializer contract all start from hand-built
+   fixtures, so every one of them would stay green if enrichment,
+   `CatalogModel`, `ManagementModelRow` or `toExportModel` dropped the field
+   tomorrow. This case starts from a canonical minimal Anthropic PROVIDER
+   CONFIG and asserts the resulting Aside document, exercising
+   `registry -> enrichProviderFromRegistry -> CatalogModel -> ManagementModelRow
+   -> toExportModel -> buildClientConfig("aside")` end to end. That route file
+   already drives model loading through the public client-config boundary, so
+   the fixture cost is small. It is red before phase 1 and green after.
+
+Run each touched file with `bun test tests/<file>.test.ts`, plus
+`bun test tests/anthropic-reasoning.test.ts` to show the wire path is
+unaffected, plus `bun run typecheck`. AGENTS.md also recommends
+`bun run test:changed` for a change with this many consumers; it selects by
+import graph and is NOT the repository-wide suite the user forbade, so it is
+included. A bare `bun test` or `bun run test` is not run under any circumstance.

--- a/devlog/_plan/260904_anthropic_effort_ladder/020_verification_and_pr.md
+++ b/devlog/_plan/260904_anthropic_effort_ladder/020_verification_and_pr.md
@@ -1,0 +1,71 @@
+# 020 — Live verification and pull request
+
+Work phase: wp3. Consumes 010.
+
+## Why a live check is required
+
+The unit tests prove the registry declares a ladder and the builder emits the
+control. Neither proves the ladder survives the path a real user exercises:
+config load, catalog assembly, the `/v1/models` serializer, then the export
+writer into the file Aside parses. The reported bug lived precisely in that
+seam — every individual component was correct.
+
+## Steps
+
+1. Rebuild/restart a SCRATCH proxy. The live proxy on port `10100` is the
+   user's working instance and must not be disturbed for an experiment: use a
+   separate `OPENCODEX_HOME` and a scratch port.
+2. `curl -s http://127.0.0.1:<scratch>/v1/models` and confirm the
+   `anthropic/claude-*` rows now carry `supports_reasoning_effort: true` and
+   the five-rung ladder. Capture the before/after rows as evidence.
+3. Render the Aside export document from the same catalog and confirm
+   `reasoning: true` plus `thinkingLevelMap` on those rows. Do NOT overwrite
+   the user's real `~/.aside/u/0/models.json` as part of the fix; render to a
+   scratch path. Rewriting it is the user's own re-export action.
+4. Optional UI confirmation via the Aside surface, if the scratch catalog can be
+   pointed at without touching the signed-in profile's live config. Skipped
+   rather than forced: mutating the user's real Aside config to take a
+   screenshot would change account state for evidence, which is not a trade
+   worth making when the file-level proof is exact.
+
+## Commit and push
+
+The worktree is DETACHED at `072df52e` and the local `dev` ref is behind it, so
+"branch off dev" is ambiguous here and could produce a stale base. Bind the base
+to a freshly fetched SHA instead:
+
+1. `git fetch origin dev` and record `FETCH_HEAD`.
+2. Confirm the current detached HEAD against it; branch from the fetched SHA.
+3. `git switch -c codex/260904-anthropic-effort-ladder <sha>` — created IN this
+   worktree (WORKTREE-GUARD-01: adopt in place, never relocate or recreate).
+4. Preserve the untracked plan directory across the switch.
+
+- Commit the three production files, the tests, and this devlog unit.
+- 030 does NOT ship in this PR (see below).
+- Push with `--no-verify` — explicitly authorized by the user for this task.
+- The repository-wide suite is explicitly forbidden by the user, so the PR
+  description states exactly which focused checks were run rather than implying
+  the full gate passed. Claiming a green full suite that was never run is worse
+  than reporting a narrower proof.
+
+## One logical change
+
+`030_related_empty_ladders.md` is an investigation of unrelated providers. It
+stays in the plan unit as a record but its FINDINGS ship separately: a reviewer
+judging an Anthropic ladder should not also have to adjudicate lidge and
+opencode-free capabilities. If 030 produces a code change, it gets its own PR.
+
+## Pull request
+
+Target `dev` (never `main`). Fill all three template sections from
+`.github/PULL_REQUEST_TEMPLATE.md`: Summary, Verification, Checklist. No
+screenshot is required because the change touches no GUI surface; the title and
+description must therefore avoid the word `gui`, which would trip the
+screenshot gate in `enforce-target`.
+
+## Accept criteria
+
+- Live catalog shows the ladder for `anthropic/claude-*`.
+- Export document shows `reasoning: true` and `thinkingLevelMap`.
+- PR is open against `dev` with every template section filled, based on the
+  exact fetched `origin/dev` SHA.

--- a/devlog/_plan/260904_anthropic_effort_ladder/030_related_empty_ladders.md
+++ b/devlog/_plan/260904_anthropic_effort_ladder/030_related_empty_ladders.md
@@ -48,3 +48,59 @@ contract — a ladder claim there needs a live probe, not a guess.
 
 A written finding per candidate naming the adapter, the capability evidence, and
 the verdict. Reported to the user regardless of whether any code changes.
+
+## Findings (260904)
+
+### `lidge/qwen3.8-27b-nvfp4` — NOT A DEFECT, and not this repository's to fix
+
+`lidge` is not a registry provider. The only two `lidge` matches in
+`src/providers/registry.ts` are maintainer-attribution comments (lines 744 and
+1781). It is the operator's own **custom provider** in `~/.opencodex/config.json`,
+pointed at `http://100.100.125.116:8081/v1` on a private network, and it is
+currently `disabled: true`. The model is a `customModels` row whose
+`reasoningEfforts` is unset.
+
+There is no registry ladder that could fill it, and there should not be: it is a
+self-hosted vLLM-style endpoint whose capabilities depend on the deployed server
+and its launch flags, not on a vendor contract this repository can assert. The
+correct fix is operator-side — set the ladder on the custom model, which the
+management API already supports (`src/server/management/model-routes.ts` reads
+`reasoningEfforts` on a custom-model PUT).
+
+Verdict: **no code change.** Report to the user as a configuration note.
+
+### `opencode-free/muse-spark-1.2-contributor-free` — NOT A DEFECT under the fix rule
+
+The provider DOES declare `modelReasoningEfforts`, but only for
+`OPENCODE_FREE_DEEPSEEK_MODELS` — a one-element list, `deepseek-v4-flash-free`
+(registry line 616). Every other Zen free model, including the muse row, falls
+through with no ladder.
+
+That is not the Anthropic shape. Zen's free roster is `liveModels: true`:
+discovered at runtime, changing on the vendor's schedule, and heterogeneous —
+DeepSeek thinking models sit beside models with no reasoning at all. The
+DeepSeek entries are declared precisely because they were pinned to a verified
+wire contract (`modelReasoningEffortMap`, `preserveReasoningContentModels`,
+issues #950/#994). Asserting a ladder for a discovered model whose upstream
+effort support nobody verified would be exactly the failure mode this unit's
+own rule forbids: an advertised control that may do nothing.
+
+Note also that `muse-spark-1.2-contributor-free` on the Zen tier is a different
+route from `meta-muse/muse-spark-1.3`, which DOES carry a ladder
+(`META_MUSE_REASONING_EFFORTS`, registry line 1508). So the capability is
+already advertised where it was verified.
+
+Verdict: **no code change without a live probe** of the Zen route's effort
+handling. Recorded as a candidate, not a defect.
+
+### What the two have in common
+
+Neither is the reported bug. The Anthropic case was a first-party provider with a
+known vendor contract and an adapter that already honored effort — every fact
+needed to assert the ladder was in the repository. These two are a private
+self-hosted endpoint and a live-discovered free roster; in both the missing
+ladder is an honest "unknown" rather than a lost fact.
+
+The general `derive.ts` per-model fill shipped in the Anthropic PR does help
+both classes going forward: any operator who pins one model on these providers
+will no longer suppress whatever registry knowledge exists for the others.

--- a/devlog/_plan/260904_anthropic_effort_ladder/030_related_empty_ladders.md
+++ b/devlog/_plan/260904_anthropic_effort_ladder/030_related_empty_ladders.md
@@ -1,0 +1,50 @@
+# 030 — Related: other rows advertising no effort ladder
+
+Work phase: wp4. Consumes 020. Investigation first; a fix only where evidence
+supports one.
+
+## Candidates from the live catalog
+
+`GET /v1/models` on 2026-09-04 returned an empty ladder for three rows besides
+the Anthropic ones. Two are genuine candidates:
+
+| Row | Provider block state |
+|---|---|
+| `lidge/qwen3.8-27b-nvfp4` | no `models` key, no `modelReasoningEfforts` |
+| `opencode-free/muse-spark-1.2-contributor-free` | `modelReasoningEfforts` declares `deepseek-v4-flash-free` only |
+
+## The question to answer for each
+
+Not "does it have a ladder" — the catalog already answers that. The question is
+whether the ADAPTER would honor an effort if one were declared, which is what
+made the Anthropic case a safe fix. An empty ladder on a model whose adapter
+ignores or rejects effort is CORRECT, and adding one there would advertise a
+control that silently does nothing.
+
+So for each candidate:
+
+1. Which adapter serves it, and does that adapter have an effort path?
+2. Is the model reasoning-capable at all, per its own vendor surface?
+3. Is it excluded on purpose (a `noReasoningModels` entry, a deliberate empty
+   `reasoningEfforts: []`)? Several providers in the registry declare
+   `reasoningEfforts: []` explicitly, which is a positive statement of "no
+   reasoning", not an oversight.
+
+`lidge` is a local/self-hosted block with `allowPrivateNetwork` and an API-key
+pool, so its capabilities depend on the deployed server rather than a vendor
+contract — a ladder claim there needs a live probe, not a guess.
+
+## Disposition rule
+
+- Adapter honors effort AND the model reasons -> same fix shape as 010, but as
+  its own change with its own evidence. It does NOT ride along in the Anthropic
+  PR; a reviewer evaluating a Claude fix should not have to also adjudicate an
+  unrelated provider's capabilities.
+- Adapter ignores effort, or capability is unproven -> report to the user with
+  the evidence and leave the catalog honest. An unproven ladder is a worse defect
+  than a missing one, because the control appears to work.
+
+## Deliverable
+
+A written finding per candidate naming the adapter, the capability evidence, and
+the verdict. Reported to the user regardless of whether any code changes.

--- a/src/providers/derive.ts
+++ b/src/providers/derive.ts
@@ -490,7 +490,14 @@ export function enrichProviderFromRegistry(name: string, prov: OcxProviderConfig
   if ((!prov.reasoningEfforts || hasLegacyClinePassReasoningEfforts(name, prov)) && seed.reasoningEfforts) {
     prov.reasoningEfforts = [...seed.reasoningEfforts];
   }
-  if (!prov.modelReasoningEfforts && seed.modelReasoningEfforts) prov.modelReasoningEfforts = cloneRecordOfArrays(seed.modelReasoningEfforts);
+  // Per-model fill for the same reason as modelInputModalities above: an all-or-nothing
+  // copy let ONE customized model hide the registry's ladder for every other model on the
+  // provider. That split the two planes apart — routing merges these maps per key
+  // (mergeRecordFill in src/router.ts), so the wire honored the effort while /v1/models and
+  // every client export showed no effort control at all.
+  if (seed.modelReasoningEfforts) {
+    prov.modelReasoningEfforts = fillRecordOfArrays(seed.modelReasoningEfforts, prov.modelReasoningEfforts);
+  }
   if (!prov.modelDefaultReasoningEfforts && seed.modelDefaultReasoningEfforts) prov.modelDefaultReasoningEfforts = { ...seed.modelDefaultReasoningEfforts };
   if (!prov.reasoningEffortMap && seed.reasoningEffortMap) prov.reasoningEffortMap = { ...seed.reasoningEffortMap };
   if (!prov.modelReasoningEffortMap && seed.modelReasoningEffortMap) prov.modelReasoningEffortMap = cloneNestedRecord(seed.modelReasoningEffortMap);

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -349,6 +349,34 @@ export type ProviderConfigSeed = Pick<
 // always on, per the official models overview and pricing page (platform.claude.com).
 const ANTHROPIC_MODELS = ["claude-fable-5-1", "claude-fable-5", "claude-sonnet-5", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"];
 const ANTHROPIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = { "claude-fable-5-1": 1_000_000, "claude-sonnet-5": 1_000_000, "claude-fable-5": 1_000_000, "claude-opus-5": 1_000_000, "claude-opus-4-8": 1_000_000, "claude-opus-4-7": 1_000_000, "claude-opus-4-6": 1_000_000, "claude-sonnet-4-6": 1_000_000, "claude-haiku-4-5": 200_000 };
+/**
+ * The effort rungs opencodex exposes for native Anthropic models. Without this the
+ * providers advertised no ladder at all, so every client that keys its effort control off
+ * `reasoningEfforts` — Aside and the rest of the Pi-shaped exports — wrote these models
+ * with no control, while the SAME Claude models routed through `cursor` or
+ * `google-antigravity` had one.
+ *
+ * This is an opencodex ladder, not a claim that each model takes `output_config.effort`.
+ * The adapter serves two wire shapes (src/adapters/anthropic.ts): adaptive families
+ * (fable, sonnet >= 5, opus >= 4.7) send the effort directly, while opus 4.6, sonnet 4.6
+ * and haiku 4.5 take the legacy path where `reasoningBudget` TRANSLATES each rung into
+ * `thinking.budget_tokens`. Anthropic documents `low|medium|high|max` for the 4.6 models
+ * and no effort parameter at all for haiku 4.5; the budget translation is what makes five
+ * rungs meaningful there, and it clamps below `max_tokens` so none of them 400.
+ *
+ * Deliberately excluded, each because advertising it would offer a control that does not
+ * do what it says:
+ * - `minimal`: `adaptiveEffort` rewrites it to `low` (the adaptive wire 400s on it), so
+ *   it is not a distinct setting.
+ * - `none`: only sonnet >= 5 accepts an explicit thinking disable
+ *   (`EXPLICIT_THINKING_DISABLE_FAMILY_MINIMUMS`); Fable rejects one outright.
+ * - `ultra`: not an Anthropic concept, and it is degraded to `max` at the request
+ *   boundary anyway (src/responses/parser.ts).
+ */
+const ANTHROPIC_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
+const ANTHROPIC_MODEL_REASONING_EFFORTS: Record<string, string[]> = Object.fromEntries(
+  ANTHROPIC_MODELS.map(id => [id, [...ANTHROPIC_REASONING_EFFORTS]]),
+);
 
 // 260814 GLM-5.3 is registered pre-emptively alongside 5.2 everywhere 5.2 appears. Z.AI's
 // devpack "How to Switch Models" page (docs.z.ai/devpack/latest-model) lists glm-5.3 and
@@ -1340,6 +1368,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     note: "Log in with your Claude account",
     models: [...ANTHROPIC_MODELS],
     modelContextWindows: { ...ANTHROPIC_MODEL_CONTEXT_WINDOWS },
+    modelReasoningEfforts: { ...ANTHROPIC_MODEL_REASONING_EFFORTS },
     defaultModel: "claude-sonnet-5",
   },
   {
@@ -1356,6 +1385,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     models: [...ANTHROPIC_MODELS],
     liveModels: true,
     modelContextWindows: { ...ANTHROPIC_MODEL_CONTEXT_WINDOWS },
+    modelReasoningEfforts: { ...ANTHROPIC_MODEL_REASONING_EFFORTS },
     defaultModel: "claude-sonnet-5",
   },
   {

--- a/src/routing/capability.ts
+++ b/src/routing/capability.ts
@@ -213,9 +213,18 @@ export function candidateCapabilityEvidence(
     || provider?.parallelToolCalls === true
     || undefined;
 
-  const reasoningEfforts = modelRecordValue(provider?.modelReasoningEfforts, modelId)
-    ?? modelRecordValue(registryEntry?.modelReasoningEfforts, modelId)
-    ?? (isNative ? nativeReasoningEfforts(modelId) : undefined);
+  // `noReasoningModels` is a POSITIVE statement that this model has no effort control, and
+  // every other consumer already reads it that way: configuredReasoningEfforts
+  // (reasoning-effort.ts), supportedLadderFor (server/effort-policy.ts) and the
+  // compatibility fingerprint (routing/compatibility/behavior.ts) all check it first.
+  // Routing evidence did not, which was harmless only while no registry ladder existed to
+  // contradict it — a provider-level ladder would otherwise report supported rungs for a
+  // model the operator explicitly disabled reasoning for.
+  const reasoningEfforts = modelInList(provider?.noReasoningModels, modelId)
+    ? []
+    : modelRecordValue(provider?.modelReasoningEfforts, modelId)
+      ?? modelRecordValue(registryEntry?.modelReasoningEfforts, modelId)
+      ?? (isNative ? nativeReasoningEfforts(modelId) : undefined);
 
   const tierSupport = provider
     ? serviceTierSupportForModel(provider, modelId, providerName)
@@ -236,7 +245,11 @@ export function candidateCapabilityEvidence(
     ...(typeof contextWindow === "number" ? { contextWindow } : {}),
     ...(typeof image === "boolean" ? { image } : {}),
     ...(typeof tools === "boolean" ? { tools } : {}),
-    ...(reasoningEfforts !== undefined && reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+    // A DEFINED but empty ladder is known-negative evidence and must survive. Dropping it
+    // made the evaluator take its `!Array.isArray` branch and record "unknown", which is
+    // permissive — "we could not tell" rather than "this model has no effort control" — so
+    // an explicitly disabled model could still satisfy a reasoning-effort requirement.
+    ...(reasoningEfforts !== undefined ? { reasoningEfforts } : {}),
     ...(serviceTier !== "unknown" ? { serviceTier } : {}),
     ...localRemote,
     ...(typeof encryptedCodexTasks === "boolean" ? { encryptedCodexTasks } : {}),

--- a/tests/aside-client.test.ts
+++ b/tests/aside-client.test.ts
@@ -98,6 +98,48 @@ describe("Aside client config", () => {
     expect(unknown.maxTokens).toBeUndefined();
   });
 
+  /**
+   * The defect this client existed to expose: native Anthropic rows reached Aside with no
+   * effort control at all, while the SAME Claude models routed through cursor or
+   * google-antigravity had one. The serializer was never wrong — it emits the control only
+   * for a non-empty ladder, and the providers advertised none.
+   *
+   * This is the SERIALIZER half of the contract. It starts from a hand-built ExportModel, so
+   * it would stay green if enrichment or the catalog dropped the ladder upstream; the
+   * end-to-end guard for that seam lives in tests/management-client-config-route.test.ts.
+   */
+  test("an Anthropic row with a ladder gets an effort control, one without stays bare", () => {
+    const withLadder = buildClientConfig("aside", {
+      baseUrl: "http://127.0.0.1:10100/v1",
+      config: CONFIG,
+      models: [
+        {
+          namespaced: "anthropic/claude-opus-5",
+          provider: "anthropic",
+          id: "claude-opus-5",
+          contextWindow: 1_000_000,
+          reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+        },
+      ],
+    }) as PiGeneratedConfig;
+
+    const claude = withLadder.providers[OPENCODE_PROVIDER_ID]!.models[0]!;
+    expect(claude.reasoning).toBe(true);
+    expect(claude.thinkingLevelMap!.low).toBe("low");
+    expect(claude.thinkingLevelMap!.max).toBe("max");
+    // The ladder declares neither, so neither is offered as a selectable level.
+    expect(claude.thinkingLevelMap!.off).toBeNull();
+    expect(claude.thinkingLevelMap!.minimal).toBeNull();
+
+    // Negative control: the fixture's ladderless Anthropic row still gets no control, so this
+    // fails if anyone makes `reasoning: true` unconditional.
+    const bare = buildClientConfig("aside", context()) as PiGeneratedConfig;
+    const bareClaude = bare.providers[OPENCODE_PROVIDER_ID]!.models
+      .find(model => model.id === "anthropic/claude-opus-5")!;
+    expect(bareClaude.reasoning).toBeUndefined();
+    expect(bareClaude.thinkingLevelMap).toBeUndefined();
+  });
+
   test("native JSON round-trips and never carries a credential", () => {
     const sentinel = ["sk", "live", "aside", "sentinel"].join("-");
     const withKey = { ...CONFIG, apiKeys: [{ key: sentinel }] } as OcxConfig;

--- a/tests/management-client-config-route.test.ts
+++ b/tests/management-client-config-route.test.ts
@@ -8,6 +8,7 @@ import {
   seedCodexModelEntitlementsForTests,
 } from "../src/codex/model-entitlements";
 import { handleManagementAPI } from "../src/server/management-api";
+import { loadExportModels } from "../src/server/management/model-rows";
 import {
   OPENCODE_API_KEY_ENV,
   OPENCODE_CONFIG_SCHEMA,
@@ -157,6 +158,60 @@ function toExportModel(row: ModelRow): ExportModel {
   };
 }
 
+
+describe("native Anthropic effort ladder reaches the Aside document", () => {
+  /**
+   * The end-to-end guard for the defect: native Anthropic rows used to reach Aside with no
+   * effort control, while the SAME Claude models routed through cursor or google-antigravity
+   * had one. Every other test for this fix starts from a hand-built ExportModel or registry
+   * lookup, so all of them would stay green if enrichment, CatalogModel, ManagementModelRow
+   * or toExportModel dropped the field tomorrow. This one starts from a bare PROVIDER CONFIG
+   * and asserts the emitted document, so it covers the whole chain:
+   *
+   *   registry -> enrichProviderFromRegistry -> CatalogModel -> ManagementModelRow
+   *   -> toExportModel -> buildClientConfig("aside")
+   *
+   * It calls the production loader directly rather than the ?client=aside route, because that
+   * route resolves ~/.aside/accounts.json for its destination and this must not depend on the
+   * developer's real Aside install.
+   */
+  test("a bare Anthropic provider config emits reasoning and a thinkingLevelMap", async () => {
+    const config = {
+      port: 10100,
+      hostname: "127.0.0.1",
+      defaultProvider: "anthropic",
+      providers: {
+        anthropic: {
+          adapter: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          authMode: "oauth",
+          liveModels: false,
+        },
+      },
+    } as unknown as OcxConfig;
+
+    const models = await loadExportModels(config);
+    const document = buildClientConfig("aside", {
+      baseUrl: "http://127.0.0.1:10100/v1",
+      config,
+      models,
+    }) as PiGeneratedConfig;
+
+    const rows = document.providers[OPENCODE_PROVIDER_ID]!.models
+      .filter(model => model.id.startsWith("anthropic/claude-"));
+    expect(rows.length).toBeGreaterThan(0);
+
+    for (const row of rows) {
+      expect(row.reasoning).toBe(true);
+      expect(row.thinkingLevelMap!.low).toBe("low");
+      expect(row.thinkingLevelMap!.high).toBe("high");
+      expect(row.thinkingLevelMap!.max).toBe("max");
+      // The ladder declares neither sentinel, so neither is offered as a selectable level.
+      expect(row.thinkingLevelMap!.off).toBeNull();
+      expect(row.thinkingLevelMap!.minimal).toBeNull();
+    }
+  });
+});
 describe("GET /api/client-config", () => {
   test("opencode envelope carries the shared builder's exact bytes", async () => {
     const config = baseConfig();

--- a/tests/provider-registry-parity.test.ts
+++ b/tests/provider-registry-parity.test.ts
@@ -451,6 +451,33 @@ describe("provider registry parity", () => {
     expect(KEY_LOGIN_PROVIDERS["anthropic-apikey"].modelContextWindows).toEqual(anthropicOauth?.modelContextWindows);
   });
 
+  test("Anthropic providers advertise an effort ladder for every model on both auth flows", () => {
+    const anthropicOauth = PROVIDER_REGISTRY.find(entry => entry.id === "anthropic");
+    const apiKey = KEY_LOGIN_PROVIDERS["anthropic-apikey"];
+    // The ladder is what every client keys its effort control off. Without it Aside and the
+    // other Pi-shaped exports wrote these models with no control at all, while the same
+    // Claude models routed through cursor/google-antigravity had one.
+    for (const modelId of anthropicOauth?.models ?? []) {
+      expect(anthropicOauth?.modelReasoningEfforts?.[modelId]).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    }
+    // Both entries or neither: the effort control must not depend on whether the user signed
+    // in with OAuth or an API key.
+    expect(apiKey.modelReasoningEfforts).toEqual(anthropicOauth?.modelReasoningEfforts);
+  });
+
+  test("the Anthropic ladder omits rungs the adapter cannot honor distinctly", () => {
+    const anthropicOauth = PROVIDER_REGISTRY.find(entry => entry.id === "anthropic");
+    for (const efforts of Object.values(anthropicOauth?.modelReasoningEfforts ?? {})) {
+      // minimal is rewritten to low by adaptiveEffort (the adaptive wire 400s on it), none is
+      // only accepted by sonnet>=5 and rejected outright by Fable, and ultra is degraded to
+      // max at the request boundary. Advertising any of them offers a control that does not
+      // do what it says.
+      expect(efforts).not.toContain("minimal");
+      expect(efforts).not.toContain("none");
+      expect(efforts).not.toContain("ultra");
+    }
+  });
+
   test("Kimi coding aliases preserve model context and capability parity", () => {
     const codingModels = [
       "k3",

--- a/tests/provider-static-model-discovery.test.ts
+++ b/tests/provider-static-model-discovery.test.ts
@@ -28,6 +28,37 @@ describe("static provider model discovery policy", () => {
     }
   });
 
+  test("a partial persisted effort map does not suppress the registry ladder", () => {
+    // Per-model fill, not all-or-nothing. An operator who pinned ONE Anthropic model used to
+    // hide the registry ladder for every other model on the provider, which split the two
+    // planes apart: routedProviderConfig merges these maps per key, so the WIRE honored the
+    // effort while /v1/models and every client export showed no effort control at all.
+    const config = provider({
+      adapter: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      authMode: "oauth",
+      modelReasoningEfforts: { "claude-opus-5": ["low", "high"] },
+    });
+
+    enrichProviderFromRegistry("anthropic", config);
+
+    // The pinned model keeps the operator's value.
+    expect(config.modelReasoningEfforts?.["claude-opus-5"]).toEqual(["low", "high"]);
+    // Every untouched model still inherits the registry ladder.
+    expect(config.modelReasoningEfforts?.["claude-fable-5-1"]).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(config.modelReasoningEfforts?.["claude-haiku-4-5"]).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
+
+  test("native Anthropic models reach an enriched provider with an effort ladder", () => {
+    // The advertisement itself: without it the Aside/Pi exports wrote these models with no
+    // effort control, while the same Claude models via cursor/google-antigravity had one.
+    const config = provider({ adapter: "anthropic", baseUrl: "https://api.anthropic.com", authMode: "oauth" });
+    enrichProviderFromRegistry("anthropic", config);
+    for (const modelId of config.models ?? []) {
+      expect(config.modelReasoningEfforts?.[modelId]).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    }
+  });
+
   test("stale canonical ClinePass discovery is disabled without replacing saved models", () => {
     const savedModels = ["cline-pass/kimi-k3", "saved-selector"];
     const config = provider({

--- a/tests/routing-capability-model-matching.test.ts
+++ b/tests/routing-capability-model-matching.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { candidateCapabilityEvidence } from "../src/routing/capability";
+import { evaluatePolicyProfile } from "../src/routing/evaluator";
 import { PROVIDER_REGISTRY } from "../src/providers/registry";
 import { modelRecordValue } from "../src/reasoning-effort";
 import { isModelTextOnly } from "../src/vision";
@@ -78,6 +79,75 @@ describe("candidateCapabilityEvidence model matching", () => {
     );
     expect(evidence.contextWindow).toBe(8_000);
     expect(evidence.reasoningEfforts).toBeUndefined();
+  });
+
+  test("noReasoningModels reports an EMPTY ladder, not an absent one", () => {
+    // Every other consumer treats noReasoningModels as a positive "no effort control":
+    // configuredReasoningEfforts (reasoning-effort.ts), supportedLadderFor
+    // (server/effort-policy.ts) and the compatibility fingerprint all check it first.
+    // Evidence must agree, and the difference between [] and absent is load-bearing:
+    // absent makes the evaluator record "unknown", which is permissive.
+    const provider = {
+      ...providerWithFamilyEntries(),
+      noReasoningModels: ["gpt-oss:120b"],
+    } as unknown as OcxProviderConfig;
+
+    const evidence = candidateCapabilityEvidence(configFor(provider), "custom", "gpt-oss:120b");
+    expect(evidence.reasoningEfforts).toEqual([]);
+
+    // The sibling that is NOT disabled still inherits the family ladder.
+    const sibling = candidateCapabilityEvidence(configFor(provider), "custom", "gpt-oss:20b");
+    expect(sibling.reasoningEfforts).toEqual(["low", "high"]);
+  });
+
+  test("a disabled model is capability-unsatisfied for an effort requirement, not unknown", () => {
+    // The observable consequence of the case above. With an ABSENT ladder the evaluator took
+    // its non-array branch and emitted `unknown-capability`, which an "allow" profile lets
+    // through — so a model the operator explicitly disabled reasoning for could still
+    // satisfy a reasoning-effort requirement.
+    function configWithProfile(noReasoning: boolean): OcxConfig {
+      return {
+        providers: {
+          custom: {
+            adapter: "openai-chat",
+            baseUrl: "https://example.test/v1",
+            models: ["gpt-oss:120b"],
+            modelReasoningEfforts: { "gpt-oss": ["low", "high"] },
+            ...(noReasoning ? { noReasoningModels: ["gpt-oss:120b"] } : {}),
+          },
+        },
+        routingProfiles: {
+          effort: {
+            candidates: [{ provider: "custom", model: "gpt-oss:120b" }],
+            require: { reasoningEffort: "high" },
+            unknownEvidence: { capability: "allow", health: "allow", quota: "allow", cost: "allow" },
+          },
+        },
+      } as unknown as OcxConfig;
+    }
+
+    const disabled = configWithProfile(true);
+    const result = evaluatePolicyProfile(disabled, "effort", {}, [
+      {
+        provider: "custom",
+        model: "gpt-oss:120b",
+        capability: candidateCapabilityEvidence(disabled, "custom", "gpt-oss:120b"),
+      },
+    ]);
+    const candidate = result.candidates[0]!;
+    expect(candidate.exclusions.some(e => e.code === "capability-unsatisfied" && e.detail === "reasoning-effort")).toBe(true);
+    expect(candidate.exclusions.some(e => e.code === "unknown-capability")).toBe(false);
+
+    // Control: the same profile without noReasoningModels is satisfied by the ladder.
+    const enabled = configWithProfile(false);
+    const allowed = evaluatePolicyProfile(enabled, "effort", {}, [
+      {
+        provider: "custom",
+        model: "gpt-oss:120b",
+        capability: candidateCapabilityEvidence(enabled, "custom", "gpt-oss:120b"),
+      },
+    ]);
+    expect(allowed.candidates[0]!.exclusions).toEqual([]);
   });
 
   test("a registry entry covers its tagged siblings with no provider configured", () => {


### PR DESCRIPTION
## Summary

Native Anthropic models reached Aside — and every other client that keys its effort control off `reasoningEfforts` — with **no reasoning-effort control at all**, while the *same* Claude models routed through `cursor` or `google-antigravity` had one.

The discriminator was never the model. The `anthropic` and `anthropic-apikey` provider entries declared `models` and `modelContextWindows` but no `modelReasoningEfforts`, so `configuredReasoningEfforts` resolved to `undefined`, the catalog omitted the field, and `buildPiClientConfig` (which Aside reuses) emits `reasoning: true` + `thinkingLevelMap` only for a non-empty ladder. The adapter has honored effort all along — `output_config.effort` for adaptive families, translated `thinking.budget_tokens` for the rest — so this was missing *advertisement*, not missing capability.

Two adjacent defects would have made the fix only half work. Both were found by adversarial plan audit rather than by the original symptom:

- **`src/providers/derive.ts`** copied the registry ladder only when the persisted provider had *no* map, so one customized model hid the registry's knowledge of every other model on that provider. This split the two planes apart: `routedProviderConfig` merges these maps per key, so the wire would honor the effort while `/v1/models` and every client export still showed no control. Now a per-model fill, matching the `modelInputModalities` line directly above it.
- **`src/routing/capability.ts`** never consulted `noReasoningModels` (unlike `configuredReasoningEfforts`, `supportedLadderFor` and the compatibility fingerprint) and discarded a defined-but-empty ladder, which made the evaluator record the *permissive* `unknown` rather than a known negative. A model the operator explicitly disabled reasoning for could still satisfy a reasoning-effort requirement. Both corrected; the second is a general improvement for every provider with an explicit empty ladder.

### On the ladder value

`["low","medium","high","xhigh","max"]` is an **opencodex** ladder, not a claim of uniform native `output_config.effort` support. Anthropic documents `low|medium|high|max` for the 4.6 models and no effort parameter at all for `claude-haiku-4-5`; the adapter's budget translation is what makes five rungs meaningful there, and budgets are clamped below `max_tokens` so none of them 400.

Deliberately excluded, each because advertising it would offer a control that does not do what it says:

| Rung | Why not |
|---|---|
| `minimal` | `adaptiveEffort` rewrites it to `low` (the adaptive wire 400s on it), so it is not a distinct setting |
| `none` | only sonnet >= 5 accepts an explicit thinking disable; Fable rejects one outright |
| `ultra` | not an Anthropic concept, and already degraded to `max` at the request boundary |

## Verification

Focused tests only — the repository-wide suite was deliberately not run.

```
bun run typecheck                                      # clean
bun run test:changed                                   # 14215 pass / 11 skip / 0 fail (771 files)
bun test tests/provider-registry-parity.test.ts \
         tests/routing-capability-model-matching.test.ts \
         tests/provider-static-model-discovery.test.ts \
         tests/aside-client.test.ts \
         tests/management-client-config-route.test.ts \
         tests/anthropic-reasoning.test.ts             # 157 pass / 0 fail
```

**Every new assertion was proven red before the change and green after**, by temporarily reverting the production edit and re-running:

- removing the `noReasoningModels` guard and the line-239 change -> the two new capability tests fail;
- removing `modelReasoningEfforts` from the `anthropic` entry -> the end-to-end Aside test fails.

The `management-client-config-route` case is the one that matters: it starts from a bare provider config and asserts the emitted Aside document, covering the whole chain `registry -> enrichProviderFromRegistry -> CatalogModel -> ManagementModelRow -> toExportModel -> buildClientConfig(aside)`. Fixture-based tests would all stay green if a middle hop dropped the field. It calls the production loader directly rather than the `?client=aside` route, so it never depends on a developer's real `~/.aside` install.

Confirmed live on an **isolated scratch proxy** (separate `OPENCODEX_HOME`, port 10877 — the running instance on 10100 was not touched):

```
anthropic/claude-fable-5-1    supports_reasoning_effort=True  efforts=[low, medium, high, xhigh, max]
anthropic/claude-opus-5       supports_reasoning_effort=True  efforts=[low, medium, high, xhigh, max]
... all 9 anthropic/claude-* rows
```

and the Aside document for the same catalog:

```json
{"off": null, "minimal": null, "low": "low", "medium": "medium",
 "high": "high", "xhigh": "xhigh", "max": "max"}
```

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Scope note: the plan unit records two unrelated providers that also advertise no ladder (`lidge/qwen3.8-27b-nvfp4`, `opencode-free/muse-spark-1.2-contributor-free`). They are deliberately **not** fixed here — each needs its own adapter-capability evidence, and an unproven ladder is a worse defect than a missing one. No user-facing docs describe this behavior, and the change touches no auth, secrets, or GUI surface.

Design and audit history: `devlog/_plan/260904_anthropic_effort_ladder/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Native Anthropic models now expose reasoning-effort controls: low, medium, high, xhigh, and max.
  - Anthropic model exports now include reasoning settings and available thinking-level mappings.

- **Bug Fixes**
  - Custom per-model reasoning settings are preserved while defaults fill in other models.
  - Models explicitly configured without reasoning support are correctly identified and excluded when reasoning is required.
  - Unsupported effort levels such as minimal, none, and ultra remain unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->