### PR TITLE
test(hygiene): fail on duplicate test basenames, and close out the 429 unit

### DIFF
--- a/devlog/_fin/260905_always_on_429_failover/090_outcome.md
+++ b/devlog/_fin/260905_always_on_429_failover/090_outcome.md
@@ -1,15 +1,24 @@
 # 090 — Outcome
 
-Shipped in three pull requests:
+Shipped in eight pull requests:
 
 | PR | Merge | What |
 |---|---|---|
 | [#3495](https://github.com/lidge-jun/opencodex/pull/3495) | `56a084aa9` | the failover fix itself |
 | [#3499](https://github.com/lidge-jun/opencodex/pull/3499) | `26a2e512a` | GUI copy the fix invalidated |
 | [#3503](https://github.com/lidge-jun/opencodex/pull/3503) | `6edc56328` | a per-request store read #3495 introduced |
+| [#3512](https://github.com/lidge-jun/opencodex/pull/3512) | `c91c8c5b2` | rotator-set contract test |
+| [#3517](https://github.com/lidge-jun/opencodex/pull/3517) | `9be23dc41` | the `inert` DTO marker, rescoped |
+| [#3520](https://github.com/lidge-jun/opencodex/pull/3520) | `5d10a1900` | public docs, 8 locales |
+| [#3523](https://github.com/lidge-jun/opencodex/pull/3523) | `69d35a736` | the last stale guide + re-gating guard |
+| [#3526](https://github.com/lidge-jun/opencodex/pull/3526) | `99fc38c39` | a duplicated test file |
 
-The second and third were not planned. Both were found by auditing the merged result against
-the tree rather than against the plan, and both are recorded in `091`.
+**Only the first was planned.** Every other one came from auditing the merged result against
+the tree rather than against the plan — the plan's own criteria were satisfied after #3495.
+Two were defects the fix itself created (#3499, #3503), three were surfaces still describing the
+old contract (#3517, #3520, #3523), one closed the structural gap that let this unit ship two
+subset-rotator loops (#3512), and one cleaned up after a collision with concurrent maintainer
+work (#3526). All are recorded in `091`.
 
 ## What changed
 

--- a/devlog/_fin/260905_always_on_429_failover/091_post_merge_audit.md
+++ b/devlog/_fin/260905_always_on_429_failover/091_post_merge_audit.md
@@ -55,3 +55,35 @@ resource pressure that was timing the job out. Rebasing onto it turned macOS gre
 
 **Rule:** when a rerun fails the same way twice, stop rerunning and check whether the base
 branch already carries the fix. A stale branch point is a cause, not a flake.
+
+## A merge I should not have made
+
+I merged #3523 on `gh pr checks` reporting five passes. The test and macOS jobs were still
+**queued** — that command lists only the check runs GitHub has reported so far, so a partial set
+reads exactly like a complete green one. A count of passes is not a statement that anything
+finished.
+
+The post-merge run on `dev` then showed `ci failure`, which was a genuinely alarming way to find
+out. It turned out to be cancellation by the maintainer's next merge two minutes later, not a
+real failure — every job read `cancelled`, not `failure`.
+
+**Rule:** verify with the check-runs API and require zero `null` conclusions, not a pass count:
+
+```bash
+gh api repos/<owner>/<repo>/commits/<sha>/check-runs \
+  --jq '[.check_runs[] | .conclusion] | group_by(.) | map({(.[0]//"null"): length}) | add'
+```
+
+A clean result looks like `{"skipped":3,"success":24}` — no `null` key at all.
+
+The near-miss paid for itself: sweeping `dev` afterwards found a real defect. #3511 and #3513
+landed concurrently, one moving `anthropic-quorum-cache.test.ts` into `tests/routing/` and the
+other placing a copy in `tests/adapters/anthropic/`. Different paths, so git saw no conflict and
+both survived — a byte-identical duplicate running the same six tests twice. Removed in #3526.
+
+## Reviewer credit
+
+CodeRabbit caught that the first Claude Code guide assertion was too weak: requiring the intro to
+mention `429` and carry emphasis is satisfied by the **original stale sentence**, so a revert
+would have passed. Each locale now bans the phrase pattern that actually attributed failover to
+the pool, and the test was driven red against the restored sentence before committing.

--- a/tests/repo-hygiene.test.ts
+++ b/tests/repo-hygiene.test.ts
@@ -264,3 +264,27 @@ describe("devlog is tracked, with no submodule left behind", () => {
     expect(missing).toEqual([]);
   });
 });
+
+describe("test layout", () => {
+  test("no two test files share a basename", () => {
+    // Two reorganizations landed on the same day (#3511, #3513) and independently relocated the
+    // same file to different domain directories. Different paths, so git saw no conflict and both
+    // copies survived -- a byte-identical duplicate running its suite twice, invisible until
+    // someone listed the tree by hand.
+    //
+    // A duplicated basename is also how a real fix goes stale: an author edits one copy, CI keeps
+    // running both, and the stale one silently disagrees. Names are the only thing a human uses
+    // to find a test, so they have to be unique.
+    const byName = new Map<string, string[]>();
+    for (const path of trackedFiles()) {
+      if (!path.startsWith("tests/")) continue;
+      if (!path.endsWith(".test.ts") && !path.endsWith(".test.tsx")) continue;
+      const name = path.split("/").pop()!;
+      byName.set(name, [...(byName.get(name) ?? []), path]);
+    }
+    const duplicates = [...byName.entries()]
+      .filter(([, paths]) => paths.length > 1)
+      .map(([name, paths]) => `${name}: ${paths.join(", ")}`);
+    expect(duplicates).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes out the always-on 429 failover unit, and adds the hygiene guard that would have caught last night's duplicate.

**The guard.** #3511 and #3513 landed the same day and independently relocated `anthropic-quorum-cache.test.ts` — one into `tests/routing/`, the other into `tests/adapters/anthropic/`. Different paths, so git saw no conflict and both copies survived: a byte-identical duplicate running its six tests twice, invisible until someone listed the tree by hand (#3526 removed it).

A duplicated basename is also how a real fix goes stale: an author edits one copy, CI keeps running both, and the stale one silently disagrees while the suite stays green. Names are the only handle a human has on a test, so `repo-hygiene` now fails when two share one. Driven red against the exact collision — it names both paths — before being committed green.

**The record.** `090_outcome.md` still claimed a three-PR outcome. The unit actually shipped eight, and **only the first was planned**: two were defects the fix itself created, three were surfaces still describing the old contract, one closed the structural gap that let this unit ship two subset-rotator loops, and one cleaned up the collision above.

`091` gains the honest version of a mistake worth not repeating. I merged #3523 on `gh pr checks` reporting five passes while the test and macOS jobs were still **queued** — that command lists only what has been reported, so a partial set reads exactly like a complete green one. The fix is to require zero `null` conclusions from the check-runs API rather than counting passes:

```bash
gh api repos/<owner>/<repo>/commits/<sha>/check-runs \
  --jq '[.check_runs[] | .conclusion] | group_by(.) | map({(.[0]//"null"): length}) | add'
```

Clean looks like `{"skipped":3,"success":24}` — no `null` key. The near-miss paid for itself: sweeping `dev` afterwards is what surfaced the duplicate.

CodeRabbit is credited in `091` for catching that the earlier guide assertion was satisfied by the original stale sentence.

## Verification

- `bun run typecheck` — clean.
- `bun test` across six focused files — 103 pass, 0 fail.
- No repository-wide local suite; repository-wide validation is delegated to CI on this head.

No `src/` change — one test and the devlog record.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded post-merge audit records with additional shipped changes, review findings, and verification guidance.
  * Documented a merge-checking pitfall and clarified how to verify pending CI results.
  * Recorded the removal of duplicate test coverage and strengthened localized documentation assertions.

* **Tests**
  * Added repository hygiene checks to detect duplicate test filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->