### PR TITLE
docs(devlog): close out the admin-token unit with the preload guard fix

### DIFF
--- a/devlog/_plan/260905_admin_token_local_ux/020_dialog_repair.md
+++ b/devlog/_plan/260905_admin_token_local_ux/020_dialog_repair.md
@@ -61,3 +61,13 @@ The dialog now carries a help paragraph plus a link to a new
 (`target="_blank"`, `rel="noreferrer"`, accent colour) per
 `gui/src/pages/dashboard-dialogs.tsx`. Copy landed in all nine locales;
 `gui/tests/i18n-locales.test.ts` enforces key parity.
+
+## Landed
+
+- #3483: PR [#3491](https://github.com/lidge-jun/opencodex/pull/3491), `85e42117c`.
+- #3353: PR [#3493](https://github.com/lidge-jun/opencodex/pull/3493), `8b961b198`.
+
+Both issues are closed with landing comments naming the mechanism rather than
+just the fix, because in both cases the mechanism is the non-obvious part: a
+cascade origin rule for one, and a prompt that could not have helped for the
+other.

--- a/devlog/_plan/260905_admin_token_local_ux/030_windows_baseline.md
+++ b/devlog/_plan/260905_admin_token_local_ux/030_windows_baseline.md
@@ -2,6 +2,9 @@
 
 Work-phase `wp3`. Criterion `c-5`. Evidence, not a landed fix.
 
+> Superseded in part: carry-forward item 1 below was subsequently fixed in
+> PR #3507 (`663fdbb0a`). The rest of this document stands as written.
+
 A full Windows suite was already running on `desktop-c795oh4` when this unit
 started (`/c/ocxwin/repo` at `00834d710`, shards `base-1..4`). It was read-only
 evidence for this unit and was not disturbed. A second run on Bun `1.4.0`
@@ -68,15 +71,44 @@ in that surface, and each needs its own reproduction on Windows before a fix is
 more than a guess — the `base` run's evidence is contaminated by the guard
 cascade, so a fix written against it would be written against an artifact.
 
-The honest carry-forward is three separate units:
+The honest carry-forward was three separate units. The first is now closed.
 
