### PR TITLE
test(oauth): restore a deleted contract test, and fail when one disappears

### DIFF
--- a/tests/adapters/anthropic/anthropic-quorum-cache.test.ts
+++ b/tests/adapters/anthropic/anthropic-quorum-cache.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The quorum predicate must not read the auth store on every request.
+ *
+ * `hasAnthropicFailoverQuorum` decides whether an Anthropic request records the account that
+ * served it, so it runs on the INITIAL resolution of ordinary traffic -- not only after a 429.
+ * `getAccountSet` goes through `loadAuthStore`, which has no cache: it chmods the config dir,
+ * chmods the secret, reads the whole file and normalizes it on every call. An uncached predicate
+ * therefore puts a synchronous file read in front of every Anthropic turn.
+ *
+ * The generic module already solved this with a TTL-bounded count cache. These tests pin the same
+ * three properties for the Anthropic twin: the read is shared inside the window, a fresh login is
+ * still visible once it expires, and a rotation invalidates immediately rather than answering the
+ * next question from a pre-failure count.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, statSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearAnthropicAccountPoolState,
+  clearAnthropicSessionAffinityForAccount,
+  forgetAnthropicFailoverQuorum,
+  hasAnthropicFailoverQuorum,
+  resetAnthropicRoutingForManualSelection,
+  rotateAnthropicAccountOn429,
+} from "../../../src/oauth/anthropic-routing";
+import { getAccountSet, saveCredential } from "../../../src/oauth/store";
+import { removeTreeWithRetry } from "../../helpers/remove-tree";
+
+const originalHome = process.env.OPENCODEX_HOME;
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ocx-quorum-cache-"));
+  process.env.OPENCODEX_HOME = home;
+  clearAnthropicAccountPoolState();
+  forgetAnthropicFailoverQuorum();
+});
+
+afterEach(() => {
+  clearAnthropicAccountPoolState();
+  forgetAnthropicFailoverQuorum();
+  if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = originalHome;
+  removeTreeWithRetry(home);
+});
+
+async function seed(count: number, offset = 0): Promise<string[]> {
+  for (let i = offset; i < offset + count; i++) {
+    await saveCredential("anthropic", {
+      access: `access-${i}`,
+      refresh: `refresh-${i}`,
+      expires: Date.now() + 3_600_000,
+      accountId: `uuid-${i}`,
+      email: `user${i}@example.test`,
+    } as never);
+  }
+  return getAccountSet("anthropic")?.accounts.map(a => a.id) ?? [];
+}
+
+/**
+ * Observe the store read without stubbing the module: `loadAuthStore` calls `readFileSync`,
+ * which updates atime. Pinning atime into the past and checking whether it moved is a direct
+ * observation of the syscall this cache exists to avoid.
+ */
+function storePath(): string {
+  return join(home, "auth.json");
+}
+
+function markStoreUnread(): void {
+  const stats = statSync(storePath());
+  utimesSync(storePath(), new Date(Date.now() - 60_000), stats.mtime);
+}
+
+function storeWasRead(): boolean {
+  return statSync(storePath()).atimeMs > Date.now() - 30_000;
+}
+
+describe("Anthropic failover quorum cache", () => {
+  test("a burst of requests inside the TTL window shares one store read", async () => {
+    const start = Date.now();
+    await seed(2);
+    // Prime the cache, then prove the next calls do not touch the file at all.
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    markStoreUnread();
+    for (let i = 0; i < 25; i++) expect(hasAnthropicFailoverQuorum(start + i)).toBe(true);
+    expect(storeWasRead()).toBe(false);
+  });
+
+  test("a fresh login is visible once the window expires", async () => {
+    // The cache must not be able to strand an operator who just logged a second account in:
+    // a stale false would keep failover off for exactly the traffic that needs it.
+    const start = Date.now();
+    await seed(1);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(false);
+    await seed(1, 1);
+    // Same instant: still the memoized answer.
+    expect(hasAnthropicFailoverQuorum(start)).toBe(false);
+    // Past the window: seen without any explicit invalidation call.
+    expect(hasAnthropicFailoverQuorum(start + 2_001)).toBe(true);
+  });
+
+  test("a rotation invalidates immediately rather than waiting out the TTL", async () => {
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    expect(rotateAnthropicAccountOn429({ providers: {} } as never, ids[0]!, null, null, start)).toBe(ids[1]);
+    // The roster in use just changed, so the next question re-reads instead of answering from
+    // the count taken before the failure.
+    markStoreUnread();
+    hasAnthropicFailoverQuorum(start + 1);
+    expect(storeWasRead()).toBe(true);
+  });
+
+  test("the cache holds no credential material", async () => {
+    // A boolean derived from a count. If this ever became an id or a token the cache would
+    // outlive the store's own hardening, which is the thing loadAuthStore re-applies per read.
+    await seed(2);
+    expect(typeof hasAnthropicFailoverQuorum()).toBe("boolean");
+  });
+
+  test("removing an account invalidates immediately, not after the TTL", async () => {
+    // The management DELETE route calls clearAnthropicSessionAffinityForAccount for Anthropic.
+    // Without invalidation there, deleting the second account would leave quorum true for up to
+    // 2s -- long enough for a request to record an id whose credential is already gone.
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    clearAnthropicSessionAffinityForAccount(ids[1]!);
+    markStoreUnread();
+    hasAnthropicFailoverQuorum(start + 1);
+    expect(storeWasRead()).toBe(true);
+  });
+
+  test("a manual account selection invalidates immediately", async () => {
+    // An operator picking an account is a statement about the roster, so the next activation
+    // question must not be answered from a count read before it.
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    resetAnthropicRoutingForManualSelection(ids[0]!);
+    markStoreUnread();
+    hasAnthropicFailoverQuorum(start + 1);
+    expect(storeWasRead()).toBe(true);
+  });
+});

