### PR TITLE
test(oauth): prove the unobservable quorum staleness window is harmless

### DIFF
--- a/src/oauth/anthropic-routing.ts
+++ b/src/oauth/anthropic-routing.ts
@@ -249,6 +249,19 @@ export function getEligibleAnthropicAccounts(now = Date.now()): string[] {
  * enough that a login in another window is visible before the operator can switch back and send a
  * prompt, long enough that a burst of requests shares one read. The cache holds a BOOLEAN derived
  * from a count — never a credential, never an account id.
+ *
+ * Staleness is bounded by consequence, not only by the TTL. Explicit invalidation covers the
+ * roster mutations this module can see (rotation, pool-state reset, affinity clear on account
+ * removal, manual selection), but not one it cannot: a 401 elsewhere flagging an account
+ * `needsReauth` drops the real quorum to one while a cached `true` survives for up to 2s.
+ *
+ * That window is harmless in both directions, which is why it is left rather than plumbed
+ * through the store. A stale `true` only lets the caller ASK for an alternate;
+ * `pickAlternateAnthropicAccount` re-reads the roster through `getEligibleAnthropicAccounts`,
+ * skips the reauth-flagged account and returns `null`, so the 429 surfaces exactly as it would
+ * have. A stale `false` costs one un-rotated 429 and self-corrects on the next read. Neither
+ * can dispatch on an unusable credential, which is the only outcome worth adding a store hook
+ * to prevent.
  */
 const QUORUM_CACHE_TTL_MS = 2_000;
 

--- a/tests/routing/anthropic-quorum-cache.test.ts
+++ b/tests/routing/anthropic-quorum-cache.test.ts
@@ -24,7 +24,7 @@ import {
   resetAnthropicRoutingForManualSelection,
   rotateAnthropicAccountOn429,
 } from "../../src/oauth/anthropic-routing";
-import { getAccountSet, saveCredential } from "../../src/oauth/store";
+import { getAccountSet, markAccountNeedsReauth, saveCredential } from "../../src/oauth/store";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 
 const originalHome = process.env.OPENCODEX_HOME;
@@ -117,6 +117,28 @@ describe("Anthropic failover quorum cache", () => {
     // outlive the store's own hardening, which is the thing loadAuthStore re-applies per read.
     await seed(2);
     expect(typeof hasAnthropicFailoverQuorum()).toBe("boolean");
+  });
+
+  test("a stale quorum cannot dispatch on a reauth-flagged account", async () => {
+    // The one roster mutation this module cannot observe: a 401 elsewhere flags an account
+    // needsReauth, dropping the real quorum to one while the cached `true` survives the TTL.
+    //
+    // The window is left unplumbed deliberately, so this pins the reason: a stale `true` only
+    // lets the caller ASK. pickAlternateAnthropicAccount re-reads the roster, skips the flagged
+    // account and answers null, so the 429 surfaces exactly as it would have. If that ever
+    // stopped being true, the comment above the cache would be a lie and this fails.
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+
+    await markAccountNeedsReauth("anthropic", ids[1]!, true);
+    // Deliberately NOT invalidating: this is the stale-cache state under test.
+    expect(hasAnthropicFailoverQuorum(start + 1)).toBe(true);
+
+    // The rotator admits the request, then finds nothing usable and refuses.
+    expect(
+      rotateAnthropicAccountOn429({ providers: {} } as never, ids[0]!, null, null, start + 1),
+    ).toBeNull();
   });
 
   test("removing an account invalidates immediately, not after the TTL", async () => {


### PR DESCRIPTION
## Summary

The quorum cache has one roster mutation it cannot observe, and the comment above it did not say so.

Explicit invalidation covers what this module can see — rotation, pool-state reset, affinity clear on account removal, manual selection. It cannot see a 401 **elsewhere** flagging an account `needsReauth`, which drops the real quorum to one while the cached `true` survives up to 2 s.

I left that window unplumbed rather than threading a hook through the credential store, so the reason is now written down and, more importantly, **proven**:

- A stale `true` only lets the caller *ask*. `pickAlternateAnthropicAccount` re-reads the roster through `getEligibleAnthropicAccounts`, skips the flagged account, and returns `null` — the 429 surfaces exactly as it would have.
- A stale `false` costs one un-rotated 429 and self-corrects on the next read.

Neither can dispatch on an unusable credential, which is the only outcome that would justify a store hook. The new test leaves the cache deliberately stale and asserts the rotator still refuses; if that ever stops holding, the comment becomes a lie and the test fails.

## Verification

- `bun run typecheck` — clean.
- `bun test` across six focused files — 60 pass, 0 fail.
- No repository-wide local suite; repository-wide validation is delegated to CI on this head.

Also re-verified the whole unit against current `dev` rather than memory: the Anthropic gate is the presence-or-flag form at `anthropic-routing.ts:647`, `isGenericOAuthFailoverEnabled` is presence-only with no boolean short-circuit, and the rotator counts are 4 generic / 3 Anthropic / 2 key-pool as pinned by the contract test.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Anthropic account failover cache staleness is handled and bounded.

* **Tests**
  * Added coverage confirming that accounts requiring reauthentication are skipped during failover, even when cached quorum information remains temporarily stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->