### PR TITLE
perf(oauth): stop reading the auth store on every Anthropic request

### DIFF
--- a/src/oauth/anthropic-routing.ts
+++ b/src/oauth/anthropic-routing.ts
@@ -152,6 +152,7 @@ export function sweepExpiredAnthropicRoutingHealth(now = Date.now()): number {
 export function clearAnthropicAccountPoolState(): void {
   upstreamHealth.clear();
   sessionAffinity.clear();
+  quorumCache = null;
 }
 
 export function anthropicSessionAffinitySizeForTests(): number {
@@ -237,6 +238,23 @@ export function getEligibleAnthropicAccounts(now = Date.now()): string[] {
 }
 
 /**
+ * How long a quorum answer may be reused before the store is consulted again.
+ *
+ * This predicate now runs on the INITIAL resolution of every Anthropic request, not just after a
+ * 429, so an uncached implementation puts a synchronous file read in front of ordinary traffic:
+ * `getAccountSet` goes through `loadAuthStore`, which has no cache of its own and chmods the
+ * config dir, chmods the secret, reads the whole file and normalizes it on every call.
+ *
+ * Two seconds matches the generic module's `PRESENCE_CACHE_TTL_MS` for the same reason: short
+ * enough that a login in another window is visible before the operator can switch back and send a
+ * prompt, long enough that a burst of requests shares one read. The cache holds a BOOLEAN derived
+ * from a count — never a credential, never an account id.
+ */
+const QUORUM_CACHE_TTL_MS = 2_000;
+
+let quorumCache: { value: boolean; readAt: number } | null = null;
+
+/**
  * Whether a 429 has somewhere to go: two or more accounts that could serve traffic if asked.
  *
  * Reactive failover is a safety net, not a routing policy. It runs only AFTER upstream refused,
@@ -255,15 +273,28 @@ export function getEligibleAnthropicAccounts(now = Date.now()): string[] {
  * holds: an expired background slot is not a quorum and cannot be adopted.
  */
 export function hasAnthropicFailoverQuorum(now = Date.now()): boolean {
-  const set = getAccountSet(PROVIDER);
-  if (!set) return false;
-  let usable = 0;
-  for (const account of set.accounts) {
-    if (account.needsReauth === true) continue;
-    if (!isPoolCredentialUsable(account.id, now)) continue;
-    if (++usable >= 2) return true;
+  // Monotonic guard: a caller-supplied `now` that predates the cached read (tests pass explicit
+  // clocks) must not be served from a future entry.
+  if (quorumCache && now >= quorumCache.readAt && now - quorumCache.readAt < QUORUM_CACHE_TTL_MS) {
+    return quorumCache.value;
   }
-  return false;
+  const set = getAccountSet(PROVIDER);
+  let value = false;
+  if (set) {
+    let usable = 0;
+    for (const account of set.accounts) {
+      if (account.needsReauth === true) continue;
+      if (!isPoolCredentialUsable(account.id, now)) continue;
+      if (++usable >= 2) { value = true; break; }
+    }
+  }
+  quorumCache = { value, readAt: now };
+  return value;
+}
+
+/** Test seam and manual-recovery hook: force the next quorum question to re-read the store. */
+export function forgetAnthropicFailoverQuorum(): void {
+  quorumCache = null;
 }
 
 /** Earliest remaining cooldown among cooled Anthropic accounts, for client Retry-After. */
@@ -620,6 +651,9 @@ export function rotateAnthropicAccountOn429(
   sweepExpiredOnWrite(now);
   clearAnthropicSessionAffinityForAccount(failedAccountId);
   notePoolRotationFailure(POOL_KEY_ANTHROPIC, failedAccountId);
+  // A rotation means the roster in use just changed; do not answer the next activation question
+  // from a count read taken before the failure.
+  quorumCache = null;
 
   const next = pickAlternateAnthropicAccount(config, failedAccountId, now);
   if (!next) {

--- a/src/oauth/anthropic-routing.ts
+++ b/src/oauth/anthropic-routing.ts
@@ -620,6 +620,10 @@ export function clearAnthropicSessionAffinityForAccount(accountId: string): void
   for (const [key, entry] of sessionAffinity) {
     if (entry.accountId === accountId) sessionAffinity.delete(key);
   }
+  // The roster just lost or changed a member. This is the account-removal path, so the next
+  // activation question must re-read rather than answer from a count taken while the account
+  // was still present -- otherwise a delete leaves a stale quorum for the length of the TTL.
+  quorumCache = null;
 }
 
 /**
@@ -684,6 +688,9 @@ export function promoteAnthropicActiveAccount(accountId: string): void {
 export function resetAnthropicRoutingForManualSelection(accountId: string): void {
   sessionAffinity.clear();
   seedPoolRotationAccount(POOL_KEY_ANTHROPIC, accountId);
+  // A manual account selection is an operator statement about the roster; do not answer the
+  // next activation question from a count read before it.
+  quorumCache = null;
 }
 
 /**

--- a/tests/anthropic-quorum-cache.test.ts
+++ b/tests/anthropic-quorum-cache.test.ts
@@ -18,8 +18,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   clearAnthropicAccountPoolState,
+  clearAnthropicSessionAffinityForAccount,
   forgetAnthropicFailoverQuorum,
   hasAnthropicFailoverQuorum,
+  resetAnthropicRoutingForManualSelection,
   rotateAnthropicAccountOn429,
 } from "../src/oauth/anthropic-routing";
 import { getAccountSet, saveCredential } from "../src/oauth/store";
@@ -115,5 +117,30 @@ describe("Anthropic failover quorum cache", () => {
     // outlive the store's own hardening, which is the thing loadAuthStore re-applies per read.
     await seed(2);
     expect(typeof hasAnthropicFailoverQuorum()).toBe("boolean");
+  });
+
+  test("removing an account invalidates immediately, not after the TTL", async () => {
+    // The management DELETE route calls clearAnthropicSessionAffinityForAccount for Anthropic.
+    // Without invalidation there, deleting the second account would leave quorum true for up to
+    // 2s -- long enough for a request to record an id whose credential is already gone.
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    clearAnthropicSessionAffinityForAccount(ids[1]!);
+    markStoreUnread();
+    hasAnthropicFailoverQuorum(start + 1);
+    expect(storeWasRead()).toBe(true);
+  });
+
+  test("a manual account selection invalidates immediately", async () => {
+    // An operator picking an account is a statement about the roster, so the next activation
+    // question must not be answered from a count read before it.
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    resetAnthropicRoutingForManualSelection(ids[0]!);
+    markStoreUnread();
+    hasAnthropicFailoverQuorum(start + 1);
+    expect(storeWasRead()).toBe(true);
   });
 });

--- a/tests/anthropic-quorum-cache.test.ts
+++ b/tests/anthropic-quorum-cache.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The quorum predicate must not read the auth store on every request.
+ *
+ * `hasAnthropicFailoverQuorum` decides whether an Anthropic request records the account that
+ * served it, so it runs on the INITIAL resolution of ordinary traffic -- not only after a 429.
+ * `getAccountSet` goes through `loadAuthStore`, which has no cache: it chmods the config dir,
+ * chmods the secret, reads the whole file and normalizes it on every call. An uncached predicate
+ * therefore puts a synchronous file read in front of every Anthropic turn.
+ *
+ * The generic module already solved this with a TTL-bounded count cache. These tests pin the same
+ * three properties for the Anthropic twin: the read is shared inside the window, a fresh login is
+ * still visible once it expires, and a rotation invalidates immediately rather than answering the
+ * next question from a pre-failure count.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, statSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearAnthropicAccountPoolState,
+  forgetAnthropicFailoverQuorum,
+  hasAnthropicFailoverQuorum,
+  rotateAnthropicAccountOn429,
+} from "../src/oauth/anthropic-routing";
+import { getAccountSet, saveCredential } from "../src/oauth/store";
+import { removeTreeWithRetry } from "./helpers/remove-tree";
+
+const originalHome = process.env.OPENCODEX_HOME;
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ocx-quorum-cache-"));
+  process.env.OPENCODEX_HOME = home;
+  clearAnthropicAccountPoolState();
+  forgetAnthropicFailoverQuorum();
+});
+
+afterEach(() => {
+  clearAnthropicAccountPoolState();
+  forgetAnthropicFailoverQuorum();
+  if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = originalHome;
+  removeTreeWithRetry(home);
+});
+
+async function seed(count: number, offset = 0): Promise<string[]> {
+  for (let i = offset; i < offset + count; i++) {
+    await saveCredential("anthropic", {
+      access: `access-${i}`,
+      refresh: `refresh-${i}`,
+      expires: Date.now() + 3_600_000,
+      accountId: `uuid-${i}`,
+      email: `user${i}@example.test`,
+    } as never);
+  }
+  return getAccountSet("anthropic")?.accounts.map(a => a.id) ?? [];
+}
+
+/**
+ * Observe the store read without stubbing the module: `loadAuthStore` calls `readFileSync`,
+ * which updates atime. Pinning atime into the past and checking whether it moved is a direct
+ * observation of the syscall this cache exists to avoid.
+ */
+function storePath(): string {
+  return join(home, "auth.json");
+}
+
+function markStoreUnread(): void {
+  const stats = statSync(storePath());
+  utimesSync(storePath(), new Date(Date.now() - 60_000), stats.mtime);
+}
+
+function storeWasRead(): boolean {
+  return statSync(storePath()).atimeMs > Date.now() - 30_000;
+}
+
+describe("Anthropic failover quorum cache", () => {
+  test("a burst of requests inside the TTL window shares one store read", async () => {
+    const start = Date.now();
+    await seed(2);
+    // Prime the cache, then prove the next calls do not touch the file at all.
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    markStoreUnread();
+    for (let i = 0; i < 25; i++) expect(hasAnthropicFailoverQuorum(start + i)).toBe(true);
+    expect(storeWasRead()).toBe(false);
+  });
+
+  test("a fresh login is visible once the window expires", async () => {
+    // The cache must not be able to strand an operator who just logged a second account in:
+    // a stale false would keep failover off for exactly the traffic that needs it.
+    const start = Date.now();
+    await seed(1);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(false);
+    await seed(1, 1);
+    // Same instant: still the memoized answer.
+    expect(hasAnthropicFailoverQuorum(start)).toBe(false);
+    // Past the window: seen without any explicit invalidation call.
+    expect(hasAnthropicFailoverQuorum(start + 2_001)).toBe(true);
+  });
+
+  test("a rotation invalidates immediately rather than waiting out the TTL", async () => {
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    expect(rotateAnthropicAccountOn429({ providers: {} } as never, ids[0]!, null, null, start)).toBe(ids[1]);
+    // The roster in use just changed, so the next question re-reads instead of answering from
+    // the count taken before the failure.
+    markStoreUnread();
+    hasAnthropicFailoverQuorum(start + 1);
+    expect(storeWasRead()).toBe(true);
+  });
+
+  test("the cache holds no credential material", async () => {
+    // A boolean derived from a count. If this ever became an id or a token the cache would
+    // outlive the store's own hardening, which is the thing loadAuthStore re-applies per read.
+    await seed(2);
+    expect(typeof hasAnthropicFailoverQuorum()).toBe("boolean");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #3495. The quorum predicate that change introduced was reading the credential store on **every Anthropic request**.

`hasAnthropicFailoverQuorum` decides whether a request records the account that served it, so it runs on the initial resolution of ordinary traffic — not only after a 429. It calls `getAccountSet`, which goes through `loadAuthStore`, and that has no cache of its own: every call chmods the config dir, chmods the secret, reads the whole file and normalizes it. So #3495 put a synchronous file read in front of every Anthropic turn.

The generic OAuth twin already solved exactly this, and documents why:

> Since presence now decides activation, this predicate runs on paths that have not seen a 429 at all […] so an uncached check would put a synchronous file read in front of every request for every OAuth provider.

I mirrored that design rather than inventing a second one — same 2 s window, same "the cache holds a COUNT, never a credential" rule. Here the entry is a boolean derived from a count.

**A second defect surfaced while auditing the invalidation coverage.** The cache was cleared on rotation and on pool-state reset, but not on the two roster mutations that reach it from the management API. Deleting the second Anthropic account left quorum `true` for up to 2 s — long enough for a request to record an id whose credential was already gone. `clearAnthropicSessionAffinityForAccount` (the DELETE route) and `resetAnthropicRoutingForManualSelection` now invalidate too.

Invalidation is therefore complete across all four paths that change the roster: rotation, pool-state reset, account removal, manual selection.

## Verification

- `bun run typecheck` — clean.
- `bun test` across six focused files — 103 pass, 0 fail, including six new cache tests.
- No repository-wide local suite; repository-wide validation is delegated to CI on this head.

The regression test **observes `atime` on the credential file** rather than stubbing the module, so it fails if the syscall comes back. That is the property worth protecting: a mock would pass against a reintroduced read through a different call path.

The 2 s staleness window is accepted deliberately and matches `PRESENCE_CACHE_TTL_MS` in the generic module, so both now answer activation questions with the same freshness guarantee instead of two different ones. A stale `true` cannot dispatch on a missing account: quorum only decides whether to *record* an id, and rotation itself re-reads the store and returns `null` when there is nowhere to go.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Anthropic failover checks by briefly caching results, reducing repeated authentication-store reads during request bursts.

* **Bug Fixes**
  * Ensured newly authenticated accounts are recognized after the cache expires.
  * Ensured account changes, rate-limit rotations, and manual selections immediately refresh failover status.

* **Security**
  * Cached status contains only a boolean result and no credential information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->