### PR TITLE
docs(devlog): record the delivery audit for the providers home/quota unit

### DIFF
--- a/devlog/_plan/260904_providers_home_and_quota_refresh/040_delivery_record.md
+++ b/devlog/_plan/260904_providers_home_and_quota_refresh/040_delivery_record.md
@@ -1,0 +1,66 @@
+# 040 — Delivery record
+
+Terminal outcome: **DONE**. Verified against `origin/dev` head `38b0c09b6`, not
+from memory of the work.
+
+## What shipped
+
+| PR | Merge commit | Content |
+|----|--------------|---------|
+| [#3466](https://github.com/lidge-jun/opencodex/pull/3466) | `1e3589531` | Brand home control, overview refresh-all-quotas, Accounts section-head refresh, i18n, docs, 4 test files |
+| [#3472](https://github.com/lidge-jun/opencodex/pull/3472) | `b08e14e91` | zh-cn and ru locale rows for the refresh-all control |
+| [#3473](https://github.com/lidge-jun/opencodex/pull/3473) | `38b0c09b6` | Removed the duplicated plan docs; recorded the locale-parity rule |
+
+All three proven with `git fetch origin dev` then
+`git merge-base --is-ancestor <sha> FETCH_HEAD`.
+
+## Requirement-by-requirement audit
+
+Read from `git show origin/dev:<path>`, so this reflects the merged tree.
+
+- **Brand is a real control, both placements.** `gui/src/App.tsx` defines one
+  `brand` node as `<button type="button" className="brand brand-home">` calling
+  `navigateToPage("dashboard")` then `setNavOpen(false)`, rendered in the mobile
+  topbar and the drawer head. Live at 700px: it is the second tab stop, named
+  "Go to dashboard", and Enter moves the hash to `#dashboard` with the drawer
+  closed. At 1280px a click from `#providers/Cursor/Models` lands on
+  `#dashboard` with `aria-current="page"` and the sidebar row active.
+- **No redundant home row.** The Providers overview header holds only the
+  refresh and JSON controls; the sidebar keeps the single 대시보드 destination.
+- **Overview refresh.** `.pws-dashboard-header-actions` carries the control,
+  wired `refreshAllProviderQuotas` -> `fetchProviderQuotas(true)` -> shell
+  forced read -> `onQuotaRefreshSettled`. Live CDP capture on the merged build:
+  `GET /api/provider-quotas?refresh=1` -> 200, status line "Quota check
+  complete" with `pws-status-ok`.
+- **Pending + disabled + truthful settle.** `disabled={refreshingQuotas}` and the
+  result derives from the awaited promise. Covered by four DOM tests including a
+  double-click that must not issue a second forced read.
+- **Locales.** All nine catalogs carry `nav.goHome`, `pws.refreshAllQuotas`, and
+  `pws.quotaRefreshDone` (grep count 3 each on `origin/dev`).
+- **Checks on the merged head.** `bun run typecheck` exit 0, `bun run lint:gui`
+  exit 0, 55 focused GUI tests pass across 10 files. The repository-wide suite
+  was never run locally, as instructed.
+
+## Scope note
+
+The objective asked for ONE pull request. It became three because review found
+real defects after the first merge: two locales documenting a control they did
+not describe, and duplicated plan docs left by a rename pushed as adds without
+deletes. Splitting the fixes was the honest response to landed defects, not
+scope drift — each is a small, separately reviewable correction to this unit.
+
+## Two judgment calls worth keeping
+
+**The status string is deliberately weaker than "refreshed."**
+`fetchProviderQuotaReports` answers 200 even when one upstream probe failed and
+that provider kept its last-good row, so "Quotas refreshed" would overstate what
+the read proved. "Quota check complete" is what the boolean actually supports;
+per-provider freshness stays in each row's own age. Raised as P2 by Codex
+review and accepted.
+
+**The Accounts refresh was moved, not added.** It already existed at the foot of
+the account list, below every account's stacked rate-limit bars — off-screen
+with two accounts, which is why it read as missing. It now sits in the section
+head beside the numbers it refreshes; the footer button stays as part of the
+account-management cluster, and the result line lives in the head only so one
+refresh is not announced twice.


### PR DESCRIPTION
## Summary

Closes the `260904_providers_home_and_quota_refresh` unit with a delivery record written from what was verified against `origin/dev` `38b0c09b6`, not from memory of doing the work.

The audit reads the merged tree directly (`git show origin/dev:<path>`) for both controls, confirms all nine locale catalogs carry the three new keys, and re-runs `bun run typecheck`, `bun run lint:gui` and 55 focused GUI tests on a branch cut from that head. Live proof was taken against a build of the merged tree on an isolated scratch instance: a CDP capture of `GET /api/provider-quotas?refresh=1` returning 200 with the "Quota check complete" status, and the brand reachable as the second tab stop at 700px where Enter navigates to `#dashboard` with the drawer closed. All three merge commits (#3466, #3472, #3473) are ancestry-proven.

It also records the two judgment calls a future reader would otherwise have to rediscover — why the success string is deliberately weaker than "refreshed" (a 200 does not prove every upstream probe succeeded), and why the Accounts control was moved rather than added (it existed, below every account's stacked bars, off-screen with two accounts) — plus an honest note on why the work landed as three PRs instead of the one planned.

## Verification

- `bun run typecheck` -> exit 0 on `origin/dev` head
- `bun run lint:gui` -> exit 0
- `bun test` on 10 focused files -> 55 pass / 0 fail
- Live behavior re-checked on a build of the merged tree; scratch instance and its copied credentials deleted afterwards. The port-10100 service was never touched.
- This PR itself adds one Markdown file. Nothing in the build, typecheck, or test path reads `devlog/`, and no component, stylesheet, locale catalog, or runtime file is touched, so there is no rendered change to capture.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Devlog prose only — no auth, credential, workflow, or release surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added delivery documentation for the providers home and quota refresh work.
  - Recorded completed updates for brand home controls, quota refresh controls, the Accounts section, localization, and testing.
  - Documented validation against the latest development build and captured implementation decisions for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->