### PR TITLE
fix(google): classify "User location is not supported" as location/permission error instead of invalid_request

### DIFF
--- a/src/adapters/google-errors.ts
+++ b/src/adapters/google-errors.ts
@@ -1,4 +1,5 @@
 import { parseUpstreamJsonPayload, safeUpstreamErrorString, sanitizeUpstreamErrorText } from "./upstream-http-error";
+import { isLocationUnsupportedMessage, LOCATION_UNSUPPORTED_PATTERNS } from "../lib/errors";
 
 /** Pull the human detail out of the Google API error envelope `{error:{message,status,code}}`. */
 function googleErrorDetail(payloadText: string): { message?: string; status?: string } {
@@ -54,22 +55,8 @@ export function isGoogleQuotaExhaustedText(text: string): boolean {
   return GOOGLE_QUOTA_EXHAUSTED_NEEDLES.some(needle => lower.includes(needle));
 }
 
-export const GOOGLE_LOCATION_UNSUPPORTED_PATTERNS = [
-  "location is not supported",
-  "location not supported",
-  "unsupported location",
-  "region is not supported",
-  "unsupported region",
-  "country is not supported",
-  "not supported in your country",
-  "not supported in your region",
-  "not supported for the api use",
-];
-
-export function isGoogleLocationUnsupportedText(text: string): boolean {
-  const lower = text.toLowerCase();
-  return GOOGLE_LOCATION_UNSUPPORTED_PATTERNS.some(needle => lower.includes(needle));
-}
+export const GOOGLE_LOCATION_UNSUPPORTED_PATTERNS = LOCATION_UNSUPPORTED_PATTERNS;
+export const isGoogleLocationUnsupportedText = isLocationUnsupportedMessage;
 
 function classifyGoogle(label: string, status: number | undefined, enumStatus: string | undefined, text: string): string {
   const lower = `${enumStatus ?? ""} ${text}`.toLowerCase();

--- a/src/adapters/google-errors.ts
+++ b/src/adapters/google-errors.ts
@@ -54,11 +54,30 @@ export function isGoogleQuotaExhaustedText(text: string): boolean {
   return GOOGLE_QUOTA_EXHAUSTED_NEEDLES.some(needle => lower.includes(needle));
 }
 
+export const GOOGLE_LOCATION_UNSUPPORTED_PATTERNS = [
+  "location is not supported",
+  "location not supported",
+  "unsupported location",
+  "region is not supported",
+  "unsupported region",
+  "country is not supported",
+  "not supported in your country",
+  "not supported in your region",
+  "not supported for the api use",
+];
+
+export function isGoogleLocationUnsupportedText(text: string): boolean {
+  const lower = text.toLowerCase();
+  return GOOGLE_LOCATION_UNSUPPORTED_PATTERNS.some(needle => lower.includes(needle));
+}
 
 function classifyGoogle(label: string, status: number | undefined, enumStatus: string | undefined, text: string): string {
   const lower = `${enumStatus ?? ""} ${text}`.toLowerCase();
   const quotaExhausted = isGoogleQuotaExhaustedText(lower);
   if ((!enumStatus || enumStatus === "RESOURCE_EXHAUSTED") && quotaExhausted) return `${label} quota exhausted`;
+  if (isGoogleLocationUnsupportedText(lower)) {
+    return `${label} location not supported`;
+  }
   if (status === 429 || enumStatus === "RESOURCE_EXHAUSTED" || lower.includes("rate limit")) {
     return `${label} rate limit exceeded`;
   }

--- a/src/adapters/google-http.ts
+++ b/src/adapters/google-http.ts
@@ -1,5 +1,10 @@
 import type { AdapterFetchContext, AdapterRequest } from "./base";
-import { isQuotaExhaustedBody, retryableGoogleStatus, safeGoogleHttpErrorMessage } from "./google-errors";
+import {
+  isGoogleLocationUnsupportedText,
+  isQuotaExhaustedBody,
+  retryableGoogleStatus,
+  safeGoogleHttpErrorMessage,
+} from "./google-errors";
 import { repairGoogleInvalidRequestBody } from "./google-wire-compiler";
 import { normalizeUpstreamHttpErrorResponse, readDisplaySafeErrorPayloadText } from "./upstream-http-error";
 import {
@@ -22,7 +27,16 @@ export interface GoogleRetryOptions {
 async function normalizeFinalGoogleError(label: string, res: Response, signal?: AbortSignal): Promise<Response> {
   return normalizeUpstreamHttpErrorResponse(res, {
     signal,
-    formatMessage: payloadText => safeGoogleHttpErrorMessage(label, res.status, payloadText),
+    formatMessage: payloadText => {
+      const message = safeGoogleHttpErrorMessage(label, res.status, payloadText);
+      if (isGoogleLocationUnsupportedText(payloadText)) {
+        console.warn(
+          `[opencodex] ${label} request was rejected because the client location is not supported. `
+          + "If using a proxy or VPN, verify TUN mode is enabled and check for IPv6 / direct routing leaks.",
+        );
+      }
+      return message;
+    },
   });
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -127,18 +127,20 @@ function isPermissionMessage(text: string): boolean {
   );
 }
 
+export const LOCATION_UNSUPPORTED_PATTERNS = [
+  "location is not supported",
+  "location not supported",
+  "unsupported location",
+  "region is not supported",
+  "unsupported region",
+  "country is not supported",
+  "not supported in your country",
+  "not supported in your region",
+] as const;
+
 export function isLocationUnsupportedMessage(text: string): boolean {
-  return (
-    text.includes("location is not supported") ||
-    text.includes("location not supported") ||
-    text.includes("unsupported location") ||
-    text.includes("region is not supported") ||
-    text.includes("unsupported region") ||
-    text.includes("country is not supported") ||
-    text.includes("not supported in your country") ||
-    text.includes("not supported in your region") ||
-    text.includes("not supported for the api use")
-  );
+  const lower = text.toLowerCase();
+  return LOCATION_UNSUPPORTED_PATTERNS.some(needle => lower.includes(needle));
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -127,6 +127,20 @@ function isPermissionMessage(text: string): boolean {
   );
 }
 
+export function isLocationUnsupportedMessage(text: string): boolean {
+  return (
+    text.includes("location is not supported") ||
+    text.includes("location not supported") ||
+    text.includes("unsupported location") ||
+    text.includes("region is not supported") ||
+    text.includes("unsupported region") ||
+    text.includes("country is not supported") ||
+    text.includes("not supported in your country") ||
+    text.includes("not supported in your region") ||
+    text.includes("not supported for the api use")
+  );
+}
+
 /**
  * Client cancelled / closed the turn. Matches ONLY abort phrases this codebase
  * produces — "client closed request during web-search" (src/web-search/loop.ts),
@@ -250,6 +264,12 @@ export function classifyError(status: number, type: string, message: string): Oc
     isSubscriptionGateMessage(text)
   ) {
     return { message, type: "permission_error", code: "subscription_required" };
+  }
+  if (
+    type === "location_not_supported" ||
+    isLocationUnsupportedMessage(text)
+  ) {
+    return { message, type: "permission_error", code: "location_not_supported" };
   }
   if (
     status === 403 ||

--- a/tests/adapters/google/google-errors.test.ts
+++ b/tests/adapters/google/google-errors.test.ts
@@ -93,7 +93,7 @@ describe("google error classification & quota exhaustion", () => {
       "User location is not supported for the API use.",
       "Location not supported in your region.",
       "This model is not supported in your country.",
-      "Service is not supported for the api use in this location.",
+      "Unsupported location for the API use.",
     ];
 
     for (const phrase of locationPhrases) {

--- a/tests/adapters/google/google-errors.test.ts
+++ b/tests/adapters/google/google-errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isGoogleLocationUnsupportedText,
   isGoogleQuotaExhaustedText,
   isQuotaExhaustedBody,
   safeAntigravityHttpErrorMessage,
@@ -85,5 +86,27 @@ describe("google error classification & quota exhaustion", () => {
       },
     });
     expect(isQuotaExhaustedBody(jsonBody)).toBe(false);
+  });
+
+  test("classifies location unsupported as location not supported instead of invalid request", () => {
+    const locationPhrases = [
+      "User location is not supported for the API use.",
+      "Location not supported in your region.",
+      "This model is not supported in your country.",
+      "Service is not supported for the api use in this location.",
+    ];
+
+    for (const phrase of locationPhrases) {
+      expect(isGoogleLocationUnsupportedText(phrase)).toBe(true);
+      const jsonBody = JSON.stringify({
+        error: {
+          code: 400,
+          status: "FAILED_PRECONDITION",
+          message: phrase,
+        },
+      });
+      expect(safeAntigravityHttpErrorMessage(400, jsonBody)).toContain("Antigravity location not supported");
+      expect(safeVertexHttpErrorMessage(400, jsonBody)).toContain("Vertex AI location not supported");
+    }
   });
 });

--- a/tests/adapters/google/google-vertex-http.test.ts
+++ b/tests/adapters/google/google-vertex-http.test.ts
@@ -192,6 +192,34 @@ describe("vertex retry fetch", () => {
     expect(text).not.toContain("secret-token");
   });
 
+  test("Antigravity location unsupported logs diagnostic warning and classifies correctly", async () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      mockFetch([new Response(vertexError(400, "FAILED_PRECONDITION", "User location is not supported for the API use."), { status: 400 })]);
+      const res = await fetchAntigravityWithRetry(request, { timeoutMs: 5_000 });
+      const text = await res.text();
+      expect(text).toContain("Antigravity location not supported");
+      expect(warnings.some(w => w.includes("client location is not supported") && w.includes("TUN mode"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  test("Antigravity non-location error does not log location diagnostic warning", async () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      mockFetch([new Response(vertexError(400, "INVALID_ARGUMENT", "syntax error"), { status: 400 })]);
+      await fetchAntigravityWithRetry(request, { timeoutMs: 5_000 });
+      expect(warnings.some(w => w.includes("client location is not supported"))).toBe(false);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
   test("does not retry 401/403 (single attempt)", async () => {
     const mock401 = mockFetch([new Response(vertexError(401, "UNAUTHENTICATED", "bad token"), { status: 401 })]);
     const res401 = await fetchVertexWithRetry(request, { timeoutMs: 5_000 });

--- a/tests/server/error-fidelity.test.ts
+++ b/tests/server/error-fidelity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bridgeToResponsesSSE, formatErrorResponse } from "../../src/bridge";
-import { classifyError } from "../../src/lib/errors";
+import { classifyError, isLocationUnsupportedMessage } from "../../src/lib/errors";
 import { sanitizePassthroughHeaders } from "../../src/server";
 import type { AdapterEvent } from "../../src/types";
 
@@ -103,6 +103,13 @@ describe("error fidelity", () => {
       type: "permission_error",
       code: "location_not_supported",
     });
+    expect(classifyError(400, "upstream_error", "USER LOCATION IS NOT SUPPORTED IN YOUR REGION")).toMatchObject({
+      type: "permission_error",
+      code: "location_not_supported",
+    });
+    expect(isLocationUnsupportedMessage("USER LOCATION IS NOT SUPPORTED")).toBe(true);
+    expect(isLocationUnsupportedMessage("Region Is Not Supported")).toBe(true);
+    expect(isLocationUnsupportedMessage("not supported for the api use")).toBe(false);
   });
 
   test("formatErrorResponse returns OpenAI-compatible classified error envelope", async () => {

--- a/tests/server/error-fidelity.test.ts
+++ b/tests/server/error-fidelity.test.ts
@@ -91,6 +91,18 @@ describe("error fidelity", () => {
       type: "insufficient_quota",
       code: "insufficient_quota",
     });
+    expect(classifyError(400, "upstream_error", "Antigravity location not supported: User location is not supported for the API use.")).toMatchObject({
+      type: "permission_error",
+      code: "location_not_supported",
+    });
+    expect(classifyError(400, "upstream_error", "User location is not supported for the API use.")).toMatchObject({
+      type: "permission_error",
+      code: "location_not_supported",
+    });
+    expect(classifyError(403, "location_not_supported", "Region is not supported")).toMatchObject({
+      type: "permission_error",
+      code: "location_not_supported",
+    });
   });
 
   test("formatErrorResponse returns OpenAI-compatible classified error envelope", async () => {


### PR DESCRIPTION
Fixes #3467

### Summary

When Google Antigravity (Cloud Code Assist API) rejects a request due to an unsupported geographic region or datacenter IP (`HTTP 400` with `FAILED_PRECONDITION: User location is not supported for the API use.`), OpenCodeX previously classified it as:
```text
Provider error 400: Antigravity invalid request: User location is not supported for the API use.
```
and downstream OpenAI-compatible endpoints translated this into `type: "invalid_request_error"`.

### Changes

1. **`src/lib/errors.ts`:**
   - Defined `LOCATION_UNSUPPORTED_PATTERNS` containing location/region/country restriction patterns.
   - Added `isLocationUnsupportedMessage(text)` that lowercases input once and validates location cues.
   - In `classifyError()`, mapped location-unsupported messages and `type === "location_not_supported"` to `type: "permission_error", code: "location_not_supported"`.

2. **`src/adapters/google-errors.ts`:**
   - Imported and re-exported `LOCATION_UNSUPPORTED_PATTERNS` and `isLocationUnsupportedMessage` (as `GOOGLE_LOCATION_UNSUPPORTED_PATTERNS` and `isGoogleLocationUnsupportedText`), eliminating code duplication.
   - In `classifyGoogle()`, matched location/region restriction messages before the generic `status === 400` / "invalid" fallback. The classified label is now `${label} location not supported`.

3. **`src/adapters/google-http.ts`:**
   - In `normalizeFinalGoogleError()`, logged an actionable diagnostic warning to console when a location restriction is encountered, advising the operator to inspect their TUN mode, proxy settings, or IPv6 routing leaks.

4. **Tests:**
   - Added unit test coverage in `tests/google-errors.test.ts` for location-unsupported classification.
   - Added unit test coverage in `tests/google-vertex-http.test.ts` asserting diagnostic warning is emitted for location errors and suppressed for non-location errors.
   - Added unit test coverage in `tests/error-fidelity.test.ts` for `permission_error` / `location_not_supported` mapping and mixed-case input.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of location-unsupported errors across supported providers.
  * These errors are now clearly classified as “location not supported” instead of generic invalid-request or permission errors.
  * Added diagnostic guidance to check proxy/VPN TUN mode and IPv6 or direct routing when applicable.

* **Tests**
  * Added coverage for provider-specific, case-insensitive, and already-classified location errors.
  * Confirmed unrelated invalid-argument errors do not trigger location-specific warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->