### PR TITLE
feat(gui,docs): explain the admin token where it is asked for

### DIFF
--- a/docs-site/src/content/docs/guides/web-dashboard.md
+++ b/docs-site/src/content/docs/guides/web-dashboard.md
@@ -34,6 +34,40 @@ password manager can offer to save and autofill it. The dashboard itself still k
 in memory and does not write it to `localStorage` or `sessionStorage`; whether it is saved is entirely
 the browser or password manager's decision.
 
+### Finding the admin token
+
+You only need this on a non-loopback bind. A local dashboard never asks, and if a local one
+*does* ask, the token is not the problem — see [When a local dashboard cannot start a
+session](#when-a-local-dashboard-cannot-start-a-session) below.
+
+The proxy generates the token for you the first time it starts. It is not printed anywhere,
+by design, so read it from the file:
+
+```bash
+cat ~/.opencodex/admin-api-token
+```
+
+If `OPENCODEX_HOME` is set, the file lives at `$OPENCODEX_HOME/admin-api-token` instead. On
+Windows that is `%USERPROFILE%\.opencodex\admin-api-token`. A generated token looks like
+`ocx_admin_` followed by 43 characters; the proxy refuses a file that does not match that
+shape rather than silently regenerating one.
+
+To choose the value yourself, set `OPENCODEX_ADMIN_AUTH_TOKEN` before starting the proxy. It
+takes precedence over the file, and the file is then neither read nor created. Pick something
+distinct from your data-plane credential (`OPENCODEX_API_AUTH_TOKEN` or a configured API key) —
+reusing one is rejected.
+
+There is no CLI command that prints the token. `ocx doctor` deliberately reports whether a
+credential is present without ever revealing its value.
+
+### When a local dashboard cannot start a session
+
+A dashboard on `localhost` mints its own session, so it will not prompt you for a token. If it
+reports that it could not start a session, the cause is the address you are using rather than a
+missing credential — the proxy did not recognise the request as loopback. Open the dashboard at
+the address the proxy prints on startup (usually `http://127.0.0.1:<port>`), and prefer that exact
+host and port over a LAN IP or an alias.
+
 ## What you can do
 
 | Area | What it does |

--- a/gui/src/admin-token-dialog.ts
+++ b/gui/src/admin-token-dialog.ts
@@ -2,6 +2,7 @@ import { DICTS, getActiveLocale, type Locale } from "./i18n/shared";
 
 const ADMIN_TOKEN_DIALOG_ID = "opencodex-admin-token-dialog";
 const ADMIN_TOKEN_USERNAME = "OpenCodex";
+const ADMIN_TOKEN_DOCS_URL = "https://opencodex.me/guides/web-dashboard/#finding-the-admin-token";
 
 export type AdminTokenValidation = "accepted" | "rejected" | "unavailable";
 export type AdminTokenVerifier = (token: string) => Promise<AdminTokenValidation>;
@@ -73,6 +74,22 @@ export function promptForAdminToken(
     password.spellcheck = false;
     password.autocapitalize = "none";
     tokenField.append(tokenLabel, password);
+
+    // #3353: the bare password box told a user nothing. Say what the credential is, where
+    // the proxy already wrote it, and link the guide that spells it out.
+    const help = document.createElement("p");
+    help.className = "hint";
+    help.style.marginTop = "var(--space-2)";
+    help.textContent = messages["auth.adminTokenHelp"];
+    const docsLink = document.createElement("a");
+    docsLink.className = "text-control";
+    docsLink.href = ADMIN_TOKEN_DOCS_URL;
+    docsLink.target = "_blank";
+    docsLink.rel = "noreferrer";
+    docsLink.style.color = "var(--accent)";
+    docsLink.textContent = messages["auth.adminTokenDocsLink"];
+    help.append(" ", docsLink);
+    tokenField.append(help);
 
     const validationError = document.createElement("div");
     validationError.className = "notice notice-err";

--- a/gui/src/i18n/de.ts
+++ b/gui/src/i18n/de.ts
@@ -106,6 +106,8 @@ export const de: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "Admin-Token",
   "auth.adminTokenRejected": "Der Admin-Token wurde abgelehnt. Prüfen Sie ihn und versuchen Sie es erneut.",
   "auth.adminTokenUnavailable": "Der Admin-Token konnte nicht überprüft werden. Versuchen Sie es erneut.",
+  "auth.adminTokenHelp": "Dies ist der Admin-Token der OpenCodex-Verwaltungs-API, kein Anbieter-API-Schlüssel. Beim ersten Start schreibt der Proxy ihn nach ~/.opencodex/admin-api-token (oder $OPENCODEX_HOME/admin-api-token); OPENCODEX_ADMIN_AUTH_TOKEN hat Vorrang.",
+  "auth.adminTokenDocsLink": "So finden Sie ihn",
   "theme.label": "Design",
   "theme.light": "Hell",
   "theme.dark": "Dunkel",

--- a/gui/src/i18n/en.ts
+++ b/gui/src/i18n/en.ts
@@ -41,6 +41,8 @@ export const en = {
   "auth.adminTokenFieldLabel": "Admin token",
   "auth.adminTokenRejected": "That admin token was rejected. Check it and try again.",
   "auth.adminTokenUnavailable": "The admin token could not be verified. Try again.",
+  "auth.adminTokenHelp": "This is the OpenCodex management admin token, not a provider API key. The proxy writes it to ~/.opencodex/admin-api-token (or $OPENCODEX_HOME/admin-api-token) on first start, and OPENCODEX_ADMIN_AUTH_TOKEN overrides it.",
+  "auth.adminTokenDocsLink": "How to find it",
   "app.logoAria": "opencodex logo",
   "app.claudeOn": "Claude ON",
   "app.claudeOff": "Claude OFF",

--- a/gui/src/i18n/fr.ts
+++ b/gui/src/i18n/fr.ts
@@ -38,6 +38,8 @@ export const fr: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "Jeton d’administration",
   "auth.adminTokenRejected": "Ce jeton d’administration a été refusé. Vérifiez-le et réessayez.",
   "auth.adminTokenUnavailable": "Le jeton d’administration n’a pas pu être vérifié. Réessayez.",
+  "auth.adminTokenHelp": "Il s’agit du jeton d’administration de l’API de gestion OpenCodex, pas d’une clé API de fournisseur. Au premier démarrage, le proxy l’écrit dans ~/.opencodex/admin-api-token (ou $OPENCODEX_HOME/admin-api-token), et OPENCODEX_ADMIN_AUTH_TOKEN a la priorité.",
+  "auth.adminTokenDocsLink": "Où le trouver",
   "app.logoAria": "Logo opencodex",
   "app.claudeOn": "Claude ACTIVÉ",
   "app.claudeOff": "Claude DÉSACTIVÉ",

--- a/gui/src/i18n/ja.ts
+++ b/gui/src/i18n/ja.ts
@@ -108,6 +108,8 @@ export const ja: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "管理者トークン",
   "auth.adminTokenRejected": "管理者トークンが拒否されました。確認してもう一度お試しください。",
   "auth.adminTokenUnavailable": "管理者トークンを確認できませんでした。もう一度お試しください。",
+  "auth.adminTokenHelp": "これは OpenCodex 管理 API の管理者トークンで、プロバイダーの API キーではありません。プロキシは初回起動時に ~/.opencodex/admin-api-token（または $OPENCODEX_HOME/admin-api-token）へ書き込み、OPENCODEX_ADMIN_AUTH_TOKEN を設定するとそちらが優先されます。",
+  "auth.adminTokenDocsLink": "確認方法",
   "app.logoAria": "opencodex ロゴ",
   "app.claudeOn": "Claude オン",
   "app.claudeOff": "Claude オフ",

--- a/gui/src/i18n/ko.ts
+++ b/gui/src/i18n/ko.ts
@@ -106,6 +106,8 @@ export const ko: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "관리자 토큰",
   "auth.adminTokenRejected": "관리자 토큰이 거부되었습니다. 확인한 후 다시 시도하세요.",
   "auth.adminTokenUnavailable": "관리자 토큰을 확인할 수 없습니다. 다시 시도하세요.",
+  "auth.adminTokenHelp": "이 값은 OpenCodex 관리 API의 관리자 토큰이며 공급자 API 키가 아닙니다. 프록시가 처음 실행될 때 ~/.opencodex/admin-api-token(또는 $OPENCODEX_HOME/admin-api-token)에 기록하고, OPENCODEX_ADMIN_AUTH_TOKEN을 설정하면 그 값이 우선합니다.",
+  "auth.adminTokenDocsLink": "찾는 방법",
   "theme.label": "테마",
   "theme.light": "라이트",
   "theme.dark": "다크",

--- a/gui/src/i18n/ru.ts
+++ b/gui/src/i18n/ru.ts
@@ -108,6 +108,8 @@ export const ru: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "Токен администратора",
   "auth.adminTokenRejected": "Токен администратора отклонён. Проверьте его и повторите попытку.",
   "auth.adminTokenUnavailable": "Не удалось проверить токен администратора. Повторите попытку.",
+  "auth.adminTokenHelp": "Это административный токен управляющего API OpenCodex, а не ключ API провайдера. При первом запуске прокси записывает его в ~/.opencodex/admin-api-token (или $OPENCODEX_HOME/admin-api-token), а OPENCODEX_ADMIN_AUTH_TOKEN переопределяет это значение.",
+  "auth.adminTokenDocsLink": "Как его найти",
   "app.logoAria": "Логотип opencodex",
   "app.claudeOn": "Claude ВКЛ",
   "app.claudeOff": "Claude ВЫКЛ",

--- a/gui/src/i18n/tr.ts
+++ b/gui/src/i18n/tr.ts
@@ -40,6 +40,8 @@ export const tr: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "Yönetici jetonu",
   "auth.adminTokenRejected": "Bu yönetici jetonu reddedildi. Kontrol edip tekrar deneyin.",
   "auth.adminTokenUnavailable": "Yönetici jetonu doğrulanamadı. Tekrar deneyin.",
+  "auth.adminTokenHelp": "Bu, sağlayıcı API anahtarı değil, OpenCodex yönetim API’sinin yönetici jetonudur. Proxy ilk açılışta bunu ~/.opencodex/admin-api-token (veya $OPENCODEX_HOME/admin-api-token) dosyasına yazar; OPENCODEX_ADMIN_AUTH_TOKEN bu değeri geçersiz kılar.",
+  "auth.adminTokenDocsLink": "Nasıl bulunur",
   "app.logoAria": "opencodex logosu",
   "app.claudeOn": "Claude AÇIK",
   "app.claudeOff": "Claude KAPALI",

--- a/gui/src/i18n/zh-TW.ts
+++ b/gui/src/i18n/zh-TW.ts
@@ -1941,6 +1941,8 @@ export const zhTW: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "管理員金鑰",
   "auth.adminTokenRejected": "該管理員金鑰被拒絕。請檢查後再試一次。",
   "auth.adminTokenUnavailable": "無法驗證管理員金鑰。請再試一次。",
+  "auth.adminTokenHelp": "這是 OpenCodex 管理 API 的管理員金鑰，不是服務商 API 金鑰。代理首次啟動時會寫入 ~/.opencodex/admin-api-token（或 $OPENCODEX_HOME/admin-api-token），設定 OPENCODEX_ADMIN_AUTH_TOKEN 可覆寫該值。",
+  "auth.adminTokenDocsLink": "如何尋找",
   "lang.nativeName": "繁體中文",
   "provider.name.commandCodeAuth": "Command Code - Auth",
   "provider.name.commandCodeApi": "Command Code - API",

--- a/gui/src/i18n/zh.ts
+++ b/gui/src/i18n/zh.ts
@@ -106,6 +106,8 @@ export const zh: Record<TKey, string> = {
   "auth.adminTokenFieldLabel": "管理员令牌",
   "auth.adminTokenRejected": "管理员令牌被拒绝。请检查后重试。",
   "auth.adminTokenUnavailable": "无法验证管理员令牌。请重试。",
+  "auth.adminTokenHelp": "这是 OpenCodex 管理 API 的管理员令牌，不是服务商 API 密钥。代理首次启动时会写入 ~/.opencodex/admin-api-token（或 $OPENCODEX_HOME/admin-api-token），设置 OPENCODEX_ADMIN_AUTH_TOKEN 可覆盖该值。",
+  "auth.adminTokenDocsLink": "如何查找",
   "theme.label": "主题",
   "theme.light": "浅色",
   "theme.dark": "深色",

--- a/gui/tests/admin-token-dialog.test.ts
+++ b/gui/tests/admin-token-dialog.test.ts
@@ -179,3 +179,22 @@ test("notice display rules are scoped so a hidden notice cannot paint", async ()
     expect(selector).toContain(":not([hidden])");
   }
 });
+
+/* #3353 — a bare password box explained nothing. */
+test("the dialog explains the credential and links the setup guide", async () => {
+  const pending = promptForAdminToken(async () => "accepted");
+  const dialog = document.querySelector<HTMLDialogElement>("#opencodex-admin-token-dialog")!;
+
+  const link = dialog.querySelector<HTMLAnchorElement>('a[target="_blank"]')!;
+  expect(link).not.toBeNull();
+  expect(link.href).toBe("https://opencodex.me/guides/web-dashboard/#finding-the-admin-token");
+  expect(link.rel).toBe("noreferrer");
+  expect(link.textContent).toBe("How to find it");
+
+  const help = link.parentElement!;
+  expect(help.textContent).toContain("admin-api-token");
+  expect(help.textContent).toContain("OPENCODEX_ADMIN_AUTH_TOKEN");
+
+  dialog.dispatchEvent(new testWindow.Event("cancel", { cancelable: true }));
+  expect(await pending).toBeNull();
+});


### PR DESCRIPTION
> Final PR of the admin-token stack. Parents #3491 and #3496 are merged; this now targets `dev` directly.

## Summary

The sibling PRs stop a local user ever seeing the admin-token prompt. This one fixes the prompt for the operator who legitimately does: a non-loopback bind was still met with a bare password box titled with an environment variable name.

#3353 is that user. They upgraded to 2.40.0, were blocked from the dashboard, assumed a config-loss bug, and had to have an LLM read the codebase before learning the token was a new security feature and where to obtain one.

The dialog now states what the credential is (the management admin token, **not** a provider API key), where the proxy already wrote it, and that the environment variable overrides it — then links a docs anchor that spells it out. Copy is added to all nine locales; the existing key-parity test covers the set.

The guide gains that anchor. It already said a remote dashboard needs the token and named the file, but never how to read it, so it is now explicit: start the proxy once to mint it, `cat` the file, honour `OPENCODEX_HOME`, and do not go looking for a CLI that prints it — `ocx doctor` deliberately reports presence without ever revealing a value. A second section covers the case a *local* user actually hits, where the address is the problem rather than the credential.

![before and after](https://github.com/lidge-jun/opencodex/blob/dev/devlog/_plan/260905_admin_token_local_ux/assets/admin-token-dialog-before-after.png?raw=1)

The link follows house style for in-app docs links (`target="_blank"`, `rel="noreferrer"`, accent colour), matching `gui/src/pages/dashboard-dialogs.tsx`.

## Verification

- `bun run typecheck` — clean
- `bun run lint:gui` — clean
- `cd gui && bun test` — 1366 pass, 0 fail (220 files)
- `bun run privacy:scan` — passed

The regression asserts the href, the `rel`, and that the help text names both the token file and the environment variable. `gui/tests/i18n-locales.test.ts` enforces that all nine locales carry the new keys with no drift.

## Checklist

- [x] Focused tests cover the change
- [x] Docs updated where user-facing behavior changed
- [x] No credential, token, or request-body logging introduced — the guide tells a user how to read their own token; it never prints one
- [x] Targets `dev`

Refs #3353


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explanatory guidance to the admin-token sign-in dialog, including where the token is stored and how environment-variable overrides work.
  * Added a link to the web dashboard guide for locating the admin token, opening in a new tab.
  * Added localized admin-token guidance and documentation links in multiple languages.

* **Documentation**
  * Expanded the web dashboard sign-in guide with token discovery instructions and troubleshooting steps for local dashboard sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->