### PR TITLE
fix(responses): scope Muse web search compatibility

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2116,6 +2116,11 @@ const MUSE_SPARK_WEB_SEARCH_STRICT_MODELS = new Set([
   "muse-spark-1.2-contributor",
 ]);
 
+const MUSE_SPARK_WEB_SEARCH_STRICT_DESTINATIONS = new Set([
+  "https://opencode.ai/zen/v1",
+  "https://opencode.ai/zen/go/v1",
+]);
+
 const MUSE_SPARK_UNSUPPORTED_WEB_SEARCH_FIELDS = [
   "search_content_types",
   "indexed_web_access",
@@ -2127,10 +2132,23 @@ const MUSE_SPARK_UNSUPPORTED_WEB_SEARCH_FIELDS = [
  * remains untouched. Keep the rejected names together so a newly identified field
  * is a one-line compatibility update rather than another bespoke rewrite.
  */
-function stripMuseSparkUnsupportedWebSearchFields(body: unknown, modelId: unknown): unknown {
+function stripMuseSparkUnsupportedWebSearchFields(
+  body: unknown,
+  modelId: unknown,
+  provider: Pick<OcxProviderConfig, "baseUrl">,
+): unknown {
   if (!isPlainObject(body)) return body;
   if (typeof modelId !== "string") return body;
   if (!MUSE_SPARK_WEB_SEARCH_STRICT_MODELS.has(modelId.trim().toLowerCase())) return body;
+  let destination: string;
+  try {
+    const url = new URL(provider.baseUrl);
+    if (url.username || url.password || url.search || url.hash) return body;
+    destination = `${url.origin.toLowerCase()}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return body;
+  }
+  if (!MUSE_SPARK_WEB_SEARCH_STRICT_DESTINATIONS.has(destination)) return body;
 
   const rewriteTools = (tools: unknown[]): { tools: unknown[]; changed: boolean } => {
     let changed = false;
@@ -2409,7 +2427,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         if (provider.supportsOpenAiWebSearchToolFields === false) {
           outBody = stripOpenAiOnlyWebSearchFields(outBody);
         }
-        outBody = stripMuseSparkUnsupportedWebSearchFields(outBody, parsed.modelId);
+        outBody = stripMuseSparkUnsupportedWebSearchFields(outBody, parsed.modelId, provider);
         // Last, so promoted namespace children are also cleared of Codex-private fields.
         outBody = stripCanonicalOnlyToolFields(outBody, provider.supportsOpenAiWebSearchToolFields === false);
       }

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2116,9 +2116,9 @@ const MUSE_SPARK_WEB_SEARCH_STRICT_MODELS = new Set([
   "muse-spark-1.2-contributor",
 ]);
 
-const MUSE_SPARK_WEB_SEARCH_STRICT_DESTINATIONS = new Set([
-  "https://opencode.ai/zen/v1",
-  "https://opencode.ai/zen/go/v1",
+const MUSE_SPARK_WEB_SEARCH_STRICT_RESPONSE_URLS = new Set([
+  "https://opencode.ai/zen/v1/responses",
+  "https://opencode.ai/zen/go/v1/responses",
 ]);
 
 const MUSE_SPARK_UNSUPPORTED_WEB_SEARCH_FIELDS = [
@@ -2129,26 +2129,28 @@ const MUSE_SPARK_UNSUPPORTED_WEB_SEARCH_FIELDS = [
 /**
  * OpenCode Zen / Go Muse Spark Responses gateway refuses a short list of Codex
  * `web_search` fields. `web_search_preview` keeps its accepted shape, and Luna
- * remains untouched. Keep the rejected names together so a newly identified field
- * is a one-line compatibility update rather than another bespoke rewrite.
+ * remains untouched. Match the exact effective request URL; malformed, credentialed,
+ * or parameterized destinations keep their original body instead of assuming this
+ * gateway contract. Keep the rejected names together so a newly identified field is
+ * a one-line compatibility update rather than another bespoke rewrite.
  */
 function stripMuseSparkUnsupportedWebSearchFields(
   body: unknown,
   modelId: unknown,
-  provider: Pick<OcxProviderConfig, "baseUrl">,
+  responseUrl: string,
 ): unknown {
   if (!isPlainObject(body)) return body;
   if (typeof modelId !== "string") return body;
   if (!MUSE_SPARK_WEB_SEARCH_STRICT_MODELS.has(modelId.trim().toLowerCase())) return body;
   let destination: string;
   try {
-    const url = new URL(provider.baseUrl);
+    const url = new URL(responseUrl);
     if (url.username || url.password || url.search || url.hash) return body;
     destination = `${url.origin.toLowerCase()}${url.pathname.replace(/\/+$/, "")}`;
   } catch {
     return body;
   }
-  if (!MUSE_SPARK_WEB_SEARCH_STRICT_DESTINATIONS.has(destination)) return body;
+  if (!MUSE_SPARK_WEB_SEARCH_STRICT_RESPONSE_URLS.has(destination)) return body;
 
   const rewriteTools = (tools: unknown[]): { tools: unknown[]; changed: boolean } => {
     let changed = false;
@@ -2427,7 +2429,7 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         if (provider.supportsOpenAiWebSearchToolFields === false) {
           outBody = stripOpenAiOnlyWebSearchFields(outBody);
         }
-        outBody = stripMuseSparkUnsupportedWebSearchFields(outBody, parsed.modelId, provider);
+        outBody = stripMuseSparkUnsupportedWebSearchFields(outBody, parsed.modelId, url);
         // Last, so promoted namespace children are also cleared of Codex-private fields.
         outBody = stripCanonicalOnlyToolFields(outBody, provider.supportsOpenAiWebSearchToolFields === false);
       }

--- a/tests/muse-spark-web-search-compat.test.ts
+++ b/tests/muse-spark-web-search-compat.test.ts
@@ -18,6 +18,18 @@ const ZEN_GO_PROVIDER = {
   baseUrl: "https://opencode.ai/zen/go/v1",
 };
 
+const ZEN_PATH_PROVIDER = {
+  ...ZEN_PROVIDER,
+  baseUrl: "https://opencode.ai",
+  responsesPath: "/zen/v1/responses",
+};
+
+const ZEN_GO_PATH_PROVIDER = {
+  ...ZEN_PROVIDER,
+  baseUrl: "https://opencode.ai",
+  responsesPath: "/zen/go/v1/responses",
+};
+
 const META_PROVIDER = {
   ...ZEN_PROVIDER,
   baseUrl: "https://api.meta.ai/v1",
@@ -33,6 +45,7 @@ function webSearchTool(): Record<string, unknown> {
   };
 }
 
+/** Build one passthrough request for an explicit Responses provider fixture. */
 function buildForProvider(
   provider: OcxProviderConfig,
   modelId: string,
@@ -48,6 +61,7 @@ function buildForProvider(
   return JSON.parse(request.body) as Record<string, unknown>;
 }
 
+/** Build with the default OpenCode Zen fixture used by the original regressions. */
 function build(modelId: string, rawBody: Record<string, unknown>): Record<string, unknown> {
   return buildForProvider(ZEN_PROVIDER, modelId, rawBody);
 }
@@ -151,6 +165,17 @@ describe("#2617/#3378 Muse Spark web_search compatibility", () => {
     const tool = toolsOf(body)[0]!;
     expect(Object.hasOwn(tool, "search_content_types")).toBe(false);
     expect(Object.hasOwn(tool, "indexed_web_access")).toBe(false);
+  });
+
+  test("split baseUrl and responsesPath configurations derive both strict destinations", () => {
+    for (const provider of [ZEN_PATH_PROVIDER, ZEN_GO_PATH_PROVIDER]) {
+      const body = buildForProvider(provider, "muse-spark-1.3-contributor", {
+        tools: [webSearchTool()],
+      });
+      const tool = toolsOf(body)[0]!;
+      expect(Object.hasOwn(tool, "search_content_types")).toBe(false);
+      expect(Object.hasOwn(tool, "indexed_web_access")).toBe(false);
+    }
   });
 
   test("direct Meta preserves its web_search fields at both tool positions", () => {

--- a/tests/muse-spark-web-search-compat.test.ts
+++ b/tests/muse-spark-web-search-compat.test.ts
@@ -7,11 +7,21 @@ import { withTestTranslatorBudget } from "./helpers/translator-budget";
 const createResponsesPassthroughAdapter = (...args: Parameters<typeof createResponsesPassthroughAdapterProduction>) =>
   withTestTranslatorBudget(createResponsesPassthroughAdapterProduction(...args));
 
-const PROVIDER = {
+const ZEN_PROVIDER = {
   adapter: "openai-responses",
   baseUrl: "https://opencode.ai/zen/v1",
   apiKey: "test-key",
 } as unknown as OcxProviderConfig;
+
+const ZEN_GO_PROVIDER = {
+  ...ZEN_PROVIDER,
+  baseUrl: "https://opencode.ai/zen/go/v1",
+};
+
+const META_PROVIDER = {
+  ...ZEN_PROVIDER,
+  baseUrl: "https://api.meta.ai/v1",
+};
 
 /** A Codex web_search declaration exactly as `hosted_spec.rs` emits it for TextAndImage. */
 function webSearchTool(): Record<string, unknown> {
@@ -23,8 +33,12 @@ function webSearchTool(): Record<string, unknown> {
   };
 }
 
-function build(modelId: string, rawBody: Record<string, unknown>): Record<string, unknown> {
-  const request = createResponsesPassthroughAdapter(PROVIDER).buildRequest({
+function buildForProvider(
+  provider: OcxProviderConfig,
+  modelId: string,
+  rawBody: Record<string, unknown>,
+): Record<string, unknown> {
+  const request = createResponsesPassthroughAdapter(provider).buildRequest({
     modelId,
     context: { messages: [] },
     stream: true,
@@ -32,6 +46,10 @@ function build(modelId: string, rawBody: Record<string, unknown>): Record<string
     _rawBody: { model: modelId, input: "ping", ...rawBody },
   }, { headers: new Headers() });
   return JSON.parse(request.body) as Record<string, unknown>;
+}
+
+function build(modelId: string, rawBody: Record<string, unknown>): Record<string, unknown> {
+  return buildForProvider(ZEN_PROVIDER, modelId, rawBody);
 }
 
 const toolsOf = (body: Record<string, unknown>) => body.tools as Array<Record<string, unknown>>;
@@ -124,5 +142,28 @@ describe("#2617/#3378 Muse Spark web_search compatibility", () => {
     expect(nested.type).toBe("web_search");
     expect(Object.hasOwn(nested, "search_content_types")).toBe(false);
     expect(Object.hasOwn(nested, "indexed_web_access")).toBe(false);
+  });
+
+  test("OpenCode Go applies the same Muse compatibility guard", () => {
+    const body = buildForProvider(ZEN_GO_PROVIDER, "muse-spark-1.3-contributor", {
+      tools: [webSearchTool()],
+    });
+    const tool = toolsOf(body)[0]!;
+    expect(Object.hasOwn(tool, "search_content_types")).toBe(false);
+    expect(Object.hasOwn(tool, "indexed_web_access")).toBe(false);
+  });
+
+  test("direct Meta preserves its web_search fields at both tool positions", () => {
+    const body = buildForProvider(META_PROVIDER, "muse-spark-1.3-contributor", {
+      tools: [webSearchTool()],
+      input: [{ type: "additional_tools", tools: [webSearchTool()] }],
+    });
+    const tool = toolsOf(body)[0]!;
+    const item = (body.input as Array<Record<string, unknown>>)[0]!;
+    const nested = (item.tools as Array<Record<string, unknown>>)[0]!;
+    for (const declaration of [tool, nested]) {
+      expect(declaration.search_content_types).toEqual(["text", "image"]);
+      expect(declaration.indexed_web_access).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- limit Muse Spark web-search sanitization to the exact effective OpenCode Zen and Zen Go Responses destinations
- preserve `search_content_types` and `indexed_web_access` for direct Meta and unrelated Responses providers
- cover full `baseUrl` and split `baseUrl` + `responsesPath` configurations, including nested `additional_tools`

## Problem

`stripMuseSparkUnsupportedWebSearchFields` was keyed only by model id and ran for every noncanonical Responses provider. The direct `meta-model` and `meta-muse` providers expose the same Muse Spark Contributor ids, so OpenCodex removed fields there even though the rejection evidence applies only to the OpenCode gateways.

This is a focused follow-up to the out-of-diff review finding on #3394; it does not change that merged Grok fix.

## Fix

The sanitizer now receives the effective request URL already constructed by `buildRequest` and applies the existing removal only for:

- `https://opencode.ai/zen/v1/responses`
- `https://opencode.ai/zen/go/v1/responses`

This covers both canonical provider base URLs and root URLs paired with `responsesPath`. Malformed, credentialed, query-bearing, hash-bearing, and unrelated destinations keep their original request shape.

## Validation

- [x] `bun test tests/muse-spark-web-search-compat.test.ts` — 11 passed
- [x] `bun run typecheck`
- [x] `bun run privacy:scan`
- [x] `bun run test` — 17,611 passed, 14 skipped, 0 failed

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Muse Spark web search compatibility across supported OpenCode and OpenCode Go configurations.
  - Ensured web search requests are adjusted only for recognized Muse Spark destinations.
  - Preserved supported web search options for direct Meta requests.
  - Added coverage for split endpoint configurations and nested web search settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
