### PR TITLE
feat(logs): add composable log filter engine

### DIFF
--- a/gui/src/pages/logs-filter.ts
+++ b/gui/src/pages/logs-filter.ts
@@ -48,6 +48,7 @@ export interface FilterableLogEntry {
   };
 }
 
+/** Return whether any filter differs from the inert default state. */
 export function hasActiveLogFilters(filters: LogFilterState): boolean {
   return filters.surface !== "all"
     || filters.model.trim() !== ""
@@ -60,6 +61,7 @@ export function hasActiveLogFilters(filters: LogFilterState): boolean {
     || filters.conversationId.trim() !== "";
 }
 
+/** Safely retain only object-shaped failover attempts from untrusted log data. */
 function attempts(log: FilterableLogEntry): FilterableLogAttempt[] {
   if (!Array.isArray(log.attempts)) return [];
   return log.attempts.filter(
@@ -67,10 +69,14 @@ function attempts(log: FilterableLogEntry): FilterableLogAttempt[] {
   );
 }
 
+/** Canonicalize a filter value for case-insensitive matching and deduplication. */
 function normalized(value: unknown): string | undefined {
-  return typeof value === "string" ? value.toLowerCase() : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
 }
 
+/** Resolve a relative time-window lower bound against an injected clock. */
 function timeThreshold(window: LogTimeWindow, now: number): number | undefined {
   if (window === "15m") return now - 15 * 60 * 1000;
   if (window === "1h") return now - 60 * 60 * 1000;
@@ -78,6 +84,7 @@ function timeThreshold(window: LogTimeWindow, now: number): number | undefined {
   return undefined;
 }
 
+/** Apply every active filter to a bounded request-log snapshot. */
 export function filterLogs<T extends FilterableLogEntry>(
   logs: readonly T[],
   filters: LogFilterState,
@@ -130,22 +137,33 @@ export function filterLogs<T extends FilterableLogEntry>(
   });
 }
 
+/** Keep one stable display spelling for each case-insensitive option value. */
+function addOption(options: Map<string, string>, value: unknown): void {
+  if (typeof value !== "string") return;
+  const display = value.trim();
+  const key = normalized(display);
+  if (!key) return;
+  const current = options.get(key);
+  if (current === undefined || display < current) options.set(key, display);
+}
+
+/** Extract deterministic, selectable model and provider options from log rows. */
 export function extractLogFilterOptions(logs: readonly FilterableLogEntry[]): {
   models: string[];
   providers: string[];
 } {
-  const models = new Set<string>();
-  const providers = new Set<string>();
+  const models = new Map<string, string>();
+  const providers = new Map<string, string>();
   for (const log of logs) {
     for (const value of [log.model, log.resolvedModel, ...attempts(log).map(attempt => attempt.model)]) {
-      if (typeof value === "string" && value.trim()) models.add(value);
+      addOption(models, value);
     }
     for (const value of [log.provider, ...attempts(log).map(attempt => attempt.provider)]) {
-      if (typeof value === "string" && value.trim()) providers.add(value);
+      addOption(providers, value);
     }
   }
   return {
-    models: [...models].sort(),
-    providers: [...providers].sort(),
+    models: [...models.values()].sort(),
+    providers: [...providers.values()].sort(),
   };
 }

--- a/gui/src/pages/logs-filter.ts
+++ b/gui/src/pages/logs-filter.ts
@@ -105,9 +105,15 @@ export function filterLogs<T extends FilterableLogEntry>(
     )) return false;
 
     if (filters.status === "success"
-      && (typeof log.status !== "number" || log.status < 200 || log.status >= 300)) return false;
+      && (typeof log.status !== "number"
+        || !Number.isInteger(log.status)
+        || log.status < 200
+        || log.status >= 300)) return false;
     if (filters.status === "errors"
-      && (typeof log.status !== "number" || log.status < 400)) return false;
+      && (typeof log.status !== "number"
+        || !Number.isInteger(log.status)
+        || log.status < 400
+        || log.status > 599)) return false;
 
     const logAttempts = attempts(log);
     if (modelQuery && ![

--- a/gui/src/pages/logs-filter.ts
+++ b/gui/src/pages/logs-filter.ts
@@ -1,0 +1,151 @@
+import { matchesLogConversationId } from "../log-conversation-id";
+import type { LogSurface, LogSurfaceFilter } from "./logs-surface-filter";
+import { logMatchesSurface } from "./logs-surface-filter";
+
+export type LogTimeWindow = "all" | "15m" | "1h" | "24h";
+export type LogStatusFilter = "all" | "success" | "errors";
+
+export interface LogFilterState {
+  surface: LogSurfaceFilter;
+  model: string;
+  provider: string;
+  status: LogStatusFilter;
+  timeWindow: LogTimeWindow;
+  minTokPerSec?: number;
+  maxTokPerSec?: number;
+  interceptedOnly: boolean;
+  conversationId: string;
+  conversationQueryHash?: string;
+}
+
+export const DEFAULT_LOG_FILTER_STATE: LogFilterState = {
+  surface: "all",
+  model: "",
+  provider: "",
+  status: "all",
+  timeWindow: "all",
+  interceptedOnly: false,
+  conversationId: "",
+};
+
+export interface FilterableLogAttempt {
+  provider?: unknown;
+  model?: unknown;
+}
+
+export interface FilterableLogEntry {
+  timestamp?: unknown;
+  model?: unknown;
+  resolvedModel?: unknown;
+  provider?: unknown;
+  surface?: LogSurface;
+  status?: unknown;
+  conversationId?: string;
+  shadowCallRewrittenFrom?: unknown;
+  attempts?: unknown;
+  displayMetrics?: {
+    tokPerSecond?: { kind: "value"; value: number } | { kind: "unavailable" };
+  };
+}
+
+export function hasActiveLogFilters(filters: LogFilterState): boolean {
+  return filters.surface !== "all"
+    || filters.model.trim() !== ""
+    || filters.provider.trim() !== ""
+    || filters.status !== "all"
+    || filters.timeWindow !== "all"
+    || filters.minTokPerSec !== undefined
+    || filters.maxTokPerSec !== undefined
+    || filters.interceptedOnly
+    || filters.conversationId.trim() !== "";
+}
+
+function attempts(log: FilterableLogEntry): FilterableLogAttempt[] {
+  if (!Array.isArray(log.attempts)) return [];
+  return log.attempts.filter(
+    (attempt): attempt is FilterableLogAttempt => attempt !== null && typeof attempt === "object",
+  );
+}
+
+function normalized(value: unknown): string | undefined {
+  return typeof value === "string" ? value.toLowerCase() : undefined;
+}
+
+function timeThreshold(window: LogTimeWindow, now: number): number | undefined {
+  if (window === "15m") return now - 15 * 60 * 1000;
+  if (window === "1h") return now - 60 * 60 * 1000;
+  if (window === "24h") return now - 24 * 60 * 60 * 1000;
+  return undefined;
+}
+
+export function filterLogs<T extends FilterableLogEntry>(
+  logs: readonly T[],
+  filters: LogFilterState,
+  now: number = Date.now(),
+): T[] {
+  const modelQuery = filters.model.trim().toLowerCase();
+  const providerQuery = filters.provider.trim().toLowerCase();
+  const conversationQuery = filters.conversationId.trim();
+  const since = timeThreshold(filters.timeWindow, now);
+
+  return logs.filter(log => {
+    if (!logMatchesSurface(log, filters.surface)) return false;
+    if (filters.interceptedOnly && typeof log.shadowCallRewrittenFrom !== "string") return false;
+    if (conversationQuery && !matchesLogConversationId(
+      log.conversationId,
+      conversationQuery,
+      filters.conversationQueryHash,
+    )) return false;
+
+    if (filters.status === "success"
+      && (typeof log.status !== "number" || log.status < 200 || log.status >= 300)) return false;
+    if (filters.status === "errors"
+      && (typeof log.status !== "number" || log.status < 400)) return false;
+
+    const logAttempts = attempts(log);
+    if (modelQuery && ![
+      normalized(log.model),
+      normalized(log.resolvedModel),
+      ...logAttempts.map(attempt => normalized(attempt.model)),
+    ].some(value => value?.includes(modelQuery))) return false;
+
+    if (providerQuery && ![
+      normalized(log.provider),
+      ...logAttempts.map(attempt => normalized(attempt.provider)),
+    ].some(value => value === providerQuery)) return false;
+
+    if (since !== undefined
+      && (typeof log.timestamp !== "number" || !Number.isFinite(log.timestamp) || log.timestamp < since)) return false;
+
+    const tokPerSecond = log.displayMetrics?.tokPerSecond?.kind === "value"
+      && Number.isFinite(log.displayMetrics.tokPerSecond.value)
+      ? log.displayMetrics.tokPerSecond.value
+      : undefined;
+    if (filters.minTokPerSec !== undefined
+      && (tokPerSecond === undefined || tokPerSecond < filters.minTokPerSec)) return false;
+    if (filters.maxTokPerSec !== undefined
+      && (tokPerSecond === undefined || tokPerSecond >= filters.maxTokPerSec)) return false;
+
+    return true;
+  });
+}
+
+export function extractLogFilterOptions(logs: readonly FilterableLogEntry[]): {
+  models: string[];
+  providers: string[];
+} {
+  const models = new Set<string>();
+  const providers = new Set<string>();
+  for (const log of logs) {
+    for (const value of [log.model, log.resolvedModel, ...attempts(log).map(attempt => attempt.model)]) {
+      if (typeof value === "string" && value.trim()) models.add(value);
+    }
+    for (const value of [log.provider, ...attempts(log).map(attempt => attempt.provider)]) {
+      if (typeof value === "string" && value.trim()) providers.add(value);
+    }
+  }
+  return {
+    models: [...models].sort(),
+    providers: [...providers].sort(),
+  };
+}

--- a/gui/tests/logs-filter.test.ts
+++ b/gui/tests/logs-filter.test.ts
@@ -47,9 +47,15 @@ describe("rich Logs filtering", () => {
   });
 
   test("matches requested, resolved, and attempted models by substring", () => {
+    const attemptOnly = [{
+      id: "attempt-only",
+      model: "requested-model",
+      attempts: [{ model: "fallback-only" }],
+    }];
     expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, model: "reliable" }, NOW).map(row => row.id)).toEqual(["claude"]);
     expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, model: "SONNET-4.6" }, NOW).map(row => row.id)).toEqual(["claude"]);
     expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, model: "terra" }, NOW).map(row => row.id)).toEqual(["codex"]);
