### PR TITLE
fix(responses): keep caller cancellations out of upstream failure logs

### DIFF
--- a/docs-site/src/content/docs/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/reference/proxy-formats.md
@@ -70,6 +70,10 @@ With `stream: true`, the response is `text/event-stream`. The bridge emits Respo
 With `stream: false` or no `stream`, the same adapter events are collected into one Responses JSON
 object. Both forms preserve the selected model, output items, terminal status, and usage.
 
+For native HTTP/SSE passthrough, a client cancellation without an observed upstream terminal is
+logged as `499` with `closeReason: "client_cancel"` and does not penalize the account pool.
+A terminal captured during the bounded post-disconnect drain retains its actual outcome.
+
 Client-facing Responses SSE frames are limited to 4 MiB per frame, measured in raw bytes before the
 SSE block delimiter. On HTTP, an unterminated upstream frame that exceeds the limit fails closed
 with a synthetic `response.failed` event followed by `data: [DONE]`. On the Responses WebSocket

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -1275,6 +1275,7 @@ function startBoundedInspectionPump(options: InspectionPumpOptions): void {
     try {
       for (;;) {
         const { done, value } = await reader.read();
+        if (clientGoneSignal?.aborted) markClientGone();
         if (drainStopped) {
           // stopDrain() cancelled the reader; the settled read is the wake-up.
           clientGoneWithoutTerminal = !inspector.terminalSeen();
@@ -1312,6 +1313,9 @@ function startBoundedInspectionPump(options: InspectionPumpOptions): void {
         }
       }
     } catch {
+      // Bun can settle a fetch body read before dispatching all abort listeners.
+      // Observe the signal itself before classifying that rejection as upstream.
+      if (clientGoneSignal?.aborted) markClientGone();
       // A read error can follow a final SSE block without its blank-line
       // delimiter. Flush that candidate before classifying the transport as a
       // synthetic reset; otherwise a real completed/failed/policy terminal is

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -4922,7 +4922,10 @@ async function handleResponsesInner(
       linkAbortSignal(upstream, turnAc.signal);
       registerTurn(turnAc, options.turnAdmissionLease);
       const inspectionConsumerOptions = {
-        clientGoneSignal: clientGone.signal,
+        // Request abort can reject the fetch body before the response cancel hook runs.
+        clientGoneSignal: options.abortSignal
+          ? AbortSignal.any([clientGone.signal, options.abortSignal])
+          : clientGone.signal,
         drainBounds: { ms: 15_000, bytes: 32 * 1024 * 1024 },
         upstream,
         pinCompletedResponseIdToFirstSeen: githubCopilotRepairEnabled,

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -4175,6 +4175,10 @@ describe("server local API auth", () => {
       expect((await reader.read()).done).toBe(false);
       (await source.promise).error(new Error("fixture upstream connection reset"));
       while (!(await reader.read()).done) { /* drain the synthetic failed terminal */ }
+      const deadline = Date.now() + INTERNAL_DEADLINE_MS;
+      while (!getRequestLogEntries().some(entry => entry.requestId === requestId) && Date.now() < deadline) {
+        await Bun.sleep(5);
+      }
       const logs = getRequestLogEntries().filter(entry => entry.requestId === requestId);
       expect(logs).toHaveLength(1);
       expect(logs[0]).toMatchObject({ status: 502, closeReason: "terminal", terminalStatus: "failed" });

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -4115,6 +4115,77 @@ describe("server local API auth", () => {
     }
   });
 
+  test("native passthrough caller abort logs cancellation without penalizing the pool", async () => {
+    const enc = new TextEncoder();
+    const harness = await startPoolRetryHarness(() => new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(enc.encode('data: {"type":"response.output_text.delta","delta":"hello"}\n\n'));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    ), { secondAccount: false, streamMode: "legacy-tee" });
+    const caller = new AbortController();
+    try {
+      const response = await harness.request({ stream: true, signal: caller.signal });
+      expect(response.status).toBe(200);
+      const requestId = response.headers.get("x-opencodex-request-id");
+      const reader = response.body!.getReader();
+      expect((await reader.read()).done).toBe(false);
+      // Abort the HTTP request, without calling response.body.cancel(): the
+      // incoming request signal may reach upstream before the body cancel hook.
+      caller.abort();
+      await expect(reader.read()).rejects.toThrow();
+      const deadline = Date.now() + INTERNAL_DEADLINE_MS;
+      while (!getRequestLogEntries().some(entry => entry.requestId === requestId) && Date.now() < deadline) {
+        await Bun.sleep(5);
+      }
+      const logs = getRequestLogEntries().filter(entry => entry.requestId === requestId);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatchObject({ status: 499, closeReason: "client_cancel" });
+      expect(logs[0]?.attempts?.[0]).toMatchObject({ status: 499 });
+      expect(logs[0]?.attempts?.[0]?.streamAborted).not.toBe(true);
+      expect(readUsageEntries().filter(entry => entry.requestId === requestId)).toMatchObject([
+        { status: 499, closeReason: "client_cancel" },
+      ]);
+      expect(getCodexUpstreamHealth("pool-a")?.consecutiveFailures ?? 0).toBe(0);
+      expect(harness.dispatches).toEqual(["acct-pool-a"]);
+    } finally {
+      caller.abort();
+      await stopPoolRetryHarness(harness);
+    }
+  }, { timeout: SERVER_BUDGET_MS });
+
+  test("native passthrough upstream reset still logs 502 and penalizes the pool", async () => {
+    const enc = new TextEncoder();
+    const source = Promise.withResolvers<ReadableStreamDefaultController<Uint8Array>>();
+    const harness = await startPoolRetryHarness(() => new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          source.resolve(controller);
+          controller.enqueue(enc.encode('data: {"type":"response.output_text.delta","delta":"hello"}\n\n'));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    ), { secondAccount: false, streamMode: "legacy-tee" });
+    try {
+      const response = await harness.request({ stream: true });
+      const requestId = response.headers.get("x-opencodex-request-id");
+      const reader = response.body!.getReader();
+      expect((await reader.read()).done).toBe(false);
+      (await source.promise).error(new Error("fixture upstream connection reset"));
+      while (!(await reader.read()).done) { /* drain the synthetic failed terminal */ }
+      const logs = getRequestLogEntries().filter(entry => entry.requestId === requestId);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatchObject({ status: 502, closeReason: "terminal", terminalStatus: "failed" });
+      expect(logs[0]?.attempts?.[0]).toMatchObject({ status: 502, streamAborted: true });
+      expect(getCodexUpstreamHealth("pool-a")?.consecutiveFailures).toBe(1);
+      expect(harness.dispatches).toEqual(["acct-pool-a"]);
+    } finally {
+      await stopPoolRetryHarness(harness);
+    }
+  }, { timeout: SERVER_BUDGET_MS });
+
   test("non-forward generated stream does not mutate active pool health", async () => {
     if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
     mkdirSync(TEST_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

Aborting a native Responses HTTP stream after output can record a synthetic `502 upstream_server_error` and increment the Codex pool account's failure streak, even though the caller intentionally cancelled. Codex may do this while processing pending input and continue the task, leaving misleading failures in request history. Related to #186.

The upstream fetch already receives the caller's abort signal, but the tee inspection branch only observes its separate response-body cancellation signal. In addition, Bun can settle the failed read before dispatching all abort listeners. Combine the caller and body-cancel signals for inspection and check the signal's state when reads settle. Cancellation now records `499` / `client_cancel`, while genuine upstream resets still record 502 and update account health. Existing bounded post-disconnect inspection still preserves observed upstream terminals.

The proxy runtime is Bun-only; the package pins Bun 1.4.0, which supports `AbortSignal.any`. The Node engine requirement covers the launcher, not this streaming implementation. The post-read signal check intentionally runs before `drainStopped`: `markClientGone()` is idempotent, so a read woken by `stopDrain()` cannot restart its timer or drain budget.

The regression explicitly selects `legacy-tee` to exercise the affected path regardless of host defaults. The same fix applies whenever stream selection chooses tee, including macOS `auto`; eager relay and WebSocket behavior are outside this change. The account-health assertion and documentation refer to the Codex account pool, without claiming coverage of generic OAuth pools. This PR addresses the native HTTP tee cancellation symptom related to #186 and deliberately leaves that broader issue open.

## Verification

- Reproduced against a real local HTTP upstream and the actual `startServer` handler: the new cancellation regression fails on the base code with status 502, `streamAborted: true`, and `closeReason: terminal`.
- The regression passes after the fix, including persisted usage status 499 and unchanged pool failure count. A separate real-HTTP reset test confirms status 502 and an incremented failure count.
- `bun test tests/server-auth.test.ts tests/passthrough-abort.test.ts tests/consume-for-inspection-cancel.test.ts tests/stream-aborted-marker.test.ts tests/core-lab-boundary.test.ts`: 159 passed, 0 failed. The final additional persistence assertions also passed in the focused two-test regression run.
- `bun run typecheck`: passed.
- `cd docs-site && bun run build`: passed, 425 pages.
- `bun run prepush`: passed, including the full test runner (17,819 passed in the main batch plus 161 in serial groups; 14 skipped; 0 failed), typecheck, and privacy scan.

- After fixing the CodeRabbit test race, reran both focused regressions and the full pre-push checks on `4f09faf5d`: 17,980 passed, 14 skipped, 0 failed; typecheck and privacy scan passed.

Tested on macOS arm64 with the repository's bundled Bun 1.4.0. The fix is scoped to the native HTTP tee inspection path.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved native HTTP/SSE passthrough handling when clients cancel requests.
  - Client cancellations are recorded as `499` with `client_cancel` and no longer penalize account health.
  - Upstream stream failures continue to be recorded with their actual error outcome.

- **Documentation**
  - Updated Responses JSON/SSE output documentation to describe cancellation and post-disconnect behavior.

- **Tests**
  - Added coverage for client cancellations and upstream streaming errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->