### PR TITLE
docs(devlog): record the triage gap closure and the review round

### DIFF
--- a/devlog/_plan/260904_triage_gap_closure/020_credits_3284.md
+++ b/devlog/_plan/260904_triage_gap_closure/020_credits_3284.md
@@ -1,5 +1,7 @@
 # 020 — CREDITS row for #3284 (issue #3431)
 
+> **Landed** in PR #3478 as `3a9c4d297`. See `040_delivery_record.md`.
+
 Work-phase `wp2`. Depends on 000. Disjoint from every other phase.
 
 ## Why this is admissible
@@ -42,3 +44,5 @@ how every other row in the table cites its source.
 ## Close-out
 
 Close #3431 citing the landing SHA.
+
+Done: closed with `3a9c4d297`, quoting @Ingwannu's own words as the file requires.

--- a/devlog/_plan/260904_triage_gap_closure/030_ultrafast_optin.md
+++ b/devlog/_plan/260904_triage_gap_closure/030_ultrafast_optin.md
@@ -1,5 +1,7 @@
 # 030 — Ultra Fast as an explicit opt-in (issue #3429)
 
+> **Landed** in PR #3478 as `3a9c4d297`. See `040_delivery_record.md`.
+
 Work-phase `wp3`. Depends on 000. This is the phase that needs judgment, not just
 diffs.
 
@@ -135,6 +137,8 @@ switch that implies a speed it cannot deliver is the #2994 defect in a new place
   toggle are reachable below
 
 ## What this phase will NOT claim
+
+Done: closed #3429 with `3a9c4d297`, stating which half shipped and which did not.
 
 It will not claim Ultra Fast delivers Ultra Fast speed. If live evidence shows an
 opted-in request still cannot get the tier honored end-to-end, that is reported

--- a/devlog/_plan/260904_triage_gap_closure/040_delivery_record.md
+++ b/devlog/_plan/260904_triage_gap_closure/040_delivery_record.md
@@ -1,0 +1,69 @@
+# 040 — Delivery record
+
+Terminal outcome: **DONE**. All three gaps closed on `origin/dev` via PR #3478,
+merged as `3a9c4d297` and ancestry-proven.
+
+| Gap | Closed as | Evidence on `dev` |
+|-----|-----------|-------------------|
+| PR #3293 fable-5-1 metadata | `3a9c4d297` | `claude-fable-5-1` present in the source json and the generated `anthropic` row |
+| Issue #3431 CREDITS for #3284 | `3a9c4d297` | `CREDITS.md` carries the row quoting @Ingwannu verbatim |
+| Issue #3429 Ultra Fast | `3a9c4d297` | `ultraFastTier` in config, types, and the routed normalizer |
+
+## The review round is the part worth keeping
+
+The first implementation passed every suite and was wrong.
+
+Recognising `ultrafast` as a canonical marker routed it into `decideTier`'s
+`canonicalToWire` lookup, which maps only `priority`. An unmapped canonical fell
+through to `{ kind: "drop" }`, so the tier stopped reaching the provider —
+where previously, as a *foreign* tier, `foreignCallerTiers: "verbatim"` had
+forwarded it untouched. Recognition made the reported problem worse:
+
+```text
+before   ultrafast -> forward-caller   wire service_tier=ultrafast
+after    ultrafast -> drop             wire service_tier=(absent)
+```
+
+Every listed suite stayed green because they unit-tested
+`canonicalFastTierMarker` and `requestLogSpeedLabel` in isolation and never
+asserted the wire decision. The byte golden could not catch it either: it pins
+*catalog* bytes, not the caller routing path.
+
+Two lessons, both cheap to state and expensive to relearn:
+
+- A test that exercises the two functions you edited is not a test of the
+  behavior you changed. The gap was one call frame away.
+- Widening a predicate is not free. `callerCanonicalFast` served three different
+  questions — drop, suppression, and intent — and widening it for the third
+  silently changed the first two, which is how `callerFastSuppressedByConfig`
+  came to claim the Fast toggle had suppressed a tier that is not Fast.
+
+## What was deliberately NOT done
+
+Ultra Fast is still absent from the model picker. `upstream-models.json`
+advertises only `priority`, so a catalog row would offer a speed the wire cannot
+deliver — the exact defect PR #2994 was closed for. The opt-in preserves a tier
+the operator supplies and names it honestly in the logs; it invents nothing.
+
+If upstream ever advertises the tier, items 1 and 2 of #3429 become implementable
+and this note is where to start.
+
+## Where the pieces live
+
+- `src/providers/fastwire.ts` — `canonicalFastTierMarker` folds `ultrafast`;
+  `decideTier` falls through to the foreign-tier rules for an unmapped canonical;
+  `callerCanonicalFast` stays `=== "priority"` for the drop/suppression facts.
+- `src/codex/catalog/parsing.ts` — `retainOnlyUltraFastTier` and the memoized
+  `ultraFastTierOptIn`.
+- `src/server/request-log.ts` — the `ultrafast` speed label.
+- `gui/src/components/UltraFastTierSetting.tsx` and
+  `codex-account-pool-main-card.tsx` — the toggle and the relocated action row.
+- `tests/ultrafast-tier-honesty.test.ts` — 15 tests, including the five added
+  after the review that assert the wire decision the original suite missed.
+
+## Loop close
+
+Four work-phases: the docs-only roadmap, then the three gap closures, all landed
+through one pull request because they were small, independently reviewable, and
+shared a review round. `cxc loop validate` passes with every criterion carrying
+captured evidence.


### PR DESCRIPTION
## Summary

Closes out `devlog/_plan/260904_triage_gap_closure` with what shipped and the landing SHAs. PR #3478 (`3a9c4d297`) carried all three gaps; #3293, #3431 and #3429 are closed citing it.

The part worth keeping is the review round. The first Ultra Fast implementation passed every suite and was wrong: recognising `ultrafast` as a canonical marker routed it into `decideTier`'s `canonicalToWire` lookup, which maps only `priority`, so an unmapped canonical fell through to `drop` and the tier stopped reaching the provider — where previously, as a *foreign* tier, it was forwarded verbatim. Recognition made the reported problem worse.

Every listed suite stayed green because they unit-tested the two edited functions in isolation and never asserted the wire decision, and the byte golden pins catalog bytes rather than the caller routing path. Two lessons recorded: a test of the functions you edited is not a test of the behavior you changed, and widening a predicate that serves three questions silently changes the other two.

It also records what was deliberately **not** done — Ultra Fast is still absent from the model picker, because upstream advertises only `priority` and a catalog row would offer a speed the wire cannot deliver, which is exactly what PR #2994 was closed for.

## Verification

- Documentation only. Nothing in the build, typecheck, or test path reads `devlog/`, and no component, stylesheet, locale catalog, or runtime file is touched, so there is no rendered change to capture.
- The behavior this describes was verified on #3478: `bun run typecheck`, `bun run lint:gui`, 720 focused tests, `bun run test:changed` at 14466 pass / 0 fail, and 23 CI checks green on the merged head.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Devlog prose only — no auth, credential, workflow, or release surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project planning records to document the delivery status of recent triage items.
  * Added a delivery note covering metadata, credits, and Ultra Fast tier changes.
  * Clarified which portions of the Ultra Fast work were delivered and documented related non-goals and limitations.
  * Recorded the associated issue closures and delivery references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->