+    expect(filterLogs(attemptOnly, { ...DEFAULT_LOG_FILTER_STATE, model: "fallback-only" }, NOW).map(row => row.id)).toEqual(["attempt-only"]);
   });
 
   test("matches the selected provider on the row or any attempt", () => {
@@ -98,6 +104,18 @@ describe("rich Logs filtering", () => {
       { model: "zeta", provider: "Zulu" },
       { model: "Alpha", provider: "alpha" },
     ])).toEqual({ models: ["Alpha", "zeta"], providers: ["Zulu", "alpha"] });
+  });
+
+  test("normalizes option whitespace and casing without making selections unusable", () => {
+    const rows = [
+      { id: "lower", model: "  gpt-5  ", provider: "  openai  " },
+      { id: "upper", model: "GPT-5", provider: "OpenAI" },
+    ];
+    const options = extractLogFilterOptions(rows);
+    expect(options).toEqual({ models: ["GPT-5"], providers: ["OpenAI"] });
+    expect(extractLogFilterOptions([...rows].reverse())).toEqual(options);
+    expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, model: options.models[0] }, NOW).map(row => row.id)).toEqual(["lower", "upper"]);
+    expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, provider: options.providers[0] }, NOW).map(row => row.id)).toEqual(["lower", "upper"]);
   });
 
   test("reports every non-default field as active", () => {

--- a/gui/tests/logs-filter.test.ts
+++ b/gui/tests/logs-filter.test.ts
@@ -77,6 +77,18 @@ describe("rich Logs filtering", () => {
     }, NOW).map(row => row.id)).toEqual(["helper"]);
   });
 
