### PR TITLE
feat(fast-row): expose Codex Fast to external clients as a selectable --fast row

### DIFF
--- a/devlog/_plan/260904_external_fast_wire/000_plan.md
+++ b/devlog/_plan/260904_external_fast_wire/000_plan.md
@@ -31,9 +31,17 @@ client choose per request.
 
 ## What we build
 
-An opt-in synthetic row `<base-id>--fast`, published on external listings for exactly the
-models whose resolved FastPolicy reports `eligible`, and parsed back on every ingress to
-the base model with canonical `priority` applied through the existing FastWire path.
+An opt-in synthetic row `<base-id>--fast`, published on the two client-facing discovery
+surfaces — the raw OpenAI-style `/v1/models` list and Claude Code discovery — for exactly
+the models whose resolved FastPolicy reports `eligible`, and parsed back on all five
+request ingresses (`/v1/responses`, `/v1/responses/compact`, `/v1/chat/completions`,
+`/v1/messages`, `/v1/messages/count_tokens`) to the base model with canonical `priority`
+applied through the existing FastWire path.
+
+Deliberately NOT published: the dashboard `/api/models` `namespaced` ids. Those are
+`disabledModels` keys and the identities `ocx export` and the OpenCode integration write
+into user config files, so a synthetic id landing there would outlive the flag that
+produced it. Those clients keep emitting base ids; wp4 documents the limitation.
 
 ## The separator decision (load-bearing)
 

--- a/devlog/_plan/260904_external_fast_wire/000_plan.md
+++ b/devlog/_plan/260904_external_fast_wire/000_plan.md
@@ -1,0 +1,112 @@
+# 000 — external_fast_wire: Plan & Research
+
+## The asymmetry
+
+Codex Fast is the `priority` service tier. It is published **only** as Codex-catalog
+metadata: `applyCatalogModelMetadata` stamps `service_tiers: [{id:"priority", name:"Fast"}]`
+and `additional_speed_tiers: ["fast"]` when `model.supportsServiceTier === true`
+(`src/codex/catalog/effort.ts:160-168`). The Codex desktop picker renders those fields and
+turns them into a toggle. Nothing else does.
+
+Every other ingress selects a model by **id string alone**:
+
+| Surface | Selector | Fast reachable today |
+|---|---|---|
+| Codex app | catalog row + `service_tiers` toggle | yes |
+| `GET /v1/models` -> chat/responses | id string | no |
+| Claude Code discovery -> `/v1/messages` | id string | no |
+| Cursor | id string | yes — because Cursor's Fast is a model VARIANT |
+
+Cursor is the existence proof. Its Fast is a dimension of the picked model
+(`fastWire: {kind:"cursor-variant", canonicalToWire:{priority:"fast"}}`,
+`src/providers/registry.ts:1154`), so a `-fast` id carries the intent and any client can
+pick it. `cursorFastIdFor()` already rewrites listed Cursor ids when `config.fastMode`
+is on (`src/server/index.ts:1554`, `src/claude/model-info.ts:159`).
+
+The gap this unit closes: **that rewrite is Cursor-only, and it is a global replacement
+rather than a selectable row.** A native `gpt-5.6-sol` — which really does advertise
+`additional_speed_tiers: ["fast"]` upstream (`src/codex/data/upstream-models.json`) — has
+no external Fast selector at all, and `fastMode` forces every request instead of letting a
+client choose per request.
+
+## What we build
+
+An opt-in synthetic row `<base-id>--fast`, published on external listings for exactly the
+models whose resolved FastPolicy reports `eligible`, and parsed back on every ingress to
+the base model with canonical `priority` applied through the existing FastWire path.
+
+## The separator decision (load-bearing)
+
+**`--fast`, not `-fast`.** A single hyphen is unsafe: terminal `-fast` is already a real
+model id across this catalog, not a free suffix.
+
+| Source | Real ids ending in `-fast` |
+|---|---|
+| `src/generated/model-metadata.ts` | `grok-3-fast`, `grok-4-fast`, `grok-4-1-fast`, `grok-composer-2.5-fast`, `x-ai/grok-4.1-fast`, `anthropic/claude-opus-{4.6,4.7,4.8,5}-fast` |
+| `src/providers/registry.ts:1677` | `glm-5.3-fast`, `glm-5.3-short-fast`, `glm-5.2-fast`, `glm-5.2-short-fast`, `kimi-k2.6-fast`, `qwen3.5-397b-fast`, `qwen3.6-35b-fast` |
+| `src/providers/registry.ts:2961` | `@cf/meta/llama-3.3-70b-instruct-fp8-fast` |
+| `src/adapters/cursor/discovery.ts:286` | `gpt-5-fast`, `composer-2.5-fast` — explicitly documented as real rows that *look* like a dimension |
+| `src/adapters/cursor/catalog.ts:491,573` | `<base>-fast`, `<base>-<effort>-fast`, `<base>-thinking-<effort>-fast` |
+
+With a single hyphen, `glm-5.3-fast` is ambiguous: a real model, or the synthetic Fast row
+of `glm-5.3`? A known-id guard settles that one case for the real model — which means the
+synthetic row for `glm-5.3` becomes unpublishable, and any real `X-fast` missing from the
+request-local inventory gets mis-parsed into base `X` plus priority. That is a wrong model
+on the wire, not a degraded one.
+
+`--fast` inherits the guarantee the effort-row grammar already relies on: `--` is a
+terminal separator absent from real model namespaces (`src/server/effort-row.ts:17`). The
+two grammars compose without ambiguity because `parseEffortRowId` requires
+`isDeclaredReasoningEffort(effort)` (`effort-row.ts:90`) and `fast` is not a declared
+effort, so `x--fast` falls through the effort parser untouched. wp1 asserts that
+non-interference rather than assuming it.
+
+## Eligibility: publish on `eligible` only
+
+`resolveFastPolicy` (`src/providers/fastwire.ts:190`) returns five states. Exactly one may
+publish a row.
+
+| eligibility | meaning | publish `--fast`? |
+|---|---|---|
+| `eligible` | capability true AND the final adapter implements the wire | **yes** |
+| `capability-unsupported` | capability explicitly false | no |
+| `unclassified` | capability `undefined` — absence of evidence, not evidence of support | no |
+| `wire-unavailable` | no wire on the final adapter (incl. `fastWire: null`) | no |
+| `pin-unavailable` | a hard pin forced an adapter without the wire | no |
+
+`unclassified` is the subtle one: `decideTier` deliberately makes `fastMode` inert there
+(`fastwire.ts:320,407`), so publishing a row we cannot honour would advertise a capability
+the runtime then refuses to exercise. The listing therefore reuses the same
+`fastPolicyForModel(provider, modelId, providerName)` the catalog already calls
+(`src/codex/catalog/provider-fetch.ts:754`): pure, synchronous, no network, no `src/lab`
+import, safe on the `/v1/models` hot path.
+
+## Phase map
+
+One decade doc per implementation cycle; each is one full PABCD work-phase.
+
+| Doc | Work-phase | Deliverable |
+|---|---|---|
+| `010` | wp1 | `src/server/fast-row.ts`: id codec, collision rules, eligibility read, `fastRows` flag |
+| `020` | wp2 | listing publication: `/v1/models` + both Claude discovery loops |
+| `030` | wp3 | ingress round-trip: responses, chat-completions, messages, count_tokens, compact |
+| `040` | wp4 | docs-site reference, close-out, stacked-PR landing |
+
+Amended after audit round 1; see `005_audit_round1.md` for the eight blockers and their
+disposition. The audit changed the Claude parse ordering, made native eligibility
+policy-derived, added two ingresses, and dropped the Cursor status field.
+
+Stacked PRs: wp2 targets wp1's head, wp3 targets wp2's, wp4 targets wp3's
+(`DEV-STACK-01`). Each retargets to `dev` once its parent lands.
+
+## Out of scope
+
+FastWire tier-decision semantics and downgrade safety; Cursor's own `-fast` variant
+grammar and the `fastMode` global rewrite (both stay exactly as they are); `src/lab/**`;
+pricing and usage-cost; Desktop 3P hashed aliases.
+
+## Residual carried in from 260902_cursor_unified_identity
+
+R1 there notes that a listed fast id advertises the BASE effort ladder. The same question
+applies here and gets a different answer: a `--fast` row is the same model at a different
+service tier, not a sibling product with its own ladder, so the base ladder is correct.

--- a/devlog/_plan/260904_external_fast_wire/005_audit_round1.md
+++ b/devlog/_plan/260904_external_fast_wire/005_audit_round1.md
@@ -4,6 +4,21 @@ Adversarial plan audit of `000/010/020/030/040` returned **FAIL** with 8 blocker
 accepted; 6 change the design, 2 change scope. This doc records the decision per blocker so
 a later reader sees why the plan moved, and the decade docs are amended in place.
 
+## Round 2 outcome
+
+The amended docs were re-audited and FAILED again: appending amendment sections had left
+each doc carrying two contradictory instructions per call site, and the `hasCompositeRowMarkers`
+helper introduced for B5 was itself defective — asymmetric (it caught `x--high--fast` but
+not `x--fast--high`) and blind to a real base named `a--high`, whose legitimately published
+`a--high--fast` row it would have suppressed.
+
+Both findings are accepted. `010`, `020`, and `030` were REWRITTEN canonically rather than
+amended, so each call site has exactly one executable instruction, and the composite guard
+was deleted in favour of requiring the stripped base to be a known routable model — the
+arbitration the collision inventory already performs. The per-blocker disposition below
+records the original round-1 reasoning; where round 2 changed the mechanism, the decade doc
+is authoritative.
+
 ## B1 — Claude alias collision (design change)
 
 A Claude alias is `claude-ocx-<provider>--<model>` (`src/claude/alias.ts:89`) — it already uses
@@ -99,4 +114,3 @@ scope line. Added.
 - `parseEffortRowId("x--fast")` returning null was independently confirmed:
   `isDeclaredReasoningEffort("fast")` is false (`src/reasoning-effort.ts:39`). The two
   grammars do not interfere, as claimed.
-

--- a/devlog/_plan/260904_external_fast_wire/005_audit_round1.md
+++ b/devlog/_plan/260904_external_fast_wire/005_audit_round1.md
@@ -1,0 +1,102 @@
+# 005 — Audit round 1: synthesis and disposition
+
+Adversarial plan audit of `000/010/020/030/040` returned **FAIL** with 8 blockers. All 8 are
+accepted; 6 change the design, 2 change scope. This doc records the decision per blocker so
+a later reader sees why the plan moved, and the decade docs are amended in place.
+
+## B1 — Claude alias collision (design change)
+
+A Claude alias is `claude-ocx-<provider>--<model>` (`src/claude/alias.ts:89`) — it already uses
+`--` as its own provider separator. So a real model `foo--fast` becomes
+`claude-ocx-p--foo--fast`, and a naive suffix strip on the raw alias yields
+`claude-ocx-p--foo`, routing `p/foo`: a different model, silently.
+
+`knownEffortRowIds()` does not contain Claude aliases (`effort-row.ts:44`), so it cannot
+defend this.
+
+**Decision.** On the Claude surface the fast marker is parsed only after alias decoding, not
+before. `decodeClaudeAlias` yields `{provider, model}`; the marker is stripped from `model`,
+and the known-id check runs against the decoded routed id, where `knownEffortRowIds()` is
+authoritative. wp3 carries the amended ordering.
+
+This also means the fast row published for Claude is `claude-ocx-p--foo--fast` where the
+marker is the LAST `--` segment of the model half — well-defined, because the alias's own
+separator is the FIRST one after the prefix.
+
+## B2 — native eligibility must be policy-derived (design change)
+
+`nativeFastEligible()` read only upstream `additional_speed_tiers`, which ignores an
+operator's `supportsServiceTier: false` and the final wire resolution. Publishing on
+upstream metadata alone would advertise Fast on a route the runtime then drops.
+
+**Decision.** Both conditions required: upstream native evidence AND
+`fastRowEligible(provider, metadataId, providerName)`. Upstream evidence alone never
+publishes.
+
+## B3 — Claude native loop was missed (design change)
+
+`buildAnthropicModelInfos` has two loops: natives at `model-info.ts:143` and routed at
+`:155`. The plan only patched the routed one, so `gpt-5.6-sol` — the flagship Fast model —
+would have gained no row on Claude discovery. That contradicts the unit's own goal.
+
+**Decision.** Both loops gain the additive row, sharing one predicate.
+
+## B4 — two ingresses were missed (scope change)
+
+- `/v1/messages/count_tokens` (`claude-messages.ts:1022-1036`) resolves a model and can hand
+  it to native passthrough with no fast parsing — a synthetic id would be forwarded
+  upstream as an invalid model.
+- `/v1/responses/compact` (`compact.ts:502-515`) routes `raw.model` through
+  `routeCompactionModel` with no tier handling, so a fast id would not round-trip.
+
+**Decision.** Both join wp3. `count_tokens` only needs the model rewritten to the base
+before `wantsNativePassthrough` — it returns a token estimate and sends no tier. `compact`
+rewrites the model and carries `service_tier` so compaction runs at the tier the caller
+selected.
+
+## B5 — parse ordering made the two grammars compose by accident (design change)
+
+The Responses path parsed the effort row first and mutated `parsed.modelId`, then parsed
+fast from the mutated value. So `x--fast--high` would fire BOTH dimensions, while
+`x--high--fast` fires neither — and Chat and Messages, which parse from the immutable
+requested id, would disagree with Responses about the same string.
+
+**Decision.** Every ingress parses every grammar from the immutable original selector, and
+an id carrying both markers is accepted as NEITHER. One grammar per id, enforced
+identically on all five surfaces. wp1 owns the check so it cannot drift per call site.
+
+## B6 — `/api/models` and the exporters (scope change)
+
+`/api/models` `namespaced` ids feed `ocx export` and the OpenCode integration
+(`src/cli/opencode.ts:368`, `src/cli/export-command.ts:78`). Those are external clients by
+any reading, so excluding them while claiming "external clients" was inconsistent.
+
+**Decision.** Narrow the claim rather than widen the blast radius. `namespaced` ids are
+`disabledModels` keys and export identities; adding synthetic rows there risks writing a
+synthetic id into a user's persisted config. wp4's docs state plainly that `fastRows`
+covers the request-serving surfaces — `/v1/models`, Claude discovery, and the four
+ingresses — and that `ocx export` and OpenCode emit base ids only. Revisit on request.
+
+## B7 — Cursor management status patch was underspecified (scope change)
+
+The proposed `fastRow` field referenced an `eligible` value the mapper cannot derive: it
+keeps only the public id, not `{provider, modelId}` (`cursor-integration-routes.ts:69`).
+
+**Decision.** Dropped from wp2. It is a Cursor-integration status panel, not a client-facing
+selector, and plumbing model identity through it buys nothing for this unit's goal.
+
+## B8 — wp1 write scope (correction)
+
+`src/server/effort-row.ts` is edited by wp1 (exporting `isKnownId`) but was absent from its
+scope line. Added.
+
+## Non-blocking notes accepted
+
+- `applyCatalogMetadata` misnamed; the writer is `applyCatalogModelMetadata`
+  (`effort.ts:160`). Corrected in `000`.
+- `UPSTREAM_NATIVE_ENTRIES` is not currently imported by `server/index.ts` nor re-exported
+  by the catalog facade; wp2 names the direct import from `src/codex/catalog/metadata.ts`.
+- `parseEffortRowId("x--fast")` returning null was independently confirmed:
+  `isDeclaredReasoningEffort("fast")` is false (`src/reasoning-effort.ts:39`). The two
+  grammars do not interfere, as claimed.
+

--- a/devlog/_plan/260904_external_fast_wire/006_wp0_receipt.md
+++ b/devlog/_plan/260904_external_fast_wire/006_wp0_receipt.md
@@ -1,0 +1,50 @@
+# wp0 verification receipt — docs-only work-phase
+
+Work-phase: wp0 (docs-only roadmap cycle, LOOP-DOCS-FIRST-01)
+Branch: codex/260904-fast-row-core
+Date: 2026-09-04
+
+## What was produced
+
+devlog/_plan/260904_external_fast_wire/
+  000_plan.md                   research + the separator decision + phase map
+  005_audit_round1.md           per-blocker disposition + round-2 outcome
+  010_wp1_fast_row_core.md      grammar, eligibility, config flag  -> wp1
+  020_wp2_listing.md            listing publication                -> wp2
+  030_wp3_ingress.md            five-ingress round-trip            -> wp3
+  040_wp4_docs_and_landing.md   docs + stacked-PR landing          -> wp4
+
+## Why no test run
+
+No production code changed in this phase; the diff is entirely under devlog/.
+Nothing in the build, typecheck, or test path reads from devlog/ (AGENTS.md),
+so a focused test would exercise nothing this phase produced. The applicable
+verification for a plan is adversarial review, recorded below.
+
+## Verification performed
+
+Eight rounds of independent adversarial audit (gpt-5.6-sol, medium, read-only,
+no file writes, no local suite). Every finding was checked against source before
+acceptance.
+
+  round 1  FAIL  8 blockers
+  round 2  FAIL  appended amendments left docs self-contradictory; the composite
+                 guard introduced for B5 was asymmetric and suppressed rows the
+                 unit itself publishes
+  round 3  FAIL  the known-id set is the wrong oracle for a routable base: bare
+                 natives carry no declared models list, so gpt-5.6-sol--fast
+                 would be published and then refused at ingress
+  round 4  FAIL  fastRowBases named but never defined; nested-marker guard wired
+                 into no call site; collision set a placeholder comment
+  round 5  FAIL  the wrapper regressed the shipped cursorEffortRows path
+  round 6  FAIL  visibleNativeSlugs both reads the catalog and shrinks with
+                 runtime state; eager thunk evaluation on the off path
+  round 7  FAIL  the Claude predicate was passed unconditionally, which would
+                 have enabled the feature on a default install
+  round 8  PASS  "No remaining compile, scope, type, behavioral, or
+                 underspecified-symbol blocker was found across 010 -> 020 ->
+                 030. The plan is ready to implement."
+
+## Criterion closed
+
+c1 — the unit's decade docs map 1:1 onto wp1..wp4.

--- a/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
+++ b/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
@@ -78,9 +78,42 @@ The two questions stay separate:
 | Which exact ids beat the grammar? | `knownEffortRowIds(config)` | refusing to strip a real `x--fast` |
 | Which bases may carry a fast row? | `fastRowBases(config)` (new) | validating the strip |
 
-`fastRowBases()` is built by the same enumeration wp2 publishes from — every visible native
-slug (bare and account-qualified) plus every routed public id — so publication and parsing
-read one source and cannot drift. Test 9 asserts that invariant directly.
+`fastRowBases()` is a synchronous SUPERSET of what wp2 publishes, deliberately — not the
+same enumeration. wp2's list depends on request-local async state: `fetchAllModels`, the
+entitlement snapshot, and the gathered catalog (`index.ts:1350`, `:1404`, `:1421`). A
+request-side parser has only `config` and cannot reproduce it.
+
+A superset is the right shape anyway. Being too permissive here costs nothing: the router
+still rejects a base it cannot serve, and the exact-id guard above still protects real
+models. Being too strict is what breaks the feature — that was the round-3 defect, where a
+published row could not be parsed. So the parser answers "could this plausibly be a base we
+publish for?" and lets routing make the final call.
+
+```ts
+/**
+ * Bases that may carry a fast row. A superset of the published set: entitlement filtering
+ * is deliberately NOT applied, because it needs an async snapshot the request path does not
+ * have, and an unavailable selector is already rejected downstream by routing.
+ */
+export function fastRowBases(config: OcxConfig): Set<string> {
+  const bases = new Set<string>(knownEffortRowIds(config));
+  // Bare natives carry no declared models list and route by family pattern, so the known-id
+  // set omits them entirely (router.ts:529). They are also the models Fast matters most for.
+  if (shouldIncludeNativeOpenAi(config)) {
+    for (const slug of visibleNativeSlugs(config)) bases.add(slug);
+  }
+  if (shouldIncludeAccountBoundNativeOpenAi(config)) {
+    for (const [selector, slugs] of accountBoundNativeOpenAiSlugsBySelector(config)) {
+      for (const slug of slugs) bases.add(`${selector}/${slug}`);
+    }
+  }
+  return bases;
+}
+```
+
+All three helpers are synchronous and config-only (`metadata.ts:430`, `:450`, `:763`), so
+this builds on the request path. wp2 asserts the containment direction that matters: every
+base it publishes a row for is in this set (test 10). The reverse does not hold, by design.
 
 ```ts
 export interface ParsedFastRowId { baseId: string; }
@@ -88,8 +121,10 @@ export interface ParsedFastRowId { baseId: string; }
 export function parseFastRowId(
   id: string,
   config: Pick<OcxConfig, "fastRows">,
-  knownIds: EffortRowKnownIds | undefined,
-  routableBases: EffortRowKnownIds | undefined,
+  // Both optional so a unit test can call the parser with neither inventory and get the
+  // flag-off / shape-only behaviour without constructing a config.
+  knownIds?: EffortRowKnownIds,
+  routableBases?: EffortRowKnownIds,
 ): ParsedFastRowId | null {
   if (config.fastRows !== true) return null;
   if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
@@ -137,17 +172,45 @@ wp3 applies it at each ingress: when the effort parser returns a base for which 
 the selector is treated as unrecognized. Both marker orders then behave identically on all
 five surfaces.
 
-## Request-time entry points
+## Request-time entry point
+
+One wrapper parses BOTH grammars, so no call site can apply the nested-marker rule
+differently from another. wp3 uses only this:
 
 ```ts
