### PR TITLE
fix(codex): fail closed on uncertain account deletion

### DIFF
--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -98,8 +98,8 @@ function restoreRuntimeConfig(target: OcxConfig, snapshot: OcxConfig): void {
   Object.assign(target, snapshot);
 }
 
-function assertPersistedConfigUnchanged(configPath: string, previousBytes: string): void {
-  if (readFileSync(configPath, "utf8") !== previousBytes) {
+function assertPersistedConfigUnchanged(configPath: string, previousBytes: Buffer): void {
+  if (!readFileSync(configPath).equals(previousBytes)) {
     throw new CodexAccountDeleteRollbackError();
   }
 }
@@ -121,7 +121,7 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
     const previousConfig = structuredClone(runtimeConfig);
     const configPath = getConfigPath();
     const hasPersistedConfig = existsSync(configPath);
-    const previousPersistedConfig = hasPersistedConfig ? readFileSync(configPath, "utf8") : undefined;
+    const previousPersistedConfig = hasPersistedConfig ? readFileSync(configPath) : undefined;
     const hadStoredAccount = (runtimeConfig.codexAccounts ?? [])
       .some(account => !account.isMain && account.id === accountId);
     const hadVisiblePickerBinding = hadStoredAccount

--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
 import {
-  atomicWriteFile,
   deleteConfigTopLevelKey,
   getConfigPath,
   saveConfigPreservingClaudeCode,
@@ -99,13 +98,10 @@ function restoreRuntimeConfig(target: OcxConfig, snapshot: OcxConfig): void {
   Object.assign(target, snapshot);
 }
 
-function restorePersistedConfig(configPath: string, previousBytes: string): void {
-  try {
-    if (readFileSync(configPath, "utf8") === previousBytes) return;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+function assertPersistedConfigUnchanged(configPath: string, previousBytes: string): void {
+  if (readFileSync(configPath, "utf8") !== previousBytes) {
+    throw new CodexAccountDeleteRollbackError();
   }
-  atomicWriteFile(configPath, previousBytes);
 }
 
 /**
@@ -154,7 +150,7 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
       } catch (error) {
         restoreRuntimeConfig(runtimeConfig, previousConfig);
         try {
-          restorePersistedConfig(configPath, previousPersistedConfig);
+          assertPersistedConfigUnchanged(configPath, previousPersistedConfig);
         } catch {
           throw new CodexAccountDeleteRollbackError();
         }

--- a/tests/codex-integration/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-integration/codex-account-delete-atomicity.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync} from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import * as accountStoreModule from "../../src/codex/account-store";
 import {
@@ -8,6 +14,7 @@ import {
 } from "../../src/codex/account-store";
 import {
   CodexAccountDeleteCleanupError,
+  CodexAccountDeleteRollbackError,
   deleteCodexAccount,
 } from "../../src/codex/account-lifecycle";
 import {
@@ -85,7 +92,26 @@ describe("Codex account delete persistence ordering", () => {
     }
   });
 
-  test("a failure after durable config replacement restores the prior config", () => {
+  test("a failure before durable config replacement rethrows while disk remains unchanged", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const beforeBytes = readFileSync(getConfigPath(), "utf8");
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(() => { throw new Error("forced pre-write failure"); });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow("forced pre-write failure");
+      expect(config).toEqual(before);
+      expect(readFileSync(getConfigPath(), "utf8")).toBe(beforeBytes);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  test("a failure after durable config replacement leaves changed disk untouched", () => {
     const config = seededConfig();
     const before = structuredClone(config);
     const beforeBytes = readFileSync(getConfigPath(), "utf8");
@@ -97,11 +123,61 @@ describe("Codex account delete persistence ordering", () => {
       });
 
     try {
-      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow("forced post-write failure");
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
 
       expect(config).toEqual(before);
-      expect(readFileSync(getConfigPath(), "utf8")).toBe(beforeBytes);
-      expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(true);
+      expect(readFileSync(getConfigPath(), "utf8")).not.toBe(beforeBytes);
+      expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  test("a concurrent external edit remains byte-identical after uncertain failure", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const realSave = configModule.saveConfigPreservingClaudeCode;
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(candidate => {
+        realSave(candidate);
+        const external = loadConfig();
+        external.port = 12345;
+        writeFileSync(getConfigPath(), JSON.stringify(external, null, 2) + "\n");
+        throw new Error("forced concurrent failure");
+      });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
+      const persisted = loadConfig();
+      expect(persisted.port).toBe(12345);
+      expect(persisted.codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+      expect(config).toEqual(before);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  test("a missing config after uncertain failure is not recreated", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const realSave = configModule.saveConfigPreservingClaudeCode;
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(candidate => {
+        realSave(candidate);
+        unlinkSync(getConfigPath());
+        throw new Error("forced missing-file failure");
+      });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
+      expect(existsSync(getConfigPath())).toBe(false);
+      expect(config).toEqual(before);
       expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
       expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
       expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();

--- a/tests/codex-integration/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-integration/codex-account-delete-atomicity.test.ts
@@ -163,6 +163,36 @@ describe("Codex account delete persistence ordering", () => {
     }
   });
 
+  test("distinct bytes with the same decoded text are treated as changed", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const validBytes = Buffer.from('{"value":"\uFFFD"}\n', "utf8");
+    const malformedBytes = Buffer.concat([
+      Buffer.from('{"value":"', "utf8"),
+      Buffer.from([0x80]),
+      Buffer.from('"}\n', "utf8"),
+    ]);
+    expect(validBytes.equals(malformedBytes)).toBe(false);
+    expect(validBytes.toString("utf8")).toBe(malformedBytes.toString("utf8"));
+    writeFileSync(getConfigPath(), validBytes);
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(() => {
+        writeFileSync(getConfigPath(), malformedBytes);
+        throw new Error("forced byte-alias failure");
+      });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
+      expect(readFileSync(getConfigPath()).equals(malformedBytes)).toBe(true);
+      expect(config).toEqual(before);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
   test("a missing config after uncertain failure is not recreated", () => {
     const config = seededConfig();
     const before = structuredClone(config);


### PR DESCRIPTION
## Summary

- Make account deletion fail closed when configuration persistence reports an error after the on-disk file may already have changed.
- Restore only the in-memory snapshot. If raw persisted bytes changed, disappeared, or became unreadable, return the fixed rollback error without overwriting a concurrent edit or recreating a missing config file.
- Compare raw bytes rather than decoded text, so malformed and valid UTF-8 sequences cannot alias through replacement-character decoding.
- Keep credential, reauthentication, and quota cleanup deferred until durable persistence is certain.
- Keep this slice narrow: the management DELETE route second-save/error response contract and coordination with non-cooperating external file writers remain separate follow-ups.

This changes internal failure handling only. It does not change the config schema, credential format, commands, API success shape, or dashboard, so no user-facing documentation update is needed.

## Verification

- `bun test ./tests/codex-integration/codex-account-delete-atomicity.test.ts` — 8 pass, 0 fail on `74808a8bc`.
- `bun run typecheck` — pass on `74808a8bc`.
- `bun run privacy:scan` — pass on `74808a8bc`.
- `bun run test` — complete repository suite passes on `74808a8bc` after upstream #3622.
- `git diff --check` — pass on `74808a8bc`.
- Independent security/concurrency review confirmed that changed, missing, and concurrently edited files are not overwritten or recreated, and destructive cleanup does not run under persistence uncertainty.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

