### PR TITLE
docs(devlog): make CI completion audit fail closed

### DIFF
--- a/devlog/_fin/260905_always_on_429_failover/090_outcome.md
+++ b/devlog/_fin/260905_always_on_429_failover/090_outcome.md
@@ -18,7 +18,7 @@ the tree rather than against the plan — the plan's own criteria were satisfied
 Two were defects the fix itself created (#3499, #3503), three were surfaces still describing the
 old contract (#3517, #3520, #3523), one closed the structural gap that let this unit ship two
 subset-rotator loops (#3512), and one cleaned up after a collision with concurrent maintainer
-work (#3526). All are recorded in `091`.
+work (#3526). The runtime post-merge findings and CI lessons are recorded in `091`.
 
 ## What changed
 

--- a/devlog/_fin/260905_always_on_429_failover/091_post_merge_audit.md
+++ b/devlog/_fin/260905_always_on_429_failover/091_post_merge_audit.md
@@ -67,14 +67,37 @@ The post-merge run on `dev` then showed `ci failure`, which was a genuinely alar
 out. It turned out to be cancellation by the maintainer's next merge two minutes later, not a
 real failure — every job read `cancelled`, not `failure`.
 
-**Rule:** verify with the check-runs API and require zero `null` conclusions, not a pass count:
+**Rule:** use the exact head SHA, require every expected aggregate or policy gate by name, and
+also require zero non-terminal check runs. A missing check is not success. Paginate before treating
+the returned set as complete:
 
 ```bash
-gh api repos/<owner>/<repo>/commits/<sha>/check-runs \
-  --jq '[.check_runs[] | .conclusion] | group_by(.) | map({(.[0]//"null"): length}) | add'
+set -o pipefail
+gh api --paginate repos/<owner>/<repo>/commits/<sha>/check-runs \
+  | jq -se '
+      [.[].check_runs[]] as $runs
+      | ["ci", "enforce-target", "hygiene", "react-doctor"] as $expected
+      | ($expected - [
+          $runs[]
+          | select(.status == "completed" and .conclusion == "success")
+          | .name
+        ]) as $missing
+      | [
+          $runs[]
+          | select(.status != "completed" or .conclusion == null)
+          | .name
+        ] as $pending
+      | if ($missing | length) == 0 and ($pending | length) == 0
+        then {ready: true, expected: $expected}
+        else error("missing=\($missing) pending=\($pending)")
+        end'
 ```
 
-A clean result looks like `{"skipped":3,"success":24}` — no `null` key at all.
+A clean result is `{"ready":true,...}` with exit status 0. This does not replace review-policy
+checks such as confirming the approval belongs to the same head. Every `$expected` value is an
+exact Checks API `.check_runs[].name`, not a workflow title or workflow-run name. If those required
+check-run names change, update this list with the policy; silently accepting an absent name
+recreates the original bug.
 
 The near-miss paid for itself: sweeping `dev` afterwards found a real defect. #3511 and #3513
 landed concurrently, one moving `anthropic-quorum-cache.test.ts` into `tests/routing/` and the


### PR DESCRIPTION
## Summary

This narrows #3532 to the unresolved documentation correctness findings from #3527:

- Paginate exact-head check runs before evaluating them.
- Require the expected aggregate and policy check-run names, so a check that has not registered yet is treated as missing rather than success.
- Reject every reported non-terminal run.
- Enable shell `pipefail`, so a later pagination failure cannot be hidden by a successful `jq` over partial output.
- State that `$expected` values match Checks API `.check_runs[].name` exactly, not workflow titles or workflow-run names.
- Narrow the `090_outcome.md` wording so it no longer claims that every listed follow-up is individually recorded in `091_post_merge_audit.md`.

#3530 has now landed with the separate test restoration and missing-contract guard. #3532 is rebased onto that merge and changes only maintainer devlog records.

## Why this is needed

The check-runs API can only return runs that already exist. Counting zero `null` conclusions does not prove completeness: during workflow scheduling delay, a small completed subset can contain no null values while expected checks are still absent. The revised command requires the exact check-run names `ci`, `enforce-target`, `hygiene`, and `react-doctor` to be present and successful, in addition to rejecting non-terminal runs. `set -o pipefail` also propagates a failed later page instead of accepting the earlier pages that `jq` could parse successfully.

## Verification

- Revised command returns `ready: true` with exit status 0 on a completed exact head.
- Negative probe with one expected check-run name absent exits 5.
- Synthetic partial-page producer that emits valid completed checks and then exits 7 makes the documented pipeline exit 7 under `pipefail`.
- `bun run typecheck` — pass under isolated runtime homes.
- `bun run privacy:scan` — pass under isolated runtime homes.
- `git diff --check` — pass.
- Protected local runtime config modes, sizes, and SHA-256 values remained unchanged.

No runtime, test implementation, credential, GUI, release, dependency, or Go-native behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified post-merge audit guidance for verifying CI checks.
  - Added stricter validation requiring all expected workflows to complete successfully.
  - Documented handling for missing, pending, or incomplete checks, including pagination and exact commit verification.
  - Updated the outcome note to reference runtime findings and CI lessons recorded in the post-merge audit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->