### PR TITLE
docs(devlog): record how the Codex Set chrome unit was delivered

### DIFF
--- a/devlog/_plan/260904_codex_set_head_and_logo/030_live_verification_record.md
+++ b/devlog/_plan/260904_codex_set_head_and_logo/030_live_verification_record.md
@@ -39,3 +39,23 @@ path, rendered at 17x17 — the icon set's CSS sizing applies unchanged to the
 `bun run typecheck`, `bun run lint:gui`, `bun run build:gui`, and the focused
 `gui/tests/sidebar-codex-set.test.ts` (2 pass). The repository-wide suite was not
 run — operator constraint for this unit.
+
+## Delivery record
+
+Two pull requests, both against `dev`, both merged with admin:
+
+| PR | Content | Merge commit |
+|---|---|---|
+| #3465 | The two chrome fixes | `24c0409ae` |
+| #3468 | Regression guards for both (`040`) | `903dfd6bc` |
+
+Ancestry proven for each with `git fetch origin dev` followed by
+`git merge-base --is-ancestor <merge-sha> FETCH_HEAD`; `origin/dev` moved
+`2421e44ce → 24c0409ae → 903dfd6bc`.
+
+#3468 needed the maintainer `gui-screenshot-waived` label. Its `enforce-target`
+run failed on "missing UI screenshot" because the gate matches the word `gui` in
+a title or path, and this PR is two test files and a devlog note with no runtime
+change — there is no UI delta to capture. That is the false positive the waiver
+label exists for, and the reason is recorded on the PR itself rather than only
+here.


### PR DESCRIPTION
## Summary

Documentation only — a follow-up to #3465 and #3468, both already on `dev`.

The Codex Set chrome unit shipped across two pull requests rather than one, so `030_live_verification_record.md` now names both merge commits and the ancestry proof for each, instead of leaving a reader to reconstruct the delivery from the PR list.

It also records why #3468 needed the `gui-screenshot-waived` label: `enforce-target` matches the word `gui` in a title or path, and that PR is two test files and a devlog note with no runtime change, so there was no UI delta to capture. That is the false positive the label exists for. A waiver with no written reason is the kind of thing that reads as a bypass six months later, so the reason is now in the tree as well as on the PR.

## Verification

No code, no test, and no build input changed — the diff is 20 added lines in one markdown file under `devlog/_plan/`, which nothing in the build, typecheck, or test path reads.

The facts asserted in the added table were verified against the live remote before writing them, not from memory:

- `gh pr view 3465` → `MERGED`, `24c0409ae33b90180aa34e80d96a4829bb8b1f32`
- `gh pr view 3468` → `MERGED`, `903dfd6bca7abd0b9ca863ac95356cfd70c6c9b3`
- `git fetch origin dev` then `git merge-base --is-ancestor <sha> FETCH_HEAD` → true for both
- `origin/dev` tip → `903dfd6bc`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a delivery record to the live verification documentation.
  - Documented the merged changes, associated merge commits, and ancestry verification results.
  - Recorded the screenshot-gate exception applied during regression verification when no runtime UI changes were present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->