### PR TITLE
fix(discovery): allow canonical model endpoints through fake-IP TUN DNS

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -68,6 +68,7 @@ import {
 import { redactSecretString } from "../../lib/redact";
 import {
   extractProviderModelItems,
+  isRegistryModelDiscoveryUrl,
   readBoundedDiscoveryJson,
   resolveProviderModelDiscovery,
   type ModelDiscoveryResponseFailure,
@@ -1665,16 +1666,24 @@ async function fetchProviderModelsWithAuth(
     };
   };
   try {
+    // Canonical-URL TUN transparency for Clash/Surge/Mihomo fake-IP DNS:
+    // `isRegistryModelDiscoveryUrl` proves the FINAL request URL is the
+    // registry's own fixed discovery URL, so a purely-benchmark DNS answer may
+    // be pin-connected through the intercepting TUN without proxy env. The
+    // proof is on the URL — not the provider name — because an OAuth/forward
+    // name matches any baseUrl by design. Retargeted or renamed custom rows
+    // fetch a different URL and keep the rejection.
+    const outboundDependencies = { isCanonicalUrl: isRegistryModelDiscoveryUrl };
     const res = request.method === "POST"
       ? await providerOutboundPost(name, prov, url, {
         headers,
         body: JSON.stringify({ project }),
         signal: AbortSignal.timeout(8000),
-      })
+      }, outboundDependencies)
       : await providerOutboundGet(name, prov, url, {
         headers,
         signal: AbortSignal.timeout(8000),
-      });
+      }, outboundDependencies);
     const redirectError = await providerRedirectError(res, url);
     if (redirectError) {
       const { models, fallback, shouldLog } = failedDiscoveryFallback({ reason: "http", httpStatus: res.status });

--- a/src/lib/provider-outbound.ts
+++ b/src/lib/provider-outbound.ts
@@ -19,6 +19,14 @@ export interface ProviderOutboundDependencies {
   resolveAddresses?: typeof resolvePublicAddresses;
   pinnedGet?: typeof pinnedHttpGet;
   pinnedPost?: typeof pinnedHttpPost;
+  /**
+   * Canonical-URL proof for the transparent fake-IP exception (Clash TUN mode
+   * without proxy env). Injected so this transport core stays decoupled from
+   * the registry module; production compares the final request URL against the
+   * registry's own fixed discovery URL. Defaults to "not canonical" so a caller
+   * that forgets the seam fails closed, never open.
+   */
+  isCanonicalUrl?: (name: string, url: string) => boolean;
 }
 
 export class ProviderOutboundPolicyError extends Error {
@@ -31,6 +39,42 @@ function pickPinnedAddress(addresses: Array<{ address: string; family: number }>
 
 function configuredProxyFor(): boolean {
   return outboundProxyConfigured();
+}
+
+/**
+ * Registry-owned fake-IP transparency exception (Clash/Surge/Mihomo TUN mode).
+ *
+ * Under TUN mode the packet path intercepts the fake-IP destination itself, so a
+ * canonical registry destination whose local DNS answer is ONLY Clash fake-IP
+ * space (198.18.0.0/15) is reachable by pin-connecting through the TUN — no
+ * outbound HTTP(S) proxy env is required. The exception is deliberately narrow:
+ *
+ * - hostname-only: a literal 198.18.x.x URL never reaches it (the literal gate
+ *   in `resolvePublicAddresses` rejects before DNS answers are examined);
+ * - canonical-URL-only: `isCanonicalUrl` must prove the FINAL request URL is
+ *   the registry's own fixed discovery URL for this provider (not merely that
+ *   the provider NAME matches — OAuth/forward names match any baseUrl by
+ *   design, and the bearer is pinned to the registry destination independently
+ *   in `buildModelsRequest`). A retargeted row or a renamed custom row sends
+ *   its credential to the registry URL anyway, so the proof must be on the URL
+ *   actually fetched. The check is injected so the transport core stays
+ *   decoupled from the registry module;
+ * - pure-answer-only: `resolvePublicAddresses` admits the exception only when
+ *   EVERY answer is benchmark space; any loopback/RFC1918/link-local/metadata
+ *   companion (or a public+benchmark mix resolving through a rebind) still
+ *   rejects, and `privateNetwork` stays false so proxy/NO_PROXY semantics and
+ *   the private-network gate are unchanged for every other destination.
+ *
+ * Image/Lab fetch never passes the underlying flag and is unaffected.
+ */
+function transparentFakeIpException(
+  url: string,
+  parsed: URL,
+  isCanonicalUrl: (name: string, url: string) => boolean,
+  name: string,
+): boolean {
+  if (noProxyMatches(parsed)) return false;
+  return isCanonicalUrl(name, url);
 }
 
 function normalizeProxyHostname(hostname: string): string {
@@ -142,6 +186,7 @@ async function providerOutboundRequest(
   const resolveAddresses = dependencies.resolveAddresses ?? resolvePublicAddresses;
   const pinnedGet = dependencies.pinnedGet ?? pinnedHttpGet;
   const pinnedPost = dependencies.pinnedPost ?? pinnedHttpPost;
+  const isCanonicalUrl = dependencies.isCanonicalUrl ?? (() => false);
   const allowPrivate = providerAllowsPrivateNetwork(name, provider);
   let resolved: Awaited<ReturnType<typeof resolvePublicAddresses>>;
   try {
@@ -154,7 +199,15 @@ async function providerOutboundRequest(
       // destination or being pin-connected to the fake-IP (credit #1748). A NO_PROXY
       // match is a direct route, so it keeps the benchmark answer rejected. Image/Lab
       // fetch never passes this flag.
-      allowBenchmarkAddresses: proxyConfigured && !noProxyMatches(parsed),
+      //
+      // TUN-mode transparency: with no proxy env, Clash/Surge/Mihomo TUN still
+      // intercepts the fake-IP destination itself, so the REGISTRY's own fixed
+      // discovery URL stays reachable by pin-connecting through the TUN. The
+      // proof is on the final request URL — not the provider name — because an
+      // OAuth/forward name matches any baseUrl by design while the bearer is
+      // pinned to the registry destination independently.
+      allowBenchmarkAddresses: (proxyConfigured && !noProxyMatches(parsed))
+        || transparentFakeIpException(url, parsed, isCanonicalUrl, name),
     });
   } catch (error) {
     const dnsResolutionFailed = error instanceof DestinationDnsResolutionError

--- a/src/providers/model-discovery.ts
+++ b/src/providers/model-discovery.ts
@@ -170,13 +170,19 @@ function appendDiscoveryQuery(url: URL, query: Readonly<Record<string, string>> 
  * against registry spec URLs keeps a renamed custom row fetching an
  * attacker-controlled URL from gaining the exception.
  *
- * Both spec shapes are covered: an absolute `url` spec matches its own URL,
- * and a `path` spec matches the URL it resolves to against the registry's own
- * baseUrl (so the `commandcode` key preset's `path: "models"` proves the same
+ * Both spec shapes are covered: an absolute `url` spec matches its own URL
+ * (plus the spec's fixed query), and a `path` spec matches the URL it resolves
+ * to against the registry's own baseUrl (plus the spec's fixed query) — so the
+ * `commandcode` key preset's `path: "models"` proves the same
  * `https://api.commandcode.ai/provider/v1/models` string the `command-code`
- * OAuth `url` spec proves). A caller-supplied query or fragment never matches:
- * the registry spec owns the query allow-list, so `?token=` smuggling on the
- * right origin+path is not canonical.
+ * OAuth `url` spec proves, and the `nebius` `path: "models"` plus
+ * `query: { verbose: "true" }` proves
+ * `https://api.tokenfactory.nebius.com/v1/models?verbose=true`.
+ *
+ * Registry-owned fixed query parameters are canonical only on EXACT match:
+ * a missing, changed, or additional parameter is not canonical, so `?token=`
+ * smuggling on the right origin+path stays rejected. Fragments are never
+ * canonical.
  */
 export function isRegistryModelDiscoveryUrl(providerName: string, url: string): boolean {
   const entry = getProviderRegistryEntry(providerName);
@@ -190,7 +196,7 @@ export function isRegistryModelDiscoveryUrl(providerName: string, url: string): 
   }
   if (candidate.protocol !== "https:") return false;
   if (candidate.username || candidate.password) return false;
-  if (candidate.search || candidate.hash) return false;
+  if (candidate.hash) return false;
   const sameUrl = (canonical: string): boolean => {
     let expected: URL;
     try {
@@ -199,9 +205,21 @@ export function isRegistryModelDiscoveryUrl(providerName: string, url: string): 
       return false;
     }
     return candidate.origin === expected.origin
-      && candidate.pathname.replace(/\/+$/, "") === expected.pathname.replace(/\/+$/, "");
+      && candidate.pathname.replace(/\/+$/, "") === expected.pathname.replace(/\/+$/, "")
+      && candidate.search === expected.search;
   };
-  if ("url" in spec && spec.url) return sameUrl(spec.url);
+  // One shared construction with `resolveProviderModelDiscoveryUrl` below: the
+  // absolute `url` form carries the spec's fixed query (if any), and the `path`
+  // form resolves against the REGISTRY's own baseUrl (never a configured one)
+  // before appending the spec's fixed query. The candidate's own query must
+  // equal the registry-owned query exactly — no subset/superset matching.
+  if ("url" in spec && spec.url) {
+    try {
+      return sameUrl(appendDiscoveryQuery(new URL(spec.url), spec.query).toString());
+    } catch {
+      return false;
+    }
+  }
   if ("path" in spec && spec.path) {
     try {
       const base = new URL(entry.baseUrl.endsWith("/") ? entry.baseUrl : `${entry.baseUrl}/`);

--- a/src/providers/model-discovery.ts
+++ b/src/providers/model-discovery.ts
@@ -158,6 +158,64 @@ function appendDiscoveryQuery(url: URL, query: Readonly<Record<string, string>> 
   return url;
 }
 
+/**
+ * Whether a model-discovery request URL is a registry-owned fixed discovery
+ * URL — the canonical-URL proof for the transparent fake-IP (Clash/Surge/
+ * Mihomo TUN) exception in provider-outbound.
+ *
+ * The proof is on the FINAL URL, not the provider name: an OAuth/forward name
+ * matches any baseUrl by design (`providerMatchesRegistryTransport` returns
+ * true regardless of destination), while the bearer is pinned to the registry
+ * destination independently in `buildModelsRequest`. Comparing the fetched URL
+ * against registry spec URLs keeps a renamed custom row fetching an
+ * attacker-controlled URL from gaining the exception.
+ *
+ * Both spec shapes are covered: an absolute `url` spec matches its own URL,
+ * and a `path` spec matches the URL it resolves to against the registry's own
+ * baseUrl (so the `commandcode` key preset's `path: "models"` proves the same
+ * `https://api.commandcode.ai/provider/v1/models` string the `command-code`
+ * OAuth `url` spec proves). A caller-supplied query or fragment never matches:
+ * the registry spec owns the query allow-list, so `?token=` smuggling on the
+ * right origin+path is not canonical.
+ */
+export function isRegistryModelDiscoveryUrl(providerName: string, url: string): boolean {
+  const entry = getProviderRegistryEntry(providerName);
+  const spec = entry?.modelDiscovery;
+  if (!spec) return false;
+  let candidate: URL;
+  try {
+    candidate = new URL(url);
+  } catch {
+    return false;
+  }
+  if (candidate.protocol !== "https:") return false;
+  if (candidate.username || candidate.password) return false;
+  if (candidate.search || candidate.hash) return false;
+  const sameUrl = (canonical: string): boolean => {
+    let expected: URL;
+    try {
+      expected = new URL(canonical);
+    } catch {
+      return false;
+    }
+    return candidate.origin === expected.origin
+      && candidate.pathname.replace(/\/+$/, "") === expected.pathname.replace(/\/+$/, "");
+  };
+  if ("url" in spec && spec.url) return sameUrl(spec.url);
+  if ("path" in spec && spec.path) {
+    try {
+      const base = new URL(entry.baseUrl.endsWith("/") ? entry.baseUrl : `${entry.baseUrl}/`);
+      const resolved = spec.path.startsWith("/")
+        ? new URL(spec.path, base.origin)
+        : new URL(spec.path, base);
+      return sameUrl(appendDiscoveryQuery(resolved, spec.query).toString());
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 /** Apply a registry-owned URL/path/query policy to the adapter's normal discovery endpoint. */
 export function resolveProviderModelDiscoveryUrl(
   providerName: string,

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -45,6 +45,7 @@ import { effectiveGoogleMode, providerCodexAccountMode, providerMatchesRegistryT
 import {
   extractModelEnvelopeRows,
   extractProviderModelItems,
+  isRegistryModelDiscoveryUrl,
   readBoundedDiscoveryJson,
   resolveProviderModelDiscovery,
 } from "../../providers/model-discovery";
@@ -1236,16 +1237,20 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     const discovery = resolveProviderModelDiscovery(name, prov);
     const started = Date.now();
     try {
+      // Same canonical-URL TUN transparency as catalog discovery: the registry's
+      // own fixed discovery URL survives purely-benchmark (Clash/Surge/Mihomo
+      // fake-IP) DNS without proxy env.
+      const outboundDependencies = { isCanonicalUrl: isRegistryModelDiscoveryUrl };
       const res = method === "POST"
         ? await providerOutboundPost(name, prov, modelsUrl, {
           headers,
           body: JSON.stringify({ project }),
           signal: AbortSignal.timeout(8000),
-        })
+        }, outboundDependencies)
         : await providerOutboundGet(name, prov, modelsUrl, {
           headers,
           signal: AbortSignal.timeout(8000),
-        });
+        }, outboundDependencies);
       const latencyMs = Date.now() - started;
       const redirectError = await providerRedirectError(res, modelsUrl);
       if (redirectError) {

--- a/tests/command-code-fakeip-discovery.test.ts
+++ b/tests/command-code-fakeip-discovery.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Regression: canonical Command Code OAuth discovery must survive Clash /
+// Surge / Mihomo fake-IP DNS (198.18.0.0/15) WITHOUT proxy env.
+//
+// Production shape: the daemon runs under launchd/systemd WITHOUT
+// HTTP(S)_PROXY in its environment (system/VPN proxying happens at the IP
+// layer via TUN), while local DNS answers every hostname with a fake IP. The
+// old outbound path armed the `allowBenchmarkAddresses` exception ONLY when a
+// proxy env was configured, so the canonical
+// `GET https://api.commandcode.ai/provider/v1/models` was rejected with
+// `ProviderOutboundPolicyError: ... benchmark address ...`, the catalog marked
+// `{ status: "failed", reason: "blocked" }`, and the dashboard showed "Model
+// discovery was blocked by destination policy" with 0/0 visible models.
+//
+// The fix adds a narrow TUN transparency exception: the REGISTRY's own fixed
+// discovery URL (proven by `isRegistryModelDiscoveryUrl` against the final
+// request URL — not the provider name) may pin-connect through the
+// intercepting TUN when EVERY DNS answer is benchmark space. Literal
+// 198.18.x.x URLs, loopback/RFC1918/link-local/metadata answers, mixed
+// answers, query/fragment smuggling, renamed rows, and non-canonical URLs all
+// stay rejected.
+//
+// DNS is mocked at the node:dns/promises seam so the test is deterministic and
+// independent of the machine's resolver. Bun isolates modules per test file,
+// so this mock cannot leak into other suites.
+const lookupMock = mock(async (_hostname: string, _opts: unknown): Promise<{ address: string; family: number }[]> => []);
+mock.module("node:dns/promises", () => ({ lookup: lookupMock }));
+
+const { buildModelsRequest } = await import("../src/oauth");
+const { providerOutboundGet, ProviderOutboundPolicyError } = await import("../src/lib/provider-outbound");
+const { isRegistryModelDiscoveryUrl } = await import("../src/providers/model-discovery");
+const { PROXY_ENV_KEYS } = await import("../src/lib/proxy-env");
+const { gatherRoutedModels, clearGatherRoutedModelsInflight } = await import("../src/codex/catalog/provider-fetch");
+const { clearModelCache, clearProviderDiscoveryStatus, getProviderDiscoveryStatus } = await import("../src/codex/model-cache");
+const { withStubbedProviderFetch } = await import("./helpers/catalog-provider-fetch");
+import type { OcxConfig, OcxProviderConfig } from "../src/types";
+
+const FIXTURE = readFileSync(join(import.meta.dir, "fixtures/commandcode-models.json"), "utf8");
+
+const proxyKeys = PROXY_ENV_KEYS.flatMap(key => [key, key.toLowerCase()]);
+const originalProxyEnv = Object.fromEntries(proxyKeys.map(key => [key, process.env[key]]));
+const originalFetch = globalThis.fetch;
+
+function clearProxyEnv(): void {
+  for (const key of proxyKeys) delete process.env[key];
+}
+
+function canonicalOAuthRow(): OcxProviderConfig {
+  return {
+    adapter: "command-code",
+    baseUrl: "https://api.commandcode.ai",
+    authMode: "oauth",
+    liveModels: true,
+    defaultModel: "deepseek/deepseek-v4-flash",
+  };
+}
+
+function canonicalConfig(): OcxConfig {
+  return {
+    providers: {
+      "command-code": {
+        ...canonicalOAuthRow(),
+        apiKey: "simulated-oauth-bearer",
+      },
+    },
+  } as unknown as OcxConfig;
+}
+
+afterEach(() => {
+  for (const key of proxyKeys) {
+    const previous = originalProxyEnv[key];
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
+  globalThis.fetch = originalFetch;
+  lookupMock.mockReset();
+  clearModelCache("command-code");
+  clearProviderDiscoveryStatus("command-code");
+  clearGatherRoutedModelsInflight();
+});
+
+describe("command-code OAuth discovery under Clash/Mihomo fake-IP DNS", () => {
+  test("canonical request targets the registry discovery URL with the account bearer", () => {
+    const request = buildModelsRequest(canonicalOAuthRow(), "account-bearer", "command-code");
+    expect(request.url).toBe("https://api.commandcode.ai/provider/v1/models");
+    expect(request.headers.Authorization).toBe("Bearer account-bearer");
+    expect(isRegistryModelDiscoveryUrl("command-code", request.url)).toBe(true);
+  });
+
+  test("canonical URL pin-connects through the TUN without proxy env", async () => {
+    clearProxyEnv();
+    lookupMock.mockResolvedValue([{ address: "198.18.0.29", family: 4 }]);
+    const request = buildModelsRequest(canonicalOAuthRow(), "account-bearer", "command-code");
+
+    const response = await providerOutboundGet(
+      "command-code",
+      canonicalOAuthRow(),
+      request.url,
+      { headers: request.headers },
+      {
+        isCanonicalUrl: isRegistryModelDiscoveryUrl,
+        pinnedGet: (async (_url, pinned, _signal, requestOptions) => {
+          expect(pinned.address).toBe("198.18.0.29");
+          expect(new Headers(requestOptions?.headers).get("authorization")).toBe("Bearer account-bearer");
+          return new Response(FIXTURE, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }) as never,
+      },
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  test("full catalog gather discovers the live OAuth catalog without proxy env", async () => {
+    clearProxyEnv();
+    // Production resolves the OAuth bearer through the OBSERVED auth-store path
+    // (filesystem evidence -> observedModelsAuthResolver), never the provider
+    // row. Mirror that here: write a command-code account into an isolated
+    // OPENCODEX_HOME auth store and gather through the observed entry point.
+    // The stubbed executor asserts the materialized bearer without exposing it.
+    const { mkdtempSync, mkdirSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { gatherRoutedModelsForCatalogGather } = await import("../src/codex/catalog/provider-fetch");
+    const root = mkdtempSync(join(tmpdir(), "ocx-cc-fakeip-"));
+    const home = join(root, "opencodex");
+    mkdirSync(home, { recursive: true });
+    const previousHome = process.env.OPENCODEX_HOME;
+    process.env.OPENCODEX_HOME = home;
+    const now = Date.now();
+    writeFileSync(
+      join(home, "auth.json"),
+      JSON.stringify({
+        "command-code": {
+          activeAccountId: "account-1",
+          accounts: [{
+            id: "account-1",
+            credential: { access: "observed-oauth-bearer", refresh: "r", expires: now + 3_600_000 },
+          }],
+        },
+      }) + "\n",
+    );
+    const observedBuffer = new Uint8Array(
+      await Bun.file(join(home, "auth.json")).arrayBuffer(),
+    );
+    globalThis.fetch = (async (input, init) => {
+      expect(String(input)).toBe("https://api.commandcode.ai/provider/v1/models");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer observed-oauth-bearer");
+      expect(init?.redirect).toBe("manual");
+      return new Response(FIXTURE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    try {
+      const config: OcxConfig = {
+        providers: {
+          "command-code": {
+            adapter: "command-code",
+            baseUrl: "https://api.commandcode.ai",
+            authMode: "oauth",
+            liveModels: true,
+            defaultModel: "deepseek/deepseek-v4-flash",
+          },
+        },
+      };
+      const models = await gatherRoutedModelsForCatalogGather(
+        withStubbedProviderFetch(config),
+        { authStoreBuffer: observedBuffer },
+      );
+      const ours = models.filter(model => model.provider === "command-code");
+
+      expect(ours.length).toBeGreaterThan(1);
+      expect(ours.map(model => model.id)).toContain("deepseek/deepseek-v4-flash");
+      expect(getProviderDiscoveryStatus("command-code")).toEqual({ status: "ok" });
+    } finally {
+      if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = previousHome;
+      const { removeTreeWithRetry } = await import("./helpers/remove-tree");
+      removeTreeWithRetry(root);
+    }
+  });
+
+  test("literal 198.18.x.x discovery URLs stay rejected", async () => {
+    clearProxyEnv();
+    await expect(providerOutboundGet(
+      "command-code",
+      canonicalOAuthRow(),
+      "https://198.18.0.29/provider/v1/models",
+      {},
+      { isCanonicalUrl: isRegistryModelDiscoveryUrl },
+    )).rejects.toBeInstanceOf(ProviderOutboundPolicyError);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  test("loopback / RFC1918 / metadata / link-local companions stay rejected", async () => {
+    clearProxyEnv();
+    for (const address of ["127.0.0.1", "10.0.0.5", "192.168.1.50", "169.254.169.254", "169.254.10.20"]) {
+      lookupMock.mockResolvedValueOnce([
+        { address: "198.18.0.29", family: 4 },
+        { address, family: 4 },
+      ]);
+      await expect(providerOutboundGet(
+        "command-code",
+        canonicalOAuthRow(),
+        "https://api.commandcode.ai/provider/v1/models",
+        {},
+        { isCanonicalUrl: isRegistryModelDiscoveryUrl },
+      )).rejects.toThrow(ProviderOutboundPolicyError);
+    }
+  });
+
+  test("query/fragment smuggling on the canonical origin+path stays rejected", async () => {
+    clearProxyEnv();
+    for (const url of [
+      "https://api.commandcode.ai/provider/v1/models?token=secret",
+      "https://api.commandcode.ai/provider/v1/models#fragment",
+    ]) {
+      expect(isRegistryModelDiscoveryUrl("command-code", url)).toBe(false);
+      lookupMock.mockResolvedValueOnce([{ address: "198.18.0.29", family: 4 }]);
+      await expect(providerOutboundGet(
+        "command-code",
+        canonicalOAuthRow(),
+        url,
+        {},
+        { isCanonicalUrl: isRegistryModelDiscoveryUrl },
+      )).rejects.toThrow(ProviderOutboundPolicyError);
+    }
+  });
+
+  test("renamed rows fetching an attacker URL gain nothing", async () => {
+    clearProxyEnv();
+    expect(isRegistryModelDiscoveryUrl("renamed-row", "https://api.commandcode.ai/provider/v1/models")).toBe(false);
+    expect(isRegistryModelDiscoveryUrl("command-code", "https://evil.example/provider/v1/models")).toBe(false);
+    lookupMock.mockResolvedValueOnce([{ address: "198.18.0.29", family: 4 }]);
+    await expect(providerOutboundGet(
+      "renamed-row",
+      { adapter: "openai-chat", baseUrl: "https://evil.example/v1" },
+      "https://evil.example/v1/models",
+      {},
+      { isCanonicalUrl: isRegistryModelDiscoveryUrl },
+    )).rejects.toThrow(ProviderOutboundPolicyError);
+  });
+
+  test("NO_PROXY-matched canonical hosts keep the rejection (direct route)", async () => {
+    process.env.HTTPS_PROXY = "http://127.0.0.1:9";
+    process.env.NO_PROXY = "api.commandcode.ai";
+    process.env.no_proxy = "api.commandcode.ai";
+    lookupMock.mockResolvedValueOnce([{ address: "198.18.0.29", family: 4 }]);
+    await expect(providerOutboundGet(
+      "command-code",
+      canonicalOAuthRow(),
+      "https://api.commandcode.ai/provider/v1/models",
+      {},
+      { isCanonicalUrl: isRegistryModelDiscoveryUrl },
+    )).rejects.toThrow(ProviderOutboundPolicyError);
+  });
+
+  test("explicit-zero mapped benchmark answers stay covered, hostile tails stay rejected", async () => {
+    clearProxyEnv();
+    lookupMock.mockResolvedValueOnce([{ address: "::ffff:0:c612:1b", family: 6 }]);
+    const accepted = await providerOutboundGet(
+      "command-code",
+      canonicalOAuthRow(),
+      "https://api.commandcode.ai/provider/v1/models",
+      {},
+      {
+        isCanonicalUrl: isRegistryModelDiscoveryUrl,
+        pinnedGet: (async () => new Response(FIXTURE, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as never,
+      },
+    );
+    expect(accepted.status).toBe(200);
+
+    lookupMock.mockResolvedValueOnce([{ address: "::ffff:0:5db8:d822", family: 6 }]);
+    await expect(providerOutboundGet(
+      "command-code",
+      canonicalOAuthRow(),
+      "https://api.commandcode.ai/provider/v1/models",
+      {},
+      { isCanonicalUrl: isRegistryModelDiscoveryUrl },
+    )).rejects.toThrow(ProviderOutboundPolicyError);
+  });
+
+  test("without the canonical-URL proof the fake-IP answer still blocks (fail-closed seam)", async () => {
+    clearProxyEnv();
+    lookupMock.mockResolvedValueOnce([{ address: "198.18.0.29", family: 4 }]);
+    const request = buildModelsRequest(canonicalOAuthRow(), "account-bearer", "command-code");
+    await expect(providerOutboundGet(
+      "command-code",
+      canonicalOAuthRow(),
+      request.url,
+      { headers: request.headers },
+    )).rejects.toThrow(/benchmark address \(198\.18\.0\.29\)/);
+  });
+});

--- a/tests/command-code-fakeip-discovery.test.ts
+++ b/tests/command-code-fakeip-discovery.test.ts
@@ -79,6 +79,8 @@ afterEach(() => {
   lookupMock.mockReset();
   clearModelCache("command-code");
   clearProviderDiscoveryStatus("command-code");
+  clearModelCache("nebius");
+  clearProviderDiscoveryStatus("nebius");
   clearGatherRoutedModelsInflight();
 });
 
@@ -232,6 +234,78 @@ describe("command-code OAuth discovery under Clash/Mihomo fake-IP DNS", () => {
         { isCanonicalUrl: isRegistryModelDiscoveryUrl },
       )).rejects.toThrow(ProviderOutboundPolicyError);
     }
+  });
+
+  // CodeRabbit round 1 on PR #3489: the proof blanket-rejected every query, so a
+  // registry-owned fixed query (Nebius `path: "models"` + `query: { verbose:
+  // "true" }`) could never receive the TUN exception even though the normal
+  // discovery resolver appends that exact query to the final request URL.
+  // Registry-owned fixed queries are canonical ONLY on exact match; anything
+  // missing, changed, added, or fragmented stays rejected.
+  test("registry-owned fixed queries match exactly (real Nebius entry)", async () => {
+    clearProxyEnv();
+    const canonical = "https://api.tokenfactory.nebius.com/v1/models?verbose=true";
+    expect(isRegistryModelDiscoveryUrl("nebius", canonical)).toBe(true);
+    // The production request builder must emit exactly the proven URL.
+    const request = buildModelsRequest(
+      { adapter: "openai-chat", baseUrl: "https://api.tokenfactory.nebius.com/v1", authMode: "key" },
+      "nebius-key",
+      "nebius",
+    );
+    expect(request.url).toBe(canonical);
+
+    // Canonical query pin-connects through the TUN without proxy env.
+    lookupMock.mockResolvedValueOnce([{ address: "198.18.0.29", family: 4 }]);
+    const accepted = await providerOutboundGet(
+      "nebius",
+      { baseUrl: "https://api.tokenfactory.nebius.com/v1" },
+      canonical,
+      { headers: request.headers },
+      {
+        isCanonicalUrl: isRegistryModelDiscoveryUrl,
+        pinnedGet: (async (_url, pinned, _signal, requestOptions) => {
+          expect(pinned.address).toBe("198.18.0.29");
+          expect(new Headers(requestOptions?.headers).get("authorization")).toBe("Bearer nebius-key");
+          return new Response(JSON.stringify({ data: [{ id: "moonshotai/Kimi-K3" }] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }) as never,
+      },
+    );
+    expect(accepted.status).toBe(200);
+
+    // Missing, changed, additional, and fragmented queries stay rejected.
+    for (const url of [
+      "https://api.tokenfactory.nebius.com/v1/models",
+      "https://api.tokenfactory.nebius.com/v1/models?verbose=false",
+      "https://api.tokenfactory.nebius.com/v1/models?verbose=true&x=1",
+      "https://api.tokenfactory.nebius.com/v1/models?verbose=true#fragment",
+    ]) {
+      expect(isRegistryModelDiscoveryUrl("nebius", url)).toBe(false);
+      lookupMock.mockResolvedValueOnce([{ address: "198.18.0.29", family: 4 }]);
+      await expect(providerOutboundGet(
+        "nebius",
+        { baseUrl: "https://api.tokenfactory.nebius.com/v1" },
+        url,
+        {},
+        { isCanonicalUrl: isRegistryModelDiscoveryUrl },
+      )).rejects.toThrow(ProviderOutboundPolicyError);
+    }
+  });
+
+  test("absolute url specs with a fixed registry query require the exact query", async () => {
+    const { withRegistryDiscovery } = await import("./helpers/provider-registry-discovery");
+    await withRegistryDiscovery("together", {
+      url: "https://api.together.xyz/v1/catalog",
+      query: { capability: "chat" },
+    }, async () => {
+      const canonical = "https://api.together.xyz/v1/catalog?capability=chat";
+      expect(isRegistryModelDiscoveryUrl("together", canonical)).toBe(true);
+      expect(isRegistryModelDiscoveryUrl("together", "https://api.together.xyz/v1/catalog")).toBe(false);
+      expect(isRegistryModelDiscoveryUrl("together", "https://api.together.xyz/v1/catalog?capability=embed")).toBe(false);
+      expect(isRegistryModelDiscoveryUrl("together", "https://api.together.xyz/v1/catalog?capability=chat&x=1")).toBe(false);
+    });
   });
 
   test("renamed rows fetching an attacker URL gain nothing", async () => {

--- a/tests/provider-model-discovery-contract.test.ts
+++ b/tests/provider-model-discovery-contract.test.ts
@@ -9,6 +9,7 @@ import { KEY_LOGIN_PROVIDERS, validateApiKey } from "../src/oauth/key-providers"
 import { deriveKeyLoginMap, providerConfigSeed } from "../src/providers/derive";
 import {
   extractProviderModelItems,
+  isRegistryModelDiscoveryUrl,
   providerModelDiscoverySpecError,
   readBoundedDiscoveryJson,
   resolveProviderModelDiscovery,
@@ -540,6 +541,65 @@ describe("registry-owned provider model discovery", () => {
     ]);
     expect(gateway.modelDiscovery).toBeUndefined();
     expect(gateway.liveModels).toBeUndefined();
+  });
+
+  // CodeRabbit round 2 on PR #3489 (parity): `resolveProviderModelDiscoveryUrl`
+  // and `isRegistryModelDiscoveryUrl` resolve `url`/`path`/fixed-query
+  // independently, so drift between them would silently drop the TUN fake-IP
+  // exception for a canonical entry (blocked catalog) without any test naming
+  // the pair. Loop every registry entry that declares `modelDiscovery`:
+  // resolving its canonical discovery URL must always satisfy the proof.
+  test("every canonical registry discovery URL satisfies the canonical proof", () => {
+    const entries = PROVIDER_REGISTRY.filter(entry => entry.modelDiscovery);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      const seed = providerConfigSeed(entry);
+      const resolved = resolveProviderModelDiscoveryUrl(
+        entry.id,
+        seed,
+        entry.baseUrl,
+        `${entry.baseUrl.replace(/\/+$/, "")}/models`,
+      );
+      expect(isRegistryModelDiscoveryUrl(entry.id, resolved)).toBe(true);
+    }
+  });
+
+  // The resolver accepts an effective (possibly custom) baseUrl while the proof
+  // must stay registry-owned: a custom destination that merely resembles the
+  // registry shape must NOT gain the benchmark-address exception. Nebius opts
+  // into `preserveCustomDestination`, so a same-named custom row keeps its own
+  // destination entirely (no registry query/filter), while the renamed-preset
+  // fallback recovers the registry policy only for the exact canonical
+  // destination. Either way the proof is name+URL bound: the attacker-shaped
+  // URL and the renamed row both fail it.
+  test("a custom-destination discovery URL is not registry-canonical", () => {
+    const custom = resolveProviderModelDiscoveryUrl(
+      "nebius",
+      {
+        adapter: "openai-chat",
+        baseUrl: "https://attacker.example/v1",
+        authMode: "key",
+      },
+      "https://attacker.example/v1",
+      "https://attacker.example/v1/models",
+    );
+    expect(custom).toBe("https://attacker.example/v1/models");
+    expect(isRegistryModelDiscoveryUrl("nebius", custom)).toBe(false);
+    expect(isRegistryModelDiscoveryUrl("nebius", "https://attacker.example/v1/models?verbose=true")).toBe(false);
+
+    // The renamed-preset fallback recovers the registry URL for the exact
+    // canonical destination — but the proof stays name-bound, so a renamed row
+    // fetching even the canonical string gains no exception.
+    const renamed = { adapter: "openai-chat", baseUrl: "https://api.tokenfactory.nebius.com/v1", authMode: "key" };
+    const renamedUrl = resolveProviderModelDiscoveryUrl(
+      "nebius-team",
+      renamed,
+      "https://api.tokenfactory.nebius.com/v1",
+      "https://api.tokenfactory.nebius.com/v1/models",
+    );
+    expect(renamedUrl).toBe("https://api.tokenfactory.nebius.com/v1/models?verbose=true");
+    expect(isRegistryModelDiscoveryUrl("nebius-team", renamedUrl)).toBe(false);
+    expect(isRegistryModelDiscoveryUrl("nebius", renamedUrl)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Model discovery fails under transparent fake-IP TUN DNS when the OpenCodex daemon has no `HTTP(S)_PROXY` environment. Command Code OAuth exposed the bug because its catalog depends on authenticated live discovery (`GET https://api.commandcode.ai/provider/v1/models`) and ships no static model list: after login the dashboard reported "Model discovery was blocked by destination policy" with 0/0 visible models.

## Root cause

- Clash/Mihomo/Surge-style fake-IP DNS answers every hostname with `198.18.0.0/15` (here: `api.commandcode.ai` → `198.18.0.29`).
- PR #2037's benchmark-address exception only arms when `proxyConfigured && !noProxyMatches`.
- The daemon runs under launchd/systemd without proxy env, so `proxyConfigured` is false.
- `resolvePublicAddresses` rejects the canonical request before the transparent TUN layer — which would otherwise intercept the fake IP — can handle the connection: `ProviderOutboundPolicyError: ... resolves to benchmark address (198.18.0.29)`, catalog records `{ failed, blocked }`.

| Environment | Result |
| normal public DNS | succeeds |
| fake-IP DNS + explicit HTTPS proxy | succeeds via existing #2037 behavior |
| fake-IP TUN + no daemon proxy env, before fix | blocked |
| fake-IP TUN + no daemon proxy env, after fix | succeeds |

The canonical endpoint returned HTTP 200 when connectivity was tested through both the real public address and the TUN fake IP, proving the failure was destination admission rather than the Command Code service.

## Fix

A narrowly scoped extension of the existing benchmark-address exception to registry-proven canonical model-discovery URLs:

- new `isRegistryModelDiscoveryUrl` proves the **final request URL** against the registry's own fixed discovery URL — not the provider name (OAuth/forward names match any baseUrl by design);
- exact HTTPS origin/path semantics plus exact registry-owned query match; userinfo, fragment, host-suffix tricks, and modified ports all fail the proof. Registry-owned fixed query parameters are accepted only on exact match (e.g. Nebius `.../v1/models?verbose=true`); caller-added or modified query parameters remain rejected;
- covers both registry spec shapes (`url` and `path` with optional fixed `query`, so the `commandcode` key preset's `path: "models"` proves the same string the `command-code` OAuth `url` spec proves);
- injected `isCanonicalUrl` seam in `provider-outbound` that defaults closed (callers that forget it fail closed);
- wired into catalog discovery and `/api/providers/test` only — image/Lab callers are untouched;
- no generic `allowPrivateNetwork`, no arbitrary OAuth destination exception.


## Security boundary

These remain rejected (each covered by regression tests or existing suites):

- literal benchmark IP URLs (`https://198.18.x.x/...`, including IPv6 spellings)
- loopback, RFC1918 (incl. CGNAT), link-local, unspecified, multicast/reserved, documentation addresses
- cloud metadata endpoints
- unsafe mixed DNS answers (any non-benchmark companion, or public+benchmark mixes)
- modified/custom destinations and renamed rows fetching attacker URLs
- caller-added/modified query parameters and fragments on the canonical origin+path (registry-owned fixed query accepted only on exact match)
- `NO_PROXY`-matched hosts (direct route keeps the rejection)
- unrelated outbound callers (image/Lab fetch never pass the flag)

Redirect handling is unchanged: discovery still uses `redirect: "manual"` and surfaces credential-stripped guidance via `providerRedirectError`; redirects are never followed, so canonical authorization cannot leak to another origin. OAuth bearer pinning in `buildModelsRequest` is unchanged — a retargeted row still sends its credential only to the registry origin.

## Verification

- `tests/command-code-fakeip-discovery.test.ts` (12 tests): **12/12 green**, including the Nebius exact-query regression (`?verbose=true` accepted; bare/`?verbose=false`/`?verbose=true&x=1`/fragment rejected) and the temporary-registry absolute-`url`+fixed-query case. Ablation with the core seam forced false gives **10 pass / 2 fail** (the two TUN acceptance tests), restored byte-identical → 12/12.
- `tests/provider-model-discovery-contract.test.ts`: **38/38 green**, including the new registry-driven parity test (all 17 canonical `modelDiscovery` entries: resolver output satisfies the proof across `url`/`path`/fixed-query shapes) and the custom-destination negative guard.
- Focused set: **171 pass / 0 fail** (fakeip-discovery, discovery-contract, sambanova-nebius, outbound, outbound-private-network, destination-policy-resolved, command-code, commandcode, live-models).
- Adjacent sets: **368 pass / 0 fail** (live-models, oauth-observation, codex-catalog, discovery-management-api, discovery-log-suppression, connection-test, gather-authority, command-code-quota, registry-parity) and **74 pass / 0 fail** (pinned-http, static-discovery, outbound-body-guard, claude-models-discovery, command-code-error-finish, workspace-cache, slug-codec).
- `bun run typecheck`: clean. `bun run privacy:scan`: passed. `git diff --check`: clean.
- Baseline note: `management-provider-validation` shows **78 pass / 19 fail identically on unmodified upstream/dev** — this host's fake-IP DNS maps `*.example.test` into `198.18.0.0/15`, so the write-time DNS gate fires before the intended assertions. Environmental, unrelated to this change.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider connectivity checks in TUN mode when registry model-discovery requests use transparent fake-IP DNS.
  * Canonical registry discovery URLs can now connect successfully without proxy environment settings.
  * Continued rejecting modified, unsafe, private, loopback, metadata, and NO_PROXY-matched destinations.

* **Tests**
  * Added coverage for successful canonical discovery, OAuth authentication flows, dynamically registered providers, and rejection of altered or unsafe URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