--- a/tests/repo-hygiene.test.ts
+++ b/tests/repo-hygiene.test.ts
@@ -288,3 +288,32 @@ describe("test layout", () => {
     expect(duplicates).toEqual([]);
   });
 });
+
+describe("429 failover contracts stay covered", () => {
+  test("every contract test this unit shipped is still tracked", () => {
+    // A deleted test is invisible: removing it removes its assertions, so CI stays green and no
+    // reviewer sees red. That is exactly what happened to the quorum cache test -- #3516 rebased
+    // against a branch point where the file sat elsewhere and resolved the conflict by dropping
+    // it, and nothing noticed. The duplicate-basename guard could not help: one copy is not a
+    // duplicate.
+    //
+    // These four are listed by NAME rather than path so the domain reorganizations can keep
+    // moving them freely; what may not happen is a file quietly ceasing to exist. They are worth
+    // naming because each observes something nothing else does -- most sharply the quorum cache,
+    // whose subject is a performance property: the runtime behaves identically without it, so
+    // its loss would surface only as latency nobody attributes.
+    const required = [
+      "always-on-429-failover.test.ts",
+      "anthropic-quorum-cache.test.ts",
+      "generic-oauth-failover.test.ts",
+      "docs-429-failover-claims.test.ts",
+    ];
+    const tracked = new Set(
+      trackedFiles()
+        .filter((path) => path.startsWith("tests/"))
+        .map((path) => path.split("/").pop()!),
+    );
+    const missing = required.filter((name) => !tracked.has(name));
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/routing/anthropic-quorum-cache.test.ts
+++ b/tests/routing/anthropic-quorum-cache.test.ts
@@ -23,9 +23,9 @@ import {
   hasAnthropicFailoverQuorum,
   resetAnthropicRoutingForManualSelection,
   rotateAnthropicAccountOn429,
-} from "../../../src/oauth/anthropic-routing";
-import { getAccountSet, saveCredential } from "../../../src/oauth/store";
-import { removeTreeWithRetry } from "../../helpers/remove-tree";
+} from "../../src/oauth/anthropic-routing";
+import { getAccountSet, saveCredential } from "../../src/oauth/store";
+import { removeTreeWithRetry } from "../helpers/remove-tree";
 
 const originalHome = process.env.OPENCODEX_HOME;
 let home: string;


### PR DESCRIPTION
## Summary

A test this unit shipped was deleted from `dev` and nothing noticed.

#3516 rebased against a branch point where `anthropic-quorum-cache.test.ts` still sat in `tests/routing/`, and resolved the conflict with #3526 by dropping the file entirely rather than keeping the surviving copy in `tests/adapters/anthropic/`. Its commit message says it honours the #3523 placement; the diff shows a 146-line deletion and no corresponding add.

**Nothing failed, because nothing could.** Deleting a test removes its assertions — the suite stays green and no reviewer sees red. The duplicate-basename guard from #3527 could not help either: one copy is not a duplicate.

The file is restored at `tests/adapters/anthropic/`, beside `anthropic-account-pool.test.ts`, with import depth corrected for the domain directory. Its `atime` observation still fails if the per-request auth-store read returns.

**The guard.** `repo-hygiene` now fails when any of the four 429 contract tests stops being tracked. Listed by **name, not path**, so the ongoing domain reorganizations keep moving them freely — what may not happen is a file quietly ceasing to exist.

Four is a deliberate list, not a policy: each observes something nothing else does. The quorum cache is the sharpest case, because its subject is a *performance* property. The runtime behaves identically with or without the cache, so losing that test would surface only as latency nobody attributes to a cause.

Swept the three reorganizations for other casualties — this was the only one.

## Verification

- `bun run typecheck` — clean.
- `bun test` across six focused files — 104 pass, 0 fail.
- Both guards were driven red against their real failures before being committed green: the duplicate guard against the #3511/#3513 collision, this one against the exact #3516 deletion.
- No repository-wide local suite; repository-wide validation is delegated to CI on this head.

No `src/` change — a restored test and one guard.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for Anthropic failover quorum caching, including cache expiration and immediate invalidation after account or selection changes.
  - Added safeguards ensuring required failover contract tests remain tracked and continue running in CI.
  - Verified that cached failover state does not retain credential material.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->