-1. Arm `OCX_TEST_HOME_GUARD` before `acquireTestRunLock`, or make the SID lookup
-   fail closed instead of proceeding unguarded. Highest value: it is a safety
-   defect, not just a flake.
-2. Diagnose `multi-account auth store` on Windows.
+1. ~~Arm `OCX_TEST_HOME_GUARD` before `acquireTestRunLock`~~ — **done** in PR
+   [#3507](https://github.com/lidge-jun/opencodex/pull/3507), merged `663fdbb0a`.
+   The preload now runs sandbox → arm + assert → lock. Two regressions guard it:
+   a source-order assertion (nothing else can see this — with a lock that happens
+   to succeed the runtime state is identical either way) and a probe proving an
+   armed process with a real `HOME` and no lock still refuses the protected home.
+   Stashing the reorder was verified to turn the first one red. The order was
+   re-confirmed on `desktop-c795oh4` itself, read-only, without contending with
+   the suite running there: `sandbox 1414, arm 2969, assert 3228, lock 4168`.
+2. Diagnose `multi-account auth store` on Windows — 22 of the surviving 25.
 3. Decide whether `keep-native-v1` should assert on parsed argv rather than the
    raw ComSpec string.
 
 Issue #3320 (non-ASCII account names misclassifying a valid scheduler task) is
 adjacent to (1) — both are Windows identity handling — but it is `needs-info`
 and was not reproduced here, so it stays open.
+
+## Why the guard fix was worth doing on its own
+
+It is tempting to read "161 of 179 failures" as a noise-reduction win and stop
+there. The number is the least interesting part.
+
+Those 161 were the *visible* consequence. The invisible one is that
+`src/lib/windows-elevation.ts` and `src/service.ts` refuse live elevation and
+machine-global Task Scheduler mutation ONLY while the guard is armed. A worker
+that lost the guard did not merely fail loudly — it silently gained the ability
+to do the things those refusals exist to prevent, and two suites took it:
+a real PowerShell process at pid 18144, and real scheduler registration.
+
+So the failure mode was inverted from how it looked. The 161 red tests were the
+alarm, not the damage; the damage was in the handful that went green by doing
+something to the developer's machine. A run that had been slightly luckier with
+its SID lookup would have shown fewer failures and done the same writes.
+
+That is also why the regression asserts source ORDER rather than runtime state.
+When the lock succeeds — which is almost always — an armed-after-lock preload
+and an armed-before-lock preload produce byte-identical environments. There is
+no runtime observation that separates them except on the exact runs where it
+already went wrong.

--- a/devlog/_plan/260905_admin_token_local_ux/031_preload_guard_ordering.md
+++ b/devlog/_plan/260905_admin_token_local_ux/031_preload_guard_ordering.md
@@ -1,0 +1,55 @@
+# 031 — Arm the guard before the run lock
+
+Work-phase `wp5`. Closes carry-forward item 1 from `030`. Merged as PR #3507
+(`663fdbb0a`).
+
+## What was wrong
+
+`tests/preload.ts` acquired the run lock before arming `OCX_TEST_HOME_GUARD`,
+with no `try/finally` between them. Taking the lock resolves a user-scoped path,
+which on Windows spawns PowerShell for the effective SID. Under four-shard load
+that spawn timed out, the refusal threw straight out of the preload, and every
+statement below it — the sandbox, the arming, and the assertion written to catch
+exactly this — never ran.
+
+## Why the failure count was the wrong headline
+
+161 red tests looked like the problem. They were the alarm.
+
+`src/lib/windows-elevation.ts` and `src/service.ts` refuse live elevation and
+machine-global Task Scheduler mutation ONLY while the guard is armed. An
+unguarded worker did not just fail loudly — it quietly gained the ability to do
+the things those refusals exist to prevent, and two suites took it: a real
+PowerShell process at pid 18144, and real scheduler registration.
+
+A luckier run would have shown FEWER failures and done the same writes.
+
+## The fix, and the part the audit changed
+
+Shipped order: sandbox → arm + assert → lock.
+
+The original plan was arm-then-lock. The plan-audit lane rejected it as
+incomplete: arming before the lock while sandboxing after it still leaves a
+worker armed-but-unsandboxed, which blocks writes but not reads of the real
+home. Putting the lock last closes that.
+
+Arming early is safe because the guard is a deny-list keyed on a path captured
+at module import, not a "sandbox is present" flag — its worst case when armed
+early is refusing a write to the real home, which is the direction that fails
+closed. The lock error stays unswallowed: a run that cannot take the lock must
+still fail, it just must not fail while unprotected.
+
+## Testing something with no runtime signature
+
+When the lock succeeds — nearly always — an armed-after-lock preload and an
+armed-before-lock preload produce byte-identical environments. There is no
+runtime observation that separates them except on the runs where it already went
+wrong.
+
+So the regression asserts source ORDER, and was driven red against the old
+arrangement (`Expected: < 1931, Received: 3245`) before being accepted. A second
+test proves an armed process with a real `HOME` and no lock still refuses the
+protected home — the state the timed-out worker was actually in.
+
+Re-verified on the affected host itself, read-only and without contending with
+the suite running there: `sandbox 1414, arm 2969, assert 3228, lock 4168`.

--- a/devlog/_plan/260905_admin_token_local_ux/040_delivery_record.md
+++ b/devlog/_plan/260905_admin_token_local_ux/040_delivery_record.md
@@ -7,6 +7,8 @@ Work-phase `wp4`. All three PRs merged to `dev` with admin authority.
 | [#3491](https://github.com/lidge-jun/opencodex/pull/3491) | `85e42117c` | #3483 empty red notice (CSS cascade) |
 | [#3496](https://github.com/lidge-jun/opencodex/pull/3496) | `3e65218ba` | never prompt a local dashboard |
 | [#3493](https://github.com/lidge-jun/opencodex/pull/3493) | `8b961b198` | #3353 dialog guidance + docs anchor |
+| [#3504](https://github.com/lidge-jun/opencodex/pull/3504) | `2fb11f4a0` | this devlog unit |
+| [#3507](https://github.com/lidge-jun/opencodex/pull/3507) | `663fdbb0a` | preload arms the guard before the run lock |
 
 Ancestry proven for each: `git fetch origin dev` then
 `git merge-base --is-ancestor <sha> FETCH_HEAD` exit 0.


### PR DESCRIPTION
## Summary

Closes out the `260905_admin_token_local_ux` devlog unit now that the Windows carry-forward it named has landed.

Records PR #3507 (`663fdbb0a`) against carry-forward item 1 of the baseline triage, and adds `031` for why that fix was worth doing independently of the 161 failures it removed:

> Those 161 were the *visible* consequence. `src/lib/windows-elevation.ts` and `src/service.ts` refuse live elevation and machine-global Task Scheduler mutation **only while the guard is armed**. A worker that lost the guard did not merely fail loudly — it quietly gained the ability to do the things those refusals exist to prevent, and two suites took it. A run that had been slightly luckier with its SID lookup would have shown fewer failures and done the same writes.

`031` also records what the plan audit changed. The original plan was arm-then-lock; the reviewer rejected it as incomplete, because arming before the lock while sandboxing after it still leaves a worker armed-but-unsandboxed — writes blocked, reads not. Shipped order is sandbox → arm + assert → lock.

Delivery record gains rows for #3504 and #3507. Items 2 and 3 (the `multi-account auth store` failures, 22 of the surviving 25, and the `keep-native-v1` argv assertion) stay open with their real counts rather than being quietly dropped.

## Verification

`bun run privacy:scan` — passed. Documentation only; nothing in the build, typecheck, or test path reads from `devlog/`. No pre-disclosure security material: every defect described is already public in a merged diff, which is the `AGENTS.md` test for what may live here.

## Checklist

- [x] Documentation only; no code paths touched
- [x] No credential, token, or request-body values recorded
- [x] Targets `dev`