-export function parseRequestFastRowId(id: string, config: OcxConfig): ParsedFastRowId | null {
-  if (config.fastRows !== true) return null;
-  // Ordinary ids do not carry the marker; bail before building either inventory so the
-  // flag costs nothing per request for models that are not fast rows.
-  if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
-  return parseFastRowId(id, config, knownEffortRowIds(config), fastRowBases(config));
+export interface ParsedSyntheticRow {
+  fastRow: ParsedFastRowId | null;
+  effortRow: ParsedEffortRowId | null;
+}
+
+/**
+ * Resolve one ingress selector against both synthetic grammars. Callers pass the id the
+ * client sent and never a value another parser mutated.
+ */
+export function parseSyntheticRowId(id: string, config: OcxConfig): ParsedSyntheticRow {
+  // Ordinary ids carry no marker at all; bail before building either inventory so the
+  // flags cost nothing per request for models that are not synthetic rows.
+  if (id.lastIndexOf("--") <= 0) return { fastRow: null, effortRow: null };
+  const knownIds = knownEffortRowIds(config);
+  const fastRow = config.fastRows === true && id.endsWith(FAST_ROW_SUFFIX)
+    ? parseFastRowId(id, config, knownIds, fastRowBases(config))
+    : null;
+  if (fastRow) return { fastRow, effortRow: null };
+  const effortRow = parseEffortRowId(id, config, {
+    knownIds,
+    table: loadDetectedCursorEffortTable(),
+  });
+  // Composition is not supported (020 R1) and the effort parser cannot see the problem: it
+  // validates the terminal effort but never that the base is real (effort-row.ts:78-95), so
+  // "x--fast--high" would otherwise resolve to the nonexistent base "x--fast".
+  return effortRow && effortBaseCarriesFastMarker(effortRow.baseId, knownIds)
+    ? { fastRow: null, effortRow: null }
+    : { fastRow: null, effortRow };
 }
 ```
+
+`parseRequestFastRowId` is not introduced; the wrapper subsumes it. Existing effort-row
+call sites migrate to the wrapper in wp3 so both grammars are resolved in one place.
 
 `isKnownId` is module-private in `effort-row.ts:32` today. wp1 exports it there rather than
 duplicating the Set-or-predicate branch.
@@ -203,8 +266,8 @@ with `providerConfigSeed(getProviderRegistryEntry(...))` rather than hand-writin
 so the test cannot drift from real capability data.
 
 1. **Default off.** `parseFastRowId("x--fast", {})` returns null and
-   `expandFastRow(row, true, {})` returns the row alone. This is the path every existing
-   install runs.
+   `expandFastRow(row, true, {})` returns the row alone — both inventories are optional, so
+   this needs no config. This is the path every existing install runs.
 2. **Eligible publishes, unclassified does not.** Three fixture providers —
    `supportsServiceTier: true` on an `openai-responses` adapter (eligible), `false`
    (capability-unsupported), and absent (unclassified) — and only the first expands. This

--- a/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
+++ b/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
@@ -1,0 +1,192 @@
+# 010 — wp1 / PR1: the fast-row grammar and its eligibility rule
+
+Scope IN: `src/server/fast-row.ts` (new), `src/server/effort-row.ts` (export `isKnownId`),
+`src/config.ts`, `src/types/config.ts`,
+`tests/fast-row.test.ts` (new). Scope OUT: every listing and ingress call site — wp1 ships
+the module and its tests with no caller, so the diff is reviewable on its own and the
+runtime is byte-identical until wp2 wires it.
+
+## Why a separate module rather than growing `effort-row.ts`
+
+They share a separator and nothing else. `effort-row.ts` answers "which effort rung" and
+consults an installed Cursor bundle table (`predictCursorEffort`, `detectCursorInstalls`).
+A fast row answers "which service tier" and consults the FastWire policy. Folding the
+second into the first would put Cursor install detection on the path of a feature that has
+nothing to do with Cursor, and `cursorEffortRows` gates the whole file's work today.
+
+What IS shared is the collision inventory, and that is already exported:
+`knownEffortRowIds(config)` (`effort-row.ts:43`) collects configured, registry, live-cached
+and custom model ids, routed slugs, provider/alias namespaces, `modelAliases` values, combo
+ids, and routing-profile ids. wp1 imports it rather than rebuilding it. The name is
+effort-flavoured for historical reasons; the set is not.
+
+## The module
+
+```ts
+// src/server/fast-row.ts
+import { fastPolicyForModel } from "../providers/service-tier";
+import type { InboundWire } from "../providers/registry";
+import type { OcxConfig, OcxProviderConfig } from "../types";
+import { knownEffortRowIds, type EffortRowKnownIds } from "./effort-row";
+
+/**
+ * Terminal marker for a synthetic Fast selector. `--` rather than `-` because terminal
+ * `-fast` is a REAL id across this catalog (grok-4-fast, glm-5.3-fast, gpt-5-fast,
+ * every Cursor fast variant), so a single hyphen cannot tell a product apart from a tier.
+ * See 000_plan.md for the full collision table.
+ */
+const FAST_ROW_SUFFIX = "--fast";
+
+export function fastRowId(baseId: string): string {
+  return `${baseId}${FAST_ROW_SUFFIX}`;
+}
+
+/** Provider/model pair whose resolved Fast policy may be published as a row. */
+export function fastRowEligible(
+  provider: Parameters<typeof fastPolicyForModel>[0],
+  modelId: string,
+  providerName?: string,
+  inbound: InboundWire = "responses",
+): boolean {
+  // `eligible` alone. `unclassified` means capability is undefined, and decideTier makes
+  // fastMode inert there (fastwire.ts:320) — publishing it would advertise a tier the
+  // runtime then refuses to send.
+  return fastPolicyForModel(provider, modelId, providerName, inbound).eligibility === "eligible";
+}
+```
+
+Parsing mirrors `parseRequestEffortRowId`'s shape, including its cheap bail:
+
+```ts
+export interface ParsedFastRowId { baseId: string; }
+
+export function parseFastRowId(
+  id: string,
+  config: Pick<OcxConfig, "fastRows">,
+  knownIds?: EffortRowKnownIds,
+): ParsedFastRowId | null {
+  if (config.fastRows !== true) return null;
+  if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
+  // An exact configured/public id always beats the synthetic grammar, the same precedence
+  // effort rows use. An operator who really named a model `x--fast` keeps it.
+  if (isKnownId(knownIds, id)) return null;
+  const baseId = id.slice(0, -FAST_ROW_SUFFIX.length);
+  return baseId.length > 0 ? { baseId } : null;
+}
+
+/** Parse one ingress selector against the current config. */
+export function parseRequestFastRowId(id: string, config: OcxConfig): ParsedFastRowId | null {
+  if (config.fastRows !== true) return null;
+  // Ordinary ids do not carry the marker; bail before building the known-id inventory so
+  // the flag costs nothing per request for models that are not fast rows.
+  if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
+  return parseFastRowId(id, config, knownEffortRowIds(config));
+}
+```
+
+`isKnownId` is currently module-private in `effort-row.ts:32`. wp1 exports it there (a
+two-word diff) rather than duplicating the Set-or-predicate branch.
+
+Publication helper, shaped like `expandCursorEffortRow` so wp2's call sites read the same:
+
+```ts
+export function expandFastRow<T extends { id: string }>(
+  row: T,
+  eligible: boolean,
+  config: Pick<OcxConfig, "fastRows">,
+  knownIds?: EffortRowKnownIds,
+): T[] {
+  if (config.fastRows !== true || !eligible) return [row];
+  const id = fastRowId(row.id);
+  return isKnownId(knownIds, id) ? [row] : [row, { ...row, id }];
+}
+```
+
+The base row is always kept: a fast row is an addition, never a replacement. This is the
+deliberate difference from `fastMode`, which replaces the listed Cursor id
+(`src/server/index.ts:1603`). Replacement suits a global switch; a per-request selector
+has to leave the default reachable.
+
+## Config flag
+
+Following the `cursorEffortRows` precedent exactly (`src/config.ts:1052`).
+
+```diff
+ // src/config.ts
+   cursorEffortRows: z.boolean().optional().catch(false),
++  // Malformed hand edits disable this opt-in projection without rejecting providers.
++  fastRows: z.boolean().optional().catch(false),
+```
+
+```diff
+ // src/types/config.ts
++  /**
++   * Opt-in synthetic Fast selectors. When true, external model listings add a
++   * `<base-id>--fast` row for every model whose resolved Fast policy is `eligible`,
++   * and selecting one routes the base model with the canonical `priority` service
++   * tier. Omitted/false preserves discovery output exactly.
++   */
++  fastRows?: boolean;
+```
+
+`.catch(false)` matters: a hand-edited config with `fastRows: "yes"` must degrade to off,
+not reject every provider.
+
+## Tests — `tests/fast-row.test.ts`
+
+Fixtures follow `tests/cursor-fast-listing.test.ts:74`: build the provider from the
+registry with `providerConfigSeed(getProviderRegistryEntry(...))` instead of hand-writing
+a config, so the test cannot drift from real capability data.
+
+1. **Default off.** `parseFastRowId("x--fast", {})` and `expandFastRow(row, true, {})`
+   return null / `[row]`. The flag-off path is the one every existing install runs.
+2. **Eligible publishes, unclassified does not.** Three fixture providers — one with
+   `supportsServiceTier: true` on an `openai-responses` adapter (eligible), one with it
+   `false` (capability-unsupported), one with it absent (unclassified) — and assert only
+   the first expands. This drives the `eligibility === "eligible"` conditional directly
+   rather than asserting a table contains a value, per `cursor-fast-tier.test.ts:31`.
+3. **`wire-unavailable` does not publish.** `fastWire: null` with
+   `supportsServiceTier: true` is the config-level conflict `config.ts:1193` already
+   rejects, so use the registry case instead: an `anthropic` adapter, whose
+   `anthropic-speed` wire has an empty adapter set (`fastwire.ts:15`).
+4. **A known id beats the grammar.** With a provider declaring a literal `foo--fast`
+   model, `parseFastRowId("foo--fast")` returns null and `expandFastRow` on `foo` emits
+   no duplicate.
+5. **Effort-row non-interference, both directions.** `parseEffortRowId("x--fast", ...)`
+   returns null because `fast` is not a declared effort, and `parseFastRowId("x--high")`
+   returns null because it lacks the marker. This is the assertion that lets the two
+   grammars share `--`; without it the composition is an assumption.
+6. **Bare marker rejected.** `parseFastRowId("--fast")` returns null — an empty base is
+   not a model.
+7. **Composite rejected both ways (audit B5).** `x--high--fast` and `x--fast--high` each
+   parse to null under BOTH `parseFastRowId` and `parseEffortRowId`.
+
+## One grammar per id (audit B5)
+
+An id carrying BOTH markers resolves to neither grammar. wp1 owns the rule so it cannot
+drift between the five call sites:
+
+```ts
+/**
+ * True when a selector carries a fast marker AND a declared effort marker. Such an id is
+ * rejected by both parsers rather than resolved by whichever runs first. Ordering-derived
+ * behaviour was the audit's B5 finding: Responses parsed effort first and mutated the id,
+ * so `x--fast--high` fired both dimensions while `x--high--fast` fired neither, and Chat
+ * and Messages — which parse from the immutable requested id — disagreed with it.
+ */
+export function hasCompositeRowMarkers(id: string): boolean {
+  if (!id.endsWith(FAST_ROW_SUFFIX)) return false;
+  const stem = id.slice(0, -FAST_ROW_SUFFIX.length);
+  const sep = stem.lastIndexOf("--");
+  return sep > 0 && isDeclaredReasoningEffort(stem.slice(sep + 2));
+}
+```
+
+`parseFastRowId` returns null on it, and wp3 checks it before the effort parser on every
+ingress. Every ingress parses from the IMMUTABLE original selector, never from a value a
+previous parser mutated.
+
+## Verification
+
+`bun test tests/fast-row.test.ts`, `bun test tests/config.test.ts`, `bun run typecheck`.
+No repository-wide suite.

--- a/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
+++ b/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
@@ -27,7 +27,7 @@ import {
   accountBoundNativeOpenAiSlugsBySelector,
   shouldIncludeAccountBoundNativeOpenAi,
   shouldIncludeNativeOpenAi,
-  visibleNativeSlugs,
+  UPSTREAM_NATIVE_ENTRIES,
 } from "../codex/catalog/metadata";
 import { fastPolicyForModel } from "../providers/service-tier";
 import type { InboundWire } from "../providers/registry";
@@ -113,8 +113,14 @@ export function fastRowBases(config: OcxConfig): Set<string> {
   const bases = new Set<string>(knownEffortRowIds(config));
   // Bare natives carry no declared models list and route by family pattern, so the known-id
   // set omits them entirely (router.ts:529). They are also the models Fast matters most for.
+  //
+  // Deliberately the STATIC upstream table, not visibleNativeSlugs(): that one filters by
+  // disabled/shadowed state and reaches readCurrentCatalogOrCache() (metadata.ts:430, :807),
+  // so it would both read the catalog on every parsed selector and SHRINK as runtime state
+  // changes. A base disappearing mid-session would strand a client still holding the id it
+  // was published. A base is meant to be RECOGNIZED here and then judged by routing.
   if (shouldIncludeNativeOpenAi(config)) {
-    for (const slug of visibleNativeSlugs(config)) bases.add(slug);
+    for (const slug of UPSTREAM_NATIVE_ENTRIES.keys()) bases.add(slug);
   }
   if (shouldIncludeAccountBoundNativeOpenAi(config)) {
     // Pass an EMPTY observed-entry list on purpose. The default argument reads the Codex
@@ -130,10 +136,11 @@ export function fastRowBases(config: OcxConfig): Set<string> {
 }
 ```
 
-All four helpers are synchronous, and with the explicit empty observed-entry list none of
-them touches the filesystem (`metadata.ts:430`, `:450`, `:763`). wp2 asserts the containment
-direction that matters: every base it publishes a row for is in this set (test 10). The
-reverse does not hold, by design.
+Every source here is synchronous and, with the static native table and the explicit empty
+observed-entry list, none touches the filesystem (`metadata.ts:450`, `:763`). The set is
+also STABLE for a given config: it cannot shrink because a catalog refresh changed
+visibility. wp2 asserts the containment direction that matters — every base it publishes a
+row for is in this set (test 10). The reverse does not hold, by design.
 
 ```ts
 export interface ParsedFastRowId { baseId: string; }
@@ -211,8 +218,10 @@ export function parseSyntheticRowId(
   id: string,
   config: OcxConfig,
   // Claude surfaces decode the alias before the marker is unambiguous, so they pass the
-  // decoded form for Fast while effort parsing keeps seeing the id the client sent.
-  fastSelector: string = id,
+  // decoded form for Fast while effort parsing keeps seeing the id the client sent. A THUNK,
+  // not a string: arguments are evaluated before the call, so an eager decode would run its
+  // alias lookups even on the fastRows-off path this function exists to leave untouched.
+  fastSelector?: () => string,
 ): ParsedSyntheticRow {
   // Fast off: delegate verbatim. Not merely equivalent - the SAME function shipped today,
   // so an install that never enables this feature cannot observe any change at all, in
@@ -221,13 +230,15 @@ export function parseSyntheticRowId(
   if (config.fastRows !== true) {
     return { fastRow: null, effortRow: parseRequestEffortRowId(id, config) };
   }
+  // Evaluated only past the fastRows gate above.
+  const selector = fastSelector?.() ?? id;
   // Ordinary ids carry no marker at all; bail before building any inventory.
-  if (id.lastIndexOf("--") <= 0 && fastSelector.lastIndexOf("--") <= 0) {
+  if (id.lastIndexOf("--") <= 0 && selector.lastIndexOf("--") <= 0) {
     return { fastRow: null, effortRow: null };
   }
   const knownIds = knownEffortRowIds(config);
-  const fastRow = fastSelector.endsWith(FAST_ROW_SUFFIX)
-    ? parseFastRowId(fastSelector, config, knownIds, fastRowBases(config))
+  const fastRow = selector.endsWith(FAST_ROW_SUFFIX)
+    ? parseFastRowId(selector, config, knownIds, fastRowBases(config))
     : null;
   if (fastRow) return { fastRow, effortRow: null };
   // Cursor install detection stays behind its own flag, exactly as parseRequestEffortRowId
@@ -260,6 +271,21 @@ with `fastRows` off would have lost the `x--fast--high` effort row they get toda
 
 With `fastRows` on, the nested-marker rule is new behaviour for a new opt-in feature, which
 is the only place it is allowed to apply. Test 12 pins the delegation.
+
+Two callers have no effort-row history to preserve — `count_tokens` and `compact` never
+parsed one — so they must not acquire the delegated call either. Both use a Fast-only
+entry point that returns before any inventory work when the flag is off:
+
+```ts
+/** Fast-only resolution for surfaces that never parsed an effort row. */
+export function parseFastOnlyRowId(
+  config: OcxConfig,
+  selector: () => string,
+): ParsedFastRowId | null {
+  if (config.fastRows !== true) return null;
+  return parseSyntheticRowId("", config, selector).fastRow;
+}
+```
 
 `isKnownId` is module-private in `effort-row.ts:32` today. wp1 exports it there rather than
 duplicating the Set-or-predicate branch.

--- a/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
+++ b/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
@@ -212,6 +212,24 @@ export function parseSyntheticRowId(id: string, config: OcxConfig): ParsedSynthe
 `parseRequestFastRowId` is not introduced; the wrapper subsumes it. Existing effort-row
 call sites migrate to the wrapper in wp3 so both grammars are resolved in one place.
 
+**The migration must not regress `cursorEffortRows`.** With `fastRows` off the wrapper
+reduces to today's behaviour, and the differences are deliberate and bounded:
+
+| | `parseRequestEffortRowId` today | wrapper, `fastRows` off |
+|---|---|---|
+| flag off | returns null immediately | `parseEffortRowId` returns null on the same check |
+| no `--` in id | early bail | same early bail |
+| ordinary effort row | parsed | parsed identically |
+| base ends in `--fast`, unknown | parsed as an effort row | **discarded** |
+
+Only the last row changes, and only for an id whose base is a model that does not exist —
+today it resolves to an unroutable base and fails downstream anyway. Test 12 in wp1 pins
+the first three rows so the migration is proven behaviour-preserving rather than assumed.
+
+One ordering note: the wrapper calls `parseEffortRowId` (the pure form) rather than
+`parseRequestEffortRowId`, because it has already built `knownIds` and would otherwise
+build it twice per request.
+
 `isKnownId` is module-private in `effort-row.ts:32` today. wp1 exports it there rather than
 duplicating the Set-or-predicate branch.
 ## Publication helper
@@ -296,6 +314,10 @@ so the test cannot drift from real capability data.
 11. **Nested markers resolve to neither grammar.** `effortBaseCarriesFastMarker("x--fast")`
     is true for an unknown base and false when `x--fast` is a real known model, so
     `foo--fast--high` still works for a real `foo--fast`.
+12. **The wrapper preserves effort-row behaviour with `fastRows` off.** For a table of
+    existing selectors — flag off, no separator, ordinary `<base>--<effort>` — the
+    wrapper's `effortRow` equals `parseRequestEffortRowId`'s result exactly. This is the
+    anti-regression guard for the shipped `cursorEffortRows` feature.
 7. **Effort-row non-interference, both directions.** `parseEffortRowId("x--fast", ...)`
    returns null because `fast` is not a declared effort
    (`isDeclaredReasoningEffort("fast") === false`, `src/reasoning-effort.ts:39`), and

--- a/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
+++ b/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
@@ -1,20 +1,19 @@
 # 010 — wp1 / PR1: the fast-row grammar and its eligibility rule
 
 Scope IN: `src/server/fast-row.ts` (new), `src/server/effort-row.ts` (export `isKnownId`),
-`src/config.ts`, `src/types/config.ts`,
-`tests/fast-row.test.ts` (new). Scope OUT: every listing and ingress call site — wp1 ships
-the module and its tests with no caller, so the diff is reviewable on its own and the
-runtime is byte-identical until wp2 wires it.
+`src/config.ts`, `src/types/config.ts`, `tests/fast-row.test.ts` (new). Scope OUT: every
+listing and ingress call site — wp1 ships the module and its tests with no caller, so the
+diff is reviewable on its own and the runtime is byte-identical until wp2 wires it.
 
 ## Why a separate module rather than growing `effort-row.ts`
 
 They share a separator and nothing else. `effort-row.ts` answers "which effort rung" and
 consults an installed Cursor bundle table (`predictCursorEffort`, `detectCursorInstalls`).
 A fast row answers "which service tier" and consults the FastWire policy. Folding the
-second into the first would put Cursor install detection on the path of a feature that has
-nothing to do with Cursor, and `cursorEffortRows` gates the whole file's work today.
+second into the first would put Cursor install detection on the path of a feature unrelated
+to Cursor, and `cursorEffortRows` gates that whole file's work today.
 
-What IS shared is the collision inventory, and that is already exported:
+What IS shared is the collision inventory, and it is already built:
 `knownEffortRowIds(config)` (`effort-row.ts:43`) collects configured, registry, live-cached
 and custom model ids, routed slugs, provider/alias namespaces, `modelAliases` values, combo
 ids, and routing-profile ids. wp1 imports it rather than rebuilding it. The name is
@@ -26,13 +25,13 @@ effort-flavoured for historical reasons; the set is not.
 // src/server/fast-row.ts
 import { fastPolicyForModel } from "../providers/service-tier";
 import type { InboundWire } from "../providers/registry";
-import type { OcxConfig, OcxProviderConfig } from "../types";
-import { knownEffortRowIds, type EffortRowKnownIds } from "./effort-row";
+import type { OcxConfig } from "../types";
+import { isKnownId, knownEffortRowIds, type EffortRowKnownIds } from "./effort-row";
 
 /**
- * Terminal marker for a synthetic Fast selector. `--` rather than `-` because terminal
- * `-fast` is a REAL id across this catalog (grok-4-fast, glm-5.3-fast, gpt-5-fast,
- * every Cursor fast variant), so a single hyphen cannot tell a product apart from a tier.
+ * Terminal marker for a synthetic Fast selector. Double hyphen rather than single, because
+ * terminal -fast is a REAL id across this catalog (grok-4-fast, glm-5.3-fast, gpt-5-fast,
+ * every Cursor fast variant), so one hyphen cannot tell a product apart from a tier.
  * See 000_plan.md for the full collision table.
  */
 const FAST_ROW_SUFFIX = "--fast";
@@ -48,14 +47,27 @@ export function fastRowEligible(
   providerName?: string,
   inbound: InboundWire = "responses",
 ): boolean {
-  // `eligible` alone. `unclassified` means capability is undefined, and decideTier makes
-  // fastMode inert there (fastwire.ts:320) — publishing it would advertise a tier the
+  // "eligible" alone. "unclassified" means capability is undefined, and decideTier makes
+  // fastMode inert there (fastwire.ts:320) - publishing it would advertise a tier the
   // runtime then refuses to send.
   return fastPolicyForModel(provider, modelId, providerName, inbound).eligibility === "eligible";
 }
 ```
 
-Parsing mirrors `parseRequestEffortRowId`'s shape, including its cheap bail:
+## Parsing, and why there is no composite guard
+
+The first draft carried a `hasCompositeRowMarkers()` helper meant to reject ids bearing both
+a fast and an effort marker. Audit round 2 killed it, and the reasoning is worth keeping
+because it is the argument for the design that replaced it.
+
+The helper was asymmetric: it tested `endsWith("--fast")` then looked one segment left, so
+`x--high--fast` was caught while `x--fast--high` sailed past. Worse, it was blind to real
+models: an eligible base legitimately named `a--high` publishes `a--high--fast`, and the
+guard would have suppressed parsing of a row this very unit published.
+
+The correct arbiter already exists. A fast row is valid **iff stripping the marker leaves a
+base this proxy can actually route**, and `knownEffortRowIds()` answers exactly that. So
+parsing validates the base instead of pattern-matching the composite:
 
 ```ts
 export interface ParsedFastRowId { baseId: string; }
@@ -67,11 +79,16 @@ export function parseFastRowId(
 ): ParsedFastRowId | null {
   if (config.fastRows !== true) return null;
   if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
-  // An exact configured/public id always beats the synthetic grammar, the same precedence
-  // effort rows use. An operator who really named a model `x--fast` keeps it.
+  // An exact configured/public id always beats the synthetic grammar - the same precedence
+  // effort rows use. An operator who really named a model "x--fast" keeps it.
   if (isKnownId(knownIds, id)) return null;
   const baseId = id.slice(0, -FAST_ROW_SUFFIX.length);
-  return baseId.length > 0 ? { baseId } : null;
+  if (baseId.length === 0) return null;
+  // The base must be a model we can route. This is what makes the grammar safe without a
+  // composite guard: "a--high--fast" resolves because "a--high" is known, and
+  // "x--fast--high" is never mistaken for a fast row because it does not end in the marker
+  // - the effort parser sees base "x--fast", finds it unknown, and declines too.
+  return isKnownId(knownIds, baseId) ? { baseId } : null;
 }
 
 /** Parse one ingress selector against the current config. */
@@ -84,10 +101,14 @@ export function parseRequestFastRowId(id: string, config: OcxConfig): ParsedFast
 }
 ```
 
-`isKnownId` is currently module-private in `effort-row.ts:32`. wp1 exports it there (a
-two-word diff) rather than duplicating the Set-or-predicate branch.
+Requiring a known base is a real tightening over the effort-row grammar, which accepts any
+stem. It is affordable here because a fast row is only ever published for a model that
+resolved a Fast policy, and a policy cannot resolve for a model the router does not know.
 
-Publication helper, shaped like `expandCursorEffortRow` so wp2's call sites read the same:
+`isKnownId` is module-private in `effort-row.ts:32` today. wp1 exports it there rather
+than duplicating the Set-or-predicate branch.
+
+## Publication helper
 
 ```ts
 export function expandFastRow<T extends { id: string }>(
@@ -102,10 +123,10 @@ export function expandFastRow<T extends { id: string }>(
 }
 ```
 
-The base row is always kept: a fast row is an addition, never a replacement. This is the
+The base row is always kept: a fast row is an addition, never a replacement. That is the
 deliberate difference from `fastMode`, which replaces the listed Cursor id
-(`src/server/index.ts:1603`). Replacement suits a global switch; a per-request selector
-has to leave the default reachable.
+(`src/server/index.ts:1603`). Replacement suits a global switch; a per-request selector has
+to leave the default reachable.
 
 ## Config flag
 
@@ -121,10 +142,10 @@ Following the `cursorEffortRows` precedent exactly (`src/config.ts:1052`).
 ```diff
  // src/types/config.ts
 +  /**
-+   * Opt-in synthetic Fast selectors. When true, external model listings add a
-+   * `<base-id>--fast` row for every model whose resolved Fast policy is `eligible`,
-+   * and selecting one routes the base model with the canonical `priority` service
-+   * tier. Omitted/false preserves discovery output exactly.
++   * Opt-in synthetic Fast selectors. When true, the raw OpenAI-style /v1/models list and
++   * Claude Code discovery add a "<base-id>--fast" row for every model whose resolved Fast
++   * policy is eligible, and selecting one routes the base model with the canonical
++   * "priority" service tier. Omitted/false preserves discovery output exactly.
 +   */
 +  fastRows?: boolean;
 ```
@@ -134,59 +155,41 @@ not reject every provider.
 
 ## Tests — `tests/fast-row.test.ts`
 
-Fixtures follow `tests/cursor-fast-listing.test.ts:74`: build the provider from the
-registry with `providerConfigSeed(getProviderRegistryEntry(...))` instead of hand-writing
-a config, so the test cannot drift from real capability data.
+Fixtures follow `tests/cursor-fast-listing.test.ts:74`: build the provider from the registry
+with `providerConfigSeed(getProviderRegistryEntry(...))` rather than hand-writing a config,
+so the test cannot drift from real capability data.
 
-1. **Default off.** `parseFastRowId("x--fast", {})` and `expandFastRow(row, true, {})`
-   return null / `[row]`. The flag-off path is the one every existing install runs.
-2. **Eligible publishes, unclassified does not.** Three fixture providers — one with
-   `supportsServiceTier: true` on an `openai-responses` adapter (eligible), one with it
-   `false` (capability-unsupported), one with it absent (unclassified) — and assert only
-   the first expands. This drives the `eligibility === "eligible"` conditional directly
-   rather than asserting a table contains a value, per `cursor-fast-tier.test.ts:31`.
-3. **`wire-unavailable` does not publish.** `fastWire: null` with
-   `supportsServiceTier: true` is the config-level conflict `config.ts:1193` already
-   rejects, so use the registry case instead: an `anthropic` adapter, whose
-   `anthropic-speed` wire has an empty adapter set (`fastwire.ts:15`).
-4. **A known id beats the grammar.** With a provider declaring a literal `foo--fast`
-   model, `parseFastRowId("foo--fast")` returns null and `expandFastRow` on `foo` emits
-   no duplicate.
-5. **Effort-row non-interference, both directions.** `parseEffortRowId("x--fast", ...)`
-   returns null because `fast` is not a declared effort, and `parseFastRowId("x--high")`
-   returns null because it lacks the marker. This is the assertion that lets the two
-   grammars share `--`; without it the composition is an assumption.
-6. **Bare marker rejected.** `parseFastRowId("--fast")` returns null — an empty base is
-   not a model.
-7. **Composite rejected both ways (audit B5).** `x--high--fast` and `x--fast--high` each
-   parse to null under BOTH `parseFastRowId` and `parseEffortRowId`.
-
-## One grammar per id (audit B5)
-
-An id carrying BOTH markers resolves to neither grammar. wp1 owns the rule so it cannot
-drift between the five call sites:
-
-```ts
-/**
- * True when a selector carries a fast marker AND a declared effort marker. Such an id is
- * rejected by both parsers rather than resolved by whichever runs first. Ordering-derived
- * behaviour was the audit's B5 finding: Responses parsed effort first and mutated the id,
- * so `x--fast--high` fired both dimensions while `x--high--fast` fired neither, and Chat
- * and Messages — which parse from the immutable requested id — disagreed with it.
- */
-export function hasCompositeRowMarkers(id: string): boolean {
-  if (!id.endsWith(FAST_ROW_SUFFIX)) return false;
-  const stem = id.slice(0, -FAST_ROW_SUFFIX.length);
-  const sep = stem.lastIndexOf("--");
-  return sep > 0 && isDeclaredReasoningEffort(stem.slice(sep + 2));
-}
-```
-
-`parseFastRowId` returns null on it, and wp3 checks it before the effort parser on every
-ingress. Every ingress parses from the IMMUTABLE original selector, never from a value a
-previous parser mutated.
+1. **Default off.** `parseFastRowId("x--fast", {})` returns null and
+   `expandFastRow(row, true, {})` returns the row alone. This is the path every existing
+   install runs.
+2. **Eligible publishes, unclassified does not.** Three fixture providers —
+   `supportsServiceTier: true` on an `openai-responses` adapter (eligible), `false`
+   (capability-unsupported), and absent (unclassified) — and only the first expands. This
+   drives the `eligibility === "eligible"` conditional rather than asserting a table
+   contains a value, per `cursor-fast-tier.test.ts:31`.
+3. **`wire-unavailable` does not publish.** `fastWire: null` with `supportsServiceTier: true`
+   is the config-level conflict `config.ts:1193` already rejects, so use the registry case:
+   an `anthropic` adapter, whose `anthropic-speed` wire has an empty adapter set
+   (`fastwire.ts:15`).
+4. **A known id beats the grammar.** With a provider declaring a literal `foo--fast` model,
+   `parseFastRowId("foo--fast")` returns null and `expandFastRow` on `foo` emits no
+   duplicate.
+5. **An unknown base is refused.** `parseFastRowId("nonexistent--fast")` returns null even
+   with the flag on.
+6. **A base that itself ends in an effort marker still works.** A known model `a--high`
+   yields a parsable `a--high--fast`. This is the audit-round-2 regression: the discarded
+   composite guard failed it.
+7. **Effort-row non-interference, both directions.** `parseEffortRowId("x--fast", ...)`
+   returns null because `fast` is not a declared effort
+   (`isDeclaredReasoningEffort("fast") === false`, `src/reasoning-effort.ts:39`), and
+   `parseFastRowId("x--high")` returns null for want of the marker. This is the assertion
+   that lets the two grammars share the separator; without it the composition is an
+   assumption.
+8. **Bare marker rejected.** `parseFastRowId("--fast")` returns null — an empty base is not
+   a model.
 
 ## Verification
 
 `bun test tests/fast-row.test.ts`, `bun test tests/config.test.ts`, `bun run typecheck`.
 No repository-wide suite.
+

--- a/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
+++ b/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
@@ -23,10 +23,24 @@ effort-flavoured for historical reasons; the set is not.
 
 ```ts
 // src/server/fast-row.ts
+import {
+  accountBoundNativeOpenAiSlugsBySelector,
+  shouldIncludeAccountBoundNativeOpenAi,
+  shouldIncludeNativeOpenAi,
+  visibleNativeSlugs,
+} from "../codex/catalog/metadata";
 import { fastPolicyForModel } from "../providers/service-tier";
 import type { InboundWire } from "../providers/registry";
 import type { OcxConfig } from "../types";
-import { isKnownId, knownEffortRowIds, type EffortRowKnownIds } from "./effort-row";
+import {
+  isKnownId,
+  knownEffortRowIds,
+  parseEffortRowId,
+  parseRequestEffortRowId,
+  loadDetectedCursorEffortTable,
+  type EffortRowKnownIds,
+  type ParsedEffortRowId,
+} from "./effort-row";
 
 /**
  * Terminal marker for a synthetic Fast selector. Double hyphen rather than single, because
@@ -103,7 +117,12 @@ export function fastRowBases(config: OcxConfig): Set<string> {
     for (const slug of visibleNativeSlugs(config)) bases.add(slug);
   }
   if (shouldIncludeAccountBoundNativeOpenAi(config)) {
-    for (const [selector, slugs] of accountBoundNativeOpenAiSlugsBySelector(config)) {
+    // Pass an EMPTY observed-entry list on purpose. The default argument reads the Codex
+    // models cache and catalog from disk (metadata.ts:765), which would put a file read on
+    // every parsed selector. The empty form still seeds every selector with
+    // NATIVE_OPENAI_MODELS (:773), and an observed native this unit could publish for must
+    // already be in UPSTREAM_NATIVE_ENTRIES anyway, so nothing publishable is lost.
+    for (const [selector, slugs] of accountBoundNativeOpenAiSlugsBySelector(config, [])) {
       for (const slug of slugs) bases.add(`${selector}/${slug}`);
     }
   }
@@ -111,9 +130,10 @@ export function fastRowBases(config: OcxConfig): Set<string> {
 }
 ```
 
-All three helpers are synchronous and config-only (`metadata.ts:430`, `:450`, `:763`), so
-this builds on the request path. wp2 asserts the containment direction that matters: every
-base it publishes a row for is in this set (test 10). The reverse does not hold, by design.
+All four helpers are synchronous, and with the explicit empty observed-entry list none of
+them touches the filesystem (`metadata.ts:430`, `:450`, `:763`). wp2 asserts the containment
+direction that matters: every base it publishes a row for is in this set (test 10). The
+reverse does not hold, by design.
 
 ```ts
 export interface ParsedFastRowId { baseId: string; }
@@ -187,22 +207,38 @@ export interface ParsedSyntheticRow {
  * Resolve one ingress selector against both synthetic grammars. Callers pass the id the
  * client sent and never a value another parser mutated.
  */
-export function parseSyntheticRowId(id: string, config: OcxConfig): ParsedSyntheticRow {
-  // Ordinary ids carry no marker at all; bail before building either inventory so the
-  // flags cost nothing per request for models that are not synthetic rows.
-  if (id.lastIndexOf("--") <= 0) return { fastRow: null, effortRow: null };
+export function parseSyntheticRowId(
+  id: string,
+  config: OcxConfig,
+  // Claude surfaces decode the alias before the marker is unambiguous, so they pass the
+  // decoded form for Fast while effort parsing keeps seeing the id the client sent.
+  fastSelector: string = id,
+): ParsedSyntheticRow {
+  // Fast off: delegate verbatim. Not merely equivalent - the SAME function shipped today,
+  // so an install that never enables this feature cannot observe any change at all, in
+  // behaviour or in cost. Building knownIds or touching the Cursor table here would be a
+  // regression on the existing cursorEffortRows path.
+  if (config.fastRows !== true) {
+    return { fastRow: null, effortRow: parseRequestEffortRowId(id, config) };
+  }
+  // Ordinary ids carry no marker at all; bail before building any inventory.
+  if (id.lastIndexOf("--") <= 0 && fastSelector.lastIndexOf("--") <= 0) {
+    return { fastRow: null, effortRow: null };
+  }
   const knownIds = knownEffortRowIds(config);
-  const fastRow = config.fastRows === true && id.endsWith(FAST_ROW_SUFFIX)
-    ? parseFastRowId(id, config, knownIds, fastRowBases(config))
+  const fastRow = fastSelector.endsWith(FAST_ROW_SUFFIX)
+    ? parseFastRowId(fastSelector, config, knownIds, fastRowBases(config))
     : null;
   if (fastRow) return { fastRow, effortRow: null };
-  const effortRow = parseEffortRowId(id, config, {
-    knownIds,
-    table: loadDetectedCursorEffortTable(),
-  });
+  // Cursor install detection stays behind its own flag, exactly as parseRequestEffortRowId
+  // gates it today.
+  const effortRow = config.cursorEffortRows === true
+    ? parseEffortRowId(id, config, { knownIds, table: loadDetectedCursorEffortTable() })
+    : null;
   // Composition is not supported (020 R1) and the effort parser cannot see the problem: it
   // validates the terminal effort but never that the base is real (effort-row.ts:78-95), so
-  // "x--fast--high" would otherwise resolve to the nonexistent base "x--fast".
+  // "x--fast--high" would otherwise resolve to the nonexistent base "x--fast". This rule
+  // applies only with fastRows ON, so it can never change a shipped-config outcome.
   return effortRow && effortBaseCarriesFastMarker(effortRow.baseId, knownIds)
     ? { fastRow: null, effortRow: null }
     : { fastRow: null, effortRow };
@@ -215,20 +251,15 @@ call sites migrate to the wrapper in wp3 so both grammars are resolved in one pl
 **The migration must not regress `cursorEffortRows`.** With `fastRows` off the wrapper
 reduces to today's behaviour, and the differences are deliberate and bounded:
 
-| | `parseRequestEffortRowId` today | wrapper, `fastRows` off |
-|---|---|---|
-| flag off | returns null immediately | `parseEffortRowId` returns null on the same check |
-| no `--` in id | early bail | same early bail |
-| ordinary effort row | parsed | parsed identically |
-| base ends in `--fast`, unknown | parsed as an effort row | **discarded** |
+With `fastRows` off the wrapper **delegates to `parseRequestEffortRowId` itself**, so the
+shipped path is not reimplemented and cannot drift. An earlier draft reconstructed the
+logic inline and regressed two cases the audit caught: it built the known-id inventory and
+loaded the Cursor bundle table for any id containing `--` (work the shipped early-return
+skips), and it applied the nested-marker rule unconditionally, so a `cursorEffortRows` user
+with `fastRows` off would have lost the `x--fast--high` effort row they get today.
 
-Only the last row changes, and only for an id whose base is a model that does not exist —
-today it resolves to an unroutable base and fails downstream anyway. Test 12 in wp1 pins
-the first three rows so the migration is proven behaviour-preserving rather than assumed.
-
-One ordering note: the wrapper calls `parseEffortRowId` (the pure form) rather than
-`parseRequestEffortRowId`, because it has already built `knownIds` and would otherwise
-build it twice per request.
+With `fastRows` on, the nested-marker rule is new behaviour for a new opt-in feature, which
+is the only place it is allowed to apply. Test 12 pins the delegation.
 
 `isKnownId` is module-private in `effort-row.ts:32` today. wp1 exports it there rather than
 duplicating the Set-or-predicate branch.

--- a/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
+++ b/devlog/_plan/260904_external_fast_wire/010_wp1_fast_row_core.md
@@ -54,20 +54,33 @@ export function fastRowEligible(
 }
 ```
 
-## Parsing, and why there is no composite guard
+## Parsing: two questions, not one
 
-The first draft carried a `hasCompositeRowMarkers()` helper meant to reject ids bearing both
-a fast and an effort marker. Audit round 2 killed it, and the reasoning is worth keeping
-because it is the argument for the design that replaced it.
+Three drafts died here, and the reason is the design.
 
-The helper was asymmetric: it tested `endsWith("--fast")` then looked one segment left, so
-`x--high--fast` was caught while `x--fast--high` sailed past. Worse, it was blind to real
-models: an eligible base legitimately named `a--high` publishes `a--high--fast`, and the
-guard would have suppressed parsing of a row this very unit published.
+The first used a suffix-shape guard (`hasCompositeRowMarkers`). It was asymmetric — it
+caught `x--high--fast` but not `x--fast--high` — and it suppressed `a--high--fast`, a row this
+unit itself publishes when `a--high` is a real model.
 
-The correct arbiter already exists. A fast row is valid **iff stripping the marker leaves a
-base this proxy can actually route**, and `knownEffortRowIds()` answers exactly that. So
-parsing validates the base instead of pattern-matching the composite:
+The second required the stripped base to be in `knownEffortRowIds()`. That set answers
+"which exact ids defeat the synthetic grammar"; it does NOT answer "which bases are
+routable". Native slugs prove the gap: the `openai` registry entry declares no `models`
+list (`registry.ts:1128`) and the default provider config declares none either
+(`config.ts:3552`), because bare natives route through a family-pattern rule instead
+(`isBareOpenAiFamilyModel`, `router.ts:529`). So `gpt-5.6-sol` — the flagship Fast model —
+is absent from that set, and the second draft would have published `gpt-5.6-sol--fast` and
+then refused to parse it. A row nothing can select is worse than no row.
+
+The two questions stay separate:
+
+| Question | Source | Used for |
+|---|---|---|
+| Which exact ids beat the grammar? | `knownEffortRowIds(config)` | refusing to strip a real `x--fast` |
+| Which bases may carry a fast row? | `fastRowBases(config)` (new) | validating the strip |
+
+`fastRowBases()` is built by the same enumeration wp2 publishes from — every visible native
+slug (bare and account-qualified) plus every routed public id — so publication and parsing
+read one source and cannot drift. Test 9 asserts that invariant directly.
 
 ```ts
 export interface ParsedFastRowId { baseId: string; }
@@ -75,7 +88,8 @@ export interface ParsedFastRowId { baseId: string; }
 export function parseFastRowId(
   id: string,
   config: Pick<OcxConfig, "fastRows">,
-  knownIds?: EffortRowKnownIds,
+  knownIds: EffortRowKnownIds | undefined,
+  routableBases: EffortRowKnownIds | undefined,
 ): ParsedFastRowId | null {
   if (config.fastRows !== true) return null;
   if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
@@ -84,30 +98,59 @@ export function parseFastRowId(
   if (isKnownId(knownIds, id)) return null;
   const baseId = id.slice(0, -FAST_ROW_SUFFIX.length);
   if (baseId.length === 0) return null;
-  // The base must be a model we can route. This is what makes the grammar safe without a
-  // composite guard: "a--high--fast" resolves because "a--high" is known, and
-  // "x--fast--high" is never mistaken for a fast row because it does not end in the marker
-  // - the effort parser sees base "x--fast", finds it unknown, and declines too.
-  return isKnownId(knownIds, baseId) ? { baseId } : null;
-}
-
-/** Parse one ingress selector against the current config. */
-export function parseRequestFastRowId(id: string, config: OcxConfig): ParsedFastRowId | null {
-  if (config.fastRows !== true) return null;
-  // Ordinary ids do not carry the marker; bail before building the known-id inventory so
-  // the flag costs nothing per request for models that are not fast rows.
-  if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
-  return parseFastRowId(id, config, knownEffortRowIds(config));
+  // The base must be one this proxy actually publishes a fast row FOR. Not the known-id
+  // set: that omits bare natives, which route by family pattern rather than a declared
+  // models list, and they are the models Fast matters most for.
+  return isKnownId(routableBases, baseId) ? { baseId } : null;
 }
 ```
 
-Requiring a known base is a real tightening over the effort-row grammar, which accepts any
-stem. It is affordable here because a fast row is only ever published for a model that
-resolved a Fast policy, and a policy cannot resolve for a model the router does not know.
+## Reverse-order composites
 
-`isKnownId` is module-private in `effort-row.ts:32` today. wp1 exports it there rather
-than duplicating the Set-or-predicate branch.
+`x--fast--high` does not end in the marker, so the fast parser never sees it. An earlier draft
+claimed the effort parser would then decline it too. That was wrong: `parseEffortRowId`
+validates the terminal effort and the Cursor ladder but never checks that the base is real
+(`effort-row.ts:78-95`), so it returns base `x--fast` with effort `high`.
 
+That is pre-existing effort-row behaviour and this unit does not change it. What this unit
+must not do is let a FAST marker be consumed as part of an effort row's base. One guard,
+applied where the grammars meet:
+
+```ts
+/**
+ * True when an effort-row base still carries a fast marker, i.e. the selector nested the
+ * two grammars. Composition is not supported (020 R1), so such an id resolves to neither
+ * rather than silently to whichever parser ran first.
+ *
+ * Guarded by the known-id check so a real model named "foo--fast" keeps its legitimate
+ * "foo--fast--high" effort row.
+ */
+export function effortBaseCarriesFastMarker(
+  baseId: string,
+  knownIds: EffortRowKnownIds | undefined,
+): boolean {
+  return baseId.endsWith(FAST_ROW_SUFFIX) && !isKnownId(knownIds, baseId);
+}
+```
+
+wp3 applies it at each ingress: when the effort parser returns a base for which this holds,
+the selector is treated as unrecognized. Both marker orders then behave identically on all
+five surfaces.
+
+## Request-time entry points
+
+```ts
+export function parseRequestFastRowId(id: string, config: OcxConfig): ParsedFastRowId | null {
+  if (config.fastRows !== true) return null;
+  // Ordinary ids do not carry the marker; bail before building either inventory so the
+  // flag costs nothing per request for models that are not fast rows.
+  if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
+  return parseFastRowId(id, config, knownEffortRowIds(config), fastRowBases(config));
+}
+```
+
+`isKnownId` is module-private in `effort-row.ts:32` today. wp1 exports it there rather than
+duplicating the Set-or-predicate branch.
 ## Publication helper
 
 ```ts
@@ -176,9 +219,20 @@ so the test cannot drift from real capability data.
    duplicate.
 5. **An unknown base is refused.** `parseFastRowId("nonexistent--fast")` returns null even
    with the flag on.
-6. **A base that itself ends in an effort marker still works.** A known model `a--high`
+6. **A base that itself ends in an effort marker still works.** A routable `a--high`
    yields a parsable `a--high--fast`. This is the audit-round-2 regression: the discarded
    composite guard failed it.
+9. **A bare native round-trips.** `gpt-5.6-sol--fast` parses back to `gpt-5.6-sol` on a
+   DEFAULT config, with no `models` list configured. This is the audit-round-3 regression:
+   the known-id-based draft failed it, because bare natives route by family pattern and
+   appear in no declared models list. Assert the account-qualified form too.
+10. **Publication and parsing share one source.** For a fixture config, every id
+    `fastRowBases(config)` reports is parsable, and every fast row wp2 would publish has
+    its base in that set. This is the anti-drift invariant; it fails if either side grows
+    a case the other lacks.
+11. **Nested markers resolve to neither grammar.** `effortBaseCarriesFastMarker("x--fast")`
+    is true for an unknown base and false when `x--fast` is a real known model, so
+    `foo--fast--high` still works for a real `foo--fast`.
 7. **Effort-row non-interference, both directions.** `parseEffortRowId("x--fast", ...)`
    returns null because `fast` is not a declared effort
    (`isDeclaredReasoningEffort("fast") === false`, `src/reasoning-effort.ts:39`), and
@@ -192,4 +246,3 @@ so the test cannot drift from real capability data.
 
 `bun test tests/fast-row.test.ts`, `bun test tests/config.test.ts`, `bun run typecheck`.
 No repository-wide suite.
-

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -211,6 +211,13 @@ Both id styles are covered, unlike `fastMode`. `fastMode` excludes Desktop 3P be
 *rewrites* a hashed id and would strand a saved selection (`model-info.ts:157`); an added
 row strands nothing, because the original id keeps existing.
 
+## Import changes, per file
+
+| File | Add |
+|---|---|
+| `src/server/index.ts` | `expandFastRow`, `fastRowEligible` from `./fast-row`; `UPSTREAM_NATIVE_ENTRIES` from `../codex/catalog/metadata` (the catalog facade does not re-export it) |
+| `src/claude/model-info.ts` | none — `claudeCodeAlias`/`claudeCodeNativeAlias` (`:19`), `cursorFastIdFor`, and the `aliasForRoute` parameter (`:111`) are all already in scope |
+
 ## Tests — `tests/fast-row-listing.test.ts`
 
 1. Flag off: a listing containing an eligible model has no `--fast` id, on both the

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -129,15 +129,26 @@ translation module and must not start resolving provider policy itself:
  ): AnthropicModelInfo[] {
 ```
 
+`buildAnthropicModelInfos` treats the predicate's PRESENCE as the gate — both loops call
+`fastRows?.(...)` — so the caller must pass `undefined` when the flag is off. The predicate
+itself answers eligibility, not enablement; conflating the two would publish rows on a
+default install.
+
 The caller at `src/server/index.ts:1454` binds it to `config` and routes the `native`
 pseudo-provider explicitly, since `config.providers.native` does not exist:
 
 ```ts
-(provider, modelId) => provider === "native"
-  ? nativeFastEligible(modelId)
-  : (config.providers[provider] !== undefined
-    && fastRowEligible(config.providers[provider], modelId, provider)),
+config.fastRows === true
+  ? (provider: string, modelId: string) => provider === "native"
+    ? nativeFastEligible(modelId)
+    : (config.providers[provider] !== undefined
+      && fastRowEligible(config.providers[provider], modelId, provider))
+  : undefined,
 ```
+
+`nativeFastEligible` must be declared BEFORE this call. The raw OpenAI mapper that also
+uses it sits further down the handler, so a `const` defined there would leave this call in
+its temporal dead zone.
 
 One helper serves both loops, alongside the existing `push1mVariant`:
 

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -153,6 +153,14 @@ const nativeDiscoveryId = (slug: string): string => idStyle === "readable"
   ? claudeCodeNativeAlias(slug)
   : aliasForRoute("native", slug);
 
+// The existing `fastModelId ?? m.id` expression at model-info.ts:159-162, lifted so the
+// collision set and the routed loop compute one value. The fastMode Cursor rewrite must be
+// reflected here, or a rewritten row would look synthetic to the collision check.
+const listedModelIdFor = (m: CatalogModel): string =>
+  fastMode === true && m.provider === "cursor" && idStyle === "readable"
+    ? cursorFastIdFor(m.id) ?? m.id
+    : m.id;
+
 const routedDiscoveryId = (m: CatalogModel, listedModelId: string): string =>
   idStyle === "readable"
     ? claudeCodeAlias(m.provider, listedModelId)
@@ -176,12 +184,10 @@ const pushFastVariant = (base: AnthropicModelInfo) => {
 };
 ```
 
-`listedModelIdFor(m)` is the existing `fastModelId ?? m.id` expression at
-`model-info.ts:162`, lifted to a helper for the same reason: the fastMode Cursor rewrite
-must be reflected in the collision set, or a rewritten row would look synthetic. Both loops
-then call these helpers for their own row ids too, so the set and the output cannot drift.
-`claudeCodeAlias` and `claudeCodeNativeAlias` are already imported at `model-info.ts:19`,
-and `aliasForRoute` is a parameter of `buildAnthropicModelInfos` (`:111`).
+Both loops call these helpers for their own row ids too, so the collision set and the
+published output cannot drift. `claudeCodeAlias` and `claudeCodeNativeAlias` are already
+imported at `model-info.ts:19`, `aliasForRoute` is a parameter of `buildAnthropicModelInfos`
+(`:111`), and `cursorFastIdFor` is already imported for the existing fastMode rewrite.
 
 ```diff
    for (const slug of nativeSlugs) {

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -145,20 +145,26 @@ One `discoveryId` helper computes the id for a row, and BOTH the loops and the c
 set use it, so the two can never disagree about what a real id looks like:
 
 ```ts
-// The existing per-loop id expressions, extracted verbatim so there is one definition.
-const discoveryId = (provider: string, modelId: string): string => provider === "native"
-  ? (idStyle === "readable" ? claudeCodeNativeAlias(modelId) : aliasForRoute("native", modelId))
-  : (idStyle === "readable" ? claudeCodeAlias(provider, modelId) : aliasForRoute(provider, modelId));
+// The existing per-loop id expressions, extracted so there is ONE definition. Note the
+// asymmetry, which is real and must be preserved: the readable style uses the LISTED id
+// (so a fastMode-rewritten Cursor id is reflected), while the Desktop 3P style hashes the
+// RAW m.id (model-info.ts:164-165), because a hash rewrite would strand a saved selection.
+const nativeDiscoveryId = (slug: string): string => idStyle === "readable"
+  ? claudeCodeNativeAlias(slug)
+  : aliasForRoute("native", slug);
+
+const routedDiscoveryId = (m: CatalogModel, listedModelId: string): string =>
+  idStyle === "readable"
+    ? claudeCodeAlias(m.provider, listedModelId)
+    : aliasForRoute(m.provider, m.id);
 
 // Every real id BOTH loops will emit, computed before either runs. `seen` alone is not
 // enough: it grows as the loops run, so whether a synthetic id collided with a real one
 // would depend on iteration order. With both `foo` and a real `foo--fast` in the roster,
 // the synthetic id for `foo` IS the real model's id, and whichever ran first would win.
 const realDiscoveryIds = new Set<string>([
-  ...nativeSlugs.map(slug => discoveryId("native", slug)),
-  // The routed loop's own listedModelId, so a fastMode-rewritten Cursor id is counted as
-  // the real id it will actually be published under.
-  ...routedModels.map(m => discoveryId(m.provider, listedModelIdFor(m))),
+  ...nativeSlugs.map(nativeDiscoveryId),
+  ...routedModels.map(m => routedDiscoveryId(m, listedModelIdFor(m))),
 ]);
 
 const pushFastVariant = (base: AnthropicModelInfo) => {
@@ -172,7 +178,10 @@ const pushFastVariant = (base: AnthropicModelInfo) => {
 
 `listedModelIdFor(m)` is the existing `fastModelId ?? m.id` expression at
 `model-info.ts:162`, lifted to a helper for the same reason: the fastMode Cursor rewrite
-must be reflected in the collision set, or a rewritten row would look synthetic.
+must be reflected in the collision set, or a rewritten row would look synthetic. Both loops
+then call these helpers for their own row ids too, so the set and the output cannot drift.
+`claudeCodeAlias` and `claudeCodeNativeAlias` are already imported at `model-info.ts:19`,
+and `aliasForRoute` is a parameter of `buildAnthropicModelInfos` (`:111`).
 
 ```diff
    for (const slug of nativeSlugs) {

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -1,17 +1,35 @@
 # 020 — wp2 / PR2: publish the row on external listings
 
+Stacked on PR1. Scope IN: `src/server/index.ts` (`/v1/models` and the Claude Code discovery
+call only), `src/claude/model-info.ts`, `tests/fast-row-listing.test.ts` (new). Scope OUT:
+ingress parsing (wp3); the dashboard `/api/models` `namespaced` ids; Desktop 3P hashed
+aliases are covered but never rewritten; the Cursor integration status panel.
 
-## Amendments from audit round 1
+## Which surfaces publish, and which deliberately do not
 
-### A1 — native eligibility is policy-derived, not metadata-derived (B2)
+`/api/models` `namespaced` ids are `disabledModels` keys and the identities `ocx export`
+and the OpenCode integration write into user config files (`src/cli/opencode.ts:368`,
+`src/cli/export-command.ts:78`). A synthetic id landing in a persisted config outlives the
+flag that produced it, so those surfaces keep emitting base ids only. That is a real
+limitation, not an oversight, and wp4 documents it as one.
 
-`nativeFastEligible()` as first written read only upstream `additional_speed_tiers`, which
-ignores an operator's `supportsServiceTier: false` and the final wire resolution. Both
-conditions are now required:
+The surfaces that DO publish are the two a client uses to pick a model for a live request:
+the raw OpenAI-style `/v1/models` list, and Claude Code discovery.
+
+## Eligibility at listing time
+
+Routed models have everything in scope already: `m.provider` names the provider and
+`config.providers[m.provider]` is available at `src/server/index.ts:1605`. So the row mapper
+calls `fastRowEligible(provider, m.id, m.provider)` — the same `fastPolicyForModel` the
+catalog uses, pure and synchronous (`service-tier.ts:181`), adding no await to a branch that
+must not gain one.
+
+Natives need both halves of the evidence. Upstream asserts Fast per model, and the operator
+can still withdraw it:
 
 ```ts
-// Direct import: UPSTREAM_NATIVE_ENTRIES lives in src/codex/catalog/metadata.ts and is NOT
-// re-exported by the catalog facade (audit note 5).
+// src/server/index.ts. UPSTREAM_NATIVE_ENTRIES lives in src/codex/catalog/metadata.ts and
+// is NOT re-exported by the catalog facade, so import it directly.
 import { UPSTREAM_NATIVE_ENTRIES } from "../codex/catalog/metadata";
 
 const nativeFastEligible = (metadataId: string): boolean => {
@@ -19,82 +37,18 @@ const nativeFastEligible = (metadataId: string): boolean => {
   const upstreamSaysFast = Array.isArray(entry?.additional_speed_tiers)
     && entry.additional_speed_tiers.includes("fast");
   if (!upstreamSaysFast) return false;
-  // Upstream evidence alone never publishes: an operator capability override or a wire
-  // resolution can still make the route ineligible, and decideTier would drop the tier.
+  // Upstream evidence alone never publishes: an operator capability override or the final
+  // wire resolution can still make the route ineligible, and decideTier would then drop
+  // the tier the row advertised.
   const provider = config.providers[OPENAI_CODEX_PROVIDER_ID];
   return provider !== undefined
     && fastRowEligible(provider, metadataId, OPENAI_CODEX_PROVIDER_ID);
 };
 ```
 
-### A2 — both Claude discovery loops, not just the routed one (B3)
-
-`buildAnthropicModelInfos` builds natives at `model-info.ts:143` and routed models at
-`:155`. The original draft patched only the routed loop, which would have left
-`gpt-5.6-sol` — the flagship Fast model — without a row on Claude discovery, contradicting
-this unit's goal. The native loop gains the same additive block, sharing one predicate:
-
-```diff
-   for (const slug of nativeSlugs) {
-     const id = idStyle === "readable" ? claudeCodeNativeAlias(slug) : aliasForRoute("native", slug);
-     ...
-     out.push(info);
-     push1mVariant(info, nativeWindow, nativeMaxInput);
-+    if (fastRows?.("native", slug) === true) pushFastVariant(info);
-   }
-```
-
-`pushFastVariant` is a local helper alongside `push1mVariant`, used by both loops, so the
-two surfaces cannot drift. It applies to both id styles: an ADDED row strands no saved
-selection, which is why the `fastMode` rewrite's Desktop 3P exclusion does not apply here.
-
-### A3 — Cursor management status field dropped (B7)
-
-The proposed `fastRow` field referenced an eligibility value the mapper cannot derive: it
-retains only the public id, not a `{provider, modelId}` pair
-(`cursor-integration-routes.ts:69`). It is a Cursor-integration status panel, not a
-client-facing selector, so it leaves this unit entirely.
-`src/server/management/cursor-integration-routes.ts` is removed from scope, and the
-"Management route" section above is superseded.
-
-### A4 — additional tests
-
-7. A native model WITH upstream `additional_speed_tiers` but an operator
-   `supportsServiceTier: false` gets NO row. This is the A1 guard, and it fails against
-   the pre-audit design.
-8. Claude discovery publishes a fast row for a native slug in BOTH id styles.
-
-Stacked on PR1. Scope IN: `src/server/index.ts` (`/v1/models` and Claude Code discovery
-branches only), `src/claude/model-info.ts`, `src/server/management/cursor-integration-routes.ts`,
-`tests/fast-row-listing.test.ts` (new). Scope OUT: ingress parsing (wp3), the dashboard
-`namespaced` ids (they are `disabledModels` keys), Desktop 3P hashed aliases.
-
-## Where the eligibility comes from at listing time
-
-The routed branch already has everything needed: `m.provider` names the provider and
-`config.providers[m.provider]` is in scope at `src/server/index.ts:1605`. So the row mapper
-can call `fastRowEligible(provider, m.id, m.provider)` directly — the same
-`fastPolicyForModel` the catalog uses, which is pure and synchronous
-(`service-tier.ts:181`), so it adds no await to a branch that must not gain one.
-
-Natives are the case that needs a decision. A native slug like `gpt-5.6-sol` has no
-`config.providers` entry of its own; its Fast support is asserted upstream, and
-`UPSTREAM_NATIVE_ENTRIES` carries `additional_speed_tiers: ["fast"]` for exactly the
-models that have it (`src/codex/data/upstream-models.json`). wp2 reads that snapshot
-rather than inventing a second source:
-
-```ts
-// src/server/index.ts, near nativeModelRow (1532)
-const nativeFastEligible = (metadataId: string): boolean => {
-  const entry = UPSTREAM_NATIVE_ENTRIES.get(metadataId);
-  return Array.isArray(entry?.additional_speed_tiers)
-    && entry.additional_speed_tiers.includes("fast");
-};
-```
-
-This is the same evidence the Codex picker's own toggle is built from
-(`src/codex/catalog/effort.ts:167` writes that field; upstream asserts it), so the external
-row and the in-app toggle cannot disagree about which natives have Fast.
+Reading the same `additional_speed_tiers` the Codex picker's toggle is built from
+(`src/codex/catalog/effort.ts:167` writes it; upstream asserts it) is what keeps the
+external row and the in-app toggle from disagreeing about which natives have Fast.
 
 ## `/v1/models`
 
@@ -115,19 +69,18 @@ then composes the two expansions:
 ```diff
          const expandedNativeModelRow = (id: string, metadataId = id) => {
            const reasoningEfforts = nativeReasoningEfforts(metadataId);
--          return expandCursorEffortRow(nativeModelRow(id, metadataId), reasoningEfforts, config, {
+           return expandCursorEffortRow(nativeModelRow(id, metadataId), reasoningEfforts, config, {
 -            knownIds: effortRowKnownIds,
--            table: cursorEffortTable,
--            supportsReasoning: reasoningEfforts.length > 0,
--          });
-+          return expandCursorEffortRow(nativeModelRow(id, metadataId), reasoningEfforts, config, {
 +            knownIds: syntheticKnownIds,
-+            table: cursorEffortTable,
-+            supportsReasoning: reasoningEfforts.length > 0,
+             table: cursorEffortTable,
+             supportsReasoning: reasoningEfforts.length > 0,
+-          });
 +          }).flatMap(row => expandFastRow(
 +            row,
-+            // Only the base row earns a fast sibling: `x--high--fast` would be a second
-+            // grammar stacked on the first, and nothing parses it.
++            // Only the base row earns a fast sibling. An effort row already spent the
++            // grammar, and wp1's parser requires the stripped base to be a KNOWN model -
++            // "<base>--<effort>" is synthetic, so "<base>--<effort>--fast" would publish a
++            // row that no ingress can resolve.
 +            row.id === id && nativeFastEligible(metadataId),
 +            config,
 +            syntheticKnownIds,
@@ -135,23 +88,15 @@ then composes the two expansions:
          };
 ```
 
-The `row.id === id` guard is load-bearing. Without it every `<base>--<effort>` row would
-also sprout `--fast`, and wp3's parser splits on one marker, so those ids would resolve to
-a base of `<base>--<effort>` — a model that does not exist. Composition of the two
-dimensions is deliberately not supported in this unit; it is recorded as a residual.
-
-The routed branch takes the same shape, with policy-derived eligibility:
+The routed branch takes the same shape with policy-derived eligibility:
 
 ```diff
--          return expandCursorEffortRow(row, m.reasoningEfforts, config, {
+           return expandCursorEffortRow(row, m.reasoningEfforts, config, {
 -            knownIds: effortRowKnownIds,
--            table: cursorEffortTable,
--            supportsReasoning: (m.reasoningEfforts ?? []).length > 0,
--          });
-+          return expandCursorEffortRow(row, m.reasoningEfforts, config, {
 +            knownIds: syntheticKnownIds,
-+            table: cursorEffortTable,
-+            supportsReasoning: (m.reasoningEfforts ?? []).length > 0,
+             table: cursorEffortTable,
+             supportsReasoning: (m.reasoningEfforts ?? []).length > 0,
+-          });
 +          }).flatMap(expanded => expandFastRow(
 +            expanded,
 +            expanded.id === row.id
@@ -162,16 +107,19 @@ The routed branch takes the same shape, with policy-derived eligibility:
 +          ));
 ```
 
-`m.id` (not `publicId`) is the model identity the policy is resolved against, while the
-row id that gets the suffix is the public one — a routed slug, or an operator alias when
-one exists. An alias is an explicit operator decision, and it keeps its own `--fast`
-sibling rather than being bypassed.
+`m.id` (not `publicId`) is the identity the policy resolves against, while the id that
+receives the suffix is the public one — a routed slug, or an operator alias when one
+exists. An alias is an explicit operator decision and keeps its own `--fast` sibling rather
+than being bypassed.
 
 ## Claude Code discovery
 
-`buildAnthropicModelInfos` already takes `fastMode` (`src/claude/model-info.ts:113`) and
-already knows how to publish a dimension as an extra row rather than a replacement:
-`push1mVariant`. The fast row follows `push1mVariant`, not the `fastMode` rewrite.
+`buildAnthropicModelInfos` builds natives at `model-info.ts:143` and routed models at
+`:155`. **Both loops publish**, or the flagship Fast model — native `gpt-5.6-sol` — would
+be missing from the surface this unit exists to serve.
+
+The signature gains a predicate rather than a config object, because `model-info.ts` is a
+translation module and must not start resolving provider policy itself:
 
 ```diff
  export function buildAnthropicModelInfos(
@@ -181,60 +129,73 @@ already knows how to publish a dimension as an extra row rather than a replaceme
  ): AnthropicModelInfo[] {
 ```
 
-A predicate rather than a config object: `model-info.ts` is a translation module and must
-not start resolving provider policy itself. The caller in `src/server/index.ts:1454`
-supplies it, already bound to `config`.
+The caller at `src/server/index.ts:1454` binds it to `config` and routes the `native`
+pseudo-provider explicitly, since `config.providers.native` does not exist:
+
+```ts
+(provider, modelId) => provider === "native"
+  ? nativeFastEligible(modelId)
+  : (config.providers[provider] !== undefined
+    && fastRowEligible(config.providers[provider], modelId, provider)),
+```
+
+One helper serves both loops, alongside the existing `push1mVariant`:
+
+```ts
+const pushFastVariant = (base: AnthropicModelInfo) => {
+  const fastId = `${id}--fast`;
+  if (seen.has(fastId)) return;
+  seen.add(fastId);
+  out.push({ ...base, id: fastId, display_name: `${base.display_name} · Fast` });
+};
+```
 
 ```diff
-     const info = modelInfo(id, `${listedModelId} (${m.provider})`, ladder, imageInput, routedMaxInput ?? m.contextWindow);
+   for (const slug of nativeSlugs) {
+     ...
+     out.push(info);
+     push1mVariant(info, nativeWindow, nativeMaxInput);
++    if (fastRows?.("native", slug) === true) pushFastVariant(info);
+   }
+```
+
+```diff
+     const info = modelInfo(id, ..., routedMaxInput ?? m.contextWindow);
      out.push(info);
 +    // An additive sibling, deliberately unlike the fastMode rewrite above: fastMode is a
 +    // global switch with no per-request choice, so it replaces; a selector must leave the
-+    // default pickable next to it.
-+    if (fastRows?.(m.provider, m.id) === true) {
-+      const fastId = `${id}--fast`;
-+      if (!seen.has(fastId)) {
-+        seen.add(fastId);
-+        out.push({ ...info, id: fastId, display_name: `${listedModelId} (${m.provider}, Fast)` });
-+      }
-+    }
++    // default pickable beside it.
++    if (fastRows?.(m.provider, m.id) === true) pushFastVariant(info);
 ```
 
-Both id styles are covered here, unlike `fastMode`. The reason `fastMode` excludes Desktop
-3P is that it *rewrites* the hashed id and would strand a saved selection
-(`model-info.ts:157`); an added row strands nothing, because the original id keeps
-existing.
-
-## Management route
-
-`cursor-integration-routes.ts:90` reports what the Cursor integration published. It gains
-a sibling field rather than mixing grammars into `effortRows`:
-
-```diff
-       effortRows: expandCursorEffortRow({ id }, reasoningEfforts, config, {...}).slice(1).map(row => row.id),
-+      fastRow: fastRowsEnabled && eligible ? fastRowId(id) : undefined,
-```
+Both id styles are covered, unlike `fastMode`. `fastMode` excludes Desktop 3P because it
+*rewrites* a hashed id and would strand a saved selection (`model-info.ts:157`); an added
+row strands nothing, because the original id keeps existing.
 
 ## Tests — `tests/fast-row-listing.test.ts`
 
-1. Flag off: a listing containing an eligible model has no `--fast` id anywhere. Run this
-   against both the `/v1/models` shape and `buildAnthropicModelInfos`.
+1. Flag off: a listing containing an eligible model has no `--fast` id, on both the
+   `/v1/models` shape and `buildAnthropicModelInfos`.
 2. Flag on: the eligible model gains exactly one `--fast` row AND keeps its base row.
-3. Flag on, ineligible/unclassified model: no `--fast` row.
+3. Flag on, ineligible or unclassified model: no `--fast` row.
 4. Effort rows and fast rows both on: `<base>--high` exists, `<base>--fast` exists,
-   `<base>--high--fast` does NOT. This is the guard for the `row.id === id` condition.
-5. Claude Code discovery: the fast id appears alongside the base id and the row count is
-   base + 1.
-6. A native without `additional_speed_tiers` gets no row, one with it does.
+   `<base>--high--fast` does NOT. Guards the `row.id === id` condition.
+5. Claude discovery, ROUTED model: the fast row appears beside the base id in both id
+   styles, and the row count is base + 1.
+6. Claude discovery, NATIVE slug: same. This is the audit-round-2 regression — the
+   routed-only draft failed it.
+7. A native WITHOUT upstream `additional_speed_tiers` gets no row; one WITH it does.
+8. A native WITH upstream evidence but operator `supportsServiceTier: false` gets NO row.
+   The metadata-only draft failed this one.
 
 ## Verification
 
-`bun test tests/fast-row-listing.test.ts tests/fast-row.test.ts`, plus the existing
-`tests/cursor-fast-listing.test.ts` to prove the neighbouring grammar is unchanged.
-`bun run typecheck`. No full suite.
+`bun test tests/fast-row-listing.test.ts tests/fast-row.test.ts tests/cursor-fast-listing.test.ts`
+(the last proves the neighbouring grammar is unchanged), `bun run typecheck`. No full suite.
 
 ## Residual
 
-R1 — effort and fast do not compose (`<base>--high--fast` is not published). Fixing it
-means a combined codec and a two-marker parser; deferred until someone asks for a specific
-effort at Fast, since the base row's default effort already reaches Fast.
+R1 — effort and fast do not compose (`<base>--high--fast` is not published). Fixing it needs
+a combined codec and a two-marker parser; deferred until someone asks for a specific effort
+at Fast, since the base row's default effort already reaches Fast.
+

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -141,21 +141,38 @@ pseudo-provider explicitly, since `config.providers.native` does not exist:
 
 One helper serves both loops, alongside the existing `push1mVariant`:
 
+One `discoveryId` helper computes the id for a row, and BOTH the loops and the collision
+set use it, so the two can never disagree about what a real id looks like:
+
 ```ts
-// Every real discovery id, computed BEFORE the loops. `seen` alone is not enough: it grows
-// as the loops run, so whether a synthetic id collided with a real one would depend on
-// iteration order. With both `foo` and a real `foo--fast` in the roster, the synthetic
-// alias for `foo` IS the real model's alias, and whichever ran first would win the row.
-const realDiscoveryIds = new Set<string>(/* every id both loops will emit */);
+// The existing per-loop id expressions, extracted verbatim so there is one definition.
+const discoveryId = (provider: string, modelId: string): string => provider === "native"
+  ? (idStyle === "readable" ? claudeCodeNativeAlias(modelId) : aliasForRoute("native", modelId))
+  : (idStyle === "readable" ? claudeCodeAlias(provider, modelId) : aliasForRoute(provider, modelId));
+
+// Every real id BOTH loops will emit, computed before either runs. `seen` alone is not
+// enough: it grows as the loops run, so whether a synthetic id collided with a real one
+// would depend on iteration order. With both `foo` and a real `foo--fast` in the roster,
+// the synthetic id for `foo` IS the real model's id, and whichever ran first would win.
+const realDiscoveryIds = new Set<string>([
+  ...nativeSlugs.map(slug => discoveryId("native", slug)),
+  // The routed loop's own listedModelId, so a fastMode-rewritten Cursor id is counted as
+  // the real id it will actually be published under.
+  ...routedModels.map(m => discoveryId(m.provider, listedModelIdFor(m))),
+]);
 
 const pushFastVariant = (base: AnthropicModelInfo) => {
   const fastId = `${base.id}--fast`;
-  // A real model always wins its own id.
+  // A real model always wins its own id, whatever the iteration order.
   if (realDiscoveryIds.has(fastId) || seen.has(fastId)) return;
   seen.add(fastId);
   out.push({ ...base, id: fastId, display_name: `${base.display_name} · Fast` });
 };
 ```
+
+`listedModelIdFor(m)` is the existing `fastModelId ?? m.id` expression at
+`model-info.ts:162`, lifted to a helper for the same reason: the fastMode Cursor rewrite
+must be reflected in the collision set, or a rewritten row would look synthetic.
 
 ```diff
    for (const slug of nativeSlugs) {
@@ -194,6 +211,12 @@ row strands nothing, because the original id keeps existing.
 7. A native WITHOUT upstream `additional_speed_tiers` gets no row; one WITH it does.
 8. A native WITH upstream evidence but operator `supportsServiceTier: false` gets NO row.
    The metadata-only draft failed this one.
+9. **Order-independent collision.** A roster containing both `foo` and a real `foo--fast`
+   publishes the REAL model's row under that id, asserted with the roster in BOTH orders.
+   The `seen`-only draft passed one order and failed the other.
+10. **Publication is inside the parser's superset.** Every base this listing publishes a
+    fast row for is in `fastRowBases(config)`. This is the anti-drift invariant that makes
+    a published row guaranteed-parsable; it is the round-3 regression.
 
 ## Verification
 

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -142,9 +142,16 @@ pseudo-provider explicitly, since `config.providers.native` does not exist:
 One helper serves both loops, alongside the existing `push1mVariant`:
 
 ```ts
+// Every real discovery id, computed BEFORE the loops. `seen` alone is not enough: it grows
+// as the loops run, so whether a synthetic id collided with a real one would depend on
+// iteration order. With both `foo` and a real `foo--fast` in the roster, the synthetic
+// alias for `foo` IS the real model's alias, and whichever ran first would win the row.
+const realDiscoveryIds = new Set<string>(/* every id both loops will emit */);
+
 const pushFastVariant = (base: AnthropicModelInfo) => {
-  const fastId = `${id}--fast`;
-  if (seen.has(fastId)) return;
+  const fastId = `${base.id}--fast`;
+  // A real model always wins its own id.
+  if (realDiscoveryIds.has(fastId) || seen.has(fastId)) return;
   seen.add(fastId);
   out.push({ ...base, id: fastId, display_name: `${base.display_name} · Fast` });
 };
@@ -198,4 +205,3 @@ row strands nothing, because the original id keeps existing.
 R1 — effort and fast do not compose (`<base>--high--fast` is not published). Fixing it needs
 a combined codec and a two-marker parser; deferred until someone asks for a specific effort
 at Fast, since the base row's default effort already reaches Fast.
-

--- a/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
+++ b/devlog/_plan/260904_external_fast_wire/020_wp2_listing.md
@@ -1,0 +1,240 @@
+# 020 — wp2 / PR2: publish the row on external listings
+
+
+## Amendments from audit round 1
+
+### A1 — native eligibility is policy-derived, not metadata-derived (B2)
+
+`nativeFastEligible()` as first written read only upstream `additional_speed_tiers`, which
+ignores an operator's `supportsServiceTier: false` and the final wire resolution. Both
+conditions are now required:
+
+```ts
+// Direct import: UPSTREAM_NATIVE_ENTRIES lives in src/codex/catalog/metadata.ts and is NOT
+// re-exported by the catalog facade (audit note 5).
+import { UPSTREAM_NATIVE_ENTRIES } from "../codex/catalog/metadata";
+
+const nativeFastEligible = (metadataId: string): boolean => {
+  const entry = UPSTREAM_NATIVE_ENTRIES.get(metadataId);
+  const upstreamSaysFast = Array.isArray(entry?.additional_speed_tiers)
+    && entry.additional_speed_tiers.includes("fast");
+  if (!upstreamSaysFast) return false;
+  // Upstream evidence alone never publishes: an operator capability override or a wire
+  // resolution can still make the route ineligible, and decideTier would drop the tier.
+  const provider = config.providers[OPENAI_CODEX_PROVIDER_ID];
+  return provider !== undefined
+    && fastRowEligible(provider, metadataId, OPENAI_CODEX_PROVIDER_ID);
+};
+```
+
+### A2 — both Claude discovery loops, not just the routed one (B3)
+
+`buildAnthropicModelInfos` builds natives at `model-info.ts:143` and routed models at
+`:155`. The original draft patched only the routed loop, which would have left
+`gpt-5.6-sol` — the flagship Fast model — without a row on Claude discovery, contradicting
+this unit's goal. The native loop gains the same additive block, sharing one predicate:
+
+```diff
+   for (const slug of nativeSlugs) {
+     const id = idStyle === "readable" ? claudeCodeNativeAlias(slug) : aliasForRoute("native", slug);
+     ...
+     out.push(info);
+     push1mVariant(info, nativeWindow, nativeMaxInput);
++    if (fastRows?.("native", slug) === true) pushFastVariant(info);
+   }
+```
+
+`pushFastVariant` is a local helper alongside `push1mVariant`, used by both loops, so the
+two surfaces cannot drift. It applies to both id styles: an ADDED row strands no saved
+selection, which is why the `fastMode` rewrite's Desktop 3P exclusion does not apply here.
+
+### A3 — Cursor management status field dropped (B7)
+
+The proposed `fastRow` field referenced an eligibility value the mapper cannot derive: it
+retains only the public id, not a `{provider, modelId}` pair
+(`cursor-integration-routes.ts:69`). It is a Cursor-integration status panel, not a
+client-facing selector, so it leaves this unit entirely.
+`src/server/management/cursor-integration-routes.ts` is removed from scope, and the
+"Management route" section above is superseded.
+
+### A4 — additional tests
+
+7. A native model WITH upstream `additional_speed_tiers` but an operator
+   `supportsServiceTier: false` gets NO row. This is the A1 guard, and it fails against
+   the pre-audit design.
+8. Claude discovery publishes a fast row for a native slug in BOTH id styles.
+
+Stacked on PR1. Scope IN: `src/server/index.ts` (`/v1/models` and Claude Code discovery
+branches only), `src/claude/model-info.ts`, `src/server/management/cursor-integration-routes.ts`,
+`tests/fast-row-listing.test.ts` (new). Scope OUT: ingress parsing (wp3), the dashboard
+`namespaced` ids (they are `disabledModels` keys), Desktop 3P hashed aliases.
+
+## Where the eligibility comes from at listing time
+
+The routed branch already has everything needed: `m.provider` names the provider and
+`config.providers[m.provider]` is in scope at `src/server/index.ts:1605`. So the row mapper
+can call `fastRowEligible(provider, m.id, m.provider)` directly — the same
+`fastPolicyForModel` the catalog uses, which is pure and synchronous
+(`service-tier.ts:181`), so it adds no await to a branch that must not gain one.
+
+Natives are the case that needs a decision. A native slug like `gpt-5.6-sol` has no
+`config.providers` entry of its own; its Fast support is asserted upstream, and
+`UPSTREAM_NATIVE_ENTRIES` carries `additional_speed_tiers: ["fast"]` for exactly the
+models that have it (`src/codex/data/upstream-models.json`). wp2 reads that snapshot
+rather than inventing a second source:
+
+```ts
+// src/server/index.ts, near nativeModelRow (1532)
+const nativeFastEligible = (metadataId: string): boolean => {
+  const entry = UPSTREAM_NATIVE_ENTRIES.get(metadataId);
+  return Array.isArray(entry?.additional_speed_tiers)
+    && entry.additional_speed_tiers.includes("fast");
+};
+```
+
+This is the same evidence the Codex picker's own toggle is built from
+(`src/codex/catalog/effort.ts:167` writes that field; upstream asserts it), so the external
+row and the in-app toggle cannot disagree about which natives have Fast.
+
+## `/v1/models`
+
+```diff
+         const effortRowsEnabled = config.cursorEffortRows === true;
++        // Same opt-in discipline: with the flag off, no policy resolution and no extra rows.
++        const fastRowsEnabled = config.fastRows === true;
++        // One inventory serves both grammars; building it twice would double the work on a
++        // hot path for no benefit.
++        const syntheticKnownIds = effortRowsEnabled || fastRowsEnabled
++          ? knownEffortRowIds(config)
++          : undefined;
+```
+
+`effortRowKnownIds` becomes `syntheticKnownIds` at its two existing uses. The native mapper
+then composes the two expansions:
+
+```diff
+         const expandedNativeModelRow = (id: string, metadataId = id) => {
+           const reasoningEfforts = nativeReasoningEfforts(metadataId);
+-          return expandCursorEffortRow(nativeModelRow(id, metadataId), reasoningEfforts, config, {
+-            knownIds: effortRowKnownIds,
+-            table: cursorEffortTable,
+-            supportsReasoning: reasoningEfforts.length > 0,
+-          });
++          return expandCursorEffortRow(nativeModelRow(id, metadataId), reasoningEfforts, config, {
++            knownIds: syntheticKnownIds,
++            table: cursorEffortTable,
++            supportsReasoning: reasoningEfforts.length > 0,
++          }).flatMap(row => expandFastRow(
++            row,
++            // Only the base row earns a fast sibling: `x--high--fast` would be a second
++            // grammar stacked on the first, and nothing parses it.
++            row.id === id && nativeFastEligible(metadataId),
++            config,
++            syntheticKnownIds,
++          ));
+         };
+```
+
+The `row.id === id` guard is load-bearing. Without it every `<base>--<effort>` row would
+also sprout `--fast`, and wp3's parser splits on one marker, so those ids would resolve to
+a base of `<base>--<effort>` — a model that does not exist. Composition of the two
+dimensions is deliberately not supported in this unit; it is recorded as a residual.
+
+The routed branch takes the same shape, with policy-derived eligibility:
+
+```diff
+-          return expandCursorEffortRow(row, m.reasoningEfforts, config, {
+-            knownIds: effortRowKnownIds,
+-            table: cursorEffortTable,
+-            supportsReasoning: (m.reasoningEfforts ?? []).length > 0,
+-          });
++          return expandCursorEffortRow(row, m.reasoningEfforts, config, {
++            knownIds: syntheticKnownIds,
++            table: cursorEffortTable,
++            supportsReasoning: (m.reasoningEfforts ?? []).length > 0,
++          }).flatMap(expanded => expandFastRow(
++            expanded,
++            expanded.id === row.id
++              && provider !== undefined
++              && fastRowEligible(provider, m.id, m.provider),
++            config,
++            syntheticKnownIds,
++          ));
+```
+
+`m.id` (not `publicId`) is the model identity the policy is resolved against, while the
+row id that gets the suffix is the public one — a routed slug, or an operator alias when
+one exists. An alias is an explicit operator decision, and it keeps its own `--fast`
+sibling rather than being bypassed.
+
+## Claude Code discovery
+
+`buildAnthropicModelInfos` already takes `fastMode` (`src/claude/model-info.ts:113`) and
+already knows how to publish a dimension as an extra row rather than a replacement:
+`push1mVariant`. The fast row follows `push1mVariant`, not the `fastMode` rewrite.
+
+```diff
+ export function buildAnthropicModelInfos(
+   ...
+   fastMode?: boolean,
++  fastRows?: (provider: string, modelId: string) => boolean,
+ ): AnthropicModelInfo[] {
+```
+
+A predicate rather than a config object: `model-info.ts` is a translation module and must
+not start resolving provider policy itself. The caller in `src/server/index.ts:1454`
+supplies it, already bound to `config`.
+
+```diff
+     const info = modelInfo(id, `${listedModelId} (${m.provider})`, ladder, imageInput, routedMaxInput ?? m.contextWindow);
+     out.push(info);
++    // An additive sibling, deliberately unlike the fastMode rewrite above: fastMode is a
++    // global switch with no per-request choice, so it replaces; a selector must leave the
++    // default pickable next to it.
++    if (fastRows?.(m.provider, m.id) === true) {
++      const fastId = `${id}--fast`;
++      if (!seen.has(fastId)) {
++        seen.add(fastId);
++        out.push({ ...info, id: fastId, display_name: `${listedModelId} (${m.provider}, Fast)` });
++      }
++    }
+```
+
+Both id styles are covered here, unlike `fastMode`. The reason `fastMode` excludes Desktop
+3P is that it *rewrites* the hashed id and would strand a saved selection
+(`model-info.ts:157`); an added row strands nothing, because the original id keeps
+existing.
+
+## Management route
+
+`cursor-integration-routes.ts:90` reports what the Cursor integration published. It gains
+a sibling field rather than mixing grammars into `effortRows`:
+
+```diff
+       effortRows: expandCursorEffortRow({ id }, reasoningEfforts, config, {...}).slice(1).map(row => row.id),
++      fastRow: fastRowsEnabled && eligible ? fastRowId(id) : undefined,
+```
+
+## Tests — `tests/fast-row-listing.test.ts`
+
+1. Flag off: a listing containing an eligible model has no `--fast` id anywhere. Run this
+   against both the `/v1/models` shape and `buildAnthropicModelInfos`.
+2. Flag on: the eligible model gains exactly one `--fast` row AND keeps its base row.
+3. Flag on, ineligible/unclassified model: no `--fast` row.
+4. Effort rows and fast rows both on: `<base>--high` exists, `<base>--fast` exists,
+   `<base>--high--fast` does NOT. This is the guard for the `row.id === id` condition.
+5. Claude Code discovery: the fast id appears alongside the base id and the row count is
+   base + 1.
+6. A native without `additional_speed_tiers` gets no row, one with it does.
+
+## Verification
+
+`bun test tests/fast-row-listing.test.ts tests/fast-row.test.ts`, plus the existing
+`tests/cursor-fast-listing.test.ts` to prove the neighbouring grammar is unchanged.
+`bun run typecheck`. No full suite.
+
+## Residual
+
+R1 — effort and fast do not compose (`<base>--high--fast` is not published). Fixing it
+means a combined codec and a two-marker parser; deferred until someone asks for a specific
+effort at Fast, since the base row's default effort already reaches Fast.

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -173,7 +173,7 @@ parameter is for, so this surface migrates fully rather than calling two parsers
 +    ({ fastRow, effortRow } = parseSyntheticRowId(
 +      requestedModel,
 +      config,
-+      decodeClaudeFastSelector(requestedModel, config.claudeCode),
++      () => decodeClaudeFastSelector(requestedModel, config.claudeCode),
 +    ));
      if (effortRow) { anthropicBody.model = effortRow.baseId; effortOverride = effortRow.effort; }
 +    if (fastRow) anthropicBody.model = fastRow.baseId;
@@ -221,9 +221,10 @@ returns an estimate and sends no tier:
    if (countRoute) { model = stripOneMillionMarker(countRoute); raw.model = model; }
 +  // Decode before stripping, for the same aliasing reason as /v1/messages. A token estimate
 +  // carries no tier, so only the identity is corrected here.
-+  const countFastRow = parseSyntheticRowId(
-+    model, config, decodeClaudeFastSelector(model, config.claudeCode),
-+  ).fastRow;
++  // Fast-only: count_tokens never parsed an effort row, so it must not start.
++  const countFastRow = parseFastOnlyRowId(
++    config, () => decodeClaudeFastSelector(model, config.claudeCode),
++  );
 +  if (countFastRow) { model = countFastRow.baseId; raw.model = model; }
 ```
 
@@ -236,7 +237,8 @@ concerns, and the audit caught them being conflated:
 **Identity** is corrected before routing, or the synthetic id fails to route at all:
 
 ```diff
-+  const compactFastRow = parseSyntheticRowId(raw.model, config).fastRow;
++  // Fast-only: compact never parsed an effort row either.
++  const compactFastRow = parseFastOnlyRowId(config, () => raw.model);
 +  if (compactFastRow) raw.model = compactFastRow.baseId;
    route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
 ```
@@ -292,6 +294,20 @@ Each test drives one conditional and asserts an observable effect, per
     model on both Messages and `count_tokens`.
 14. **Nested markers resolve to neither grammar,** in both orders, identically on all five
     surfaces: `x--fast--high` must NOT reach the effort grammar with base `x--fast`.
+
+## Import changes, per file
+
+Every symbol the diffs above introduce, so the implementer does not have to infer them:
+
+| File | Add | Remove |
+|---|---|---|
+| `src/server/responses/core.ts` | `parseSyntheticRowId` from `../fast-row` | `parseRequestEffortRowId` import, now unused |
+| `src/server/chat-completions.ts` | `parseSyntheticRowId` from `./fast-row` | `parseRequestEffortRowId` import, now unused |
+| `src/server/claude-messages.ts` | `parseSyntheticRowId`, `parseFastOnlyRowId`, and type `ParsedFastRowId` from `./fast-row` | `parseRequestEffortRowId` import, now unused |
+| `src/server/responses/compact.ts` | `parseFastOnlyRowId` from `../fast-row`; `fastPolicyForModel` from `../../providers/service-tier`; `decideTier` from `../../providers/fastwire` | — |
+
+`compact.ts` imports none of the tier helpers today, which is exactly why its Fast handling
+had to be written as an explicit post-routing policy call rather than assumed.
 
 ## Verification
 

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -1,0 +1,241 @@
+# 030 — wp3 / PR3: the ingress round-trip
+
+
+## Amendments from audit round 1
+
+### A1 — Claude surfaces parse AFTER alias decoding (B1)
+
+A Claude alias is `claude-ocx-<provider>--<model>` (`src/claude/alias.ts:89`): it already
+uses `--` as its own separator. A real model named `foo--fast` therefore produces
+`claude-ocx-p--foo--fast`, and stripping the marker off the RAW alias yields
+`claude-ocx-p--foo`, which routes `p/foo` — a different model, silently, with no error.
+`knownEffortRowIds()` holds routed ids, not Claude aliases (`effort-row.ts:44`), so it
+cannot defend the raw form.
+
+So on `/v1/messages` and `/v1/messages/count_tokens` the marker is stripped only after the
+alias is decoded, and the known-id check runs against the decoded routed id where the
+inventory is authoritative. The alias's own separator is the FIRST `--` after the prefix
+and the fast marker is the LAST one in the model half, so the two are unambiguous once
+decoding has happened — and ambiguous before it.
+
+### A2 — every ingress parses the IMMUTABLE original selector (B5)
+
+The original wp3 draft parsed the effort row, mutated `parsed.modelId`, then parsed fast
+from the mutated value. That made `x--fast--high` fire both dimensions while
+`x--high--fast` fired neither, and Chat and Messages — parsing from the unmutated
+requested id — disagreed with Responses about the same string.
+
+Every ingress now captures the requested id once, checks `hasCompositeRowMarkers()` first
+(wp1), and parses both grammars from that captured value:
+
+```ts
+const selector = parsed.modelId;             // captured BEFORE any mutation
+if (!hasCompositeRowMarkers(selector)) {
+  const effortRow = parseRequestEffortRowId(selector, config);
+  const fastRow = parseRequestFastRowId(selector, config);
+  // ... apply at most one
+}
+```
+
+### A3 — `/v1/messages/count_tokens` (B4)
+
+`claude-messages.ts:1022` resolves a model and can hand it to `wantsNativePassthrough` at
+`:1036`. Without parsing, a listed fast alias is forwarded upstream as a model Anthropic
+has never heard of. It needs the model rewritten to the base before that guard — and
+nothing else, because `count_tokens` returns a token estimate and sends no tier:
+
+```diff
+   const countRoute = extractOcxRouteDirective(raw);
+   if (countRoute) { model = stripOneMillionMarker(countRoute); raw.model = model; }
++  // A token estimate carries no tier, so only the identity is corrected here. Without this
++  // the synthetic id reaches native passthrough as an unknown upstream model.
++  const countFastRow = parseRequestFastRowId(model, config);
++  if (countFastRow) { model = countFastRow.baseId; raw.model = model; }
+```
+
+### A4 — `/v1/responses/compact` (B4)
+
+`compact.ts:502-515` routes `raw.model` through `routeCompactionModel` with no tier
+handling, so a fast id selected from `/v1/models` would fail to route at compaction time.
+Parse before the routing call and carry the tier, since compaction is a real turn:
+
+```diff
++  const compactFastRow = parseRequestFastRowId(raw.model, config);
++  if (compactFastRow) {
++    raw.model = compactFastRow.baseId;
++    (raw as Record<string, unknown>).service_tier = "priority";
++  }
+   route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
+```
+
+### A5 — additional tests
+
+8. `count_tokens` with a fast alias returns an estimate for the BASE model and does not
+   forward the synthetic id upstream.
+9. `compact` with a fast id routes the base model and reaches the adapter with the tier.
+10. A real model literally named `foo--fast` routes to ITSELF on every ingress, including
+    through its Claude alias. This is the B1 regression and it fails against the pre-audit
+    design.
+11. `x--high--fast` and `x--fast--high` resolve to neither grammar, identically on all
+    five surfaces.
+
+### A6 — scope
+
+Scope IN gains `src/server/responses/compact.ts` and the `count_tokens` handler in
+`src/server/claude-messages.ts`.
+
+Stacked on PR2. Scope IN: `src/server/responses/core.ts`, `src/server/chat-completions.ts`,
+`src/server/claude-messages.ts`, `tests/fast-row-ingress.test.ts` (new). Scope OUT: the tier
+state machine itself — wp3 supplies a caller intent and lets `decideTier` rule on it.
+
+## The one rule this phase obeys
+
+A fast row sets `service_tier: "priority"` as a **caller-supplied tier** and changes nothing
+else. It never writes `tierDecision` and never bypasses `decideTier`. Everything that already
+governs Fast keeps governing it:
+
+- `fastMode: false` still suppresses the request (`fastwire.ts:420` returns `{kind:"drop"}`
+  even for an explicit caller tier). An operator who turned Fast off globally is not
+  overridden by a client picking a fast row.
+- An ineligible route still drops the tier (`fastwire.ts:413`), so a stale client holding a
+  `--fast` id after the model lost eligibility degrades to a normal request rather than
+  erroring.
+- Pricing and usage keep reading the same `tierDecision`, so no cost path changes.
+
+`"priority"` is the canonical spelling; `"fast"` is accepted as an alias and folded to it
+(`fastwire.ts:247`). wp3 writes the canonical value.
+
+## `/v1/responses`
+
+Two insertion points, both alongside the existing effort-row handling.
+
+The combo pre-dispatch at `core.ts:2726` runs before `comboIdFromRawBody`, so the rewrite has
+to happen there or a combo child is built from the synthetic id:
+
+```diff
+     const comboEffortRow = typeof (body as { model?: unknown }).model === "string"
+       ? parseRequestEffortRowId((body as { model: string }).model, config)
+       : null;
++    const comboFastRow = typeof (body as { model?: unknown }).model === "string"
++      ? parseRequestFastRowId((body as { model: string }).model, config)
++      : null;
++    if (comboFastRow) {
++      const raw = body as Record<string, unknown>;
++      raw.model = comboFastRow.baseId;
++      // A caller intent, not a decision: decideTier still rules on eligibility below.
++      raw.service_tier = "priority";
++    }
+```
+
+The ordinary path at `core.ts:2795` must update both representations, for the reason the
+effort row already does: the typed route reads `parsed.*` while the Responses passthrough
+starts its outbound body from `parsed._rawBody` (`openai-responses.ts:2179`).
+
+```diff
+     const effortRow = parseRequestEffortRowId(parsed.modelId, config);
+     ...
++    const fastRow = parseRequestFastRowId(parsed.modelId, config);
++    if (fastRow) {
++      parsed.modelId = fastRow.baseId;
++      parsed.options.serviceTier = "priority";
++      const raw = parsed._rawBody as Record<string, unknown>;
++      raw.model = fastRow.baseId;
++      raw.service_tier = "priority";
++    }
+```
+
+Downstream is untouched: `core.ts:2109` reads `parsed.options.serviceTier` as `callerTier`,
+`decideTier` rules, and `applyTierDecisionToResponsesBody` writes the final field.
+
+**Core-lab boundary.** `src/server/responses/core.ts` is one of the four protected roots
+(`tests/core-lab-boundary.test.ts:19`). `src/server/fast-row.ts` imports only
+`providers/service-tier`, `providers/registry`, `types`, and `server/effort-row` — all already
+on this file's import graph, none reaching `src/lab`. The guard must stay green without
+adjustment; if it does not, the import is wrong, not the guard.
+
+## `/v1/chat/completions`
+
+Same place as the effort row, before routing (`chat-completions.ts:107`):
+
+```diff
+     const effortRow = parseRequestEffortRowId(requestedModel, config);
+     if (effortRow) chatBody.model = effortRow.baseId;
++    const fastRow = parseRequestFastRowId(requestedModel, config);
++    if (fastRow) {
++      chatBody.model = fastRow.baseId;
++      chatBody.service_tier = "priority";
++    }
+```
+
+Unlike the effort row, a fast row does **not** block the native-chat shortcut at
+`chat-completions.ts:139`. The effort row has to, because native chat cannot carry a
+Responses-style reasoning effort. Native chat carries `service_tier` natively and applies
+the same policy (`openai-chat.ts:144-150`), so blocking it would degrade the request for no
+reason. Leaving that guard alone is the change.
+
+The translated path needs nothing: `chat/inbound.ts:315` already copies
+`raw.service_tier` into the Responses body.
+
+## `/v1/messages`
+
+Parse after the `ocx-route` directive, like the effort row (`claude-messages.ts:629`), so a
+fast id inside a directive works too:
+
+```diff
+     effortRow = parseRequestEffortRowId(requestedModel, config);
+     if (effortRow) { anthropicBody.model = effortRow.baseId; effortOverride = effortRow.effort; }
++    const fastRow = parseRequestFastRowId(requestedModel, config);
++    if (fastRow) anthropicBody.model = fastRow.baseId;
+```
+
+The Anthropic translator does **not** carry `service_tier` — `claude/inbound.ts:500` builds
+its body from model/input/store/stream plus sampling fields only. So the tier is applied to
+the translated body, immediately after translation (`claude-messages.ts:670`):
+
+```diff
+     const translation = anthropicToResponsesTranslation(anthropicBody, ...);
+     internalBody = translation.body;
++    // The Anthropic translator carries no service_tier, so the caller intent is applied to
++    // the translated body rather than the inbound one.
++    if (fastRow) internalBody.service_tier = "priority";
+```
+
+Native Anthropic passthrough at `claude-messages.ts:660` **must** be blocked for a fast row,
+the opposite of the chat case: that path forwards the request to Anthropic's own API, whose
+wire has no `service_tier` field, and the `anthropic-speed` FastWire kind has an empty
+adapter set by design (`fastwire.ts:15`). Sending it there would silently drop the tier.
+
+```diff
+-    if (!effortRow && ... wantsNativePassthrough(...))
++    if (!effortRow && !fastRow && ... wantsNativePassthrough(...))
+```
+
+In practice an `anthropic`-adapter route is `wire-unavailable` and never publishes a fast
+row at all, so this guard is defence for a hand-typed id rather than a listed one.
+
+## Tests — `tests/fast-row-ingress.test.ts`
+
+Each test drives one conditional and asserts an observable effect, per
+`cursor-fast-tier.test.ts:31`.
+
+1. **Responses:** a `--fast` model resolves to the base model and reaches the adapter with
+   `service_tier: "priority"`. Assert on the outbound body, not on `parsed`.
+2. **Chat completions:** same, through the translated path.
+3. **Messages:** same, and assert the native passthrough was not taken.
+4. **Flag off:** the same `--fast` id is treated as an ordinary unknown model on all three
+   ingresses — no rewrite, no tier. This proves default-off at the request path, not only
+   at listing.
+5. **Ineligible route:** a `--fast` id on a `capability-unsupported` model reaches the
+   adapter with **no** `service_tier` — `decideTier` dropped it. The route still resolves
+   to the base model.
+6. **`fastMode: false` wins:** a `--fast` id with the global switch off produces
+   `{kind:"drop"}`. The operator's switch is not overridable by id.
+7. **Round-trip identity:** the id published by wp2 for a model parses back to exactly that
+   model. This is the equivalence guard `cursor-fast-listing.test.ts:27` uses, and it is
+   what keeps listing and ingress from drifting apart.
+
+## Verification
+
+`bun test tests/fast-row-ingress.test.ts tests/fast-row-listing.test.ts tests/fast-row.test.ts`,
+`bun test tests/core-lab-boundary.test.ts` (mandatory: a protected root was touched),
+`bun run typecheck`, `bun run privacy:scan` (request-path change). No full suite.

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -28,6 +28,22 @@ fast from the mutated id — which made `x--fast--high` fire both dimensions whi
 `x--high--fast` fired neither, and made Responses disagree with Chat and Messages about the
 same string.
 
+### Nested markers, at every ingress
+
+Composition is not supported (020 R1), and the effort parser cannot detect the problem on
+its own: it validates the terminal effort but never checks that the base is real
+(`effort-row.ts:78-95`), so `x--fast--high` would otherwise resolve to base `x--fast` with
+effort `high` — a model that does not exist. Each ingress therefore discards an effort row
+whose base still carries the marker, using wp1's guard:
+
+```ts
+if (effortRow && effortBaseCarriesFastMarker(effortRow.baseId, knownIds)) effortRow = null;
+```
+
+The known-id argument is what keeps a real model named `foo--fast` able to publish and
+resolve its own `foo--fast--high` effort row. Test 14 asserts both orders behave the same
+on all five surfaces.
+
 ## `/v1/responses`
 
 Two insertion points. The combo pre-dispatch at `core.ts:2726` runs before
@@ -113,22 +129,49 @@ uses `--` as its own separator. A real model named `foo--fast` therefore arrives
 `knownEffortRowIds()` holds routed ids, not Claude aliases (`effort-row.ts:44`), so it
 cannot defend the raw form.
 
-The alias is decoded by `resolveInboundModel` (`src/claude/inbound.ts:59`), which is called
-inside `anthropicToResponsesTranslation` at `inbound.ts:500` — after the point where the
-effort row parses. wp3 therefore decodes explicitly, before parsing, and leaves the
-inbound body's own model resolution to run as it always has:
+The alias is decoded by `resolveInboundModel` (`src/claude/inbound.ts:59`, already imported
+at `claude-messages.ts:13`), which normally runs inside `anthropicToResponsesTranslation`
+at `inbound.ts:500` — after the effort row parses. wp3 decodes explicitly, before parsing.
+
+A Desktop 3P alias needs one more step: it is a HASH, and the registry maps only the
+unsuffixed hash (`desktop-3p.ts:273`) through an exact lookup (`:316`). So
+`resolveInboundModel("<hash>--fast")` returns its input unchanged, and the base check then
+fails. Decoding tries the exact form first, and only then treats the marker as synthetic:
+
+```ts
+/**
+ * Decode a Claude selector that may carry the fast marker. The exact form is tried first,
+ * so a real model whose alias genuinely ends in the marker keeps winning; only then is the
+ * marker treated as synthetic and the bare base decoded. Desktop 3P aliases are hashes
+ * registered WITHOUT the marker, so an exact lookup can never resolve a synthetic one.
+ */
+function decodeClaudeFastSelector(raw: string, cc?: OcxClaudeCodeConfig): string {
+  const exact = resolveInboundModel(raw, cc);
+  if (exact !== raw || !raw.endsWith("--fast")) return exact;
+  const bare = raw.slice(0, -"--fast".length);
+  const decodedBase = resolveInboundModel(bare, cc);
+  return decodedBase === bare ? exact : `${decodedBase}--fast`;
+}
+```
+
+`fastRow` is declared beside `effortRow` at `claude-messages.ts:608`, NOT inside the
+model-validation block: the passthrough guard and the post-translation tier write both
+read it, and a block-scoped `const` would not compile.
 
 ```diff
+     let effortRow: ParsedEffortRowId | null = null;
++    let fastRow: ParsedFastRowId | null = null;
+     ...
      effortRow = parseRequestEffortRowId(requestedModel, config);
      if (effortRow) { anthropicBody.model = effortRow.baseId; effortOverride = effortRow.effort; }
-+    // Decode first: the alias grammar and the fast marker share "--", so the marker is only
-+    // unambiguous once the provider half has been split off.
-+    const decoded = resolveInboundModel(requestedModel, config.claudeCode);
-+    const fastRow = parseRequestFastRowId(decoded, config);
++    // Decode first: the alias grammar and the fast marker share the separator, so the
++    // marker is unambiguous only once the provider half has been split off.
++    fastRow = parseRequestFastRowId(decodeClaudeFastSelector(requestedModel, config.claudeCode), config);
 +    if (fastRow) anthropicBody.model = fastRow.baseId;
 ```
 
-`parseRequestFastRowId` then checks the stripped base against the routed inventory, where
+`parseRequestFastRowId` then checks the stripped base against the routable-base set, and for
+a real `p/foo--fast` the exact-id guard refuses the strip.
 `p/foo--fast` is present and the strip is refused.
 
 The Anthropic translator carries no `service_tier` — `claude/inbound.ts:500` builds its body
@@ -166,7 +209,7 @@ returns an estimate and sends no tier:
    if (countRoute) { model = stripOneMillionMarker(countRoute); raw.model = model; }
 +  // Decode before stripping, for the same aliasing reason as /v1/messages. A token estimate
 +  // carries no tier, so only the identity is corrected here.
-+  const countFastRow = parseRequestFastRowId(resolveInboundModel(model, config.claudeCode), config);
++  const countFastRow = parseRequestFastRowId(decodeClaudeFastSelector(model, config.claudeCode), config);
 +  if (countFastRow) { model = countFastRow.baseId; raw.model = model; }
 ```
 
@@ -226,12 +269,18 @@ Each test drives one conditional and asserts an observable effect, per
    unconditional write.
 10. **A real `foo--fast` model routes to ITSELF** on every ingress, including through its
     Claude alias. This is the alias-collision regression.
-11. **`a--high--fast` resolves** when `a--high` is a real model — the row wp2 published is
-    the row wp3 accepts.
+11. **`a--high--fast` resolves** when `a--high` is routable — the row wp2 published is the
+    row wp3 accepts.
+12. **A bare native round-trips on a DEFAULT config.** `gpt-5.6-sol--fast` reaches the
+    adapter as `gpt-5.6-sol` with the tier, with no `models` list configured. The
+    known-id-based draft failed this.
+13. **Desktop 3P round-trips.** A hashed Claude alias plus the marker decodes to its base
+    model on both Messages and `count_tokens`.
+14. **Nested markers resolve to neither grammar,** in both orders, identically on all five
+    surfaces: `x--fast--high` must NOT reach the effort grammar with base `x--fast`.
 
 ## Verification
 
 `bun test tests/fast-row-ingress.test.ts tests/fast-row-listing.test.ts tests/fast-row.test.ts`,
 `bun test tests/core-lab-boundary.test.ts` (mandatory: a protected root was touched),
 `bun run typecheck`, `bun run privacy:scan` (request-path change). No full suite.
-

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -28,54 +28,51 @@ fast from the mutated id — which made `x--fast--high` fire both dimensions whi
 `x--high--fast` fired neither, and made Responses disagree with Chat and Messages about the
 same string.
 
-### Nested markers, at every ingress
+### One wrapper, every ingress
 
 Composition is not supported (020 R1), and the effort parser cannot detect the problem on
-its own: it validates the terminal effort but never checks that the base is real
+its own: it validates the terminal effort but never that the base is real
 (`effort-row.ts:78-95`), so `x--fast--high` would otherwise resolve to base `x--fast` with
-effort `high` — a model that does not exist. Each ingress therefore discards an effort row
-whose base still carries the marker, using wp1's guard:
+effort `high` — a model that does not exist.
 
-```ts
-if (effortRow && effortBaseCarriesFastMarker(effortRow.baseId, knownIds)) effortRow = null;
-```
-
-The known-id argument is what keeps a real model named `foo--fast` able to publish and
-resolve its own `foo--fast--high` effort row. Test 14 asserts both orders behave the same
-on all five surfaces.
+Rather than repeat that rule at four call sites and hope they stay identical, every ingress
+calls wp1's `parseSyntheticRowId(selector, config)`, which resolves both grammars and
+returns at most one. The existing `parseRequestEffortRowId` call sites migrate to it.
 
 ## `/v1/responses`
 
 Two insertion points. The combo pre-dispatch at `core.ts:2726` runs before
 `comboIdFromRawBody`, so the rewrite happens there or a combo child is built from the
-synthetic id:
+synthetic id. The selector is captured ONCE, before either parser can mutate the body:
 
 ```diff
-     const comboEffortRow = typeof (body as { model?: unknown }).model === "string"
-       ? parseRequestEffortRowId((body as { model: string }).model, config)
-       : null;
-+    const comboFastRow = typeof (body as { model?: unknown }).model === "string"
-+      ? parseRequestFastRowId((body as { model: string }).model, config)
+-    const comboEffortRow = typeof (body as { model?: unknown }).model === "string"
+-      ? parseRequestEffortRowId((body as { model: string }).model, config)
+-      : null;
++    const comboSelector = typeof (body as { model?: unknown }).model === "string"
++      ? (body as { model: string }).model
 +      : null;
-+    if (comboFastRow) {
++    const comboRows = comboSelector === null
++      ? { fastRow: null, effortRow: null }
++      : parseSyntheticRowId(comboSelector, config);
++    const comboEffortRow = comboRows.effortRow;
++    if (comboRows.fastRow) {
 +      const raw = body as Record<string, unknown>;
-+      raw.model = comboFastRow.baseId;
++      raw.model = comboRows.fastRow.baseId;
 +      // A caller intent, not a decision: decideTier still rules on eligibility below.
 +      raw.service_tier = "priority";
 +    }
 ```
 
-The ordinary path at `core.ts:2795` captures the selector first, then updates both
+The ordinary path at `core.ts:2795` captures the selector before mutating, then updates both
 representations — the typed route reads `parsed.*` while the Responses passthrough starts
 its outbound body from `parsed._rawBody` (`openai-responses.ts:2179`):
 
 ```diff
+-    const effortRow = parseRequestEffortRowId(parsed.modelId, config);
 +    // Captured before any parser mutates it, so both grammars see the client's id.
 +    const selector = parsed.modelId;
--    const effortRow = parseRequestEffortRowId(parsed.modelId, config);
-+    const effortRow = parseRequestEffortRowId(selector, config);
-     ...
-+    const fastRow = parseRequestFastRowId(selector, config);
++    const { fastRow, effortRow } = parseSyntheticRowId(selector, config);
 +    if (fastRow) {
 +      parsed.modelId = fastRow.baseId;
 +      parsed.options.serviceTier = "priority";
@@ -90,26 +87,27 @@ Downstream is untouched: `core.ts:2109` reads `parsed.options.serviceTier` as `c
 
 **Core-lab boundary.** `src/server/responses/core.ts` is one of the four protected roots
 (`tests/core-lab-boundary.test.ts:19`). `src/server/fast-row.ts` imports only
-`providers/service-tier`, `providers/registry`, `types`, and `server/effort-row` — all
-already on this file's graph, none reaching `src/lab`. The guard must stay green without
-adjustment; if it does not, the import is wrong, not the guard.
+`providers/service-tier`, `providers/registry`, `types`, `server/effort-row`, and the
+synchronous catalog metadata helpers — all already on this file's graph, none reaching
+`src/lab`. The guard must stay green without adjustment; if it does not, the import is
+wrong, not the guard.
 
 ## `/v1/chat/completions`
 
-Same place as the effort row, before routing (`chat-completions.ts:107`):
+Same place as the effort row, before routing (`chat-completions.ts:107`). `requestedModel`
+is already captured before mutation here, which is why this surface never had the ordering
+defect:
 
 ```diff
-     const effortRow = parseRequestEffortRowId(requestedModel, config);
-     if (effortRow) chatBody.model = effortRow.baseId;
-+    const fastRow = parseRequestFastRowId(requestedModel, config);
+-    const effortRow = parseRequestEffortRowId(requestedModel, config);
+-    if (effortRow) chatBody.model = effortRow.baseId;
++    const { fastRow, effortRow } = parseSyntheticRowId(requestedModel, config);
++    if (effortRow) chatBody.model = effortRow.baseId;
 +    if (fastRow) {
 +      chatBody.model = fastRow.baseId;
 +      chatBody.service_tier = "priority";
 +    }
 ```
-
-`requestedModel` is already captured before mutation here, which is why this surface never
-had the ordering defect.
 
 Unlike the effort row, a fast row does **not** block the native-chat shortcut at
 `chat-completions.ts:139`. The effort row must, because native chat cannot carry a
@@ -144,8 +142,11 @@ fails. Decoding tries the exact form first, and only then treats the marker as s
  * so a real model whose alias genuinely ends in the marker keeps winning; only then is the
  * marker treated as synthetic and the bare base decoded. Desktop 3P aliases are hashes
  * registered WITHOUT the marker, so an exact lookup can never resolve a synthetic one.
+ *
+ * Typed as OcxConfig["claudeCode"] rather than OcxClaudeCodeConfig: claude-messages.ts
+ * imports only OcxConfig from ../types today, and this avoids widening that import.
  */
-function decodeClaudeFastSelector(raw: string, cc?: OcxClaudeCodeConfig): string {
+function decodeClaudeFastSelector(raw: string, cc?: OcxConfig["claudeCode"]): string {
   const exact = resolveInboundModel(raw, cc);
   if (exact !== raw || !raw.endsWith("--fast")) return exact;
   const bare = raw.slice(0, -"--fast".length);
@@ -166,11 +167,11 @@ read it, and a block-scoped `const` would not compile.
      if (effortRow) { anthropicBody.model = effortRow.baseId; effortOverride = effortRow.effort; }
 +    // Decode first: the alias grammar and the fast marker share the separator, so the
 +    // marker is unambiguous only once the provider half has been split off.
-+    fastRow = parseRequestFastRowId(decodeClaudeFastSelector(requestedModel, config.claudeCode), config);
++    fastRow = parseSyntheticRowId(decodeClaudeFastSelector(requestedModel, config.claudeCode), config).fastRow;
 +    if (fastRow) anthropicBody.model = fastRow.baseId;
 ```
 
-`parseRequestFastRowId` then checks the stripped base against the routable-base set, and for
+`parseSyntheticRowId` then checks the stripped base against the routable-base set, and for
 a real `p/foo--fast` the exact-id guard refuses the strip.
 `p/foo--fast` is present and the strip is refused.
 
@@ -209,7 +210,7 @@ returns an estimate and sends no tier:
    if (countRoute) { model = stripOneMillionMarker(countRoute); raw.model = model; }
 +  // Decode before stripping, for the same aliasing reason as /v1/messages. A token estimate
 +  // carries no tier, so only the identity is corrected here.
-+  const countFastRow = parseRequestFastRowId(decodeClaudeFastSelector(model, config.claudeCode), config);
++  const countFastRow = parseSyntheticRowId(decodeClaudeFastSelector(model, config.claudeCode), config).fastRow;
 +  if (countFastRow) { model = countFastRow.baseId; raw.model = model; }
 ```
 
@@ -222,7 +223,7 @@ concerns, and the audit caught them being conflated:
 **Identity** is corrected before routing, or the synthetic id fails to route at all:
 
 ```diff
-+  const compactFastRow = parseRequestFastRowId(raw.model, config);
++  const compactFastRow = parseSyntheticRowId(raw.model, config).fastRow;
 +  if (compactFastRow) raw.model = compactFastRow.baseId;
    route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
 ```

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -237,8 +237,11 @@ concerns, and the audit caught them being conflated:
 **Identity** is corrected before routing, or the synthetic id fails to route at all:
 
 ```diff
-+  // Fast-only: compact never parsed an effort row either.
-+  const compactFastRow = parseFastOnlyRowId(config, () => raw.model);
++  // Fast-only: compact never parsed an effort row either. Capture the narrowed value
++  // first: `raw.model` is `unknown` until the guard above, a dotted-property narrowing is
++  // not retained inside a callback, and the property is reassigned on the next line.
++  const compactSelector = raw.model;
++  const compactFastRow = parseFastOnlyRowId(config, () => compactSelector);
 +  if (compactFastRow) raw.model = compactFastRow.baseId;
    route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
 ```

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -259,7 +259,13 @@ settles, exactly as `core.ts:2109` does it:
 +      config.fastMode,
 +      "priority",
 +    );
-+    if (decision.kind === "set") (raw as Record<string, unknown>).service_tier = decision.value;
++    // The WHOLE decision, not just `set`. Native compact spreads `raw` into the forwarded
++    // body (compact.ts:645, serialized at :735), so leaving a caller's existing service_tier
++    // in place on a `drop` would forward a tier that fastMode:false or a capability loss
++    // just suppressed - the one rule this phase exists to preserve.
++    const serviceTier = tierValueAfterDecision(decision, "priority");
++    if (serviceTier === undefined) delete (raw as Record<string, unknown>).service_tier;
++    else (raw as Record<string, unknown>).service_tier = serviceTier;
 +  }
 ```
 
@@ -297,6 +303,12 @@ Each test drives one conditional and asserts an observable effect, per
     model on both Messages and `count_tokens`.
 14. **Nested markers resolve to neither grammar,** in both orders, identically on all five
     surfaces: `x--fast--high` must NOT reach the effort grammar with base `x--fast`.
+15. **Compact drops a caller's stale tier.** A compact fast selector sent WITH an existing
+    `service_tier`, under `fastMode: false`, forwards no tier at all. The `set`-only draft
+    left the old value in the body.
+16. **The combo pre-dispatch branch is covered on its own.** A `<combo-public-id>--fast`
+    selector dispatches as a combo under the BASE id and carries `priority` into the child
+    turns - a distinct control-flow branch the ordinary Responses test does not exercise.
 
 ## Import changes, per file
 
@@ -307,7 +319,7 @@ Every symbol the diffs above introduce, so the implementer does not have to infe
 | `src/server/responses/core.ts` | `parseSyntheticRowId` from `../fast-row` | `parseRequestEffortRowId` import, now unused |
 | `src/server/chat-completions.ts` | `parseSyntheticRowId` from `./fast-row` | `parseRequestEffortRowId` import, now unused |
 | `src/server/claude-messages.ts` | `parseSyntheticRowId`, `parseFastOnlyRowId`, and type `ParsedFastRowId` from `./fast-row` | `parseRequestEffortRowId` import, now unused |
-| `src/server/responses/compact.ts` | `parseFastOnlyRowId` from `../fast-row`; `fastPolicyForModel` from `../../providers/service-tier`; `decideTier` from `../../providers/fastwire` | — |
+| `src/server/responses/compact.ts` | `parseFastOnlyRowId` from `../fast-row`; `fastPolicyForModel` from `../../providers/service-tier`; `decideTier` and `tierValueAfterDecision` from `../../providers/fastwire` | — |
 
 `compact.ts` imports none of the tier helpers today, which is exactly why its Fast handling
 had to be written as an explicit post-routing policy call rather than assumed.

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -158,18 +158,29 @@ function decodeClaudeFastSelector(raw: string, cc?: OcxConfig["claudeCode"]): st
 `fastRow` is declared beside `effortRow` at `claude-messages.ts:608`, NOT inside the
 model-validation block: the passthrough guard and the post-translation tier write both
 read it, and a block-scoped `const` would not compile.
+Messages needs both selector forms at once: effort parsing must keep seeing the id the
+client sent, while Fast parsing needs the decoded one. That is what the wrapper's third
+parameter is for, so this surface migrates fully rather than calling two parsers:
 
 ```diff
      let effortRow: ParsedEffortRowId | null = null;
 +    let fastRow: ParsedFastRowId | null = null;
      ...
-     effortRow = parseRequestEffortRowId(requestedModel, config);
+-    effortRow = parseRequestEffortRowId(requestedModel, config);
++    // Decode for Fast only: the alias grammar and the fast marker share the separator, so
++    // the marker is unambiguous only once the provider half has been split off. Effort
++    // parsing keeps the raw selector, so existing behaviour is untouched.
++    ({ fastRow, effortRow } = parseSyntheticRowId(
++      requestedModel,
++      config,
++      decodeClaudeFastSelector(requestedModel, config.claudeCode),
++    ));
      if (effortRow) { anthropicBody.model = effortRow.baseId; effortOverride = effortRow.effort; }
-+    // Decode first: the alias grammar and the fast marker share the separator, so the
-+    // marker is unambiguous only once the provider half has been split off.
-+    fastRow = parseSyntheticRowId(decodeClaudeFastSelector(requestedModel, config.claudeCode), config).fastRow;
 +    if (fastRow) anthropicBody.model = fastRow.baseId;
 ```
+
+`parseSyntheticRowId` then checks the stripped base against the routable-base set, and for
+a real `p/foo--fast` the exact-id guard refuses the strip.
 
 `parseSyntheticRowId` then checks the stripped base against the routable-base set, and for
 a real `p/foo--fast` the exact-id guard refuses the strip.
@@ -210,7 +221,9 @@ returns an estimate and sends no tier:
    if (countRoute) { model = stripOneMillionMarker(countRoute); raw.model = model; }
 +  // Decode before stripping, for the same aliasing reason as /v1/messages. A token estimate
 +  // carries no tier, so only the identity is corrected here.
-+  const countFastRow = parseSyntheticRowId(decodeClaudeFastSelector(model, config.claudeCode), config).fastRow;
++  const countFastRow = parseSyntheticRowId(
++    model, config, decodeClaudeFastSelector(model, config.claudeCode),
++  ).fastRow;
 +  if (countFastRow) { model = countFastRow.baseId; raw.model = model; }
 ```
 

--- a/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
+++ b/devlog/_plan/260904_external_fast_wire/030_wp3_ingress.md
@@ -1,98 +1,15 @@
 # 030 — wp3 / PR3: the ingress round-trip
 
-
-## Amendments from audit round 1
-
-### A1 — Claude surfaces parse AFTER alias decoding (B1)
-
-A Claude alias is `claude-ocx-<provider>--<model>` (`src/claude/alias.ts:89`): it already
-uses `--` as its own separator. A real model named `foo--fast` therefore produces
-`claude-ocx-p--foo--fast`, and stripping the marker off the RAW alias yields
-`claude-ocx-p--foo`, which routes `p/foo` — a different model, silently, with no error.
-`knownEffortRowIds()` holds routed ids, not Claude aliases (`effort-row.ts:44`), so it
-cannot defend the raw form.
-
-So on `/v1/messages` and `/v1/messages/count_tokens` the marker is stripped only after the
-alias is decoded, and the known-id check runs against the decoded routed id where the
-inventory is authoritative. The alias's own separator is the FIRST `--` after the prefix
-and the fast marker is the LAST one in the model half, so the two are unambiguous once
-decoding has happened — and ambiguous before it.
-
-### A2 — every ingress parses the IMMUTABLE original selector (B5)
-
-The original wp3 draft parsed the effort row, mutated `parsed.modelId`, then parsed fast
-from the mutated value. That made `x--fast--high` fire both dimensions while
-`x--high--fast` fired neither, and Chat and Messages — parsing from the unmutated
-requested id — disagreed with Responses about the same string.
-
-Every ingress now captures the requested id once, checks `hasCompositeRowMarkers()` first
-(wp1), and parses both grammars from that captured value:
-
-```ts
-const selector = parsed.modelId;             // captured BEFORE any mutation
-if (!hasCompositeRowMarkers(selector)) {
-  const effortRow = parseRequestEffortRowId(selector, config);
-  const fastRow = parseRequestFastRowId(selector, config);
-  // ... apply at most one
-}
-```
-
-### A3 — `/v1/messages/count_tokens` (B4)
-
-`claude-messages.ts:1022` resolves a model and can hand it to `wantsNativePassthrough` at
-`:1036`. Without parsing, a listed fast alias is forwarded upstream as a model Anthropic
-has never heard of. It needs the model rewritten to the base before that guard — and
-nothing else, because `count_tokens` returns a token estimate and sends no tier:
-
-```diff
-   const countRoute = extractOcxRouteDirective(raw);
-   if (countRoute) { model = stripOneMillionMarker(countRoute); raw.model = model; }
-+  // A token estimate carries no tier, so only the identity is corrected here. Without this
-+  // the synthetic id reaches native passthrough as an unknown upstream model.
-+  const countFastRow = parseRequestFastRowId(model, config);
-+  if (countFastRow) { model = countFastRow.baseId; raw.model = model; }
-```
-
-### A4 — `/v1/responses/compact` (B4)
-
-`compact.ts:502-515` routes `raw.model` through `routeCompactionModel` with no tier
-handling, so a fast id selected from `/v1/models` would fail to route at compaction time.
-Parse before the routing call and carry the tier, since compaction is a real turn:
-
-```diff
-+  const compactFastRow = parseRequestFastRowId(raw.model, config);
-+  if (compactFastRow) {
-+    raw.model = compactFastRow.baseId;
-+    (raw as Record<string, unknown>).service_tier = "priority";
-+  }
-   route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
-```
-
-### A5 — additional tests
-
-8. `count_tokens` with a fast alias returns an estimate for the BASE model and does not
-   forward the synthetic id upstream.
-9. `compact` with a fast id routes the base model and reaches the adapter with the tier.
-10. A real model literally named `foo--fast` routes to ITSELF on every ingress, including
-    through its Claude alias. This is the B1 regression and it fails against the pre-audit
-    design.
-11. `x--high--fast` and `x--fast--high` resolve to neither grammar, identically on all
-    five surfaces.
-
-### A6 — scope
-
-Scope IN gains `src/server/responses/compact.ts` and the `count_tokens` handler in
-`src/server/claude-messages.ts`.
-
 Stacked on PR2. Scope IN: `src/server/responses/core.ts`, `src/server/chat-completions.ts`,
-`src/server/claude-messages.ts`, `tests/fast-row-ingress.test.ts` (new). Scope OUT: the tier
-state machine itself — wp3 supplies a caller intent and lets `decideTier` rule on it.
+`src/server/claude-messages.ts` (both the messages handler and `count_tokens`),
+`src/server/responses/compact.ts`, `tests/fast-row-ingress.test.ts` (new). Scope OUT: the
+tier state machine itself — wp3 supplies a caller intent and lets `decideTier` rule on it.
 
-## The one rule this phase obeys
+## The rule every surface obeys
 
 A fast row sets `service_tier: "priority"` as a **caller-supplied tier** and changes nothing
-else. It never writes `tierDecision` and never bypasses `decideTier`. Everything that already
-governs Fast keeps governing it:
+else. It never writes `tierDecision` and never bypasses `decideTier`. Everything that
+already governs Fast keeps governing it:
 
 - `fastMode: false` still suppresses the request (`fastwire.ts:420` returns `{kind:"drop"}`
   even for an explicit caller tier). An operator who turned Fast off globally is not
@@ -105,12 +22,17 @@ governs Fast keeps governing it:
 `"priority"` is the canonical spelling; `"fast"` is accepted as an alias and folded to it
 (`fastwire.ts:247`). wp3 writes the canonical value.
 
+Every ingress parses from the selector as the client sent it, never from a value a previous
+parser mutated. Responses used to parse the effort row, mutate `parsed.modelId`, then parse
+fast from the mutated id — which made `x--fast--high` fire both dimensions while
+`x--high--fast` fired neither, and made Responses disagree with Chat and Messages about the
+same string.
+
 ## `/v1/responses`
 
-Two insertion points, both alongside the existing effort-row handling.
-
-The combo pre-dispatch at `core.ts:2726` runs before `comboIdFromRawBody`, so the rewrite has
-to happen there or a combo child is built from the synthetic id:
+Two insertion points. The combo pre-dispatch at `core.ts:2726` runs before
+`comboIdFromRawBody`, so the rewrite happens there or a combo child is built from the
+synthetic id:
 
 ```diff
      const comboEffortRow = typeof (body as { model?: unknown }).model === "string"
@@ -127,14 +49,17 @@ to happen there or a combo child is built from the synthetic id:
 +    }
 ```
 
-The ordinary path at `core.ts:2795` must update both representations, for the reason the
-effort row already does: the typed route reads `parsed.*` while the Responses passthrough
-starts its outbound body from `parsed._rawBody` (`openai-responses.ts:2179`).
+The ordinary path at `core.ts:2795` captures the selector first, then updates both
+representations — the typed route reads `parsed.*` while the Responses passthrough starts
+its outbound body from `parsed._rawBody` (`openai-responses.ts:2179`):
 
 ```diff
-     const effortRow = parseRequestEffortRowId(parsed.modelId, config);
++    // Captured before any parser mutates it, so both grammars see the client's id.
++    const selector = parsed.modelId;
+-    const effortRow = parseRequestEffortRowId(parsed.modelId, config);
++    const effortRow = parseRequestEffortRowId(selector, config);
      ...
-+    const fastRow = parseRequestFastRowId(parsed.modelId, config);
++    const fastRow = parseRequestFastRowId(selector, config);
 +    if (fastRow) {
 +      parsed.modelId = fastRow.baseId;
 +      parsed.options.serviceTier = "priority";
@@ -149,8 +74,8 @@ Downstream is untouched: `core.ts:2109` reads `parsed.options.serviceTier` as `c
 
 **Core-lab boundary.** `src/server/responses/core.ts` is one of the four protected roots
 (`tests/core-lab-boundary.test.ts:19`). `src/server/fast-row.ts` imports only
-`providers/service-tier`, `providers/registry`, `types`, and `server/effort-row` — all already
-on this file's import graph, none reaching `src/lab`. The guard must stay green without
+`providers/service-tier`, `providers/registry`, `types`, and `server/effort-row` — all
+already on this file's graph, none reaching `src/lab`. The guard must stay green without
 adjustment; if it does not, the import is wrong, not the guard.
 
 ## `/v1/chat/completions`
@@ -167,43 +92,59 @@ Same place as the effort row, before routing (`chat-completions.ts:107`):
 +    }
 ```
 
+`requestedModel` is already captured before mutation here, which is why this surface never
+had the ordering defect.
+
 Unlike the effort row, a fast row does **not** block the native-chat shortcut at
-`chat-completions.ts:139`. The effort row has to, because native chat cannot carry a
+`chat-completions.ts:139`. The effort row must, because native chat cannot carry a
 Responses-style reasoning effort. Native chat carries `service_tier` natively and applies
-the same policy (`openai-chat.ts:144-150`), so blocking it would degrade the request for no
-reason. Leaving that guard alone is the change.
+the same policy (`chat-native.ts:186`, `openai-chat.ts:144-150`), so blocking it would
+degrade the request for no reason. Leaving that guard alone is the change.
 
-The translated path needs nothing: `chat/inbound.ts:315` already copies
-`raw.service_tier` into the Responses body.
+The translated path needs nothing: `chat/inbound.ts:315` already copies `raw.service_tier`
+into the Responses body.
 
-## `/v1/messages`
+## `/v1/messages` — decode the alias before touching the marker
 
-Parse after the `ocx-route` directive, like the effort row (`claude-messages.ts:629`), so a
-fast id inside a directive works too:
+A Claude alias is `claude-ocx-<provider>--<model>` (`src/claude/alias.ts:89`): it already
+uses `--` as its own separator. A real model named `foo--fast` therefore arrives as
+`claude-ocx-p--foo--fast`, and stripping the marker off the RAW alias would leave
+`claude-ocx-p--foo`, routing `p/foo` — a different model, silently, with no error.
+`knownEffortRowIds()` holds routed ids, not Claude aliases (`effort-row.ts:44`), so it
+cannot defend the raw form.
+
+The alias is decoded by `resolveInboundModel` (`src/claude/inbound.ts:59`), which is called
+inside `anthropicToResponsesTranslation` at `inbound.ts:500` — after the point where the
+effort row parses. wp3 therefore decodes explicitly, before parsing, and leaves the
+inbound body's own model resolution to run as it always has:
 
 ```diff
      effortRow = parseRequestEffortRowId(requestedModel, config);
      if (effortRow) { anthropicBody.model = effortRow.baseId; effortOverride = effortRow.effort; }
-+    const fastRow = parseRequestFastRowId(requestedModel, config);
++    // Decode first: the alias grammar and the fast marker share "--", so the marker is only
++    // unambiguous once the provider half has been split off.
++    const decoded = resolveInboundModel(requestedModel, config.claudeCode);
++    const fastRow = parseRequestFastRowId(decoded, config);
 +    if (fastRow) anthropicBody.model = fastRow.baseId;
 ```
 
-The Anthropic translator does **not** carry `service_tier` — `claude/inbound.ts:500` builds
-its body from model/input/store/stream plus sampling fields only. So the tier is applied to
-the translated body, immediately after translation (`claude-messages.ts:670`):
+`parseRequestFastRowId` then checks the stripped base against the routed inventory, where
+`p/foo--fast` is present and the strip is refused.
+
+The Anthropic translator carries no `service_tier` — `claude/inbound.ts:500` builds its body
+from model/input/store/stream plus sampling fields only — so the tier is applied to the
+translated body at `claude-messages.ts:670`:
 
 ```diff
      const translation = anthropicToResponsesTranslation(anthropicBody, ...);
      internalBody = translation.body;
-+    // The Anthropic translator carries no service_tier, so the caller intent is applied to
-+    // the translated body rather than the inbound one.
 +    if (fastRow) internalBody.service_tier = "priority";
 ```
 
 Native Anthropic passthrough at `claude-messages.ts:660` **must** be blocked for a fast row,
-the opposite of the chat case: that path forwards the request to Anthropic's own API, whose
-wire has no `service_tier` field, and the `anthropic-speed` FastWire kind has an empty
-adapter set by design (`fastwire.ts:15`). Sending it there would silently drop the tier.
+the opposite of the chat case: that path forwards to Anthropic's own API, whose wire has no
+`service_tier` field, and the `anthropic-speed` FastWire kind has an empty adapter set by
+design (`fastwire.ts:15`). Sending it there would silently drop the tier.
 
 ```diff
 -    if (!effortRow && ... wantsNativePassthrough(...))
@@ -211,7 +152,54 @@ adapter set by design (`fastwire.ts:15`). Sending it there would silently drop t
 ```
 
 In practice an `anthropic`-adapter route is `wire-unavailable` and never publishes a fast
-row at all, so this guard is defence for a hand-typed id rather than a listed one.
+row, so this guard defends a hand-typed id rather than a listed one.
+
+## `/v1/messages/count_tokens`
+
+`claude-messages.ts:1022` resolves a model and can hand it to `wantsNativePassthrough` at
+`:1036`. Without parsing, a listed fast alias is forwarded upstream as a model Anthropic has
+never heard of. It needs the identity corrected — and nothing else, because `count_tokens`
+returns an estimate and sends no tier:
+
+```diff
+   const countRoute = extractOcxRouteDirective(raw);
+   if (countRoute) { model = stripOneMillionMarker(countRoute); raw.model = model; }
++  // Decode before stripping, for the same aliasing reason as /v1/messages. A token estimate
++  // carries no tier, so only the identity is corrected here.
++  const countFastRow = parseRequestFastRowId(resolveInboundModel(model, config.claudeCode), config);
++  if (countFastRow) { model = countFastRow.baseId; raw.model = model; }
+```
+
+## `/v1/responses/compact`
+
+`compact.ts:502-515` routes `raw.model` through `routeCompactionModel`, and `config` is in
+scope from `handleResponsesCompact`'s own signature (`compact.ts:485`). Two separate
+concerns, and the audit caught them being conflated:
+
+**Identity** is corrected before routing, or the synthetic id fails to route at all:
+
+```diff
++  const compactFastRow = parseRequestFastRowId(raw.model, config);
++  if (compactFastRow) raw.model = compactFastRow.baseId;
+   route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
+```
+
+**The tier** is NOT written unconditionally. Native compact forwards its body directly
+(`compact.ts:594`, `compact.ts:735`) and never calls `decideTier`, so an unconditional
+`service_tier: "priority"` would bypass `fastMode: false`, a withdrawn capability, and wire
+eligibility — the one rule this phase exists to preserve. The policy runs after the route
+settles, exactly as `core.ts:2109` does it:
+
+```diff
++  if (compactFastRow) {
++    const decision = decideTier(
++      fastPolicyForModel(route.provider, route.modelId, route.providerName),
++      config.fastMode,
++      "priority",
++    );
++    if (decision.kind === "set") (raw as Record<string, unknown>).service_tier = decision.value;
++  }
+```
 
 ## Tests — `tests/fast-row-ingress.test.ts`
 
@@ -221,21 +209,29 @@ Each test drives one conditional and asserts an observable effect, per
 1. **Responses:** a `--fast` model resolves to the base model and reaches the adapter with
    `service_tier: "priority"`. Assert on the outbound body, not on `parsed`.
 2. **Chat completions:** same, through the translated path.
-3. **Messages:** same, and assert the native passthrough was not taken.
-4. **Flag off:** the same `--fast` id is treated as an ordinary unknown model on all three
-   ingresses — no rewrite, no tier. This proves default-off at the request path, not only
-   at listing.
+3. **Messages:** same, and the native passthrough was not taken.
+4. **Flag off:** the same id is an ordinary unknown model on all five surfaces — no
+   rewrite, no tier. Default-off at the request path, not only at listing.
 5. **Ineligible route:** a `--fast` id on a `capability-unsupported` model reaches the
-   adapter with **no** `service_tier` — `decideTier` dropped it. The route still resolves
-   to the base model.
-6. **`fastMode: false` wins:** a `--fast` id with the global switch off produces
-   `{kind:"drop"}`. The operator's switch is not overridable by id.
-7. **Round-trip identity:** the id published by wp2 for a model parses back to exactly that
-   model. This is the equivalence guard `cursor-fast-listing.test.ts:27` uses, and it is
-   what keeps listing and ingress from drifting apart.
+   adapter with NO `service_tier`; the route still resolves to the base model.
+6. **`fastMode: false` wins:** the decision is `{kind:"drop"}`. The operator's switch is not
+   overridable by id.
+7. **Round-trip identity:** the id wp2 publishes for a model parses back to that model. This
+   is the equivalence guard `cursor-fast-listing.test.ts:27` uses, and it is what keeps
+   listing and ingress from drifting.
+8. **`count_tokens`:** a fast alias returns an estimate for the BASE model and does not
+   forward the synthetic id upstream.
+9. **`compact`:** a fast id routes the base model and carries the tier — and with
+   `fastMode: false`, routes the base model with NO tier. The second half fails against an
+   unconditional write.
+10. **A real `foo--fast` model routes to ITSELF** on every ingress, including through its
+    Claude alias. This is the alias-collision regression.
+11. **`a--high--fast` resolves** when `a--high` is a real model — the row wp2 published is
+    the row wp3 accepts.
 
 ## Verification
 
 `bun test tests/fast-row-ingress.test.ts tests/fast-row-listing.test.ts tests/fast-row.test.ts`,
 `bun test tests/core-lab-boundary.test.ts` (mandatory: a protected root was touched),
 `bun run typecheck`, `bun run privacy:scan` (request-path change). No full suite.
+

--- a/devlog/_plan/260904_external_fast_wire/040_wp4_docs_and_landing.md
+++ b/devlog/_plan/260904_external_fast_wire/040_wp4_docs_and_landing.md
@@ -1,0 +1,54 @@
+# 040 — wp4 / PR4: documentation, close-out, and landing
+
+Stacked on PR3. Scope IN: `docs-site/src/content/docs/reference/configuration.md`,
+`devlog/_plan/260904_external_fast_wire/050_outcome.md` (written at close), the stacked-PR
+landing itself. Scope OUT: further behaviour change.
+
+## Docs
+
+The `cursorEffortRows` entry at `configuration.md:51` is the template. The new section sits
+beside it and states what a reader needs to decide whether to turn it on:
+
+- `fastRows` is an optional boolean, default `false`.
+- When on, external model lists add `<base-id>--fast` for every model whose Fast policy is
+  eligible, and selecting one routes the base model with the `priority` service tier.
+- The base row stays listed; the fast row is additive.
+- An exact configured model id always beats the suffix.
+- `fastMode: false` still suppresses Fast, and a model that does not support Fast never
+  gets a row.
+- This is the same Fast the Codex app exposes through its picker toggle — the flag is what
+  makes it reachable from clients that select by model id.
+
+Note the `fastMode` relationship explicitly, because the two names are close and the
+behaviours differ: `fastMode` is a global on/off applied to every request, `fastRows` is a
+per-request selector. They compose — `fastMode: false` wins over a fast row.
+
+## Landing the stack
+
+Four PRs, each targeting its parent's head branch, per `DEV-STACK-01`:
+
+| PR | Branch | Base at open | Retarget |
+|---|---|---|---|
+| PR1 | `codex/260904-fast-row-core` | `dev` | — |
+| PR2 | `codex/260904-fast-row-listing` | PR1 head | `dev` after PR1 lands |
+| PR3 | `codex/260904-fast-row-ingress` | PR2 head | `dev` after PR2 lands |
+| PR4 | `codex/260904-fast-row-docs` | PR3 head | `dev` after PR3 lands |
+
+`enforce-target` skips the wrong-base gate for children of an open PR, so the stack is a
+supported shape rather than a workaround. Every PR fills all three template sections
+(Summary, Verification, Checklist); none touches the GUI, so no screenshot is required.
+
+Pushes use `--no-verify` per the user's instruction. That skips local hooks only — the
+branch rulesets and remote CI still apply, and remote CI green on each PR's exact head SHA
+is the evidence that closes criterion c7.
+
+## Close-out
+
+`050_outcome.md` records, per PR: merge SHA, the ancestry proof
+(`git merge-base --is-ancestor <sha> FETCH_HEAD` against a freshly fetched `origin/dev`), the
+CI conclusion for that exact head, and the residuals still open. The unit then moves from
+`devlog/_plan/` to `devlog/_fin/`, which is the terminal marker for a unit whose work is
+visible in public git history.
+
+An empty `gh pr checks --required` is not green evidence — read the full rollup.
+

--- a/devlog/_plan/260904_external_fast_wire/040_wp4_docs_and_landing.md
+++ b/devlog/_plan/260904_external_fast_wire/040_wp4_docs_and_landing.md
@@ -10,8 +10,13 @@ The `cursorEffortRows` entry at `configuration.md:51` is the template. The new s
 beside it and states what a reader needs to decide whether to turn it on:
 
 - `fastRows` is an optional boolean, default `false`.
-- When on, external model lists add `<base-id>--fast` for every model whose Fast policy is
-  eligible, and selecting one routes the base model with the `priority` service tier.
+- When on, the raw OpenAI-style `/v1/models` list and Claude Code discovery add
+  `<base-id>--fast` for every model whose Fast policy is eligible, and selecting one
+  routes the base model with the `priority` service tier.
+- Name the surfaces exactly, and say plainly that `ocx export` and the OpenCode
+  integration emit base ids only, because those identities are written into config files
+  that outlive the flag. A reader who turns this on and then exports must not be surprised
+  by a missing row.
 - The base row stays listed; the fast row is additive.
 - An exact configured model id always beats the suffix.
 - `fastMode: false` still suppresses Fast, and a model that does not support Fast never
@@ -51,4 +56,3 @@ CI conclusion for that exact head, and the residuals still open. The unit then m
 visible in public git history.
 
 An empty `gh pr checks --required` is not green evidence — read the full rollup.
-

--- a/devlog/_plan/260904_external_fast_wire/050_outcome.md
+++ b/devlog/_plan/260904_external_fast_wire/050_outcome.md
@@ -61,7 +61,24 @@ between parallel suites; recorded rather than silently discarded.
 - **R2 — export surfaces emit base ids only.** `/api/models` `namespaced` ids feed
   `ocx export` and the OpenCode integration, and those identities are written into user
   config files that outlive the flag. Documented as a limitation rather than widened.
-- **R3 — remote CI is unverified.** The branch is pushed but no PR has been opened, so
-  criterion c-7 is open. The stacked-PR split described in `040` was not exercised: the
-  work landed as one dependency-ordered branch.
+- **R3 — the work landed as one branch, not a stack.** `040` described a four-PR stack. The
+  phases are dependency-ordered and each has its own commit, but they were opened as a
+  single PR: the later phases have no reviewable meaning without the grammar, and splitting
+  after the fact would have produced three PRs nobody could run.
 
+## Landing
+
+PR [#3457](https://github.com/lidge-jun/opencodex/pull/3457), targeting `dev`.
+
+Head `295892784b59bc0280fb78197d2e4094f59c8fe8`: **22 checks pass, 1 skipping, 0 fail** —
+`gates`, `test 1..4/4`, `macos`, `keyring ubuntu|windows|macos`,
+`npm-global macos|ubuntu|windows`, `api usage`, `storage policy`, `enforce-target`,
+`hygiene`, `react-doctor`, `changes`, `label`, `resolve-pr`, `select windows runner`.
+The Windows shard reports `skipping` by its own matrix rule. CodeRabbit's review was still
+in progress at close; it is a review bot, not a CI gate.
+
+`enforce-target` passing is the check worth naming: it is what confirms the PR targets
+`dev` with a description the repository's own gate accepts.
+
+Not merged. Merging is the maintainer's call, and the operator authorized pushing, not
+landing.

--- a/devlog/_plan/260904_external_fast_wire/050_outcome.md
+++ b/devlog/_plan/260904_external_fast_wire/050_outcome.md
@@ -1,0 +1,67 @@
+# 050 — Outcome
+
+Unit: expose Codex Fast (the `priority` service tier) to external clients as a selectable
+`<base-id>--fast` row. Branch `codex/260904-fast-row-core`.
+
+## What shipped
+
+| Work-phase | Commit | Surface |
+|---|---|---|
+| wp0 | af7fe0ad4 .. 5a7a7dc43 | the plan unit, eight audit rounds |
+| wp1 | d8735ba25 .. 8c5cbc6a6 | `src/server/fast-row.ts`, `fastRows` flag, `isKnownId` export |
+| wp2 | 3c1b4ae94 | `/v1/models` + both Claude discovery loops |
+| wp3 | e44d62717 | five ingresses, alias-safe decoding, compact tier policy |
+| wp4 | this commit | docs-site reference, this record |
+
+## What the reviews changed
+
+Eleven adversarial rounds across the plan and the code. The findings that changed the
+design, rather than merely tidying it:
+
+- **The separator.** A terminal `-fast` is already a real id (`grok-4-fast`,
+  `glm-5.3-fast`, `gpt-5-fast`, every Cursor fast variant), so one hyphen cannot tell a
+  product apart from a tier. Hence `--fast`.
+- **The routable-base oracle.** Two wrong answers preceded the right one. Requiring
+  membership in `knownEffortRowIds` would have published `gpt-5.6-sol--fast` and then
+  refused to parse it, because bare natives declare no models list and route by family
+  pattern. A config-only set then missed live-discovered and retained models. The answer is
+  a predicate: a known static/config id, or an id namespaced under an enabled provider.
+- **The stability claim.** My "stable for a given config" comment was false — the set read
+  the live-model cache. My defence (the base row disappears too) was disproved with routing
+  evidence: `/v1/models` is discovery, not a routing allowlist, and `routeModel` still
+  serves the base after cache churn. Only the fast selector broke. Fixed at the source.
+- **Default-off.** `buildAnthropicModelInfos` treats the predicate's PRESENCE as the gate,
+  so passing it unconditionally would have enabled the feature on a default install.
+- **Compact.** Writing only the `set` branch left a caller's stale `service_tier` riding
+  along past a `drop`, through the native forwarding path — bypassing the `fastMode: false`
+  suppression this phase exists to preserve.
+- **The shipped neighbour.** The first parser wrapper rebuilt the effort-row logic inline and
+  regressed `cursorEffortRows` for users with the new flag off. It now delegates to the
+  shipped function verbatim.
+
+## Verification
+
+- `bun run typecheck` clean.
+- 436 focused tests across ten files: `fast-row`, `fast-row-listing`,
+  `fast-row-ingress`, `core-lab-boundary`, `claude-inbound`,
+  `chat-completions-endpoint`, `responses-compaction`,
+  `responses-compaction-routing`, `cursor-fast-tier`, `config`.
+- `bun run privacy:scan` passed.
+- No repository-wide local suite was run, per the operator's standing instruction.
+
+One receipt run reported three failures that did not reproduce across three consecutive
+re-runs or the final receipt (exit 0, bound to `e44d627`). Consistent with port contention
+between parallel suites; recorded rather than silently discarded.
+
+## Residuals
+
+- **R1 — effort and fast do not compose.** `<base>--high--fast` is not published, and an id
+  carrying both markers resolves to neither. A combined codec is deferred until someone asks
+  for a specific effort at Fast; the base row's default effort already reaches Fast.
+- **R2 — export surfaces emit base ids only.** `/api/models` `namespaced` ids feed
+  `ocx export` and the OpenCode integration, and those identities are written into user
+  config files that outlive the flag. Documented as a limitation rather than widened.
+- **R3 — remote CI is unverified.** The branch is pushed but no PR has been opened, so
+  criterion c-7 is open. The stacked-PR split described in `040` was not exercised: the
+  work landed as one dependency-ordered branch.
+

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -57,6 +57,33 @@ and applies that row's effort; models Cursor already recognizes receive no varia
 terminal `--<declared-effort>` suffix for generated selectors, except when the complete value is already
 a known configured model id. Cursor may require a model-list refresh or restart after this setting changes.
 
+### Fast rows
+
+`fastRows` is an optional boolean and defaults to `false`. When enabled, the raw OpenAI-style
+`/v1/models` list and Claude Code discovery add a `<base-id>--fast` selector for every model whose
+resolved Fast policy is eligible. Selecting one routes the base model and requests the `priority`
+service tier — the same Fast the Codex app exposes through its picker toggle. The base row stays
+listed, so the row is an addition rather than a replacement.
+
+The flag exists because Fast was otherwise reachable only from Codex. Codex reads the tier from
+catalog metadata and renders a toggle; every other client selects a model by id alone, so a
+Claude Code or OpenAI-compatible client had no way to ask for it.
+
+The suffix is `--fast`, with two hyphens, because a terminal `-fast` is already a real model id for
+several providers (`grok-4-fast`, `glm-5.3-fast`, and Cursor's own fast variants), and a single
+hyphen could not tell a product apart from a tier. An exact configured model id always wins over the
+generated suffix, and an id carrying both this marker and an effort marker resolves to neither.
+
+A row appears only where the tier can actually be honoured: a model whose provider does not support
+it, or supports it on a wire the route cannot use, gets no row. `fastMode: false` still suppresses
+Fast globally and takes precedence over a selected row, and a selector whose model later loses
+eligibility degrades to an ordinary request instead of failing.
+
+Scope: this covers the request-serving surfaces — `/v1/models`, Claude Code discovery, and the
+`/v1/responses`, `/v1/chat/completions`, `/v1/messages`, `/v1/messages/count_tokens`, and
+`/v1/responses/compact` endpoints. `ocx export` and the OpenCode integration emit base ids only,
+because those identities are written into config files that outlive the flag.
+
 Valid values in `config.json` override built-in defaults. Missing optional fields use the defaults
 documented on the domain pages. `OPENCODEX_HOME` takes precedence over the default configuration
 directory. Fields that accept an environment reference, such as `apiKey: "${PROVIDER_API_KEY}"`,

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -79,6 +79,10 @@ it, or supports it on a wire the route cannot use, gets no row. `fastMode: false
 Fast globally and takes precedence over a selected row, and a selector whose model later loses
 eligibility degrades to an ordinary request instead of failing.
 
+Native models carry one extra condition: as well as an eligible policy, upstream must advertise the
+Fast tier for that model. This is the same evidence the Codex picker's own toggle is built from, so
+the two surfaces cannot disagree about which natives have Fast.
+
 Scope: this covers the request-serving surfaces — `/v1/models`, Claude Code discovery, and the
 `/v1/responses`, `/v1/chat/completions`, `/v1/messages`, `/v1/messages/count_tokens`, and
 `/v1/responses/compact` endpoints. `ocx export` and the OpenCode integration emit base ids only,

--- a/src/claude/model-info.ts
+++ b/src/claude/model-info.ts
@@ -111,9 +111,32 @@ export function buildAnthropicModelInfos(
   aliasForRoute: (provider: string, modelId: string) => string = desktop3pAlias,
   nativeContextCap?: NativeContextLimitsInput,
   fastMode?: boolean,
+  // Presence is the feature gate: the caller passes undefined when `fastRows` is off, so a
+  // default install publishes nothing. The predicate answers ELIGIBILITY, not enablement.
+  fastRows?: (model: CatalogModel | { provider: string; id: string }) => boolean,
 ): AnthropicModelInfo[] {
   const out: AnthropicModelInfo[] = [];
   const seen = new Set<string>();
+  // Every id the loops below will really emit, computed BEFORE either runs. `seen` alone is
+  // not enough: it grows as they run, so whether a synthetic id collided with a real one
+  // would depend on iteration order. With both `foo` and a real `foo--fast` in the roster,
+  // the synthetic id for `foo` IS the real model's id, and whichever ran first would win it.
+  const realDiscoveryIds = new Set<string>([
+    ...nativeSlugs.map(slug => (
+      idStyle === "readable" ? claudeCodeNativeAlias(slug) : aliasForRoute("native", slug)
+    )),
+    ...routedModels.map(m => {
+      // The same asymmetry the routed loop applies: readable uses the LISTED id, so a
+      // fastMode-rewritten Cursor row is counted under the id it is really published as,
+      // while Desktop 3P hashes the RAW id.
+      const listed = fastMode === true && m.provider === "cursor" && idStyle === "readable"
+        ? cursorFastIdFor(m.id) ?? m.id
+        : m.id;
+      return idStyle === "readable"
+        ? claudeCodeAlias(m.provider, listed)
+        : aliasForRoute(m.provider, m.id);
+    }),
+  ]);
   // [1m] picker variant (devlog 260712 B1): Claude Code accounts exactly 1M for ids
   // carrying the marker (2.1.207 binary: /\[1m\]/i → 1e6, compaction preserved), so
   // ONLY models with an authoritative >=1M window get a second selectable row —
@@ -140,6 +163,21 @@ export function buildAnthropicModelInfos(
       : ONE_MILLION;
     out.push({ ...base, id, display_name: `${base.display_name} · 1M`, max_input_tokens: advertised });
   };
+  /**
+   * Publish a Fast sibling beside a row, following `push1mVariant` rather than the
+   * `fastMode` rewrite below: `fastMode` is a global switch with no per-request choice, so
+   * it REPLACES the listed id, while a selector has to leave the default pickable beside it.
+   *
+   * Because it only ADDS a row, it is safe for the Desktop 3P hashed style too — the
+   * exclusion `fastMode` needs exists because rewriting a hash strands a saved selection.
+   */
+  const pushFastVariant = (base: AnthropicModelInfo) => {
+    const id = `${base.id}--fast`;
+    // A real model always wins its own id, whatever the iteration order.
+    if (realDiscoveryIds.has(id) || seen.has(id)) return;
+    seen.add(id);
+    out.push({ ...base, id, display_name: `${base.display_name} · Fast` });
+  };
   for (const slug of nativeSlugs) {
     const id = idStyle === "readable" ? claudeCodeNativeAlias(slug) : aliasForRoute("native", slug);
     if (seen.has(id)) continue;
@@ -151,6 +189,9 @@ export function buildAnthropicModelInfos(
     const info = modelInfo(id, `${slug} (native)`, nativeEffectiveLadder(slug), true, nativeMaxInput ?? nativeWindow);
     out.push(info);
     push1mVariant(info, nativeWindow, nativeMaxInput);
+    // Natives too, not only routed rows: gpt-5.6-sol is the flagship Fast model, and
+    // omitting it would leave this surface without the model the feature exists for.
+    if (fastRows?.({ provider: "native", id: slug }) === true) pushFastVariant(info);
   }
   for (const m of routedModels) {
     // Global Fast has no toggle on this surface, so the fast identity is what gets listed —
@@ -180,6 +221,10 @@ export function buildAnthropicModelInfos(
     // Anthropic passthrough guard (audit 021 #3): never auto-widen canonical claude
     // routes — only a genuine >=1M window earns the variant row there.
     push1mVariant(info, m.contextWindow, routedMaxInput);
+    // The whole model is passed, not a (provider, id) pair: a combo row lives in its own
+    // namespace with no config.providers entry, so the caller classifies it from the
+    // aggregated supportsServiceTier the row already carries.
+    if (fastRows?.(m) === true) pushFastVariant(info);
   }
   return out;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1050,6 +1050,9 @@ const configSchema = z.object({
   defaultModelAliases: z.boolean().optional(),
   // Malformed hand edits disable this opt-in projection without rejecting providers.
   cursorEffortRows: z.boolean().optional().catch(false),
+  // Same opt-in discipline: a malformed hand edit degrades to off rather than rejecting
+  // every provider.
+  fastRows: z.boolean().optional().catch(false),
   // Future versions remain opaque through passthrough-compatible whole-config saves.
   // Only version 1 grants deletion authority in the rebase path.
   configRebaseProvenance: z.unknown().optional(),

--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -47,6 +47,7 @@ import {
 } from "../lib/translator-budget";
 import { handleNativeChatCompletions, isNativeChatRouteEligible } from "./chat-native";
 import { parseRequestEffortRowId } from "./effort-row";
+import { parseSyntheticRowId } from "./fast-row";
 
 type Rec = Record<string, unknown>;
 
@@ -105,8 +106,15 @@ async function handleChatCompletionsWithBudget(
   }
 
   const requestedModel = chatBody.model as string;
-  const effortRow = parseRequestEffortRowId(requestedModel, config);
+  const { fastRow, effortRow } = parseSyntheticRowId(requestedModel, config);
   if (effortRow) chatBody.model = effortRow.baseId;
+  if (fastRow) {
+    chatBody.model = fastRow.baseId;
+    // A caller intent; decideTier rules on it downstream. Unlike an effort row this does NOT
+    // block the native-chat shortcut below: native chat carries service_tier itself and runs
+    // the same policy, so blocking it would degrade the request for no reason.
+    chatBody.service_tier = "priority";
+  }
   const stream = chatBody.stream === true;
   // Best-effort Grok attribution: the managed fence stamps this header on every model
   // it registers (extra_headers, sent verbatim by upstream Grok). Dashboard usage

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -54,8 +54,29 @@ import {
   parseRequestEffortRowId,
   type ParsedEffortRowId,
 } from "./effort-row";
+import {
+  parseFastOnlyRowId,
+  parseSyntheticRowId,
+  type ParsedFastRowId,
+} from "./fast-row";
 
 type Rec = Record<string, unknown>;
+
+/**
+ * Decode a Claude selector that may carry the fast marker.
+ *
+ * The exact form is tried first, so a real model whose alias genuinely ends in the marker
+ * keeps winning. Only then is the marker treated as synthetic and the bare base decoded:
+ * a Desktop 3P alias is a HASH registered WITHOUT the marker, so an exact lookup can never
+ * resolve a synthetic one.
+ */
+function decodeClaudeFastSelector(raw: string, cc?: OcxConfig["claudeCode"]): string {
+  const exact = resolveInboundModel(raw, cc);
+  if (exact !== raw || !raw.endsWith("--fast")) return exact;
+  const bare = raw.slice(0, -"--fast".length);
+  const decodedBase = resolveInboundModel(bare, cc);
+  return decodedBase === bare ? exact : `${decodedBase}--fast`;
+}
 
 function isRec(v: unknown): v is Rec {
   return !!v && typeof v === "object" && !Array.isArray(v);
@@ -606,6 +627,7 @@ async function handleClaudeMessagesWithBudget(
   let cacheKeySource: ClaudeCacheKeySource = null;
   let effortOverride: string | null = null;
   let effortRow: ParsedEffortRowId | null = null;
+  let fastRow: ParsedFastRowId | null = null;
   let requestedModel = "";
   try {
     anthropicBody = await readAnthropicBody(req, translatorBudget);
@@ -628,11 +650,20 @@ async function handleClaudeMessagesWithBudget(
     }
     if (isRec(anthropicBody) && typeof anthropicBody.model === "string") {
       requestedModel = anthropicBody.model;
-      effortRow = parseRequestEffortRowId(requestedModel, config);
+      // Decode for Fast only. A Claude alias is `claude-ocx-<provider>--<model>`, so it
+      // already uses `--` as its own separator: stripping the marker off the RAW alias would
+      // turn `claude-ocx-p--foo--fast` into `claude-ocx-p--foo` and route a DIFFERENT model.
+      // Effort parsing keeps the raw selector, so its behaviour is untouched.
+      ({ fastRow, effortRow } = parseSyntheticRowId(
+        requestedModel,
+        config,
+        () => decodeClaudeFastSelector(requestedModel, config.claudeCode),
+      ));
       if (effortRow) {
         anthropicBody.model = effortRow.baseId;
         effortOverride = effortRow.effort;
       }
+      if (fastRow) anthropicBody.model = fastRow.baseId;
     }
     // Debug capture (opt-in allowlist scalars) BEFORE the passthrough branch so
     // native, routed, and disabled-alias paths are all observable (devlog 130 B1).
@@ -657,7 +688,10 @@ async function handleClaudeMessagesWithBudget(
       );
       if (claudeConversationId) logCtx.conversationId = claudeConversationId;
     }
-    if (!effortRow && isRec(anthropicBody) && wantsNativePassthrough(req, config, requestPolicy, anthropicBody.model)) {
+    // A fast row blocks passthrough, unlike the chat case: this path forwards to Anthropic's
+    // own API, whose wire has no service_tier field and whose FastWire kind has an empty
+    // adapter set by design, so the tier would be silently dropped.
+    if (!effortRow && !fastRow && isRec(anthropicBody) && wantsNativePassthrough(req, config, requestPolicy, anthropicBody.model)) {
       return await anthropicNativePassthrough(req, config, logCtx, logIds, anthropicBody, "/v1/messages");
     }
     if (isRec(anthropicBody) && effortOverride) {
@@ -669,6 +703,10 @@ async function handleClaudeMessagesWithBudget(
     }
     const translation = anthropicToResponsesTranslation(anthropicBody, config.claudeCode);
     internalBody = translation.body;
+    // The Anthropic translator builds its body from model/input/store/stream plus sampling
+    // fields only, so the caller intent is applied to the TRANSLATED body rather than the
+    // inbound one.
+    if (fastRow) internalBody.service_tier = "priority";
     translatorBudget.chargeRetained(new TextEncoder().encode(JSON.stringify(internalBody)).byteLength, { kind: "request_copies" });
     cacheKeySource = translation.cacheKeySource;
   } catch (err) {
@@ -1030,6 +1068,16 @@ export async function handleClaudeCountTokens(
   const countRoute = extractOcxRouteDirective(raw);
   if (countRoute) {
     model = stripOneMillionMarker(countRoute);
+    raw.model = model;
+  }
+  // Fast-only: count_tokens never parsed an effort row, so it must not start. It returns a
+  // token estimate and sends no tier, so only the IDENTITY is corrected - without this the
+  // synthetic id reaches native passthrough as a model Anthropic has never heard of.
+  const countFastRow = parseFastOnlyRowId(
+    config, () => decodeClaudeFastSelector(model, config.claudeCode),
+  );
+  if (countFastRow) {
+    model = countFastRow.baseId;
     raw.model = model;
   }
   captureClaudeInbound("count_tokens", raw, resolveInboundModel(model, config.claudeCode), req.headers.get("anthropic-beta") ?? undefined);

--- a/src/server/effort-row.ts
+++ b/src/server/effort-row.ts
@@ -30,7 +30,7 @@ export interface EffortRowOptions {
 }
 
 export function isKnownId(knownIds: EffortRowKnownIds | undefined, id: string): boolean {
-return typeof knownIds === "function" ? knownIds(id) : knownIds?.has(id) === true;
+  return typeof knownIds === "function" ? knownIds(id) : knownIds?.has(id) === true;
 }
 
 export function effortRowId(baseId: string, effort: string): string {

--- a/src/server/effort-row.ts
+++ b/src/server/effort-row.ts
@@ -29,8 +29,8 @@ export interface EffortRowOptions {
   supportsReasoning?: boolean;
 }
 
-function isKnownId(knownIds: EffortRowKnownIds | undefined, id: string): boolean {
-  return typeof knownIds === "function" ? knownIds(id) : knownIds?.has(id) === true;
+export function isKnownId(knownIds: EffortRowKnownIds | undefined, id: string): boolean {
+return typeof knownIds === "function" ? knownIds(id) : knownIds?.has(id) === true;
 }
 
 export function effortRowId(baseId: string, effort: string): string {

--- a/src/server/fast-row.ts
+++ b/src/server/fast-row.ts
@@ -83,11 +83,18 @@ export function fastRowEligible(
  * through its configured provider (router.ts:680). So the base kept working while only the
  * fast selector broke — the asymmetry this set exists to prevent.
  *
- * Every source below is therefore config-derived or static. A base is RECOGNIZED here and
- * then judged by routing, which is the component that actually knows whether it can serve
- * it.
+ * A pure Set cannot express this. Listings also publish LIVE-discovered and retained models
+ * that appear in no config (`provider-fetch.ts` publishes `goModels` and `retainModels`), and
+ * enumerating them means reading the very cache whose churn caused the original defect. So
+ * this returns a PREDICATE: an id is a routable base when it is a known static/config id, or
+ * when it is namespaced under an enabled configured provider. The second clause is
+ * structural, so it holds for a live-discovered model without consulting the cache, and it
+ * is exactly the shape `routeModel` uses to accept a qualified id (router.ts:680).
+ *
+ * A base is RECOGNIZED here and then judged by routing, which is the component that actually
+ * knows whether it can serve it.
  */
-export function fastRowBases(config: OcxConfig): Set<string> {
+export function fastRowBases(config: OcxConfig): (id: string) => boolean {
   const bases = new Set<string>();
   // Configured providers: any model the router would accept for this provider, plus the
   // namespaced and alias-namespaced spellings a listing can publish. Deliberately NOT
@@ -125,7 +132,23 @@ export function fastRowBases(config: OcxConfig): Set<string> {
       for (const slug of slugs) bases.add(`${selector}/${slug}`);
     }
   }
-  return bases;
+  // Namespaces whose qualified ids route, whatever the cache currently holds.
+  const namespaces = new Set<string>();
+  for (const [providerName, providerConfig] of Object.entries(config.providers)) {
+    if (providerConfig.disabled === true) continue;
+    namespaces.add(providerName.toLowerCase());
+    if (typeof providerConfig.alias === "string" && providerConfig.alias.length > 0) {
+      namespaces.add(providerConfig.alias.toLowerCase());
+    }
+  }
+  return (id: string): boolean => {
+    if (bases.has(id)) return true;
+    const slash = id.indexOf("/");
+    if (slash <= 0 || slash === id.length - 1) return false;
+    // A live-discovered or retained model is published as `<provider>/<model>` and appears in
+    // no config, so structural recognition is the only cache-free way to accept it.
+    return namespaces.has(id.slice(0, slash).toLowerCase());
+  };
 }
 
 export function parseFastRowId(

--- a/src/server/fast-row.ts
+++ b/src/server/fast-row.ts
@@ -162,6 +162,14 @@ export function fastRowBases(config: OcxConfig): (id: string) => boolean {
     if (slash <= 0 || slash === id.length - 1) return false;
     // A live-discovered or retained model is published as `<provider>/<model>` and appears in
     // no config, so structural recognition is the only cache-free way to accept it.
+    //
+    // But NOT when the remainder itself ends in the marker. A real live model may legitimately
+    // be named `foo--fast`; its exact id is protected by the known-id guard only while the
+    // discovery cache still holds it, and after eviction that guard goes quiet while this
+    // clause would still accept `provider/foo` structurally - silently routing a DIFFERENT
+    // model than the client selected. Refusing the strip is the safe side: the caller then
+    // sends the id verbatim and routing resolves the real model, or fails honestly.
+    if (id.slice(slash + 1).endsWith(FAST_ROW_SUFFIX)) return false;
     return namespaces.has(id.slice(0, slash).toLowerCase());
   };
 }
@@ -216,18 +224,22 @@ export function parseSyntheticRowId(
     return { fastRow: null, effortRow: parseRequestEffortRowId(id, config) };
   }
   const selector = fastSelector?.() ?? id;
-  // Ordinary ids carry no marker at all; bail before building any inventory.
-  if (id.lastIndexOf("--") <= 0 && selector.lastIndexOf("--") <= 0) {
-    return { fastRow: null, effortRow: null };
-  }
+  const wantsFast = selector.endsWith(FAST_ROW_SUFFIX);
+  // Bail before building any inventory when neither grammar can match. A readable Claude
+  // alias is `claude-ocx-<provider>--<model>`, so it ALWAYS contains `--`: testing only for
+  // the separator would rebuild the whole model inventory on every Claude turn for a
+  // selector that cannot be a fast row. With effort parsing off, the terminal suffix is the
+  // only thing that can match.
+  const wantsEffort = config.cursorEffortRows === true && id.lastIndexOf("--") > 0;
+  if (!wantsFast && !wantsEffort) return { fastRow: null, effortRow: null };
   const knownIds = knownEffortRowIds(config);
-  const fastRow = selector.endsWith(FAST_ROW_SUFFIX)
+  const fastRow = wantsFast
     ? parseFastRowId(selector, config, knownIds, fastRowBases(config))
     : null;
   if (fastRow) return { fastRow, effortRow: null };
   // Cursor install detection stays behind its own flag, exactly as parseRequestEffortRowId
   // gates it today.
-  const effortRow = config.cursorEffortRows === true
+  const effortRow = wantsEffort
     ? parseEffortRowId(id, config, { knownIds, table: loadDetectedCursorEffortTable() })
     : null;
   return effortRow && effortBaseCarriesFastMarker(effortRow.baseId, knownIds)

--- a/src/server/fast-row.ts
+++ b/src/server/fast-row.ts
@@ -73,9 +73,20 @@ export function fastRowEligible(
  * Being too permissive costs nothing here: routing still rejects a base it cannot serve, and
  * the exact-id guard in `parseFastRowId` still protects real models. Being too strict breaks
  * the feature.
+ *
+ * NOT constant across a session. `knownEffortRowIds` reads the live-model cache, so a
+ * live-only model that leaves the cache also leaves this set, and a client holding its
+ * `--fast` selector stops being understood. That is deliberate rather than a gap: the SAME
+ * cache feeds publication, so the plain base row disappears from the listing in the same
+ * breath. A fast row's lifetime is exactly its base row's lifetime, which is the property
+ * that matters; pinning fast selectors alive past their base would be the real defect.
+ * The static native half below is genuinely stable, which is what bare natives need.
  */
-export function fastRowBases(config: OcxConfig): Set<string> {
-  const bases = new Set<string>(knownEffortRowIds(config));
+export function fastRowBases(config: OcxConfig, knownIds?: ReadonlySet<string>): Set<string> {
+  // Reuse the caller's inventory when it already built one: this set is a superset of it, and
+  // rebuilding walks every configured, registry, live-cached and custom model a second time
+  // on a request path.
+  const bases = new Set<string>(knownIds ?? knownEffortRowIds(config));
   // The STATIC upstream table, not `visibleNativeSlugs()`: that one filters by
   // disabled/shadowed state and reaches the catalog cache on disk, so it would both read a
   // file per parsed selector and SHRINK as runtime state changes. A base disappearing
@@ -150,7 +161,7 @@ export function parseSyntheticRowId(
   }
   const knownIds = knownEffortRowIds(config);
   const fastRow = selector.endsWith(FAST_ROW_SUFFIX)
-    ? parseFastRowId(selector, config, knownIds, fastRowBases(config))
+    ? parseFastRowId(selector, config, knownIds, fastRowBases(config, knownIds))
     : null;
   if (fastRow) return { fastRow, effortRow: null };
   // Cursor install detection stays behind its own flag, exactly as parseRequestEffortRowId
@@ -188,4 +199,3 @@ export function expandFastRow<T extends { id: string }>(
   const id = fastRowId(row.id);
   return isKnownId(knownIds, id) ? [row] : [row, { ...row, id }];
 }
-

--- a/src/server/fast-row.ts
+++ b/src/server/fast-row.ts
@@ -74,19 +74,42 @@ export function fastRowEligible(
  * the exact-id guard in `parseFastRowId` still protects real models. Being too strict breaks
  * the feature.
  *
- * NOT constant across a session. `knownEffortRowIds` reads the live-model cache, so a
- * live-only model that leaves the cache also leaves this set, and a client holding its
- * `--fast` selector stops being understood. That is deliberate rather than a gap: the SAME
- * cache feeds publication, so the plain base row disappears from the listing in the same
- * breath. A fast row's lifetime is exactly its base row's lifetime, which is the property
- * that matters; pinning fast selectors alive past their base would be the real defect.
- * The static native half below is genuinely stable, which is what bare natives need.
+ * Membership must not depend on the live-model cache. An earlier version seeded this set
+ * from `knownEffortRowIds` alone, which reads `getStaleCached` (router.ts:125), so a
+ * live-only model leaving the cache silently stopped its `--fast` selector from parsing.
+ * The argument that its base row leaves the listing at the same time is true but
+ * irrelevant: `/v1/models` is discovery, not a routing allowlist, and `routeModel` still
+ * serves the bare base through the default provider (router.ts:791) and the qualified base
+ * through its configured provider (router.ts:680). So the base kept working while only the
+ * fast selector broke — the asymmetry this set exists to prevent.
+ *
+ * Every source below is therefore config-derived or static. A base is RECOGNIZED here and
+ * then judged by routing, which is the component that actually knows whether it can serve
+ * it.
  */
-export function fastRowBases(config: OcxConfig, knownIds?: ReadonlySet<string>): Set<string> {
-  // Reuse the caller's inventory when it already built one: this set is a superset of it, and
-  // rebuilding walks every configured, registry, live-cached and custom model a second time
-  // on a request path.
-  const bases = new Set<string>(knownIds ?? knownEffortRowIds(config));
+export function fastRowBases(config: OcxConfig): Set<string> {
+  const bases = new Set<string>();
+  // Configured providers: any model the router would accept for this provider, plus the
+  // namespaced and alias-namespaced spellings a listing can publish. Deliberately NOT
+  // knownEffortRowIds, whose live-cache half makes membership time-dependent.
+  for (const [providerName, providerConfig] of Object.entries(config.providers)) {
+    if (providerConfig.disabled === true) continue;
+    const namespaces = [providerName, providerConfig.alias].filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    );
+    const declared = [
+      ...(providerConfig.models ?? []),
+      ...(providerConfig.defaultModel ? [providerConfig.defaultModel] : []),
+      ...Object.values(providerConfig.modelAliases ?? {}),
+      ...(config.customModels ?? [])
+        .filter(model => model.provider === providerName && model.modelId)
+        .map(model => model.modelId),
+    ];
+    for (const id of declared) {
+      bases.add(id);
+      for (const namespace of namespaces) bases.add(`${namespace}/${id}`);
+    }
+  }
   // The STATIC upstream table, not `visibleNativeSlugs()`: that one filters by
   // disabled/shadowed state and reaches the catalog cache on disk, so it would both read a
   // file per parsed selector and SHRINK as runtime state changes. A base disappearing
@@ -161,7 +184,7 @@ export function parseSyntheticRowId(
   }
   const knownIds = knownEffortRowIds(config);
   const fastRow = selector.endsWith(FAST_ROW_SUFFIX)
-    ? parseFastRowId(selector, config, knownIds, fastRowBases(config, knownIds))
+    ? parseFastRowId(selector, config, knownIds, fastRowBases(config))
     : null;
   if (fastRow) return { fastRow, effortRow: null };
   // Cursor install detection stays behind its own flag, exactly as parseRequestEffortRowId

--- a/src/server/fast-row.ts
+++ b/src/server/fast-row.ts
@@ -1,0 +1,191 @@
+import {
+  accountBoundNativeOpenAiSlugsBySelector,
+  shouldIncludeAccountBoundNativeOpenAi,
+  shouldIncludeNativeOpenAi,
+  UPSTREAM_NATIVE_ENTRIES,
+} from "../codex/catalog/metadata";
+import type { InboundWire } from "../providers/registry";
+import { fastPolicyForModel } from "../providers/service-tier";
+import type { OcxConfig } from "../types";
+import {
+  isKnownId,
+  knownEffortRowIds,
+  loadDetectedCursorEffortTable,
+  parseEffortRowId,
+  parseRequestEffortRowId,
+  type EffortRowKnownIds,
+  type ParsedEffortRowId,
+} from "./effort-row";
+
+/**
+ * Synthetic Fast selectors: `<base-id>--fast` published on external model listings for
+ * models whose resolved Fast policy is eligible, so a client that can only pick a model by
+ * id reaches the priority service tier. The Codex app has a picker toggle for this; nothing
+ * else did (devlog/_plan/260904_external_fast_wire).
+ *
+ * The marker is `--fast`, not `-fast`. Terminal `-fast` is a REAL id across this catalog —
+ * grok-4-fast, glm-5.3-fast, gpt-5-fast, and every Cursor fast variant — so a single hyphen
+ * cannot tell a product apart from a tier. `--` is the same terminal separator the effort-row
+ * grammar relies on for the same reason.
+ */
+const FAST_ROW_SUFFIX = "--fast";
+
+export interface ParsedFastRowId {
+  baseId: string;
+}
+
+export interface ParsedSyntheticRow {
+  fastRow: ParsedFastRowId | null;
+  effortRow: ParsedEffortRowId | null;
+}
+
+export function fastRowId(baseId: string): string {
+  return `${baseId}${FAST_ROW_SUFFIX}`;
+}
+
+/**
+ * Whether a provider/model pair's resolved Fast policy may be published as a row.
+ *
+ * `eligible` alone. `unclassified` means capability is undefined, and `decideTier` makes
+ * `fastMode` inert there, so publishing it would advertise a tier the runtime then refuses
+ * to send.
+ */
+export function fastRowEligible(
+  provider: Parameters<typeof fastPolicyForModel>[0],
+  modelId: string,
+  providerName?: string,
+  inbound: InboundWire = "responses",
+): boolean {
+  return fastPolicyForModel(provider, modelId, providerName, inbound).eligibility === "eligible";
+}
+
+/**
+ * Bases that may carry a fast row.
+ *
+ * Deliberately a SUPERSET of what the listings publish, and deliberately not
+ * `knownEffortRowIds`. That set answers "which exact ids defeat the synthetic grammar"; it
+ * does not answer "which bases are routable". Bare natives prove the gap: the `openai`
+ * registry entry declares no `models` list and the default provider config declares none
+ * either, because they route through a family-pattern rule instead. `gpt-5.6-sol` is
+ * therefore absent from it, and requiring membership would publish `gpt-5.6-sol--fast` and
+ * then refuse to parse it.
+ *
+ * Being too permissive costs nothing here: routing still rejects a base it cannot serve, and
+ * the exact-id guard in `parseFastRowId` still protects real models. Being too strict breaks
+ * the feature.
+ */
+export function fastRowBases(config: OcxConfig): Set<string> {
+  const bases = new Set<string>(knownEffortRowIds(config));
+  // The STATIC upstream table, not `visibleNativeSlugs()`: that one filters by
+  // disabled/shadowed state and reaches the catalog cache on disk, so it would both read a
+  // file per parsed selector and SHRINK as runtime state changes. A base disappearing
+  // mid-session would strand a client still holding the id it was published.
+  if (shouldIncludeNativeOpenAi(config)) {
+    for (const slug of UPSTREAM_NATIVE_ENTRIES.keys()) bases.add(slug);
+  }
+  if (shouldIncludeAccountBoundNativeOpenAi(config)) {
+    // An EMPTY observed-entry list on purpose: the default argument reads the Codex models
+    // cache and catalog from disk. The empty form still seeds every selector with the native
+    // model set, and anything publishable is in UPSTREAM_NATIVE_ENTRIES anyway.
+    for (const [selector, slugs] of accountBoundNativeOpenAiSlugsBySelector(config, [])) {
+      for (const slug of slugs) bases.add(`${selector}/${slug}`);
+    }
+  }
+  return bases;
+}
+
+export function parseFastRowId(
+  id: string,
+  config: Pick<OcxConfig, "fastRows">,
+  knownIds?: EffortRowKnownIds,
+  routableBases?: EffortRowKnownIds,
+): ParsedFastRowId | null {
+  if (config.fastRows !== true) return null;
+  if (!id.endsWith(FAST_ROW_SUFFIX)) return null;
+  // An exact configured/public id always beats the synthetic grammar, the same precedence
+  // effort rows use. An operator who really named a model `x--fast` keeps it.
+  if (isKnownId(knownIds, id)) return null;
+  const baseId = id.slice(0, -FAST_ROW_SUFFIX.length);
+  if (baseId.length === 0) return null;
+  return isKnownId(routableBases, baseId) ? { baseId } : null;
+}
+
+/**
+ * True when an effort-row base still carries a fast marker, i.e. the selector nested the two
+ * grammars. Composition is not supported, so such an id resolves to neither rather than
+ * silently to whichever parser ran first.
+ *
+ * Known-id guarded, so a real model named `foo--fast` keeps its legitimate `foo--fast--high`
+ * effort row.
+ */
+export function effortBaseCarriesFastMarker(
+  baseId: string,
+  knownIds: EffortRowKnownIds | undefined,
+): boolean {
+  return baseId.endsWith(FAST_ROW_SUFFIX) && !isKnownId(knownIds, baseId);
+}
+
+/**
+ * Resolve one ingress selector against both synthetic grammars, returning at most one.
+ * Callers pass the id the client sent and never a value another parser mutated.
+ */
+export function parseSyntheticRowId(
+  id: string,
+  config: OcxConfig,
+  // Claude surfaces decode the alias before the marker is unambiguous, so they pass the
+  // decoded form for Fast while effort parsing keeps seeing the id the client sent. A THUNK,
+  // not a string: arguments are evaluated before the call, so an eager decode would run its
+  // alias lookups even on the fastRows-off path this function exists to leave untouched.
+  fastSelector?: () => string,
+): ParsedSyntheticRow {
+  // Fast off: delegate to the SAME function shipped today, so an install that never enables
+  // this feature cannot observe any change, in behaviour or in cost.
+  if (config.fastRows !== true) {
+    return { fastRow: null, effortRow: parseRequestEffortRowId(id, config) };
+  }
+  const selector = fastSelector?.() ?? id;
+  // Ordinary ids carry no marker at all; bail before building any inventory.
+  if (id.lastIndexOf("--") <= 0 && selector.lastIndexOf("--") <= 0) {
+    return { fastRow: null, effortRow: null };
+  }
+  const knownIds = knownEffortRowIds(config);
+  const fastRow = selector.endsWith(FAST_ROW_SUFFIX)
+    ? parseFastRowId(selector, config, knownIds, fastRowBases(config))
+    : null;
+  if (fastRow) return { fastRow, effortRow: null };
+  // Cursor install detection stays behind its own flag, exactly as parseRequestEffortRowId
+  // gates it today.
+  const effortRow = config.cursorEffortRows === true
+    ? parseEffortRowId(id, config, { knownIds, table: loadDetectedCursorEffortTable() })
+    : null;
+  return effortRow && effortBaseCarriesFastMarker(effortRow.baseId, knownIds)
+    ? { fastRow: null, effortRow: null }
+    : { fastRow: null, effortRow };
+}
+
+/** Fast-only resolution for surfaces that never parsed an effort row. */
+export function parseFastOnlyRowId(
+  config: OcxConfig,
+  selector: () => string,
+): ParsedFastRowId | null {
+  if (config.fastRows !== true) return null;
+  return parseSyntheticRowId("", config, selector).fastRow;
+}
+
+/**
+ * Add a fast sibling beside an eligible row. The base row is always kept: a fast row is an
+ * addition, never a replacement. That is the deliberate difference from `fastMode`, which
+ * replaces the listed Cursor id — replacement suits a global switch, but a per-request
+ * selector has to leave the default reachable.
+ */
+export function expandFastRow<T extends { id: string }>(
+  row: T,
+  eligible: boolean,
+  config: Pick<OcxConfig, "fastRows">,
+  knownIds?: EffortRowKnownIds,
+): T[] {
+  if (config.fastRows !== true || !eligible) return [row];
+  const id = fastRowId(row.id);
+  return isKnownId(knownIds, id) ? [row] : [row, { ...row, id }];
+}
+

--- a/src/server/fast-row.ts
+++ b/src/server/fast-row.ts
@@ -4,6 +4,8 @@ import {
   shouldIncludeNativeOpenAi,
   UPSTREAM_NATIVE_ENTRIES,
 } from "../codex/catalog/metadata";
+import { comboModelId, comboPublicModelId } from "../combos/types";
+import { policyModelId, policyPublicModelId } from "../routing/profile";
 import type { InboundWire } from "../providers/registry";
 import { fastPolicyForModel } from "../providers/service-tier";
 import type { OcxConfig } from "../types";
@@ -134,6 +136,19 @@ export function fastRowBases(config: OcxConfig): (id: string) => boolean {
   }
   // Namespaces whose qualified ids route, whatever the cache currently holds.
   const namespaces = new Set<string>();
+  // Virtual rows. A combo or routing profile is published under its canonical
+  // `<namespace>/<id>` AND under an operator alias, which may be an arbitrary bare string
+  // with no namespace to vouch for it, so the structural clause below cannot reach it. A
+  // combo also cannot be covered by config.providers: declaring a provider named `combo`
+  // is rejected outright (combos/types.ts:191).
+  for (const [id, combo] of Object.entries(config.combos ?? {})) {
+    bases.add(comboModelId(id));
+    bases.add(comboPublicModelId(id, combo));
+  }
+  for (const [id, profile] of Object.entries(config.routingProfiles ?? {})) {
+    bases.add(policyModelId(id));
+    bases.add(policyPublicModelId(id, profile));
+  }
   for (const [providerName, providerConfig] of Object.entries(config.providers)) {
     if (providerConfig.disabled === true) continue;
     namespaces.add(providerName.toLowerCase());

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -230,6 +230,9 @@ import { recordCursorSeen } from "../integrations/cursor-seen";
 import { detectCursorInstalls } from "../integrations/cursor-detect";
 import { loadCursorEffortTable } from "../integrations/cursor-effort-table";
 import { expandCursorEffortRow, knownEffortRowIds } from "./effort-row";
+import { expandFastRow, fastRowEligible } from "./fast-row";
+// Direct import: the catalog facade does not re-export this table.
+import { UPSTREAM_NATIVE_ENTRIES } from "../codex/catalog/metadata";
 
 export const MAX_WS_FRAME_BYTES = 50 * 1024 * 1024;
 const WEBSOCKET_IDLE_TIMEOUT_SECONDS = 0;
@@ -1430,6 +1433,46 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         // Codex catalog (client_version) and the OpenAI list shape below stay byte-identical.
         const wantsAnthropicList = req.headers.get("anthropic-version") !== null
           || url.searchParams.get("flavor") === "anthropic";
+        /**
+         * Whether a NATIVE slug may carry a Fast sibling.
+         *
+         * Both halves are required. Upstream asserts the tier per model — the same
+         * `additional_speed_tiers` the Codex picker's own toggle is built from — but an
+         * operator capability override or the final wire resolution can still make the
+         * route ineligible, and `decideTier` would then drop the tier the row advertised.
+         *
+         * Declared here, above the Claude discovery call, because that call reads it while
+         * the raw OpenAI mapper further down does too; defining it there would leave this
+         * use in its temporal dead zone.
+         */
+        const nativeFastEligible = (metadataId: string): boolean => {
+          if (config.fastRows !== true) return false;
+          const upstream = UPSTREAM_NATIVE_ENTRIES.get(metadataId);
+          const speedTiers = upstream?.additional_speed_tiers;
+          if (!Array.isArray(speedTiers) || !speedTiers.includes("fast")) return false;
+          const nativeProvider = config.providers[OPENAI_CODEX_PROVIDER_ID];
+          return nativeProvider !== undefined
+            && fastRowEligible(nativeProvider, metadataId, OPENAI_CODEX_PROVIDER_ID);
+        };
+        /**
+         * Whether a routed catalog row may carry a Fast sibling.
+         *
+         * A combo is its own namespace with no `config.providers` entry — declaring a
+         * provider named `combo` is rejected (combos/types.ts:191) — so provider lookup
+         * cannot classify it. Its aggregated `supportsServiceTier` is already true only
+         * when EVERY member supports the tier (aggregation.ts:201), which is the right
+         * rule for a row that fans out to all of them.
+         *
+         * Declared beside nativeFastEligible, above the Claude discovery call that reads
+         * both; defining it near the raw OpenAI mapper below would leave that use in its
+         * temporal dead zone.
+         */
+        const catalogRowFastEligible = (m: { provider: string; id: string; supportsServiceTier?: boolean }): boolean => {
+          if (config.fastRows !== true) return false;
+          if (m.supportsServiceTier !== undefined) return m.supportsServiceTier === true;
+          const rowProvider = config.providers[m.provider];
+          return rowProvider !== undefined && fastRowEligible(rowProvider, m.id, m.provider);
+        };
         if (wantsAnthropicList && !url.searchParams.has("client_version")) {
           if (config.claudeCode?.enabled === false) return jsonResponse({ data: [] }, 200, req, policy);
           // Build Desktop 3P registry so inbound alias resolution works for subsequent requests.
@@ -1451,7 +1494,23 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             : idsParam === "desktop"
               ? "desktop3p" as const
               : (/^claude-code\//i.test(req.headers.get("user-agent") ?? "") ? "readable" as const : "desktop3p" as const);
-          const data = buildAnthropicModelInfos(desktopNativeSlugs, goOrdered, resolveAutoContext(config.claudeCode), idStyle, activeDesktop3pAlias, nativeContextLimits(config), config.fastMode);
+          const data = buildAnthropicModelInfos(
+            desktopNativeSlugs,
+            goOrdered,
+            resolveAutoContext(config.claudeCode),
+            idStyle,
+            activeDesktop3pAlias,
+            nativeContextLimits(config),
+            config.fastMode,
+            // Presence is the gate: undefined when the flag is off, so a default install
+            // publishes no Fast rows here.
+            config.fastRows === true
+              ? (model: { provider: string; id: string; supportsServiceTier?: boolean }) =>
+                model.provider === "native"
+                  ? nativeFastEligible(model.id)
+                  : catalogRowFastEligible(model)
+              : undefined,
+          );
           return jsonResponse({ data }, 200, req, policy);
         }
         if (url.searchParams.has("client_version")) {
@@ -1580,7 +1639,13 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         // The projection is opt-in. Keep the default path free of Cursor install detection,
         // and resolve the bundle table once for the whole list rather than once per row.
         const effortRowsEnabled = config.cursorEffortRows === true;
-        const effortRowKnownIds = effortRowsEnabled ? knownEffortRowIds(config) : undefined;
+        // Same opt-in discipline: with the flag off, no policy resolution and no extra rows.
+        const fastRowsEnabled = config.fastRows === true;
+        // One inventory serves both grammars; building it twice would double the work on a
+        // hot path for no benefit.
+        const effortRowKnownIds = effortRowsEnabled || fastRowsEnabled
+          ? knownEffortRowIds(config)
+          : undefined;
         const privateInference = effortRowsEnabled
           ? detectCursorInstalls().find(install => install.build === "private-inference")
           : undefined;
@@ -1593,7 +1658,15 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             knownIds: effortRowKnownIds,
             table: cursorEffortTable,
             supportsReasoning: reasoningEfforts.length > 0,
-          });
+          }).flatMap(row => expandFastRow(
+            row,
+            // Only the BASE row earns a fast sibling. An effort row already spent the
+            // grammar, and the parser requires the stripped base to be routable, so
+            // `<base>--<effort>--fast` would publish a row no ingress can resolve.
+            row.id === id && nativeFastEligible(metadataId),
+            config,
+            effortRowKnownIds,
+          ));
         };
         const routedRows = await Promise.all(uniqueCatalogModelsForRawPublicList(goOrdered).map(async m => {
           // Same rule as the anthropic branch: with the global fast switch on, a client
@@ -1634,7 +1707,12 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             knownIds: effortRowKnownIds,
             table: cursorEffortTable,
             supportsReasoning: (m.reasoningEfforts ?? []).length > 0,
-          });
+          }).flatMap(expanded => expandFastRow(
+            expanded,
+            expanded.id === row.id && catalogRowFastEligible(m),
+            config,
+            effortRowKnownIds,
+          ));
         }));
         const data = [
           ...visibleNatives.flatMap(id => expandedNativeModelRow(id)),

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -512,6 +512,10 @@ export async function handleResponsesCompact(
   const compactFastRow = parseFastOnlyRowId(config, () => raw.model as string);
   const compactModel = compactFastRow ? compactFastRow.baseId : raw.model;
   if (compactFastRow) (raw as Record<string, unknown>).model = compactModel;
+  // The client's own selector, kept for the request log: `raw.model` is rewritten to the
+  // base id above, and logCtx.requestedModel is assigned from it further down, so without
+  // this the log would lose which id the client actually asked for.
+  const compactRequestedModel = compactFastRow ? compactFastRow.baseId + "--fast" : raw.model;
 
   let route;
   try {
@@ -532,29 +536,13 @@ export async function handleResponsesCompact(
     return formatErrorResponse(404, "invalid_request_error", err instanceof Error ? err.message : String(err));
   }
   const selectedModelId = route.modelId;
-  if (compactFastRow) {
-    // The tier is applied AFTER the route settles, exactly as the ordinary Responses path
-    // does it. Native compact spreads `raw` into the forwarded body, so writing an
-    // unconditional "priority" here would bypass fastMode:false, a withdrawn capability,
-    // and wire eligibility - the one rule this phase exists to preserve.
-    const decision = decideTier(
-      fastPolicyForModel(route.provider, route.modelId, route.providerName),
-      config.fastMode,
-      "priority",
-    );
-    // The WHOLE decision: on a drop, a caller's pre-existing service_tier must be removed
-    // rather than left to ride along.
-    const serviceTier = tierValueAfterDecision(decision, "priority");
-    if (serviceTier === undefined) delete (raw as Record<string, unknown>).service_tier;
-    else (raw as Record<string, unknown>).service_tier = serviceTier;
-  }
   // Derive from the RESOLVED route model, not the caller's raw string. An account-qualified
   // selector like `side/gpt-daybreak-blue-latest` does not match the gated map — `slugsEquivalent`
   // reads the account namespace as a routed provider prefix — so keying on `raw.model` sent
   // exactly the selector form back down the native compact endpoint this guard exists to avoid.
   // `route.modelId` is the same value `applyCodexAccountGatedWireNormalization` uses in core.ts.
   const accountGatedCompactWireModel = codexAccountGatedCanonicalWireModel(selectedModelId);
-  logCtx.requestedModel = raw.model;
+  logCtx.requestedModel = compactRequestedModel;
   logCtx.model = selectedModelId;
   logCtx.routeDecision = route.routeDecision;
   logCtx.provider = route.codexAccountNamespace
@@ -568,6 +556,30 @@ export async function handleResponsesCompact(
     logCtx.resolvedModel = virtual.wireModelId;
   } else {
     logCtx.resolvedModel = route.modelId;
+  }
+  if (compactFastRow) {
+    // Resolved AFTER the virtual-model rewrite above, and against `route.modelId`, which is
+    // now the WIRE model: `resolveOpenAiCompactModel` maps an alias like `gpt-5.6-sol-pro`
+    // onto a different wire id, and capability overrides are keyed by exact model id, so
+    // deciding before the rewrite could set `priority` on a wire model that does not support
+    // it. `capabilityProvider` is passed for the same reason core.ts:2103 passes it.
+    const decision = decideTier(
+      fastPolicyForModel(
+        route.provider,
+        route.modelId,
+        route.providerName,
+        "responses",
+        config.providers[route.providerName],
+      ),
+      config.fastMode,
+      "priority",
+    );
+    // The WHOLE decision: native compact spreads `raw` into the forwarded body, so on a drop
+    // a caller's pre-existing service_tier must be REMOVED rather than left to ride along
+    // past the suppression.
+    const serviceTier = tierValueAfterDecision(decision, "priority");
+    if (serviceTier === undefined) delete (raw as Record<string, unknown>).service_tier;
+    else (raw as Record<string, unknown>).service_tier = serviceTier;
   }
 
   // #1686: a bearer-presented admission secret is one of ours, so the stored main credential

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -94,6 +94,9 @@ import type { DataPlaneAdmission } from "../auth-cors";
 import { listOpenAiForwardSidecarCandidates, resolveFirstUsableOpenAiSidecar, type ResolvedOpenAiForwardSidecar } from "../../providers/openai-sidecar";
 import { CODEX_FORWARD_BASE_URL, isCanonicalOpenAiForwardProvider, supportsNativeResponsesCompactEndpoint } from "../../providers/openai-tiers";
 import { slugsEquivalent } from "../../providers/slug-codec";
+import { decideTier, tierValueAfterDecision } from "../../providers/fastwire";
+import { fastPolicyForModel } from "../../providers/service-tier";
+import { parseFastOnlyRowId } from "../fast-row";
 import { applyOpenAiVirtualModel, resolveOpenAiCompactModel } from "../../providers/openai-virtual-models";
 import { isUsageDebugEnabled } from "../../usage/debug";
 import { readJsonRequestBody, DecompressedBodyTooLargeError, UnsupportedContentEncodingError } from "../request-decompress";
@@ -503,6 +506,12 @@ export async function handleResponsesCompact(
   if (typeof raw.model !== "string" || raw.model.length === 0) {
     return formatErrorResponse(400, "invalid_request_error", "compaction request requires a model");
   }
+  // Correct the IDENTITY before routing, or the synthetic id does not route at all. Held in
+  // a local rather than written back to `raw.model`: assigning to the property widens it out
+  // of the `string` narrowing the guard above just established.
+  const compactFastRow = parseFastOnlyRowId(config, () => raw.model as string);
+  const compactModel = compactFastRow ? compactFastRow.baseId : raw.model;
+  if (compactFastRow) (raw as Record<string, unknown>).model = compactModel;
 
   let route;
   try {
@@ -512,7 +521,7 @@ export async function handleResponsesCompact(
     // Codex selects a bare native model for compaction even when the operator
     // routes ordinary turns elsewhere (#2901); the compaction-scoped router
     // may land that on the configured default provider instead of 404.
-    route = routeCompactionModel(config, raw.model, evidenceFromBody(raw));
+    route = routeCompactionModel(config, compactModel, evidenceFromBody(raw));
   } catch (err) {
     if (err instanceof NoEligiblePolicyCandidateError) {
       // Persist the evaluation trace (per-candidate exclusions + the
@@ -523,6 +532,22 @@ export async function handleResponsesCompact(
     return formatErrorResponse(404, "invalid_request_error", err instanceof Error ? err.message : String(err));
   }
   const selectedModelId = route.modelId;
+  if (compactFastRow) {
+    // The tier is applied AFTER the route settles, exactly as the ordinary Responses path
+    // does it. Native compact spreads `raw` into the forwarded body, so writing an
+    // unconditional "priority" here would bypass fastMode:false, a withdrawn capability,
+    // and wire eligibility - the one rule this phase exists to preserve.
+    const decision = decideTier(
+      fastPolicyForModel(route.provider, route.modelId, route.providerName),
+      config.fastMode,
+      "priority",
+    );
+    // The WHOLE decision: on a drop, a caller's pre-existing service_tier must be removed
+    // rather than left to ride along.
+    const serviceTier = tierValueAfterDecision(decision, "priority");
+    if (serviceTier === undefined) delete (raw as Record<string, unknown>).service_tier;
+    else (raw as Record<string, unknown>).service_tier = serviceTier;
+  }
   // Derive from the RESOLVED route model, not the caller's raw string. An account-qualified
   // selector like `side/gpt-daybreak-blue-latest` does not match the gated map — `slugsEquivalent`
   // reads the account namespace as a routed provider prefix — so keying on `raw.model` sent

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -332,6 +332,7 @@ import {
 } from "../responses-image-gen-repair";
 import { createResponsesModelPayloadRewrite, rewriteResponsesModelJson } from "../responses-model-rewrite";
 import { parseRequestEffortRowId } from "../effort-row";
+import { parseSyntheticRowId } from "../fast-row";
 import {
   collectSelfNamedNamespaceScrubAuthorization,
   createSelfNamedToolCallNamespaceScrubRewrite,
@@ -2725,10 +2726,22 @@ async function handleResponsesInner(
   }
   // An effort row naming a table-less combo (`combo/x--high`) must reach the combo dispatcher
   // as its base id, so the selector is normalized here, before comboIdFromRawBody reads model.
-  const comboEffortRow = !options.comboAttempt && body && typeof body === "object" && !Array.isArray(body)
+  const comboRows = !options.comboAttempt && body && typeof body === "object" && !Array.isArray(body)
     && typeof (body as { model?: unknown }).model === "string"
-    ? parseRequestEffortRowId((body as { model: string }).model, config)
-    : null;
+    // One parse for both grammars, from the selector as the client sent it. Parsing them
+    // separately made the outcome depend on which ran first.
+    ? parseSyntheticRowId((body as { model: string }).model, config)
+    : { fastRow: null, effortRow: null };
+  const comboEffortRow = comboRows.effortRow;
+  if (comboRows.fastRow) {
+    // Same reason as the effort row above: the combo dispatcher reads `model` next, so the
+    // selector has to be normalized before it, or a combo child is built from a synthetic id.
+    const raw = body as Record<string, unknown>;
+    raw.model = comboRows.fastRow.baseId;
+    // A caller INTENT, not a decision. decideTier still rules on eligibility downstream, so
+    // fastMode:false and an ineligible route both still suppress it.
+    raw.service_tier = "priority";
+  }
   if (comboEffortRow) {
     const raw = body as Record<string, unknown>;
     raw.model = comboEffortRow.baseId;
@@ -2794,7 +2807,15 @@ async function handleResponsesInner(
   let toolBridgeMaps: ReturnType<typeof buildToolBridgeMaps>;
   try {
     parsed = parseRequest(body);
-    const effortRow = parseRequestEffortRowId(parsed.modelId, config);
+    // Captured before any parser mutates it, so both grammars see the client's id.
+    const { fastRow, effortRow } = parseSyntheticRowId(parsed.modelId, config);
+    if (fastRow) {
+      parsed.modelId = fastRow.baseId;
+      parsed.options.serviceTier = "priority";
+      const raw = parsed._rawBody as Record<string, unknown>;
+      raw.model = fastRow.baseId;
+      raw.service_tier = "priority";
+    }
     if (effortRow) {
       parsed.modelId = effortRow.baseId;
       parsed.options.reasoning = effortRow.effort;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -375,6 +375,13 @@ export interface OcxConfig {
    * from Cursor's built-in effort table. Omitted/false preserves discovery output.
    */
   cursorEffortRows?: boolean;
+  /**
+   * Opt-in synthetic Fast selectors. When true, the raw OpenAI-style `/v1/models` list and
+   * Claude Code discovery add a `<base-id>--fast` row for every model whose resolved Fast
+   * policy is eligible, and selecting one routes the base model with the canonical
+   * `priority` service tier. Omitted/false preserves discovery output exactly.
+   */
+  fastRows?: boolean;
   /** Explicit top-level deletion intent used by stale whole-config rebases. */
   configRebaseProvenance?: OcxConfigRebaseProvenance | Record<string, unknown>;
   /** OpenAI provider-contract migration marker (v2 = single `openai` provider with account mode). */

--- a/tests/fast-row-ingress.test.ts
+++ b/tests/fast-row-ingress.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { decideTier, tierValueAfterDecision } from "../src/providers/fastwire";
+import { providerConfigSeed } from "../src/providers/derive";
+import { getProviderRegistryEntry } from "../src/providers/registry";
+import { fastPolicyForModel } from "../src/providers/service-tier";
+import { parseFastOnlyRowId, parseSyntheticRowId } from "../src/server/fast-row";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+/**
+ * Ingress round-trip semantics for synthetic Fast selectors
+ * (devlog 260904_external_fast_wire/030).
+ *
+ * A fast row sets `service_tier: "priority"` as a CALLER intent and lets the existing
+ * decideTier rule on it. It never writes tierDecision and never bypasses the policy, so
+ * everything that already governs Fast keeps governing it. These tests pin that contract at
+ * the decision layer every one of the five ingresses feeds.
+ */
+
+function provider(overrides: Partial<OcxProviderConfig> = {}): OcxProviderConfig {
+  return {
+    adapter: "openai-responses",
+    baseUrl: "https://fixture.example/v1",
+    ...overrides,
+  } as OcxProviderConfig;
+}
+
+function configWith(providers: Record<string, OcxProviderConfig>, extra: Partial<OcxConfig> = {}): OcxConfig {
+  return {
+    port: 10100,
+    defaultProvider: Object.keys(providers)[0] ?? "fixture",
+    providers,
+    fastRows: true,
+    ...extra,
+  } as OcxConfig;
+}
+
+const eligible = () => configWith({
+  fixture: provider({ models: ["m"], supportsServiceTier: true }),
+});
+
+describe("a fast selector becomes a caller intent, not a decision", () => {
+  test("it resolves to the base model on the shared parser every ingress uses", () => {
+    const config = eligible();
+    expect(parseSyntheticRowId("m--fast", config).fastRow).toEqual({ baseId: "m" });
+    expect(parseSyntheticRowId("fixture/m--fast", config).fastRow).toEqual({ baseId: "fixture/m" });
+  });
+
+  test("an eligible route turns the intent into the canonical wire value", () => {
+    const config = eligible();
+    const policy = fastPolicyForModel(config.providers.fixture, "m", "fixture");
+    const decision = decideTier(policy, config.fastMode, "priority");
+    expect(decision.kind).toBe("set");
+    expect(tierValueAfterDecision(decision, "priority")).toBe("priority");
+  });
+
+  test("fastMode:false suppresses the intent — the operator switch is not overridable by id", () => {
+    const config = configWith({ fixture: provider({ models: ["m"], supportsServiceTier: true }) }, { fastMode: false });
+    // The selector still resolves: the id is understood, and the POLICY declines it.
+    expect(parseSyntheticRowId("m--fast", config).fastRow).toEqual({ baseId: "m" });
+    const decision = decideTier(
+      fastPolicyForModel(config.providers.fixture, "m", "fixture"),
+      config.fastMode,
+      "priority",
+    );
+    expect(decision).toEqual({ kind: "drop" });
+    // The value a handler writes back: undefined means REMOVE the field, which is what the
+    // compact path must do rather than leaving a caller's stale tier to ride along.
+    expect(tierValueAfterDecision(decision, "priority")).toBeUndefined();
+  });
+
+  test("an ineligible route degrades to a normal request rather than erroring", () => {
+    // A stale client holding a --fast id after the model lost eligibility still gets served.
+    const config = configWith({ fixture: provider({ models: ["m"], supportsServiceTier: false }) });
+    const decision = decideTier(
+      fastPolicyForModel(config.providers.fixture, "m", "fixture"),
+      config.fastMode,
+      "priority",
+    );
+    expect(decision).toEqual({ kind: "drop" });
+    expect(tierValueAfterDecision(decision, "priority")).toBeUndefined();
+  });
+
+  test("an unclassified route does not invent a tier", () => {
+    // Capability undefined is absence of evidence, not evidence of support.
+    const config = configWith({ fixture: provider({ models: ["m"] }) });
+    const decision = decideTier(
+      fastPolicyForModel(config.providers.fixture, "m", "fixture"),
+      config.fastMode,
+      "priority",
+    );
+    expect(decision.kind).not.toBe("set");
+  });
+});
+
+describe("cursor expresses the same intent as a model variant", () => {
+  test("the canonical intent reaches Cursor's own fast wire value", () => {
+    // Cursor's FastWire maps priority -> the `fast` variant, which is the existence proof
+    // this whole unit generalizes: one caller intent, per-provider wire.
+    const cursor = providerConfigSeed(getProviderRegistryEntry("cursor")!);
+    const decision = decideTier(fastPolicyForModel(cursor, "claude-opus-5", "cursor"), undefined, "priority");
+    expect(decision).toEqual({ kind: "set", value: "fast" });
+  });
+});
+
+describe("surfaces that never parsed an effort row", () => {
+  test("count_tokens and compact resolve Fast only, and nothing when the flag is off", () => {
+    const config = configWith({ fixture: provider({ models: ["m"] }) }, { cursorEffortRows: true });
+    expect(parseFastOnlyRowId(config, () => "m--fast")).toEqual({ baseId: "m" });
+    // An effort row is NOT acquired by these surfaces.
+    expect(parseFastOnlyRowId(config, () => "m--high")).toBeNull();
+    const off = configWith({ fixture: provider({ models: ["m"] }) }, { fastRows: false });
+    expect(parseFastOnlyRowId(off, () => "m--fast")).toBeNull();
+  });
+});
+
+describe("the flag stays off by default at the request path", () => {
+  test("a --fast selector is an ordinary unknown model when the flag is unset", () => {
+    const config = configWith({ fixture: provider({ models: ["m"], supportsServiceTier: true }) }, { fastRows: false });
+    const rows = parseSyntheticRowId("m--fast", config);
+    expect(rows.fastRow).toBeNull();
+    // And no rewrite happens, so the id reaches routing verbatim and fails there honestly
+    // rather than being silently reinterpreted.
+    expect(rows.effortRow).toBeNull();
+  });
+});
+

--- a/tests/fast-row-listing.test.ts
+++ b/tests/fast-row-listing.test.ts
@@ -66,13 +66,19 @@ describe("fast rows on Claude discovery", () => {
     // With both `foo` and a real `foo--fast` present, the synthetic id for `foo` IS the real
     // model's id. The dedupe set alone would let whichever ran first own the row, so the
     // outcome must not depend on ordering.
-    const forward = build([], [routed("foo"), routed("foo--fast")], () => true);
-    const reverse = build([], [routed("foo--fast"), routed("foo")], () => true);
-    const count = (ids: string[]) => ids.filter(id => id.endsWith("--fast")).length;
-    expect(count(forward)).toBe(count(reverse));
-    // And the real model's own row is present either way.
-    expect(forward.some(id => id.endsWith("foo--fast"))).toBe(true);
-    expect(reverse.some(id => id.endsWith("foo--fast"))).toBe(true);
+    //
+    // Asserted on display_name, not just the id: counting ids alone cannot tell the REAL
+    // `foo--fast` row apart from a synthetic sibling of `foo`, so a broken implementation
+    // that published the synthetic one in forward order still passed (CodeRabbit, PR #3457).
+    const rows = (models: CatalogModel[]) => buildAnthropicModelInfos(
+      [], models, AUTO_CONTEXT_OFF, "readable", desktop3pAlias, undefined, undefined, () => true,
+    );
+    const ownerOf = (models: CatalogModel[]) => rows(models)
+      .filter(info => info.id.endsWith("foo--fast"))
+      .map(info => info.display_name);
+    // The real model's own row names itself; a synthetic sibling would read "foo (fixture) · Fast".
+    expect(ownerOf([routed("foo"), routed("foo--fast")])).toEqual(["foo--fast (fixture)"]);
+    expect(ownerOf([routed("foo--fast"), routed("foo")])).toEqual(["foo--fast (fixture)"]);
   });
 
   test("a combo row is classified by its aggregated capability, not a provider lookup", () => {
@@ -84,4 +90,3 @@ describe("fast rows on Claude discovery", () => {
     expect(ids.some(id => id.endsWith("--fast"))).toBe(true);
   });
 });
-

--- a/tests/fast-row-listing.test.ts
+++ b/tests/fast-row-listing.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { AUTO_CONTEXT_OFF } from "../src/claude/context-windows";
+import { desktop3pAlias } from "../src/claude/desktop-3p";
+import { buildAnthropicModelInfos } from "../src/claude/model-info";
+import type { CatalogModel } from "../src/codex/catalog";
+
+/**
+ * Fast rows on Claude Code discovery (devlog 260904_external_fast_wire/020).
+ *
+ * The predicate's PRESENCE is the feature gate: the server passes undefined when `fastRows`
+ * is off, so a default install publishes nothing. These tests pin that, plus the two
+ * properties review found missing from an earlier draft — both loops publish, and a real
+ * model always wins its own id.
+ */
+
+function routed(id: string, provider = "fixture"): CatalogModel {
+  return { provider, id, contextWindow: 200_000, reasoningEfforts: ["low", "high"] } as CatalogModel;
+}
+
+const build = (
+  natives: string[],
+  models: CatalogModel[],
+  fastRows?: (m: { provider: string; id: string }) => boolean,
+  idStyle: "readable" | "desktop3p" = "readable",
+) => buildAnthropicModelInfos(
+  natives, models, AUTO_CONTEXT_OFF, idStyle, desktop3pAlias, undefined, undefined, fastRows,
+).map(info => info.id);
+
+describe("fast rows on Claude discovery", () => {
+  test("no predicate means no fast rows, whatever the models support", () => {
+    const ids = build(["gpt-5.6-sol"], [routed("m")]);
+    expect(ids.some(id => id.endsWith("--fast"))).toBe(false);
+  });
+
+  test("a routed row gains a fast sibling and KEEPS its base row", () => {
+    // Additive, unlike the fastMode rewrite: a selector has to leave the default pickable.
+    const ids = build([], [routed("m")], () => true);
+    const base = ids.find(id => id.includes("m") && !id.endsWith("--fast"));
+    expect(base).toBeDefined();
+    expect(ids).toContain(`${base}--fast`);
+  });
+
+  test("a NATIVE slug gains one too", () => {
+    // The regression an earlier draft shipped: it patched only the routed loop, which would
+    // have left gpt-5.6-sol - the flagship Fast model - off this surface entirely.
+    const ids = build(["gpt-5.6-sol"], [], m => m.provider === "native");
+    const base = ids.find(id => !id.endsWith("--fast"));
+    expect(base).toBeDefined();
+    expect(ids).toContain(`${base}--fast`);
+  });
+
+  test("an ineligible row gains nothing", () => {
+    const ids = build([], [routed("yes"), routed("no")], m => m.id === "yes");
+    expect(ids.filter(id => id.endsWith("--fast"))).toHaveLength(1);
+    expect(ids.some(id => id.includes("no") && id.endsWith("--fast"))).toBe(false);
+  });
+
+  test("the Desktop 3P hashed style publishes too", () => {
+    // fastMode excludes this style because it REWRITES a hash and strands a saved
+    // selection. An added row strands nothing, so the exclusion does not apply.
+    const ids = build([], [routed("m")], () => true, "desktop3p");
+    expect(ids.some(id => id.endsWith("--fast"))).toBe(true);
+  });
+
+  test("a real model always wins its own id, in either roster order", () => {
+    // With both `foo` and a real `foo--fast` present, the synthetic id for `foo` IS the real
+    // model's id. The dedupe set alone would let whichever ran first own the row, so the
+    // outcome must not depend on ordering.
+    const forward = build([], [routed("foo"), routed("foo--fast")], () => true);
+    const reverse = build([], [routed("foo--fast"), routed("foo")], () => true);
+    const count = (ids: string[]) => ids.filter(id => id.endsWith("--fast")).length;
+    expect(count(forward)).toBe(count(reverse));
+    // And the real model's own row is present either way.
+    expect(forward.some(id => id.endsWith("foo--fast"))).toBe(true);
+    expect(reverse.some(id => id.endsWith("foo--fast"))).toBe(true);
+  });
+
+  test("a combo row is classified by its aggregated capability, not a provider lookup", () => {
+    // A combo has no config.providers entry - declaring a provider named `combo` is
+    // rejected outright - so a (provider, id) lookup can never classify it. The predicate
+    // receives the whole row for exactly this reason.
+    const combo = { provider: "combo", id: "c1", contextWindow: 200_000, supportsServiceTier: true } as CatalogModel;
+    const ids = build([], [combo], m => (m as { supportsServiceTier?: boolean }).supportsServiceTier === true);
+    expect(ids.some(id => id.endsWith("--fast"))).toBe(true);
+  });
+});
+

--- a/tests/fast-row.test.ts
+++ b/tests/fast-row.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { parseEffortRowId } from "../src/server/effort-row";
+import {
+  effortBaseCarriesFastMarker,
+  expandFastRow,
+  fastRowBases,
+  fastRowEligible,
+  fastRowId,
+  parseFastRowId,
+  parseSyntheticRowId,
+} from "../src/server/fast-row";
+import { isDeclaredReasoningEffort } from "../src/reasoning-effort";
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+/**
+ * Synthetic Fast selectors (devlog 260904_external_fast_wire/010).
+ *
+ * Each test drives one conditional and asserts the observable effect rather than that a
+ * table contains a value. Several exist because an earlier draft failed them: the
+ * known-id-as-routable-base design published `gpt-5.6-sol--fast` and then refused to parse
+ * it, and a suffix-shape composite guard suppressed rows this feature itself publishes.
+ */
+
+const OFF = {} as Pick<OcxConfig, "fastRows">;
+const ON = { fastRows: true } as Pick<OcxConfig, "fastRows">;
+
+function provider(overrides: Partial<OcxProviderConfig> = {}): OcxProviderConfig {
+  return {
+    adapter: "openai-responses",
+    baseUrl: "https://fixture.example/v1",
+    ...overrides,
+  } as OcxProviderConfig;
+}
+
+function configWith(providers: Record<string, OcxProviderConfig>, extra: Partial<OcxConfig> = {}): OcxConfig {
+  return {
+    port: 10100,
+    defaultProvider: Object.keys(providers)[0] ?? "fixture",
+    providers,
+    fastRows: true,
+    ...extra,
+  } as OcxConfig;
+}
+
+describe("fast-row grammar", () => {
+  test("the flag is off by default, on both the parser and the expander", () => {
+    // The path every existing install runs. Both inventories are optional, so this needs no
+    // config at all.
+    expect(parseFastRowId("x--fast", OFF)).toBeNull();
+    expect(expandFastRow({ id: "x" }, true, OFF)).toEqual([{ id: "x" }]);
+  });
+
+  test("a fast row is additive, never a replacement", () => {
+    // Unlike the fastMode global rewrite: a per-request selector has to leave the default
+    // pickable beside it.
+    expect(expandFastRow({ id: "m" }, true, ON)).toEqual([{ id: "m" }, { id: "m--fast" }]);
+    expect(fastRowId("m")).toBe("m--fast");
+  });
+
+  test("an ineligible row publishes nothing", () => {
+    expect(expandFastRow({ id: "m" }, false, ON)).toEqual([{ id: "m" }]);
+  });
+
+  test("an exact known id beats the synthetic grammar", () => {
+    // An operator who really named a model `foo--fast` keeps it.
+    const known = new Set(["foo--fast"]);
+    expect(parseFastRowId("foo--fast", ON, known, new Set(["foo"]))).toBeNull();
+    expect(expandFastRow({ id: "foo" }, true, ON, known)).toEqual([{ id: "foo" }]);
+  });
+
+  test("an unroutable base is refused", () => {
+    expect(parseFastRowId("nonexistent--fast", ON, new Set(), new Set(["other"]))).toBeNull();
+  });
+
+  test("a bare marker is not a model", () => {
+    expect(parseFastRowId("--fast", ON, new Set(), new Set())).toBeNull();
+  });
+
+  test("a base that itself ends in an effort marker still parses", () => {
+    // The discarded suffix-shape composite guard failed this: it saw `--high` before
+    // `--fast` and suppressed a row this feature publishes.
+    expect(parseFastRowId("a--high--fast", ON, new Set(), new Set(["a--high"])))
+      .toEqual({ baseId: "a--high" });
+  });
+});
+
+describe("fast-row eligibility", () => {
+  test("only an eligible policy publishes", () => {
+    // `unclassified` is the subtle one: capability is undefined, and decideTier makes
+    // fastMode inert there, so a row would advertise a tier the runtime then drops.
+    expect(fastRowEligible(provider({ supportsServiceTier: true }), "m")).toBe(true);
+    expect(fastRowEligible(provider({ supportsServiceTier: false }), "m")).toBe(false);
+    expect(fastRowEligible(provider(), "m")).toBe(false);
+  });
+
+  test("an adapter without the wire does not publish", () => {
+    // The anthropic-speed wire kind has an empty adapter set by design.
+    expect(fastRowEligible(
+      provider({ adapter: "anthropic", supportsServiceTier: true }),
+      "m",
+    )).toBe(false);
+  });
+
+  test("exact-model capability is honoured over the provider default", () => {
+    const p = provider({ supportsServiceTier: true, modelSupportsServiceTier: { slow: false } });
+    expect(fastRowEligible(p, "fast-one")).toBe(true);
+    expect(fastRowEligible(p, "slow")).toBe(false);
+  });
+});
+
+describe("fast-row routable bases", () => {
+  test("bare natives are routable even with no declared models list", () => {
+    // The regression that killed the known-id-based draft: bare natives route by family
+    // pattern, so they appear in no models list, and requiring known-id membership would
+    // publish `gpt-5.6-sol--fast` and then refuse to parse it.
+    const config = configWith({ openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }) });
+    const bases = fastRowBases(config);
+    expect(bases.has("gpt-5.6-sol")).toBe(true);
+    expect(parseFastRowId("gpt-5.6-sol--fast", config, new Set(), bases))
+      .toEqual({ baseId: "gpt-5.6-sol" });
+  });
+
+  test("configured routed ids stay routable", () => {
+    const config = configWith({ fixture: provider({ models: ["m1"] }) });
+    const bases = fastRowBases(config);
+    expect(bases.has("m1")).toBe(true);
+    expect(bases.has("fixture/m1")).toBe(true);
+  });
+});
+
+describe("grammar interference", () => {
+  test("`fast` is not a declared effort, so the two grammars do not collide", () => {
+    // This is what lets both grammars share the `--` separator. Without it, the composition
+    // is an assumption rather than a fact.
+    expect(isDeclaredReasoningEffort("fast")).toBe(false);
+    expect(parseEffortRowId("x--fast", { cursorEffortRows: true })).toBeNull();
+  });
+
+  test("a fast marker is not an effort row and vice versa", () => {
+    expect(parseFastRowId("x--high", ON, new Set(), new Set(["x"]))).toBeNull();
+  });
+
+  test("a nested marker is detected, unless the base is a real model", () => {
+    expect(effortBaseCarriesFastMarker("x--fast", new Set())).toBe(true);
+    expect(effortBaseCarriesFastMarker("foo--fast", new Set(["foo--fast"]))).toBe(false);
+    expect(effortBaseCarriesFastMarker("x", new Set())).toBe(false);
+  });
+});
+
+describe("parseSyntheticRowId", () => {
+  test("with fastRows off it delegates, preserving shipped effort-row behaviour", () => {
+    // Delegation to the SAME shipped function, not a reimplementation: an install that never
+    // enables this feature must observe no change. An earlier draft rebuilt the logic inline
+    // and regressed both the early return and the nested-marker case below.
+    const config = configWith({ fixture: provider({ models: ["x"] }) }, {
+      fastRows: false,
+      cursorEffortRows: true,
+    });
+    expect(parseSyntheticRowId("x--high", config).effortRow).toEqual({ baseId: "x", effort: "high" });
+    expect(parseSyntheticRowId("x", config)).toEqual({ fastRow: null, effortRow: null });
+    // With fastRows OFF the nested-marker rule must not apply, or a cursorEffortRows user
+    // loses a row they get today.
+    expect(parseSyntheticRowId("x--fast--high", config).effortRow)
+      .toEqual({ baseId: "x--fast", effort: "high" });
+  });
+
+  test("with fastRows on it returns at most one grammar", () => {
+    const config = configWith({ fixture: provider({ models: ["x"], supportsServiceTier: true }) });
+    const fast = parseSyntheticRowId("x--fast", config);
+    expect(fast.fastRow).toEqual({ baseId: "x" });
+    expect(fast.effortRow).toBeNull();
+  });
+
+  test("a nested marker resolves to neither grammar when fast rows are on", () => {
+    const config = configWith({ fixture: provider({ models: ["x"] }) }, { cursorEffortRows: true });
+    expect(parseSyntheticRowId("x--fast--high", config)).toEqual({ fastRow: null, effortRow: null });
+  });
+
+  test("the decoded-selector thunk drives Fast while effort sees the raw id", () => {
+    const config = configWith({ fixture: provider({ models: ["x"] }) });
+    const rows = parseSyntheticRowId("opaque-alias", config, () => "x--fast");
+    expect(rows.fastRow).toEqual({ baseId: "x" });
+  });
+
+  test("the thunk is not evaluated when the flag is off", () => {
+    // Arguments evaluate before the call, which is why the parameter is a thunk: an eager
+    // decode would run alias lookups on the path this function exists to leave untouched.
+    let evaluated = false;
+    const config = configWith({ fixture: provider() }, { fastRows: false });
+    parseSyntheticRowId("x", config, () => { evaluated = true; return "x--fast"; });
+    expect(evaluated).toBe(false);
+  });
+});
+

--- a/tests/fast-row.test.ts
+++ b/tests/fast-row.test.ts
@@ -117,7 +117,7 @@ describe("fast-row routable bases", () => {
     // publish `gpt-5.6-sol--fast` and then refuse to parse it.
     const config = configWith({ openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }) });
     const bases = fastRowBases(config);
-    expect(bases.has("gpt-5.6-sol")).toBe(true);
+    expect(bases("gpt-5.6-sol")).toBe(true);
     expect(parseFastRowId("gpt-5.6-sol--fast", config, new Set(), bases))
       .toEqual({ baseId: "gpt-5.6-sol" });
   });
@@ -125,8 +125,8 @@ describe("fast-row routable bases", () => {
   test("configured routed ids stay routable", () => {
     const config = configWith({ fixture: provider({ models: ["m1"] }) });
     const bases = fastRowBases(config);
-    expect(bases.has("m1")).toBe(true);
-    expect(bases.has("fixture/m1")).toBe(true);
+    expect(bases("m1")).toBe(true);
+    expect(bases("fixture/m1")).toBe(true);
   });
 });
 
@@ -239,7 +239,7 @@ describe("publication and parsing agree", () => {
       openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }),
     }, { codexAccountNamespaces: { desktop: "@main" } } as Partial<OcxConfig>);
     const bases = fastRowBases(config);
-    expect(bases.has("desktop/gpt-5.6-sol")).toBe(true);
+    expect(bases("desktop/gpt-5.6-sol")).toBe(true);
     expect(parseFastRowId("desktop/gpt-5.6-sol--fast", config, new Set(), bases))
       .toEqual({ baseId: "desktop/gpt-5.6-sol" });
   });
@@ -257,9 +257,12 @@ describe("routable bases do not depend on the live-model cache", () => {
     clearModelCache("fixture");
     const withoutCache = fastRowBases(config);
     // A declared model is recognized either way, and cache churn changes nothing at all.
-    expect(withCache.has("declared")).toBe(true);
-    expect(withoutCache.has("declared")).toBe(true);
-    expect([...withCache].sort()).toEqual([...withoutCache].sort());
+    expect(withCache("declared")).toBe(true);
+    expect(withoutCache("declared")).toBe(true);
+    // And the live-only model is recognized both before and after churn: it is namespaced
+    // under an enabled provider, which is structural rather than cache-derived.
+    expect(withCache("fixture/live-only")).toBe(true);
+    expect(withoutCache("fixture/live-only")).toBe(true);
   });
 
   test("a bare native is recognized regardless of cache state", () => {
@@ -268,22 +271,22 @@ describe("routable bases do not depend on the live-model cache", () => {
     const config = configWith({
       openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }),
     });
-    expect(fastRowBases(config).has("gpt-5.6-sol")).toBe(true);
+    expect(fastRowBases(config)("gpt-5.6-sol")).toBe(true);
     clearModelCache();
-    expect(fastRowBases(config).has("gpt-5.6-sol")).toBe(true);
+    expect(fastRowBases(config)("gpt-5.6-sol")).toBe(true);
   });
 
   test("a disabled provider contributes no bases", () => {
     const config = configWith({ fixture: provider({ models: ["m"], disabled: true }) });
-    expect(fastRowBases(config).has("m")).toBe(false);
+    expect(fastRowBases(config)("m")).toBe(false);
   });
 
   test("namespaced and alias-namespaced spellings are recognized", () => {
     const config = configWith({ fixture: provider({ models: ["m"], alias: "fx" }) });
     const bases = fastRowBases(config);
-    expect(bases.has("m")).toBe(true);
-    expect(bases.has("fixture/m")).toBe(true);
-    expect(bases.has("fx/m")).toBe(true);
+    expect(bases("m")).toBe(true);
+    expect(bases("fixture/m")).toBe(true);
+    expect(bases("fx/m")).toBe(true);
   });
 });
 describe("delegation is the shipped function, not a lookalike", () => {
@@ -300,3 +303,42 @@ describe("delegation is the shipped function, not a lookalike", () => {
     }
   });
 });
+describe("live-discovered publication is recognized", () => {
+  test("a live-only model published under its provider namespace parses back", () => {
+    // The review blocker: listings publish goModels and retainModels, which appear in NO
+    // config. A config-only Set missed them, so wp2 would have published
+    // `fixture/live-only--fast` that no ingress could resolve. Structural namespace
+    // recognition covers it without reading the cache.
+    const config = configWith({ fixture: provider({ models: ["declared"], supportsServiceTier: true }) });
+    const bases = fastRowBases(config);
+    const published = expandFastRow({ id: "fixture/live-only" }, true, config)
+      .map(row => row.id)
+      .filter(id => id.endsWith("--fast"));
+    expect(published).toEqual(["fixture/live-only--fast"]);
+    for (const id of published) {
+      expect(parseFastRowId(id, config, new Set(), bases)).toEqual({ baseId: "fixture/live-only" });
+    }
+  });
+
+  test("an unknown namespace is still refused", () => {
+    // Structural recognition is scoped to enabled configured providers, so it does not
+    // degrade into accepting anything containing a slash.
+    const config = configWith({ fixture: provider() });
+    const bases = fastRowBases(config);
+    expect(bases("nosuchprovider/m")).toBe(false);
+    expect(parseFastRowId("nosuchprovider/m--fast", config, new Set(), bases)).toBeNull();
+  });
+
+  test("a disabled provider's namespace is refused", () => {
+    const config = configWith({ fixture: provider({ models: ["m"], disabled: true }) });
+    const bases = fastRowBases(config);
+    expect(bases("fixture/anything")).toBe(false);
+  });
+
+  test("a bare unknown id is refused", () => {
+    // No namespace to vouch for it, and not a declared or native id.
+    const config = configWith({ fixture: provider({ models: ["m"] }) });
+    expect(fastRowBases(config)("whatever")).toBe(false);
+  });
+});
+

--- a/tests/fast-row.test.ts
+++ b/tests/fast-row.test.ts
@@ -341,3 +341,32 @@ describe("live-discovered publication is recognized", () => {
     expect(fastRowBases(config)("whatever")).toBe(false);
   });
 });
+describe("review findings from PR #3457", () => {
+  test("a real live model ending in the marker is never re-interpreted after cache eviction", () => {
+    // Codex P2: the exact-id guard protects `provider/foo--fast` only while the discovery
+    // cache still holds it. After eviction that guard goes quiet, and structural namespace
+    // recognition would still accept `provider/foo` - silently routing a DIFFERENT model
+    // than the client selected. Refusing the strip is the safe side.
+    const config = configWith({ fixture: provider({ models: ["declared"] }) });
+    const bases = fastRowBases(config);
+    expect(bases("fixture/anything")).toBe(true);
+    expect(bases("fixture/foo--fast")).toBe(false);
+    expect(parseFastRowId("fixture/foo--fast--fast", config, new Set(), bases)).toBeNull();
+  });
+
+  test("an ordinary Claude alias builds no inventory when only fast rows are on", () => {
+    // Codex P2: a readable Claude alias is `claude-ocx-<provider>--<model>`, so it ALWAYS
+    // contains the separator. Testing only for that rebuilt the whole model inventory on
+    // every Claude turn for a selector that cannot be a fast row.
+    const config = configWith({ fixture: provider({ models: ["m"] }) }, { cursorEffortRows: false });
+    let decoded = 0;
+    const rows = parseSyntheticRowId("claude-ocx-fixture--m", config, () => { decoded += 1; return "fixture/m"; });
+    expect(rows).toEqual({ fastRow: null, effortRow: null });
+    // The thunk runs once to obtain the selector; what must NOT happen is the inventory scan,
+    // which is observable through the effort grammar staying inert.
+    expect(decoded).toBe(1);
+    // And a genuine fast selector still resolves on the same config.
+    expect(parseSyntheticRowId("x", config, () => "m--fast").fastRow).toEqual({ baseId: "m" });
+  });
+});
+

--- a/tests/fast-row.test.ts
+++ b/tests/fast-row.test.ts
@@ -341,4 +341,3 @@ describe("live-discovered publication is recognized", () => {
     expect(fastRowBases(config)("whatever")).toBe(false);
   });
 });
-

--- a/tests/fast-row.test.ts
+++ b/tests/fast-row.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { clearModelCache, setCached } from "../src/codex/model-cache";
 import { knownEffortRowIds, parseEffortRowId, parseRequestEffortRowId } from "../src/server/effort-row";
 import {
   effortBaseCarriesFastMarker,
@@ -232,42 +233,59 @@ describe("publication and parsing agree", () => {
   });
 
   test("an account-qualified native round-trips", () => {
+    // A configured selector, so this asserts the real qualified id rather than skipping when
+    // none exists - the earlier version returned early and reported green either way.
     const config = configWith({
       openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }),
-    });
+    }, { codexAccountNamespaces: { desktop: "@main" } } as Partial<OcxConfig>);
     const bases = fastRowBases(config);
-    const qualified = [...bases].find(id => id.includes("/") && id.endsWith("gpt-5.6-sol"));
-    if (qualified === undefined) return; // no account selector configured in this fixture
-    expect(parseFastRowId(fastRowId(qualified), config, new Set(), bases))
-      .toEqual({ baseId: qualified });
+    expect(bases.has("desktop/gpt-5.6-sol")).toBe(true);
+    expect(parseFastRowId("desktop/gpt-5.6-sol--fast", config, new Set(), bases))
+      .toEqual({ baseId: "desktop/gpt-5.6-sol" });
   });
 });
 
-describe("a fast row lives exactly as long as its base row", () => {
-  test("a base that leaves the routable set stops parsing, as its listing row also would", () => {
-    // fastRowBases is intentionally NOT constant across a session: it reads the live-model
-    // cache, and so does publication. When a live-only model leaves the cache its plain base
-    // row leaves the listing too, so the fast selector going with it is correct. Pinning fast
-    // selectors alive past their base would be the actual defect.
-    const withModel = configWith({ fixture: provider({ models: ["live-only"] }) });
-    const withoutModel = configWith({ fixture: provider({ models: [] }) });
-    expect(parseFastRowId("live-only--fast", withModel, new Set(), fastRowBases(withModel)))
-      .toEqual({ baseId: "live-only" });
-    expect(parseFastRowId("live-only--fast", withoutModel, new Set(), fastRowBases(withoutModel)))
-      .toBeNull();
+describe("routable bases do not depend on the live-model cache", () => {
+  test("a cached-only model leaving the cache does not break its fast selector", () => {
+    // The review blocker. An earlier version seeded the set from knownEffortRowIds, whose
+    // getStaleCached half made membership time-dependent: the selector stopped parsing after
+    // cache churn while routeModel still served the base through the default provider. The
+    // asymmetry is the defect, so this drives the real cache rather than swapping config.
+    const config = configWith({ fixture: provider({ models: ["declared"] }) });
+    setCached("fixture", [{ provider: "fixture", id: "live-only" } as never]);
+    const withCache = fastRowBases(config);
+    clearModelCache("fixture");
+    const withoutCache = fastRowBases(config);
+    // A declared model is recognized either way, and cache churn changes nothing at all.
+    expect(withCache.has("declared")).toBe(true);
+    expect(withoutCache.has("declared")).toBe(true);
+    expect([...withCache].sort()).toEqual([...withoutCache].sort());
   });
 
-  test("a bare native is stable regardless of cache state", () => {
-    // The static half of the set. This is what bare natives need: they route by family
-    // pattern and appear in no cache, so their selectors must never depend on one.
+  test("a bare native is recognized regardless of cache state", () => {
+    // Bare natives route by family pattern and appear in no cache, so their selectors must
+    // never depend on one.
     const config = configWith({
       openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }),
     });
     expect(fastRowBases(config).has("gpt-5.6-sol")).toBe(true);
-    expect(fastRowBases(config, new Set()).has("gpt-5.6-sol")).toBe(true);
+    clearModelCache();
+    expect(fastRowBases(config).has("gpt-5.6-sol")).toBe(true);
+  });
+
+  test("a disabled provider contributes no bases", () => {
+    const config = configWith({ fixture: provider({ models: ["m"], disabled: true }) });
+    expect(fastRowBases(config).has("m")).toBe(false);
+  });
+
+  test("namespaced and alias-namespaced spellings are recognized", () => {
+    const config = configWith({ fixture: provider({ models: ["m"], alias: "fx" }) });
+    const bases = fastRowBases(config);
+    expect(bases.has("m")).toBe(true);
+    expect(bases.has("fixture/m")).toBe(true);
+    expect(bases.has("fx/m")).toBe(true);
   });
 });
-
 describe("delegation is the shipped function, not a lookalike", () => {
   test("with fastRows off the wrapper matches parseRequestEffortRowId exactly", () => {
     // Compared against the real function across a selector table: an inline reimplementation
@@ -282,4 +300,3 @@ describe("delegation is the shipped function, not a lookalike", () => {
     }
   });
 });
-

--- a/tests/fast-row.test.ts
+++ b/tests/fast-row.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { parseEffortRowId } from "../src/server/effort-row";
+import { knownEffortRowIds, parseEffortRowId, parseRequestEffortRowId } from "../src/server/effort-row";
 import {
   effortBaseCarriesFastMarker,
   expandFastRow,
   fastRowBases,
   fastRowEligible,
   fastRowId,
+  parseFastOnlyRowId,
   parseFastRowId,
   parseSyntheticRowId,
 } from "../src/server/fast-row";
@@ -189,6 +190,96 @@ describe("parseSyntheticRowId", () => {
     const config = configWith({ fixture: provider() }, { fastRows: false });
     parseSyntheticRowId("x", config, () => { evaluated = true; return "x--fast"; });
     expect(evaluated).toBe(false);
+  });
+});
+
+describe("parseFastOnlyRowId", () => {
+  test("resolves a fast selector for a surface that never parsed an effort row", () => {
+    const config = configWith({ fixture: provider({ models: ["x"] }) }, { cursorEffortRows: true });
+    expect(parseFastOnlyRowId(config, () => "x--fast")).toEqual({ baseId: "x" });
+    // An effort row is NOT resolved here: count_tokens and compact never parsed one, so they
+    // must not start.
+    expect(parseFastOnlyRowId(config, () => "x--high")).toBeNull();
+  });
+
+  test("returns before evaluating the selector when the flag is off", () => {
+    let evaluated = false;
+    const config = configWith({ fixture: provider() }, { fastRows: false });
+    expect(parseFastOnlyRowId(config, () => { evaluated = true; return "x--fast"; })).toBeNull();
+    expect(evaluated).toBe(false);
+  });
+});
+
+describe("publication and parsing agree", () => {
+  test("every base the listing would publish a row for is accepted by the parser", () => {
+    // The anti-drift invariant. Publication and parsing read different sources, so this is
+    // the assertion that keeps a published row from being unparsable - the exact failure an
+    // earlier draft shipped for bare natives.
+    const config = configWith({
+      openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex", supportsServiceTier: true }),
+      fixture: provider({ models: ["m1", "m2"], supportsServiceTier: true }),
+    });
+    const knownIds = knownEffortRowIds(config);
+    const bases = fastRowBases(config, knownIds);
+    const published = ["gpt-5.6-sol", "m1", "m2", "fixture/m1"]
+      .flatMap(id => expandFastRow({ id }, true, config, knownIds))
+      .map(row => row.id)
+      .filter(id => id.endsWith("--fast"));
+    expect(published.length).toBeGreaterThan(0);
+    for (const id of published) {
+      expect(parseFastRowId(id, config, knownIds, bases)).not.toBeNull();
+    }
+  });
+
+  test("an account-qualified native round-trips", () => {
+    const config = configWith({
+      openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }),
+    });
+    const bases = fastRowBases(config);
+    const qualified = [...bases].find(id => id.includes("/") && id.endsWith("gpt-5.6-sol"));
+    if (qualified === undefined) return; // no account selector configured in this fixture
+    expect(parseFastRowId(fastRowId(qualified), config, new Set(), bases))
+      .toEqual({ baseId: qualified });
+  });
+});
+
+describe("a fast row lives exactly as long as its base row", () => {
+  test("a base that leaves the routable set stops parsing, as its listing row also would", () => {
+    // fastRowBases is intentionally NOT constant across a session: it reads the live-model
+    // cache, and so does publication. When a live-only model leaves the cache its plain base
+    // row leaves the listing too, so the fast selector going with it is correct. Pinning fast
+    // selectors alive past their base would be the actual defect.
+    const withModel = configWith({ fixture: provider({ models: ["live-only"] }) });
+    const withoutModel = configWith({ fixture: provider({ models: [] }) });
+    expect(parseFastRowId("live-only--fast", withModel, new Set(), fastRowBases(withModel)))
+      .toEqual({ baseId: "live-only" });
+    expect(parseFastRowId("live-only--fast", withoutModel, new Set(), fastRowBases(withoutModel)))
+      .toBeNull();
+  });
+
+  test("a bare native is stable regardless of cache state", () => {
+    // The static half of the set. This is what bare natives need: they route by family
+    // pattern and appear in no cache, so their selectors must never depend on one.
+    const config = configWith({
+      openai: provider({ authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex" }),
+    });
+    expect(fastRowBases(config).has("gpt-5.6-sol")).toBe(true);
+    expect(fastRowBases(config, new Set()).has("gpt-5.6-sol")).toBe(true);
+  });
+});
+
+describe("delegation is the shipped function, not a lookalike", () => {
+  test("with fastRows off the wrapper matches parseRequestEffortRowId exactly", () => {
+    // Compared against the real function across a selector table: an inline reimplementation
+    // producing the same few answers would pass a hand-written expectation but fail here.
+    const config = configWith({ fixture: provider({ models: ["x", "x--fast"] }) }, {
+      fastRows: false,
+      cursorEffortRows: true,
+    });
+    for (const selector of ["x", "x--high", "x--fast", "x--fast--high", "x--nonsense", "--high", ""]) {
+      expect(parseSyntheticRowId(selector, config).effortRow)
+        .toEqual(parseRequestEffortRowId(selector, config));
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Codex Fast is the `priority` service tier, and until now it was published only as Codex-catalog metadata (`service_tiers` + `additional_speed_tiers`). The desktop picker renders those fields into a toggle; every other client selects a model by id string alone, so Claude Code, Cursor, and OpenAI-compatible clients had no way to ask for Fast at all.

This adds an opt-in `fastRows` flag that publishes a `<base-id>--fast` selector for models whose resolved Fast policy is eligible, and round-trips it on every request-serving ingress. Selecting one routes the base model and requests `priority` as a **caller intent**, which the existing `decideTier` then rules on — so `fastMode: false`, a withdrawn capability, and an unusable wire all still suppress it.

Cursor already proves the shape: its Fast is a model variant, so a `-fast` id carries the intent. This generalizes that to one caller intent with a per-provider wire.

**The separator is `--fast`, not `-fast`.** Terminal `-fast` is already a real model id across this catalog — `grok-4-fast`, `glm-5.3-fast`, `gpt-5-fast`, and every Cursor fast variant — so a single hyphen cannot distinguish a product from a tier.

Default-off end to end: with the flag unset, no row is published, no ingress parses the marker, and `parseSyntheticRowId` delegates to the shipped `parseRequestEffortRowId` verbatim so the existing `cursorEffortRows` path is untouched.

Scope: `/v1/models`, Claude Code discovery, and the `/v1/responses`, `/v1/chat/completions`, `/v1/messages`, `/v1/messages/count_tokens`, `/v1/responses/compact` ingresses. `ocx export` and the OpenCode integration deliberately emit base ids only, because those identities are written into config files that outlive the flag.

Design notes and the full audit trail: `devlog/_plan/260904_external_fast_wire/`.

## Verification

- `bun run typecheck` — clean.
- `bun test tests/fast-row.test.ts tests/fast-row-listing.test.ts tests/fast-row-ingress.test.ts tests/core-lab-boundary.test.ts tests/claude-inbound.test.ts tests/chat-completions-endpoint.test.ts tests/responses-compaction.test.ts tests/responses-compaction-routing.test.ts tests/cursor-fast-tier.test.ts tests/config.test.ts` — 436 pass, 0 fail.
- `bun run privacy:scan` — passed.
- No repository-wide local suite was run, per the operator's standing instruction; CI covers it.

Notable regressions pinned by tests, each of which failed against an earlier draft:

- `gpt-5.6-sol--fast` round-trips on a default config — bare natives declare no models list and route by family pattern, so a known-id-based oracle published the row and then refused to parse it.
- A live-discovered model published under its provider namespace parses back.
- A real model always wins its own id, asserted with the roster in both orders.
- Compact drops a caller's stale `service_tier` on a `drop` decision rather than forwarding it.
- With `fastRows` off, the wrapper matches `parseRequestEffortRowId` across a selector table.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Fast rows setting, disabled by default, that publishes selectable `<base-id>--fast` model entries.
  * Fast rows appear in OpenAI model listings and Claude Code discovery for eligible models.
  * Selecting a Fast row routes requests through the base model with priority service-tier handling across supported request types.
  * Added documentation covering configuration, eligibility, naming, and behavior.

* **Tests**
  * Added coverage for Fast row creation, discovery, parsing, routing, eligibility, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->