### PR TITLE
ci(npm-global): give the Windows leg a timeout it can meet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -738,14 +738,20 @@ jobs:
     needs: changes
     if: needs.changes.outputs.packaging == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 8
+    # 8 minutes was too tight for the Windows leg: dependency installation alone takes
+    # about 7 there, leaving under a minute for pack, verify, global install, and the
+    # help smoke. The job was cancelled at the wall rather than failing, so whichever
+    # step happened to be running was reported `cancelled` — observed on step 8 four
+    # times and on step 7 once, which is what made it read as a flaky global install
+    # instead of a budget that one OS cannot meet (#3441).
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         # Deliberately NOT routed to the self-hosted box. This job runs
         # `npm install -g`, which writes into the machine's global prefix and
         # would leave an `ocx` on a maintainer's personal PATH. It is an
-        # 8-minute job, so there is nothing to win by moving it.
+        # short job on Linux and macOS, so there is nothing to win by moving it.
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -105,7 +105,13 @@ describe("GitHub Actions hardening", () => {
     // shard mid-suite, which reports as neither pass nor fail (#2152).
     expect(ci.jobs?.["platform-windows"]?.["timeout-minutes"]).toBe(25);
     expect(ci.jobs?.["keyring-smoke"]?.["timeout-minutes"]).toBe(8);
-    expect(ci.jobs?.["npm-global-smoke"]?.["timeout-minutes"]).toBe(8);
+    // Same lesson as the Windows shards above, one job later: at 8 the Windows leg
+    // spent ~7 minutes installing dependencies and was cancelled at the wall before
+    // it could pack and install. A cancellation is neither a pass nor a fail, and it
+    // landed on whichever step happened to be running — four times on the global
+    // install and once on a one-second asset check — which read as a flaky download
+    // rather than a budget one OS cannot meet (#3441).
+    expect(ci.jobs?.["npm-global-smoke"]?.["timeout-minutes"]).toBe(20);
     expect(ci.jobs?.ci?.["timeout-minutes"]).toBe(5);
     expect(ci.permissions).toEqual({ contents: "read" });
 


### PR DESCRIPTION
## Summary

Raises `npm-global-smoke` from `timeout-minutes: 8` to `20`.

The job is not flaky — it is being cancelled at the wall. Installing dependencies on the Windows runner alone takes about 7 of its 8 minutes, leaving under a minute for pack, verify, global install, and the help smoke. GitHub cancels rather than fails at a timeout, and whichever step happens to be executing is reported `cancelled`, which is what disguised this as an unreliable global install.

The tell is that across five occurrences the cancellation always lands at 8m05s–8m15s but on *different* steps: four at step 8 (global install) and one at step 7, "Verify packed GUI asset", which takes about a second and performs no network I/O. Nothing about either step is unreliable; they are just what was running when the clock expired. It reads as intermittent because Windows install time varies either side of the cap, which also explains why rerunning identical code passes.

The existing comment claiming "It is an 8-minute job, so there is nothing to win by moving it" is stale for the Windows leg specifically; both it and the timeout are updated.

Closes #3441

## Verification

- Root cause confirmed from the GitHub API job/step timings rather than inferred: runs 33848227910, 33849960040, and 33859671126, plus occurrences on `codex/260904-muse-platform-refusal` (f806eeef) and `codex/260904-windows-identity-de` (7c3a542b). Full step-timing evidence is recorded in #3441.
- No behavior change: only `timeout-minutes` and two comments in `.github/workflows/ci.yml`. No permissions added, no new secret usage, no action refs touched.
- CI on this PR exercises the changed job directly.

No GUI changes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the continuous integration smoke-test timeout to accommodate longer dependency installation times, particularly on Windows.
  * Updated workflow guidance and automated validation to reflect the extended time limit.
  * Reduced the risk of legitimate smoke tests being cancelled before packaging and installation checks complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->