+  test("accepts only finite integer HTTP statuses in status buckets", () => {
+    const rows = [
+      { id: "success", status: 200 },
+      { id: "error", status: 599 },
+      { id: "nan", status: Number.NaN },
+      { id: "fractional", status: 200.5 },
+      { id: "out-of-range", status: 600 },
+    ];
+    expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, status: "success" }, NOW).map(row => row.id)).toEqual(["success"]);
+    expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, status: "errors" }, NOW).map(row => row.id)).toEqual(["error"]);
+  });
+
   test("uses deterministic time windows and rejects rows without a usable timestamp", () => {
     const rows = [...logs, { id: "missing-time", status: 200 }];
     expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, timeWindow: "15m" }, NOW).map(row => row.id)).toEqual(["claude"]);

--- a/gui/tests/logs-filter.test.ts
+++ b/gui/tests/logs-filter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_LOG_FILTER_STATE,
+  extractLogFilterOptions,
+  filterLogs,
+  hasActiveLogFilters,
+} from "../src/pages/logs-filter";
+
+const NOW = 2_000_000_000_000;
+const logs = [
+  {
+    id: "claude",
+    timestamp: NOW - 5 * 60 * 1000,
+    model: "combo/reliable",
+    resolvedModel: "claude-sonnet-4.6",
+    provider: "primary",
+    surface: "claude" as const,
+    status: 200,
+    conversationId: "conv-123",
+    displayMetrics: { tokPerSecond: { kind: "value" as const, value: 15 } },
+    attempts: [{ provider: "anthropic", model: "claude-sonnet-4.6" }],
+  },
+  {
+    id: "codex",
+    timestamp: NOW - 30 * 60 * 1000,
+    model: "gpt-5.6-terra",
+    provider: "openai",
+    status: 500,
+    conversationId: "conv-456",
+    displayMetrics: { tokPerSecond: { kind: "value" as const, value: 50 } },
+  },
+  {
+    id: "helper",
+    timestamp: NOW - 2 * 60 * 60 * 1000,
+    model: "gemini-3.8-flash",
+    provider: "google",
+    status: 204,
+    shadowCallRewrittenFrom: "small-helper",
+    displayMetrics: { tokPerSecond: { kind: "value" as const, value: 90 } },
+  },
+];
+
+describe("rich Logs filtering", () => {
+  test("the default state is inert", () => {
+    expect(hasActiveLogFilters(DEFAULT_LOG_FILTER_STATE)).toBe(false);
+    expect(filterLogs(logs, DEFAULT_LOG_FILTER_STATE, NOW)).toEqual(logs);
+  });
+
+  test("matches requested, resolved, and attempted models by substring", () => {
+    expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, model: "reliable" }, NOW).map(row => row.id)).toEqual(["claude"]);
+    expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, model: "SONNET-4.6" }, NOW).map(row => row.id)).toEqual(["claude"]);
+    expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, model: "terra" }, NOW).map(row => row.id)).toEqual(["codex"]);
+  });
+
+  test("matches the selected provider on the row or any attempt", () => {
+    expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, provider: "OPENAI" }, NOW).map(row => row.id)).toEqual(["codex"]);
+    expect(filterLogs(logs, { ...DEFAULT_LOG_FILTER_STATE, provider: "anthropic" }, NOW).map(row => row.id)).toEqual(["claude"]);
+  });
+
+  test("composes surface, status, interception, and conversation filters", () => {
+    expect(filterLogs(logs, {
+      ...DEFAULT_LOG_FILTER_STATE,
+      surface: "claude",
+      status: "success",
+      conversationId: "conv-123",
+    }, NOW).map(row => row.id)).toEqual(["claude"]);
+    expect(filterLogs(logs, {
+      ...DEFAULT_LOG_FILTER_STATE,
+      status: "success",
+      interceptedOnly: true,
+    }, NOW).map(row => row.id)).toEqual(["helper"]);
+  });
+
+  test("uses deterministic time windows and rejects rows without a usable timestamp", () => {
+    const rows = [...logs, { id: "missing-time", status: 200 }];
+    expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, timeWindow: "15m" }, NOW).map(row => row.id)).toEqual(["claude"]);
+    expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, timeWindow: "1h" }, NOW).map(row => row.id)).toEqual(["claude", "codex"]);
+  });
+
+  test("uses non-overlapping speed boundaries and excludes unavailable metrics", () => {
+    const unavailable = { id: "unknown", displayMetrics: { tokPerSecond: { kind: "unavailable" as const } } };
+    expect(filterLogs([...logs, unavailable], { ...DEFAULT_LOG_FILTER_STATE, maxTokPerSec: 15 }, NOW).map(row => row.id)).toEqual([]);
+    expect(filterLogs([...logs, unavailable], { ...DEFAULT_LOG_FILTER_STATE, minTokPerSec: 15, maxTokPerSec: 50 }, NOW).map(row => row.id)).toEqual(["claude"]);
+    expect(filterLogs([...logs, unavailable], { ...DEFAULT_LOG_FILTER_STATE, minTokPerSec: 50 }, NOW).map(row => row.id)).toEqual(["codex", "helper"]);
+  });
+
+  test("extracts sorted unique options and ignores malformed attempts", () => {
+    const options = extractLogFilterOptions([
+      ...logs,
+      { model: 42, provider: null, attempts: [null, "bad", { model: "alpha", provider: "zeta" }] },
+    ]);
+    expect(options.models).toEqual(["alpha", "claude-sonnet-4.6", "combo/reliable", "gemini-3.8-flash", "gpt-5.6-terra"]);
+    expect(options.providers).toEqual(["anthropic", "google", "openai", "primary", "zeta"]);
+  });
+
+  test("sorts options by stable code-point order instead of the host locale", () => {
+    expect(extractLogFilterOptions([
+      { model: "zeta", provider: "Zulu" },
+      { model: "Alpha", provider: "alpha" },
+    ])).toEqual({ models: ["Alpha", "zeta"], providers: ["Zulu", "alpha"] });
+  });
+
+  test("reports every non-default field as active", () => {
+    expect(hasActiveLogFilters({ ...DEFAULT_LOG_FILTER_STATE, provider: "openai" })).toBe(true);
+    expect(hasActiveLogFilters({ ...DEFAULT_LOG_FILTER_STATE, status: "errors" })).toBe(true);
+    expect(hasActiveLogFilters({ ...DEFAULT_LOG_FILTER_STATE, minTokPerSec: 1 })).toBe(true);
+    expect(hasActiveLogFilters({ ...DEFAULT_LOG_FILTER_STATE, conversationId: "  conv  " })).toBe(true);
+  });
+});

