### PR TITLE
test(kiro): prove the bounded completion fallback runs

### DIFF
--- a/tests/kiro-stream.test.ts
+++ b/tests/kiro-stream.test.ts
@@ -1712,7 +1712,11 @@ describe("kiro adapter — parseStream", () => {
 
     resetKiroCalibration();
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response(streamOf(eventFrame({ content: "Final from fallback." })))) as typeof fetch;
+    let fallbackCalls = 0;
+    globalThis.fetch = (async () => {
+      fallbackCalls++;
+      return new Response(streamOf(eventFrame({ content: "Final from fallback." })));
+    }) as typeof fetch;
     try {
       const falling = createKiroAdapter(provider);
       await falling.buildRequest(sameConversation([bashTool]));
@@ -1722,6 +1726,7 @@ describe("kiro adapter — parseStream", () => {
         eventFrame({ content: "I am checking." }),
         eventFrame({ contextUsagePercentage: 10 }),
       ))));
+      expect(fallbackCalls).toBe(1);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

- Follow-up to #3476: make the terminal-only Kiro calibration regression prove that the bounded completion fallback actually executes.
- Count the mocked fallback fetch and require exactly one invocation, while preserving the existing assertion that the first unfinished attempt teaches no calibration.
- @lidge-jun, this is the narrow test-only follow-up to the review gap identified as #3476 merged; please review it before merge.

Without the call-count assertion, the regression also passed if fallback dispatch broke completely because that failure likewise recorded no calibration.

## Verification

- `bun test tests/kiro-stream.test.ts` with project-pinned Bun 1.4.0 and fresh isolated `HOME`, `OPENCODEX_HOME`, and `CODEX_HOME` — 109 passed, 0 failed.
- `bun run typecheck` with project-pinned Bun 1.4.0 and a separate fresh isolated home — passed.
- Protected local Codex/OpenCodex/Paseo runtime configuration modes, sizes, and SHA-256 hashes remained unchanged after both checks.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (Test-only proof; no user-facing behavior or documentation changed.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (No runtime or security boundary changed.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured fallback completion requests are made only once when an attempt falls back, preventing duplicate requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->