--- a/gui/tests/logs-filter.test.ts
+++ b/gui/tests/logs-filter.test.ts
@@ -81,12 +81,14 @@ describe("rich Logs filtering", () => {
     const rows = [
       { id: "success", status: 200 },
       { id: "error", status: 599 },
+      { id: "redirect", status: 302 },
       { id: "nan", status: Number.NaN },
       { id: "fractional", status: 200.5 },
       { id: "out-of-range", status: 600 },
     ];
     expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, status: "success" }, NOW).map(row => row.id)).toEqual(["success"]);
     expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, status: "errors" }, NOW).map(row => row.id)).toEqual(["error"]);
+    expect(filterLogs(rows, { ...DEFAULT_LOG_FILTER_STATE, status: "all" }, NOW).map(row => row.id)).toContain("redirect");
   });
 
   test("uses deterministic time windows and rejects rows without a usable timestamp", () => {


### PR DESCRIPTION
## Summary

- Add a pure, composable filter engine for the bounded request-log dataset.
- Cover surface, requested/resolved/attempt model, provider, status, time, speed, interception, and conversation filters.
- Keep malformed optional attempt data safe and option extraction deterministic.
- Deliberately leave visible controls and Logs page wiring for a follow-up PR.

## Verification

- Focused log-filter, model-filter, and surface-filter tests: 20 passed, 0 failed.
- Complete frontend test suite: 1,377 passed, 0 failed across 221 files.
- Frontend lint and production build passed.
- Root typecheck passed.
- Full repository test gate passed: 17,811 passed, 14 skipped, 0 failed in the parallel suite, with every required serial suite passing.
- Privacy scan and diff hygiene passed.
- This PR adds no visible UI, so there is no screenshot to include.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No update is needed because visible behavior is intentionally deferred.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No security-sensitive path changes.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rich log filtering by surface, status, conversation, HTTP status, model, provider, time range, and token speed.
  * Added available model and provider options with consistent sorting.
  * Added support for identifying when filters are active.
  * Filters consistently handle capitalization, extra whitespace, unavailable metrics, and malformed log attempts.

* **Tests**
  * Added coverage for combined filters, time windows, metric boundaries, unavailable data, malformed entries, and option sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
