### PR TITLE
docs(devlog): open the 260905 open-work closeout roadmap unit

### DIFF
--- a/devlog/_plan/260905_open_work_closeout/000_plan.md
+++ b/devlog/_plan/260905_open_work_closeout/000_plan.md
@@ -1,0 +1,91 @@
+# 000 — Plan and live manifest
+
+Unit: `devlog/_plan/260905_open_work_closeout`. Session `01a06e47-8897-70a0-b669-cf6c5b77d4c3`.
+Snapshot: 2026-09-04T21:19:34Z (fetch), `origin/dev` = `0f27bbeb3`
+(`test(hygiene): fail on duplicate test basenames, and close out the 429 unit (#3527)`).
+Research worktree: `/private/tmp/ocx-closeout.xomWAA/wt` (detached).
+
+## Objective
+
+Triage and land every solvable open item in four families, as dependency-ordered PR
+stacks merged bottom-up into `dev`. Constraints given by the maintainer:
+
+- No repository-wide local suite. Verifiers: focused `bun test tests/<file>.test.ts`,
+  `bun run typecheck`, `bun run test:changed`, exact-head hosted CI.
+- Commit/push with `--no-verify` (the pre-push hook would run the forbidden suite).
+- Stacked PRs (DEV-STACK-01..03), squash-merge bottom-up, admin merge authorized on `dev`.
+- Carried or reimplemented contributor work carries a `Co-authored-by` trailer.
+- Subagents: `anthropic/claude-opus-5`, unlimited.
+- Out of scope: `main`/`preview` promotion, releases, credential/account changes.
+
+## Work-phase map (dependency-ordered, one PABCD cycle each)
+
+| WP | Scope | Doc |
+|----|-------|-----|
+| wp0 | Docs-only: manifest, lane research (001-005), dispositions (006), stack decade docs | 000-006 |
+| wp1 | Stack A — bug PRs that are green/mergeable as-is | 010 |
+| wp2 | Stack B — bug PRs needing rebase/carry/reimplementation | 020 |
+| wp3 | Stack C — V2 passthrough #3444 | 030 |
+| wp4 | Stack D — usage/quota PRs | 040 |
+| wp5 | Stack E — remaining ready PRs + implementable bug issues | 050 |
+| wp6 | Closeout: PR/issue closure, merge ledger, unit to `_fin` | 060 |
+
+## Manifest (exact head at snapshot)
+
+`gh pr view` at snapshot; columns: head, mergeable, mergeState, review, +/-, files, non-green checks.
+
+| PR | Author | Head | Mergeable | State | Review | +/- | Files | Non-green checks |
+|----|--------|------|-----------|-------|--------|-----|-------|------------------|
+| #3529 | yansigit | 4f103a1e7 | MERGEABLE | BLOCKED (draft) | REVIEW_REQUIRED | 165/68 | 6 | — |
+| #3525 | Ingwannu | 288506dc6 | MERGEABLE | BLOCKED | REVIEW_REQUIRED | 305/43 | 8 | — |
+| #3524 | yansigit | cf0b3fe0a | MERGEABLE | BLOCKED (draft) | REVIEW_REQUIRED | 304/38 | 4 | hygiene FAIL, enforce-target FAIL |
+| #3519 | everton-dgn | 6b92ab7db | MERGEABLE | BLOCKED (draft) | CHANGES_REQUESTED | 319/46 | 3 | — |
+| #3515 | VXNCXNX | 4f09faf5d | MERGEABLE | BLOCKED | REVIEW_REQUIRED | 87/1 | 4 | — |
+| #3502 | Ingwannu | 6671a1623 | CONFLICTING | DIRTY | REVIEW_REQUIRED | 461/104 | 30 | — |
+| #3490 | yxr1995-maker | 3fbe8a2c7 | MERGEABLE | BLOCKED (draft) | REVIEW_REQUIRED | 159/1 | 4 | — |
+| #3489 | Flowershangfromthebranches | dbcfde8ca | CONFLICTING | DIRTY | APPROVED | 586/5 | 6 | — |
+| #3484 | Ingwannu | a4c50d104 | MERGEABLE | BLOCKED | REVIEW_REQUIRED | 187/1 | 14 | label CANCELLED |
+| #3480 | benedictusrey | 63623c640 | CONFLICTING | DIRTY | CHANGES_REQUESTED | 11/0 | 2 | cancelled runs |
+| #3469 | agentHits | e11089af8 | CONFLICTING | DIRTY | APPROVED | 115/3 | 6 | cancelled runs |
+| #3407 | turin-dev | 38d45300a | CONFLICTING | DIRTY (draft) | REVIEW_REQUIRED | 295/33 | 18 | test 1/4, 2/4, gates, macos, ci FAIL |
+| #3388 | zleo-ai | 007076ebd | CONFLICTING | DIRTY (draft) | REVIEW_REQUIRED | 843/4 | 5 | — |
+| #3348 | RHODIZSECURITY | a64ed3250 | CONFLICTING | DIRTY | REVIEW_REQUIRED | 2165/196 | 35 | enforce-target CANCELLED |
+| #3444 | cb8010d6 | baefb1334 | MERGEABLE | BLOCKED (draft) | REVIEW_REQUIRED | 111/4 | 6 | hygiene FAIL |
+| #3447 | hualiny | 745b70e1e | CONFLICTING | DIRTY | CHANGES_REQUESTED | 567/9 | 3 | — |
+| #2956 | Manson2438 | cc6aa5f48 | CONFLICTING | DIRTY (draft) | REVIEW_REQUIRED | 1261/114 | 34 | — |
+| #2783 | lidge-jun | ad74f037d | CONFLICTING | DIRTY | CHANGES_REQUESTED | 6144/73 | 52 | — |
+| #2973 | terrytan95 | b6a879267 | CONFLICTING | DIRTY (draft) | CHANGES_REQUESTED | 1025/60 | 33 | — |
+| #3530 | lidge-jun | 14fbbd187 → MERGED 6580694c7 | — | MERGED during wp0 | — | 175/0 | 2 | follow-up E0 in 050 |
+| #3323 | luvs01 | 0facdae69 | MERGEABLE | BLOCKED | REVIEW_REQUIRED | 6/4 | 1 | — |
+| #3487 | Ingwannu | ee3b22d28 | CONFLICTING | DIRTY | REVIEW_REQUIRED | 6/1 | 1 | — |
+| #3508 | yansigit | b78cadf12 | MERGEABLE | CLEAN | APPROVED | 316/0 | 2 | — |
+| #3383 | x3M3x | 51726d2c7 | CONFLICTING | DIRTY | REVIEW_REQUIRED | 562/89 | 26 | — |
+| #3329 | Veritas-7 | 1876d6001 | CONFLICTING | DIRTY | CHANGES_REQUESTED | 819/60 | 17 | — |
+| #3421 | Skyline-23 | 432016100 | MERGEABLE | BLOCKED | CHANGES_REQUESTED | 327/89 | 16 | cancelled runs |
+| #2716 | zigzag-007 | 27ba09f40 | MERGEABLE | BLOCKED | CHANGES_REQUESTED | 1325/3 | 17 | — |
+| #2432 | mdwsk88 | c83d8eda1 | MERGEABLE | BLOCKED | CHANGES_REQUESTED | 26/18 | 9 | — |
+| #3531 | benedictusrey | f486b5d60 | MERGEABLE | BLOCKED (draft) | REVIEW_REQUIRED | 74/3 | 6 | — |
+| #3528 | benedictusrey | 735e3f5c5 | CONFLICTING | DIRTY (draft) | REVIEW_REQUIRED | 666/3 | 11 | cancelled runs |
+
+Open bug-labelled issues at snapshot: #3522, #3506, #3467, #3464, #3462, #3433, #3425,
+#3424, #3406, #3352, #3320, #3245.
+
+## Research lanes (claude-opus-5, read-only)
+
+| Doc | Lane | Items |
+|-----|------|-------|
+| 001 | bug PRs A | #3529 #3525 #3524 #3519 #3515 #3502 #3490 |
+| 002 | bug PRs B | #3489 #3484 #3480 #3469 #3407 #3388 #3348 |
+| 003 | V2 + quota | #3444 #3447 #2956 #2783 #2973 |
+| 004 | else PRs | #3530 #3323 #3487 #3508 #3383 #3329 #3421 #2716 #2432 #3531 #3528 |
+| 005 | bug issues | 12 open bug issues |
+
+Dispositions are consolidated in `006_dispositions.md`; decade docs `010`-`060`
+are the diff-level plans for wp1-wp6.
+
+## Verifiers (PLAN-VERIFIER-REAL-01)
+
+- `bun run typecheck` — exit 0 on current dev (run in research worktree at P).
+- `bun test tests/<file>.test.ts` — named per landing in the decade docs.
+- `gh pr checks <n>` filtered to the exact head SHA — hosted CI.
+- `git fetch origin dev && git merge-base --is-ancestor <sha> FETCH_HEAD` — landing proof.

--- a/devlog/_plan/260905_open_work_closeout/001_lane_bug_prs_a.md
+++ b/devlog/_plan/260905_open_work_closeout/001_lane_bug_prs_a.md
@@ -1,0 +1,395 @@
+# Lane A — bug-labelled PRs (#3529, #3525, #3524, #3519, #3515, #3502, #3490)
+
+READ-ONLY adversarial review. Worktree `/private/tmp/ocx-closeout.xomWAA/wt`, detached at
+`0f27bbeb3ce6a92077652695e161d49b88eedc7a` (= `origin/dev` at review time; index re-read
+immediately before verdict, unchanged). No src/tests/gui file was left modified: every patch
+applied during verification was reverted and `git status --porcelain` shows only this new
+devlog directory.
+
+## Summary
+
+| Item | Disposition | One-line reason |
+| --- | --- | --- |
+| #3515 | LAND_AS_IS | Only fully-green, review-ready, maintainer-approved item; two regressions distinguish 499 caller-cancel from 502 upstream reset. |
+| #3529 | LAND_AS_IS | 3 tests proven RED on dev and GREEN with the fix; core/lab boundary still passes; draft checklist is the only gate. |
+| #3525 | LAND_AS_IS | 6 tests proven RED on dev, GREEN with the fix, full exact-head CI green; one stale docs line is the sole nit. |
+| #3490 | LAND_AS_IS | TOML table-header comment bug independently reproduced RED, fixed GREEN, and the existing consumer suite stays green. |
+| #3502 | LAND_WITH_FIX | All three src defects still live on dev, but CONFLICTING with dev and its docs prose contradicts #3520 that already landed. |
+| #3519 | LAND_WITH_FIX | Both reviewer blockers are genuinely fixed on the new head, but the behavior change ships with no docs-site update. |
+| #3524 | REIMPLEMENT | New unguarded startup `throw` reproduced live: a config removed between load and reconcile crashes `startServer`. |
+
+### Stack order (shared files)
+
+```
+src/server/responses/core.ts   : #3515 (2 lines, ~4922) <-> #3502 (~3364/6693)  -> land #3515 first, trivially separable
+config persistence (mutatePersistedConfig) : #3529 and #3524 use the same helper in different modules -> no textual conflict
+```
+
+No two items in this lane touch the same function. The only real ordering constraint is
+`src/server/responses/core.ts`, where #3515 and #3502 edit regions ~1,500 lines apart.
+
+---
+
+## #3515 — fix(responses): keep caller cancellations out of upstream failure logs
+
+- Head `4f09faf5d3e08275476b31f4b6a8ed30d04a8a66`, base `dev`, MERGEABLE / BLOCKED,
+  `REVIEW_REQUIRED` (branch protection needs a second approval), not draft,
+  labels `bug` + `review-ready`, gate 4/4 ticked.
+- CI on that exact head: fully green — `gates`, `storage policy`, `api usage`, all four
+  `test N/4` shards, both macOS shards, three `keyring` jobs, three `npm-global` jobs,
+  `react-doctor`, `enforce-target`, `hygiene`. CodeRabbit completed, `Ingwannu` APPROVED.
+- Conflicts: none. `git apply --check` clean against `0f27bbeb3`.
+
+**Defect (still live on dev).** `startBoundedInspectionPump` only learns the client is gone
+through the `clientGoneSignal` listener registered at
+[relay.ts:1269](/private/tmp/ocx-closeout.xomWAA/wt/src/server/relay.ts:1269), and the pump's
+`catch` at [relay.ts:1313](/private/tmp/ocx-closeout.xomWAA/wt/src/server/relay.ts:1313)
+classifies a read rejection as an upstream fault whenever `clientGone` is still false. Bun can
+settle the fetch-body read before dispatching all abort listeners, so a caller abort lands in
+that branch and reaches `options.onReadError?.()`. Compounding it,
+[core.ts:4925](/private/tmp/ocx-closeout.xomWAA/wt/src/server/responses/core.ts:4925) passes
+only `clientGone.signal` and never the inbound request's `options.abortSignal`, which is
+available on the same object (`abortSignal` is used at core.ts:1814, 1848, 1906). Result: a
+client cancel logs 502 and increments the account pool failure streak.
+
+**Test evidence.** Yes — two paired regressions in `tests/server-auth.test.ts`: *"native
+passthrough caller abort logs cancellation without penalizing the pool"* (asserts 499,
+`closeReason: "client_cancel"`, `consecutiveFailures === 0`) and its negative twin *"native
+passthrough upstream reset still logs 502 and penalizes the pool"* (asserts 502,
+`streamAborted: true`, `consecutiveFailures === 1`). The second is what makes the pair
+meaningful: it proves the fix narrows classification rather than suppressing 502 wholesale.
+
+**Blockers.** None found. No Node-only API; `AbortSignal.any` is already used in eight runtime
+modules (`hub-relay.ts:249`, `fetch-helpers.ts:184`, `gcp-adc.ts:204`). No credential or
+body logging. The `core.ts` edit is 4 lines inside the native-tee branch and does not import
+`src/lab/`. Docs updated (`proxy-formats.md`). The one CodeRabbit nit (poll for the log entry
+instead of asserting immediately) was addressed before the approval.
+
+**Disposition: LAND_AS_IS.** Highest-confidence item in the lane.
+
+---
+
+## #3529 — fix(providers): rebase key failover on persisted state
+
+- Head `4f103a1e71bd8712fc31e856ca105864811d8b7f`, base `dev`, MERGEABLE / BLOCKED,
+  `REVIEW_REQUIRED`, **draft**, label `bug`, checklist 0/4.
+- CI on that exact head: `enforce-target`, `hygiene`, `label`, `resolve-pr` all pass.
+  The full cross-platform matrix has **not** run — CodeRabbit reports "Review skipped: draft
+  pull request" and the heavy jobs are draft-gated. This is the main evidence gap.
+- Conflicts: none. `git apply --check` clean.
+
+**Defect (still live on dev).** `rotateKeyOn429` mutates the request's in-memory config and
+writes the whole object: `provider.apiKey = candidate.key` then
+`saveConfigPreservingClaudeCode(config)` at
+[key-failover.ts:219](/private/tmp/ocx-closeout.xomWAA/wt/src/providers/key-failover.ts:219).
+A key deleted from the pool through the management API between request start and rotation is
+resurrected by that whole-object write. Second defect: `rotateProviderTransportOn429` at
+[key-failover.ts:296](/private/tmp/ocx-closeout.xomWAA/wt/src/providers/key-failover.ts:296)
+spreads `{ ...routedProvider, apiKey: rotated.apiKey }`, so a concurrent edit to any other
+persisted provider field is dropped on the retry.
+
+**Test evidence — verified by execution.** Applying only `tests/` from the PR onto clean dev:
+
+```
+12 pass, 3 fail
+(fail) rotateKeyOn429 > rebases over a concurrent pool edit without resurrecting a removed key
+(fail) rotateKeyOn429 > ... (persist-failure case)
+(fail) rotateProviderTransportOn429 > inherits routed-only backfills while persisted fields stay authoritative
+        Expected: "https://api.example.com/v1"  Received: "https://registry-pinned.example/v1"
+```
+
+Adding the `src/` half turns it to **15 pass / 0 fail**. Genuinely RED on dev, GREEN with the fix.
+
+**Blockers.** One structural risk I checked and cleared: the diff adds
+`import { routedProviderConfig } from "../router"` to a module that
+`src/server/responses/core.ts` and `compact.ts` import. `src/router.ts` does **not** import
+`key-failover` (verified against router.ts:1-47), so no cycle. `tests/lab/core-lab-boundary.test.ts`
+passes 17/17 with the patch applied, so the optional-subsystem invariant in AGENTS.md holds.
+`tests/adapters/openai/openai-chat-native-policy.test.ts` and
+`tests/providers/openrouter-provider-routing.test.ts` pass 52/52. Key logging remains id-only.
+CodeRabbit's line-296 finding is exactly what the final `routedProviderConfig(...)` call addresses.
+
+**Disposition: LAND_AS_IS** on the merits — the diff is correct and its tests are honestly red on
+dev. Procedurally it cannot merge yet: it is draft with 0/4 boxes and has never run the full
+matrix. Land after the author ticks the checklist and exact-head CI goes green.
+
+---
+
+## #3525 — fix(responses): expose continuation spill write health
+
+- Head `288506dc6883fa8433cf89014e72d01c1675317d`, base `dev`, MERGEABLE / BLOCKED,
+  `REVIEW_REQUIRED`, not draft, label `bug`.
+- CI on that exact head: fully green across the whole matrix (`gates`, all four `test N/4`,
+  both macOS shards, three keyring, three npm-global, `storage policy`, `api usage`,
+  `react-doctor`). CodeRabbit: "No actionable comments". The author documented a rebase onto
+  the `dev` that contains #3526 and re-ran verification.
+- Conflicts: none against `0f27bbeb3`.
+
+**Defect (still live on dev).** `spillCounters` is
+`{ writes, writeFailures, readFailures }` at
+[state.ts:172](/private/tmp/ocx-closeout.xomWAA/wt/src/responses/state.ts:172) — three
+cumulative integers. An operator cannot tell "failed 10,000 times and is still failing" from
+"failed 10,000 times an hour ago and recovered", which is precisely the #3522 Windows report
+(successful spills frozen at 1,988 while failures climbed past 10,000, `/healthz` still
+healthy). This is observability, not a crash fix, so it does not close #3522 by itself — the
+author says so explicitly, which I count in its favor.
+
+**Test evidence — verified by execution.** Tests-only onto clean dev: **137 pass / 6 fail**,
+including *"a successful spill clears a repeated failure streak without erasing the last
+failure"*, *"Windows spill reports exhausted ACL retry and recovers after a healthy runner"*,
+and *"response-state management metrics keep every added field finite scalar and privacy-safe"*.
+With `src/` applied, `responses-state` + `memory-watchdog` + `continuation-dedup` run
+**172 pass / 0 fail**.
+
+**Blockers.** None blocking. Privacy is handled deliberately: `classifySpillWriteFailure` walks
+up to 4 `cause` levels and collapses everything to a fixed 9-member enum, so no message or path
+can leak; the diff's own comment names the nested-`cause` username/path risk. New fields are
+scalars on the already-authenticated `/api/system/memory`, explicitly *not* `/healthz`.
+`structure/05` and the management-API reference are both updated.
+
+One **Low** nit (non-blocking): `docs-site/.../troubleshooting/windows-memory.md` adds
+"run `ocx observe memory --json`". The registry has `observe` with a `memory` subcommand
+([registry.ts:237](/private/tmp/ocx-closeout.xomWAA/wt/src/cli/registry.ts:237)) and a
+`memory` alias at line 264, so the command resolves — but line 264's summary reads "Alias of
+`ocx n memory`" while the canonical name printed at line 237 is `observe`. That inconsistency
+is pre-existing on dev, not introduced here.
+
+**Disposition: LAND_AS_IS.**
+
+---
+
+## #3490 — fix(codex): diagnose invalid persistent instructions config
+
+- Head `3fbe8a2c760016fcd7c0d8aafa0ad0fe060060a5`, base `dev`, MERGEABLE / BLOCKED,
+  `REVIEW_REQUIRED`, **draft**, label `bug`, checklist 0/4.
+- CI on that exact head: `enforce-target`, `hygiene`, `label`, `resolve-pr` pass; full matrix
+  draft-gated and not run. CodeRabbit skipped (draft).
+- Conflicts: none.
+
+**Defect (still live on dev).** The hand-rolled TOML table matcher at
+[project-config-warnings.ts:65](/private/tmp/ocx-closeout.xomWAA/wt/src/codex/project-config-warnings.ts:65)
+is `/^\s*\[([^\]]+)\]\s*$/` — it does not tolerate a trailing comment. `[model_messages] # templates`
+therefore fails to match, the parser never switches sections, and every key under that header is
+attributed to the document root. That is a real misparse of valid TOML in a module already used by
+`collectProjectCodexConfigWarnings`.
+
+**Test evidence — verified by execution.** I applied only the new test file and the new
+`legacy-config-keys.ts` module while **withholding** the one-line regex fix:
+
+```
+5 pass, 1 fail
+(fail) a table header with a trailing comment does not leak fields into root
+       Expected length: 0   Received length: 1
+```
+
+That isolates the regex as load-bearing. With the full patch,
+`codex-legacy-config-keys` + `codex-integration/project-config-warnings` run **27 pass / 0 fail**,
+so the shared-parser change does not regress its existing consumer.
+
+**Blockers.** None. `node:fs` is fine here (`doctor.ts` and the surrounding `src/codex/`
+modules already use it; the Bun-native rule targets server request paths). The read is guarded by
+`existsSync` + `statSync().isFile()` and degrades to a skipped check rather than failing doctor.
+The `catch` carries the repo's `no-excuse-ok` marker. Diagnostic output is a fixed string plus
+the config path — no file contents echoed.
+
+**Disposition: LAND_AS_IS** on the merits; draft/checklist and a full-matrix run are the only gates.
+
+---
+
+## #3502 — fix(oauth): repair post-merge 429 failover boundaries
+
+- Head `6671a16238c464a4e650e95d97c05b6d8ab6b0f7`, base `dev`,
+  **CONFLICTING / DIRTY**, `REVIEW_REQUIRED`, not draft, label `bug`.
+- CI: green, but on a **stale merge base** (`2fb11f4a0`). Those results do not describe the
+  current `dev`.
+- 30 files (20 of them docs locales), ~530 added lines.
+
+**Conflicting files and rebase character.** `git apply --check` per file against `0f27bbeb3`:
+
+| File | Applies? | Character |
+| --- | --- | --- |
+| `src/oauth/anthropic-routing.ts` (hunk @621) | **no** | textual, from #3503 `6edc56328`; mechanical |
+| `docs-site/.../reference/configuration/providers.md` + 9 locale twins | **no** | **semantic** — #3520 `5d10a1900` already rewrote this prose |
+| `src/oauth/generic-account-failover.ts`, `src/server/responses/core.ts`, `src/types/{config,provider}.ts`, `structure/04` | yes | clean |
+| `tests/always-on-429-failover.test.ts`, `tests/adapter-event-oauth-failover.test.ts`, `tests/generic-oauth-failover.test.ts` | **no — file absent on dev** | renamed/removed since branch point |
+
+The `anthropic-routing.ts` conflict is mechanical: dev inserted `quorumCache = null` above the
+target line ([anthropic-routing.ts:662](/private/tmp/ocx-closeout.xomWAA/wt/src/oauth/anthropic-routing.ts:662)),
+the patched line itself is unchanged. The docs conflict is **semantic** and is the real problem —
+#3520 landed *"stop promising a 429 failover kill switch that no longer exists"*, and CodeRabbit
+flagged that this PR's own translated pages still open with the enabled-only condition its table
+contradicts. Three missing test files mean the test half must be re-targeted, not replayed.
+
+**Defects — all three confirmed live on dev.**
+
+1. [anthropic-routing.ts:662](/private/tmp/ocx-closeout.xomWAA/wt/src/oauth/anthropic-routing.ts:662)
+   calls `pickAlternateAnthropicAccount(config, failedAccountId, now)` unconditionally, so a
+   *disabled* pool still reactivates the dormant proactive strategy (round-robin / fill-first) on
+   the reactive 429 path.
+2. [generic-account-failover.ts:189](/private/tmp/ocx-closeout.xomWAA/wt/src/oauth/generic-account-failover.ts:189)
+   honours only `enabled === false` per provider, so a provider-specific `true` cannot opt back
+   in when the global default is `false` — narrow-over-broad precedence is broken in one direction.
+3. [core.ts:3380](/private/tmp/ocx-closeout.xomWAA/wt/src/server/responses/core.ts:3380) sets
+   `parsed._kiroAuthContext` on the outer request only. The terminal-guard continuation at
+   core.ts:6693 passes a **different** `nextParsed` object, so a rotated Kiro bearer is paired with
+   the failed account's region/profile on that retry.
+
+**Test evidence.** `tests/anthropic-sidecar-account-failover.test.ts` (+277 lines) is new and
+would be red on dev, but I could not execute the suite: three of the four touched test files do
+not exist on dev, so the test half cannot be applied as-is.
+
+**Blockers.** (a) CONFLICTING; (b) docs prose contradicts landed #3520; (c) stale-base CI;
+(d) it bundles three independent defects plus a 20-file locale sweep, which is exactly the shape
+that makes a security-adjacent OAuth change hard to review.
+
+**Disposition: LAND_WITH_FIX.** Exact fix list:
+
+1. Rebase onto `0f27bbeb3`; re-apply the `anthropic-routing.ts` hunk below `quorumCache = null`.
+2. Re-target the three renamed/removed test files to their current paths on dev.
+3. Rewrite the docs delta on top of #3520's text and remove the enabled-only opening condition
+   from all locale pages CodeRabbit named (fr:207, zh-cn:172, and the English 437-438 pair).
+4. Re-run exact-head CI on the rebased head.
+5. Preferably split: the Kiro `nextParsed` fix (3) is independently landable and touches
+   `core.ts` near #3515 — sequence it after #3515.
+
+---
+
+## #3519 — fix(claude): fall back to native launch when routing is off
+
+- Head `6b92ab7dbdc02b87c07050b4698b05e3f770a1f5`, base `dev`, MERGEABLE / BLOCKED,
+  **`CHANGES_REQUESTED`**, **draft**, label `bug`, checklist 0/4.
+- CI on that exact head: `enforce-target`, `hygiene`, `label`, `resolve-pr` pass; full matrix
+  draft-gated. CodeRabbit skipped (draft).
+- Conflicts: none.
+
+**Behavior change (not strictly a defect).** Today
+[claude.ts:420](/private/tmp/ocx-closeout.xomWAA/wt/src/cli/claude.ts:420) hard-errors when
+`config.claudeCode?.enabled === false`. The PR converts that into a native `claude` launch. This
+is a deliberate UX change, so "does the defect exist on dev" is less relevant than whether the new
+behavior is safe.
+
+**Both reviewer blockers are genuinely fixed on this head** (`Ingwannu` reviewed `8eb743be2`):
+
+- *Loopback credential leak.* `buildNativeClaudeEnv` no longer strips by hostname. It deletes
+  `ANTHROPIC_BASE_URL` only when `hasOwnedAdmission && targetsLocalClaudeProxy(baseUrl, config.port)`,
+  and dev's `targetsLocalClaudeProxy`
+  ([claude.ts:60](/private/tmp/ocx-closeout.xomWAA/wt/src/cli/claude.ts:60)) already requires
+  http + loopback host + **exact configured port** + no embedded credentials. The new test
+  *"preserves an unrelated loopback gateway and its user credential"* pins `http://localhost:8080`.
+- *Auto-start contract.* `ensureProxyForClaude` is still called and still spawns; only its comment
+  was reworded. Native fallback now triggers on explicit disable — config, or live
+  `enabled: false` — never on an absent proxy.
+
+CodeRabbit's ordering finding is also addressed: `claudeLaunchPreflight` runs
+invalid/mismatched, selected-client, and token-fingerprint checks **before** any native fallback.
+
+**Endpoint dependency verified.** `fetchClaudeCodeState` reads `enabled` from
+`GET /api/claude-code`, which does emit it —
+[agent-settings-routes.ts:1070](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/agent-settings-routes.ts:1070)
+returns `enabled: config.claudeCode?.enabled !== false`. `claudeLaunchPlan` treats only an
+explicit `false` as disabling, so an older proxy omitting the field stays routed.
+
+**Test evidence.** `tests/claude-integration/claude-cli.test.ts` gains 6 unit tests covering the
+plan matrix, preflight ordering, env scrubbing, the loopback negative path, `isProxyOnlyModelId`
+(including an AWS Bedrock ARN false-positive guard), and the root opt-in. These are pure-function
+tests and would fail to compile on dev because the exports do not exist — appropriate here, since
+the change is new behavior rather than a silent-wrong-answer bug.
+
+**Remaining blockers.**
+
+1. **Docs sync (High per AGENTS.md "Docs sync").** User-facing behavior changes and the
+   `docs-site/` guides still describe `ocx claude` as proxy-only.
+   `docs-site/src/content/docs/guides/claude-code.md` (and its tr/ko/zh-tw/fr locale twins)
+   is untouched by this diff.
+2. **Medium — silent `readPickerDefaultModel` failure.** It swallows every error including a
+   malformed `settings.json`, returning `null`, so the "saved model requires the proxy" warning
+   silently disappears exactly when the picker file is corrupt.
+3. **Low — unrelated churn.** The diff deletes the `#764 / SERVICE_STOP_LIVENESS` rationale
+   comment above `ensureProxyForClaude` while keeping the behavior, discarding the reason the
+   3-attempt budget exists.
+
+**Disposition: LAND_WITH_FIX.** Exact fix list: (a) update
+`docs-site/src/content/docs/guides/claude-code.md` plus locale twins to describe the native
+fallback and its trigger conditions; (b) surface a warning when `settings.json` exists but cannot
+be parsed; (c) restore the `#764` rationale comment; (d) exit draft, tick 4/4, get full exact-head
+CI; (e) `Ingwannu` must re-review to clear `CHANGES_REQUESTED`.
+
+---
+
+## #3524 — fix(oauth): persist startup reconciliation before adoption
+
+- Head `cf0b3fe0aaa3b72137b88da8b341769871e5845e`, base `dev`, MERGEABLE / BLOCKED,
+  `REVIEW_REQUIRED`, **draft**, labels `bug` + `intake: hygiene-blocked`.
+- CI on that exact head: **`enforce-target` FAIL and `hygiene` FAIL.** Hygiene reason is
+  explicit: `unsponsored_surface` — "This changes an authentication ... surface.
+  `MAINTAINERS.md` requires security review ... Paths: `src/oauth/index.ts`." The full matrix
+  never ran. This is the only item in the lane with red required checks.
+- Conflicts: none textually.
+
+**Defect (real, and correctly diagnosed).** `reconcileOAuthProviders` at
+[oauth/index.ts:1250](/private/tmp/ocx-closeout.xomWAA/wt/src/oauth/index.ts:1250) mutates the
+in-memory `config` then `saveConfig(config)`, so a startup-time snapshot can overwrite an
+operator edit made after load. `runModelRenameStartupMigration` has the same shape. The
+read-modify-write concern is legitimate.
+
+**Blocker — new uncaught `throw` on the startup path (Critical).** The rewrite adds:
+
+```ts
+if (outcome.status === "unavailable") {
+  throw new Error(\`OAuth provider reconciliation persistence unavailable: \${outcome.reason}\`);
+}
+```
+
+`reconcileOAuthProviders(config)` is called **unguarded** inside `startServer` at
+[server/index.ts:663](/private/tmp/ocx-closeout.xomWAA/wt/src/server/index.ts:663) — no
+try/catch in that window — and `runModelRenameStartupMigration` (same new throw) is called at
+[server/index.ts:651](/private/tmp/ocx-closeout.xomWAA/wt/src/server/index.ts:651). Dev's
+`saveConfig` does not throw for this condition, so the PR converts a survivable state into a
+boot failure. Every other `mutatePersistedConfig` consumer degrades instead —
+`storage/policy.ts:473`, `plan-from-token.ts:92`, `auth-api.ts:1089`,
+`agent-settings-routes.ts:124`.
+
+**Reproduced, not theorized.** Against the patched worktree with an isolated
+`OPENCODEX_HOME`, loading a valid config and then removing `config.json` before reconcile
+(config removed, unmounted volume, or a competing writer between `loadConfig()` at index.ts:651
+and reconcile at :663):
+
+```
+loaded ok, agVer= 1
+THREW: OAuth provider reconciliation persistence unavailable: missing
+```
+
+I also probed the benign paths and they are safe — fresh install with no `config.json`
+(`changed=false`), malformed JSON (`changed=false`), unreadable file (`changed=false`). So the
+throw is narrow, but it is real, reachable, and lands on the one path where an exception kills the
+proxy at boot.
+
+**Test evidence.** The PR's own tests pass (24/24) and `oauth-provider-reconcile.test.ts:81`
+asserts the throw string — but it asserts it at the *unit* level. **No test covers
+`startServer` surviving it**, which is exactly the gap: the new failure mode is proven correct
+in isolation and unexamined where it matters.
+
+**Other findings.** `adoptConfig` in `model-rename-startup.ts` deletes every key of the caller's
+object and re-assigns from a `structuredClone` — object identity is preserved but any live
+reference to a nested sub-object held elsewhere is silently detached. CodeRabbit's
+warning-emission ordering finding was valid and the author fixed it in `55b5410c3`.
+
+**Disposition: REIMPLEMENT.** Required changes: (1) replace both `throw`s with the
+degrade-and-warn pattern every other consumer uses, or wrap both call sites at
+`server/index.ts:651` and `:663` in explicit handling; (2) add a regression proving
+`startServer` survives `status: "unavailable"`; (3) obtain the `maintainer-sponsored` label
+for the `src/oauth/index.ts` security surface per `MAINTAINERS.md`; (4) fix `enforce-target`;
+(5) reconsider `adoptConfig`'s delete-all-keys mutation; (6) split the OAuth and model-rename
+halves so the security-reviewed surface is isolated.
+
+---
+
+## Verification notes
+
+- Every `bun test` invocation named a specific file; no repository-wide suite was run.
+- Patches were applied to the worktree only to establish red/green evidence and were reverted;
+  final `git status --porcelain` shows only `?? devlog/_plan/260905_open_work_closeout/`.
+- `git fetch origin pull/3502/head:tmp-pr-3502` was fetch-only; no checkout of `dev` occurred.
+- `git merge-tree` could not run (sandbox denies its temp-file creation), so 3502's conflict set
+  was established with per-file `git apply --check` plus `git log origin/dev ^tmp-pr-3502`.
+- No external claim needed web verification, so `cxc-search` was not invoked.

--- a/devlog/_plan/260905_open_work_closeout/002_lane_bug_prs_b.md
+++ b/devlog/_plan/260905_open_work_closeout/002_lane_bug_prs_b.md
@@ -1,0 +1,532 @@
+# Lane B — bug-labelled PR triage (#3489, #3484, #3480, #3469, #3407, #3388, #3348)
+
+Read-only adversarial review. Worktree `/private/tmp/ocx-closeout.xomWAA/wt`, detached at
+`origin/dev` = `0f27bbeb3ce6a92077652695e161d49b88eedc7a` ("test(hygiene): fail on duplicate test
+basenames, and close out the 429 unit (#3527)"). Every PR head was fetched with
+`git fetch origin pull/<n>/head`; no checkout of `dev` was performed and no tracked file was
+modified. Index re-read immediately before verdict (see "Index re-read" at the bottom).
+
+## Summary
+
+| Item | Disposition | One-line reason |
+| --- | --- | --- |
+| #3489 | LAND_WITH_FIX | Approved, fully green CI on exact head, real SSRF-safe fix; conflict is only the `tests/providers/` rename plus one comment-line drift. |
+| #3484 | LAND_AS_IS | Mergeable, green, defect proven at [integration-routes.ts:379](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/integration-routes.ts:379); only `BLOCKED` on a missing approval. |
+| #3480 | LAND_AS_IS | Author rebased mid-review onto `0f27bbeb3`: now MERGEABLE, test correctly in `tests/adapters/google/`, escape bug fixed; only needs the stale `CHANGES_REQUESTED` dismissed and CI to finish. |
+| #3469 | LAND_WITH_FIX | Approved, green, defect reproduced live on dev; conflict is purely the two `tests/adapters/google/` renames. |
+| #3407 | REIMPLEMENT | Real config-path defect, but draft with 5 failing CI jobs on its exact head, 121 commits behind, and a tracked 166 KB PNG that does not belong in the tree. |
+| #3388 | DEFER | Draft, 132 commits behind, test shards never ran, and a 327-line client-specific stream rewriter lands on the protected `responses/core.ts` path with no maintainer review yet. |
+| #3348 | REIMPLEMENT | Generic 410/413 are correctly terminal now, but the 2165-line diff bundles unrelated disk-persistence and a silent policy-fallback status change; land a bounded classification-only subset. |
+
+## Cross-cutting finding: the `tests/<domain>/` migration is the conflict source
+
+Six of the seven "CONFLICTING" states are not semantic. Between `8b6e4542a` and `0f27bbeb3`, dev
+moved most of `tests/` into `tests/<domain>/` and added a guard,
+[test-layout.test.ts](/private/tmp/ocx-closeout.xomWAA/wt/tests/test-layout.test.ts:20), that fails
+if a file resolves to a migrated domain but still sits at the root. Resolution is mechanical: apply
+each PR's test hunk to the file's **new** path and rewrite relative specifiers one level deeper
+(`../src/` -> `../../src/`). Resolver output for every touched test file:
+
+| PR | Test file | New path on dev | Migrated |
+| --- | --- | --- | --- |
+| #3489 | `provider-model-discovery-contract.test.ts` | `tests/providers/` | yes |
+| #3489 | `command-code-fakeip-discovery.test.ts` (new) | `tests/providers/` | yes |
+| #3484 | `management-integration-journal-delete.test.ts` | `tests/` root | no |
+| #3480 | `google-adapter.test.ts` | `tests/adapters/google/` | yes |
+| #3469 | `google-errors.test.ts`, `google-vertex-http.test.ts` | `tests/adapters/google/` | yes |
+| #3469 | `error-fidelity.test.ts` | `tests/` root | no |
+| #3407 | `native-codex-toggle.test.ts` | `tests/codex-integration/` | yes |
+| #3388 | both snapshot-repair tests | `tests/responses/` | yes |
+| #3348 | 10 of 16 test files | 6 different domains | yes |
+
+A new test file must also be placed at its resolved target, so #3489's new
+`command-code-fakeip-discovery.test.ts` has to be created under `tests/providers/`, not the root.
+
+## Stack order
+
+Only two real file-level dependencies exist in this lane:
+
+- **#3388 and #3348 both edit `src/server/responses/core.ts`.** #3388 adds a rewriter to the
+  `blockRewrites` list around line 4785; #3348 rewrites ~268 lines of the same file. Whichever
+  lands first forces a manual rebase of the other. Since #3348 is a REIMPLEMENT and #3388 a DEFER,
+  neither blocks the other today.
+- **#3407 and #3484 both edit `gui/src/pages/integrations/IntegrationsOverview.tsx`.** #3484 adds a
+  404-reconciling catch inside the delete dialog; #3407 rewrites the toggle/consequence-dialog
+  wiring. They touch different regions but the same file: land **#3484 first** (it is
+  merge-clean), then rebase the #3407 reimplementation on top.
+
+#3489, #3480 and #3469 are independent of every other item. #3469 and #3480 both touch the Google
+adapter area but different files (`google-errors.ts`/`google-http.ts`/`lib/errors.ts` vs
+`google.ts`), so they can land in either order.
+
+---
+
+## #3489 — fix(discovery): allow canonical model endpoints through fake-IP TUN DNS
+
+**Disposition: LAND_WITH_FIX**
+
+| Field | Value |
+| --- | --- |
+| Head SHA | `dbcfde8ca445c8dd04b04932904798664aae9cab` |
+| Base / merge-base | `dev` / `56a084aa9` (22 behind, 3 commits) |
+| Mergeable | `CONFLICTING` / `DIRTY` |
+| CI on exact head | **fully green** — 24 checks including all 4 test shards, macOS 15m41s, gates, storage policy, react-doctor |
+| Review | `APPROVED` by Ingwannu after explicit security-boundary review |
+| Author | Flowershangfromthebranches |
+
+**Defect.** `resolvePublicAddresses` only tolerates Clash/Surge fake-IP (198.18.0.0/15) DNS answers
+when an outbound proxy env is configured. On dev,
+[provider-outbound.ts:157](/private/tmp/ocx-closeout.xomWAA/wt/src/lib/provider-outbound.ts:157)
+passes `allowBenchmarkAddresses: proxyConfigured && !noProxyMatches(parsed)`. In TUN mode there is
+no proxy env, so every model-discovery fetch to a canonical endpoint is rejected even though the TUN
+intercepts the fake-IP destination itself and the request would succeed.
+
+**Fix shape.** A new `isRegistryModelDiscoveryUrl` proves the *final request URL* equals the
+registry's own fixed discovery URL, and that proof is injected into the transport as a dependency
+(`isCanonicalUrl`), defaulting to `() => false` so a caller that forgets the seam fails closed.
+
+**Security review (this is the part that matters).** The exception is genuinely narrow, and I tried
+to break it:
+
+- Proof is on the URL, not the provider name — correct, because an OAuth/forward name matches any
+  `baseUrl` by design, so a renamed custom row pointing at an attacker host gets no exception.
+- `protocol !== "https:"`, `username`/`password`, and `hash` are all rejected outright.
+- Query equality is exact (`candidate.search === expected.search`), so `?token=` smuggling on an
+  otherwise-canonical origin+path is rejected. A missing or extra parameter is also rejected.
+- Literal `198.18.x.x` URLs never reach the exception; the literal gate in `resolvePublicAddresses`
+  rejects first.
+- `noProxyMatches` still short-circuits to `false`, so a `NO_PROXY` direct route keeps the
+  benchmark answer rejected.
+- `privateNetwork` is untouched, so the private-network gate and image/Lab fetch paths are
+  unchanged (they never pass the flag).
+
+I could not construct a path where a non-registry destination gains the exception. No privacy,
+Node-only-API, or unrelated-churn problems in the diff.
+
+**Test evidence.** Yes — `tests/command-code-fakeip-discovery.test.ts` (378 lines, new) plus 60
+lines added to `tests/provider-model-discovery-contract.test.ts`. These are RED on dev because
+`isRegistryModelDiscoveryUrl` does not exist there at all (`git grep` on `0f27bbeb3` returns
+nothing), so the import fails outright.
+
+**Conflict.** Mechanical. Two causes, both trivial:
+
+1. `tests/provider-model-discovery-contract.test.ts` moved to `tests/providers/` on dev; the new
+   `command-code-fakeip-discovery.test.ts` must also be created there.
+2. `src/codex/catalog/provider-fetch.ts` — the only overlapping source file — changed on dev in
+   exactly one line, and it is a **comment**: `8b6e4542a` rewrote a test path inside a comment at
+   line 720. The PR's own hunk at line ~1669 is untouched by dev.
+
+**Fix list.**
+
+1. Rebase onto `0f27bbeb3`; take dev's side of the `provider-fetch.ts` comment line.
+2. Move both test files to `tests/providers/` and rewrite `../src/` -> `../../src/`.
+3. Re-run `bun test tests/providers/` and typecheck on the rebased head.
+
+---
+
+## #3484 — fix(integrations): reconcile journal deletion cleanup
+
+**Disposition: LAND_AS_IS**
+
+| Field | Value |
+| --- | --- |
+| Head SHA | `a4c50d104778d2ac11fc4c91b29b3e505cb68c2a` |
+| Base / merge-base | `dev` / `066146980` (27 behind, 1 commit) |
+| Mergeable | **`MERGEABLE`** / `BLOCKED` |
+| CI on exact head | **fully green** — 24 checks, all 4 test shards, macOS 16m1s |
+| Review | `REVIEW_REQUIRED` (this is the only thing `BLOCKED` means here) |
+| Author | Ingwannu |
+
+**Defect — two of them, both proven on dev.**
+
+1. **Stale prune-failure marker.** At
+   [integration-routes.ts:379](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/integration-routes.ts:379)
+   dev reads `if (!pruned.ok) store.markPruneFailure(...)` with no success branch. A successful
+   prune therefore never clears an earlier failure marker, so `retentionDegraded` stays latched
+   forever. This is provably an oversight rather than a design choice: the *other* two call sites
+   already pair the clear with the prune —
+   [journal.ts:180](/private/tmp/ocx-closeout.xomWAA/wt/src/integrations/journal.ts:180) and
+   [store.ts:97](/private/tmp/ocx-closeout.xomWAA/wt/src/integrations/store.ts:97) both call
+   `clearPruneFailure` on `pruned.ok`. The route handler is the one place that forgot.
+2. **404 dead-end in the GUI.** `integration_operation_not_found` exists on dev
+   ([integration-routes.ts:343](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/integration-routes.ts:343))
+   but no client-side predicate consumes it, so a second tab completing the same delete leaves the
+   first tab's dialog offering a retry that can only 404 again.
+
+**Test evidence.** Yes — `tests/management-integration-journal-delete.test.ts`, test *"a successful
+delete-triggered prune clears an older failure marker"*. It marks a failure, deletes, and asserts
+`pruneFailures.hermes` is `undefined`. On dev that assertion fails because nothing ever clears the
+marker. `gui/tests/integrations-surfaces.test.tsx` adds 69 lines covering the 404 reconcile path.
+
+**Blockers.** None found. The server change is two lines and preserves the documented post-commit
+ordering; `isMissingJournalEntry` is a narrow `instanceof` + status + code check, not a message
+match. Docs are updated in all 8 locales, matching the repo's docs-sync rule. The
+`gui-screenshot-waived` label is already applied, so the `gui` screenshot gate is satisfied.
+
+**Conflict.** None — this is the only `MERGEABLE` item in the lane, and its test file resolves to
+the `server` domain, which has **not** been migrated yet, so the root path stays correct.
+
+**Dependency.** Touches `IntegrationsOverview.tsx`, which #3407 rewrites. Land this first.
+
+---
+
+## #3480 — fix(google): steer Google models away from unrendered LaTeX math formatting
+
+**Disposition: LAND_AS_IS**
+
+> **The author rebased this PR while the lane was in progress.** My first pass reviewed
+> `63623c64` (31 behind, CONFLICTING). The current head is `74ef8faae`, rebased onto
+> `0f27bbeb3`, and it is now `MERGEABLE` with the test already in its migrated location. The
+> disposition below reflects the **new** head; the mechanical-rebase fix I had listed is done.
+
+| Field | Value |
+| --- | --- |
+| Head SHA | `74ef8faaed94d61835a6ffbade7bdc345829408b` (was `63623c64`) |
+| Base / merge-base | `dev` / `0f27bbeb3` — 1 behind, 1 commit |
+| Mergeable | **`MERGEABLE`** / `BLOCKED` (blocked only by the stale review) |
+| CI on exact head | in flight — `hygiene`/`label`/`resolve-pr` pass; `enforce-target` and CodeRabbit pending. Shards had not started at re-read time. |
+| Review | `CHANGES_REQUESTED` (Ingwannu) — **stale**, see below |
+| Author | benedictusrey |
+
+**Defect.** Google-family models emit `$...$`, `\\(...\\)`, `\\text{}` etc., which the Codex desktop
+markdown renderer does not render (no KaTeX/MathJax), so the raw delimiters stay on screen. Dev's
+`GOOGLE_BREVITY_INSTRUCTION`
+([google.ts:49](/private/tmp/ocx-closeout.xomWAA/wt/src/adapters/google.ts:49)) has four bullets and
+says nothing about formatting; `git grep -i latex` on `0f27bbeb3` returns nothing. Defect confirmed
+present.
+
+**The `CHANGES_REQUESTED` is stale — I verified this byte-exactly.** The reviewer's objection was
+that single-backslash `\text{}` in a normal JS string becomes a tab at runtime. On the current head
+`63623c64`, `git show tmp-pr-3480:src/adapters/google.ts` line 55 contains `\\(...\\)`,
+`\\text{}`, `\\times`, `\\le`, `\\ge` — properly escaped — and the test now uses `String.raw`
+for both assertions, making them independent of the source spelling. The requested fix is genuinely
+in. The review state simply was never re-dismissed.
+
+**Test evidence.** Yes — `tests/google-adapter.test.ts`, *"systemInstruction includes formatting
+guidance against unrendered LaTeX math"*. It would be RED on dev: I ran
+`bun test tests/adapters/google/google-adapter.test.ts` at `0f27bbeb3` (32 pass / 0 fail) and dev's
+instruction string contains no LaTeX text at all, so `toContain` cannot match.
+
+**Blockers.** The real blocker is **CI coverage, not code**. Only 5 non-test checks ran on this
+head; the test shards, `gates`, and macOS never executed. An approval here would rest on the
+author's local claim ("33 pass, 0 fail"), which per the repo's own gate description is an
+unverifiable author attestation. No security, privacy, or Node-only concerns — it is a
+one-line prompt string plus one test.
+
+One judgment note worth flagging: this steers Google models globally, including for non-Codex
+clients that *can* render LaTeX. That is a deliberate product tradeoff the maintainer already
+endorsed in the review thread (priority 50/80), so I am not treating it as a blocker.
+
+**Conflict.** **None.** The rebase already happened: the new head's diff is exactly two files,
+`src/adapters/google.ts` (+1) and `tests/adapters/google/google-adapter.test.ts` (+10) — the test
+is in its migrated location with correct specifiers. Nothing left to reconcile.
+
+**Remaining actions (none are code changes).**
+
+1. Ask Ingwannu to dismiss the now-satisfied `CHANGES_REQUESTED`; it is the only thing holding
+   `BLOCKED`.
+2. Let the in-flight run finish and confirm green `test 1..4/4` + `gates` before merge — this head
+   is the first one that will actually exercise the shards.
+
+---
+
+## #3469 — fix(google): classify "User location is not supported" as location/permission error
+
+**Disposition: LAND_WITH_FIX**
+
+| Field | Value |
+| --- | --- |
+| Head SHA | `e11089af85f8c1da4e67fe388b768d09078e8dcb` |
+| Base / merge-base | `dev` / `1a5c9ab23` (37 behind, 2 commits) |
+| Mergeable | `CONFLICTING` / `DIRTY` |
+| CI on exact head | **green** — 25 checks incl. shards 1/4 and 2/4, macOS 15m32s, gates, linux-systemd, macos-launchd, windows-schtasks |
+| Review | `APPROVED` (Ingwannu) |
+| Author | agentHits |
+
+**Defect — reproduced live, not inferred.** I executed dev's classifier directly:
+
+```
+classifyError(400, "upstream_error", "User location is not supported for the API use.")
+  -> { type: "invalid_request_error", code: "invalid_request_error" }
+classifyError(403, "location_not_supported", "Region is not supported")
+  -> { type: "permission_error", code: "permission_denied" }
+```
+
+A geo-blocked account is told its *request* was malformed. The cause is
+[errors.ts:272](/private/tmp/ocx-closeout.xomWAA/wt/src/lib/errors.ts:272): the generic stop-list
+matches `"invalid request"`/`"not found"` and there is no location branch anywhere in the file
+(`git grep -i location` on `0f27bbeb3` in `src/lib/errors.ts` returns nothing).
+
+**Fix shape.** Adds `LOCATION_UNSUPPORTED_PATTERNS` + `isLocationUnsupportedMessage` to
+`src/lib/errors.ts`, a `permission_error`/`location_not_supported` branch placed *before* the
+generic invalid-request branch, a shared re-export in `google-errors.ts` (so adapter and lib cannot
+drift), and a `console.warn` hinting at TUN/IPv6 leak when the rejection is geo-based.
+
+**Falsification attempt.** CodeRabbit worried the matcher was too broad. It is not: every pattern
+requires an explicit `location`/`region`/`country` cue, and the PR's own test asserts the negative
+case `isLocationUnsupportedMessage("not supported for the api use") === false`. Matching is on a
+single lowercased copy, so mixed case is handled once. The warning goes to `console.warn` with a
+static string — no request body, key, or account identifier — so `privacy:scan` is unaffected.
+
+**Test evidence.** Yes, three files, all RED on dev: `tests/error-fidelity.test.ts` (asserts
+`code: "location_not_supported"`, which dev returns as `invalid_request_error` — proven above),
+`tests/google-errors.test.ts` (imports `isGoogleLocationUnsupportedText`, which does not exist on
+dev), and `tests/google-vertex-http.test.ts` (positive + negative warning assertions).
+
+**Blockers.** None. Note the shard matrix shows only `test 1/4` and `test 2/4` in the check list;
+shards 3 and 4 are absent from the run rather than failing. Worth confirming on the rebased head.
+
+**Conflict.** Mechanical: `google-errors.test.ts` and `google-vertex-http.test.ts` both moved to
+`tests/adapters/google/`. `error-fidelity.test.ts` resolves to the unmigrated `server` domain and
+stays at the root. No source file overlaps dev.
+
+**Fix list.**
+
+1. Rebase onto `0f27bbeb3`; move the two Google test hunks into `tests/adapters/google/` with
+   `../../../src/` specifiers; leave `error-fidelity.test.ts` at root.
+2. Confirm all four shards run green on the rebased head.
+
+---
+
+## #3407 — fix(integrations): make Codex dashboard toggle truthful
+
+**Disposition: REIMPLEMENT**
+
+| Field | Value |
+| --- | --- |
+| Head SHA | `38d45300a644dd0aa641a0a9b76f293169ab8ef9` |
+| Base / merge-base | `dev` / `ea3231a82` (**121 behind**, 2 commits) |
+| Mergeable | `CONFLICTING` / `DIRTY` |
+| CI on exact head | **FAILING** — `ci`, `gates`, `macos`, `test 1/4`, `test 2/4` all fail |
+| Review | `REVIEW_REQUIRED`; **draft**; CodeRabbit skipped (draft) |
+| Author | turin-dev |
+
+**Defect is real and worth fixing.** On dev,
+[native-integration-routes.ts:686](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/native-integration-routes.ts:686)
+calls `codexStatus(config, getConfigPath())` — it hands the **opencodex** config path to the
+**Codex** client status. `codexStatus`
+([native-integration-routes.ts:164](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/native-integration-routes.ts:164))
+writes that straight into `configPath`, so the dashboard reports the wrong file for the Codex row,
+while `claudeStatus` on the same line legitimately uses `getConfigPath()`. The PR's one-line fix
+(`join(getCodexHome(), "config.toml")`) is correct. A second real defect: the switch renders
+`row.applied` (observed routing) rather than `desiredEnabled`, so the toggle can contradict the
+user's setting.
+
+**Why REIMPLEMENT rather than LAND_WITH_FIX.**
+
+1. **Five CI jobs fail on the exact head**, including `gates` and two test shards. This is not a
+   layout-rename artifact — those would surface as conflicts, not test failures — so there is a
+   genuine unresolved regression to diagnose.
+2. **121 commits behind dev**, and the overlap is the widest in the lane: all 9 i18n locale files,
+   `IntegrationsOverview.tsx`, `gui/tests/integrations-surfaces.test.tsx`, and the
+   `codex-integration` guide. i18n files are append-heavy and conflict badly.
+3. **A 166 KB PNG is committed to `docs/pr-assets/3407-codex-disable-dialog.png`.** The `gui`
+   screenshot requirement asks for a screenshot *in the PR description*, not a binary tracked in the
+   repository. This is unrelated churn and should not land.
+4. The `codexRow` rewrite carries a backward-compatibility branch for `nativeSettled === undefined`
+   that exists only to keep older callers working — dead weight in a reimplementation that can
+   update the callers.
+
+**Test evidence.** `tests/native-codex-toggle.test.ts` (+17) and `gui/tests/` (+148) exist and would
+be RED on dev for the config-path assertion. They are worth carrying, but they currently fail on the
+PR's own head, so they cannot be trusted as-is.
+
+**Fix list for the reimplementation.**
+
+1. Carry the one-line `codexConfigPath` fix and the `toggleOn = row.toggleOn ?? row.applied` switch
+   correction onto current dev.
+2. Carry the `codexResource.refresh()` addition and the `"codex"` case in `blockedText`.
+3. Add `CODEX_DISABLE_COPY` and the 6 i18n keys across all 9 locales, applied to current dev's i18n
+   files.
+4. Drop the tracked PNG; put the screenshot in the PR description instead.
+5. Drop the `nativeSettled === undefined` compatibility branch; update callers directly.
+6. Place the test at `tests/codex-integration/native-codex-toggle.test.ts`.
+7. **`Co-authored-by: turin-dev`** trailer is mandatory per AGENTS.md — a prose mention is not
+   equivalent, and `missing_coauthor_credit` exists specifically to stop the CREDITS.md list from
+   growing.
+
+**Dependency.** Rebase after #3484 lands (shared `IntegrationsOverview.tsx`).
+
+---
+
+## #3388 — fix(responses): repair sparse terminal output for Grok Build
+
+**Disposition: DEFER**
+
+| Field | Value |
+| --- | --- |
+| Head SHA | `007076ebd528c50ad5742e6eb0208300385cded7` |
+| Base / merge-base | `dev` / `e71386434` (**132 behind**, 1 commit) |
+| Mergeable | `CONFLICTING` / `DIRTY` |
+| CI on exact head | **only 5 checks** — `enforce-target`, `hygiene`, `label`, `resolve-pr`, CodeRabbit (skipped: draft). No shards, no gates, no macOS. |
+| Review | `REVIEW_REQUIRED`; **draft** |
+| Author | zleo-ai |
+
+**The problem is plausible and the implementation is careful.** Grok Build renders text deltas live
+but builds its durable assistant turn from `response.completed.response.output`; a native Responses
+stream can put the items in `output_item.done` and finish with an empty array, so Grok classifies a
+visibly-streamed answer as empty and replays a billable turn.
+`createGrokResponsesSparseTerminalBlockRewrite` does not exist on dev, so the gap is real.
+
+The rewriter is genuinely fail-closed: it taints on malformed JSON, gaps, duplicate indices,
+add/done identity mismatch, byte-budget overflow, or any open item at terminal; it requires
+contiguous indices from zero, at least one *visible* item, and an absent-or-empty terminal output;
+and it never promotes synthesized or field-repaired items. It correctly leaves the provider opt-in
+repair untouched and does not import `src/lab/`.
+
+**Why DEFER anyway — the reasons are procedural, and they are decisive.**
+
+1. **327 new lines land on `src/server/responses/core.ts`**, one of the three files AGENTS.md names
+   as carrying every user's request path. That file demands full-suite evidence. This head has
+   **never run a single test shard**.
+2. **Draft, 132 commits behind, no human review**, and CodeRabbit was skipped because of the draft
+   state. There is no reviewed judgment on this design at all yet.
+3. **The gate is `logCtx.surface === "grok"`, a client marker, not a provider opt-in.** That means
+   every Grok-surface stream on any provider gets a terminal rewriter. Dev uses that same marker for
+   `heartbeatStyle` ([core.ts:5698](/private/tmp/ocx-closeout.xomWAA/wt/src/server/responses/core.ts:5698)),
+   so the precedent exists — but broadening it from a heartbeat cosmetic to *rewriting the terminal
+   response body* is a materially larger claim that deserves an explicit maintainer decision.
+4. It conflicts with #3348 on the same file.
+
+**This is a "not yet", not a "no".** The concrete unblock is: bring it onto current dev, take it out
+of draft so the full matrix and CodeRabbit run, move both tests to `tests/responses/`, and get a
+maintainer ruling on the client-marker gate. The 481 lines of new tests are thorough and would be RED
+on dev (the export does not exist), so the work is not wasted.
+
+---
+
+## #3348 — fix(combos): harden failover across quotas, credentials, and streams
+
+**Disposition: REIMPLEMENT** (a bounded subset is landable; the whole is not)
+
+| Field | Value |
+| --- | --- |
+| Head SHA | `a64ed325020afc48584bed751ce818ab42d2c338` |
+| Base / merge-base | `dev` / `c91c8c5b2` (10 behind, **12 commits**, 35 files, +2165/-196) |
+| Mergeable | `CONFLICTING` / `DIRTY` |
+| CI on exact head | **only 5 checks** — `enforce-target`, `hygiene`, `label`, `resolve-pr`, CodeRabbit. **No shards, no gates, no macOS**, despite the `review-ready` label. |
+| Review | `REVIEW_REQUIRED` |
+| Author | RHODIZSECURITY |
+
+### The 410/413 question: resolved, and the answer is no
+
+**Generic HTTP 410 and 413 becoming retryable is NOT present in the current head.** I verified both
+by executing dev's classifier and reading the PR's:
+
+Dev baseline (executed):
+
+```
+comboFailureDecision(410, "resource is gone")      -> stop
+comboFailureDecision(413, "request too large")     -> stop
+comboFailureDecision(410, "...end of life...")     -> hop   (lifecycle, intended)
+comboFailureDecision(413, "refused", input_admission_refused) -> hop (intended)
+```
+
+In the PR, `isModelLifecycleGone` still requires `status === 410` **plus** a structured lifecycle
+code or explicit model+lifecycle prose, and the hop status list is
+`[401, 402, 403, 404, 408, 425, 429]` — 410 and 413 are absent. The PR's own tests assert
+`comboFailureDecision(410, "resource is gone") === "stop"` and
+`comboFailureDecision(413, "request too large") === "stop"`, and add a server-level test *"generic
+410 remains terminal before backup"* expecting a 410 response. The earlier concern was addressed.
+
+There is a related but *different* change: `comboFailureCooldownScope` now returns the new
+`"none"` scope for `status === 413` and request-shape codes, so an oversized request no longer cools
+a healthy target. That is a correct refinement, not a retryability change.
+
+### The landable subset
+
+Genuinely valuable and reviewable on its own — a classification-only PR of roughly 150 lines:
+
+- `comboFailureCooldownScope` gaining `"none"` for request-shape failures (413,
+  `input_admission_refused`, `context_length_exceeded`, `tool_catalog_too_large`,
+  `cursor_root_envelope_limit`, `target_incompatible`) and `"provider"` for 401/402/403 and
+  credential/billing codes.
+- `comboFailureDecision` recognizing `model_not_found`/`model_unavailable`/`unsupported_model` as
+  target-local hops, and adding 402/425.
+- Moving `free_rate_limited` out of provider-scoped quota into a request-local free-prompt cap
+  (`isRequestLocalFreePromptCap`) — dev currently cools an entire provider for a per-request cap.
+- `"malformed upstream" -> 502` in `inferHttpStatusFromAdapterMessage`
+  ([errors.ts:365](/private/tmp/ocx-closeout.xomWAA/wt/src/lib/errors.ts:365)) — upstream garbage is
+  a provider failure, not a client error.
+- The missing `!isComboTargetInCooldown(...)` predicate in `pickComboTarget`
+  ([resolve.ts:155](/private/tmp/ocx-closeout.xomWAA/wt/src/combos/resolve.ts:155)) — dev cools a
+  target and then picks it anyway. This is a clear standalone bug.
+- `key-401` added to `AttemptRecoveryKind` and `COOLDOWN_RECOVERY_KINDS`.
+
+### What must NOT ride along
+
+1. **Two new disk-persistence modules** (`src/combos/cooldown-disk.ts`,
+   `src/providers/key-cooldown-disk.ts`, ~177 lines) plus `startServer` hydration and shutdown
+   flush. New on-disk state files in the config dir are their own design decision and deserve their
+   own review.
+2. **Blocker — the debounce timers are not `unref()`'d.** Both modules do
+   `persistTimer = setTimeout(..., 250)` with no `unref`. Every other debounced persister in this
+   repository unrefs: `(persistTimer as { unref?: () => void }).unref?.()` at
+   [state.ts:1573](/private/tmp/ocx-closeout.xomWAA/wt/src/responses/state.ts:1573) and
+   [google-antigravity-replay.ts:224](/private/tmp/ocx-closeout.xomWAA/wt/src/adapters/google-antigravity-replay.ts:224),
+   the latter commented "never keep the process alive". A pending 250 ms timer can hold the event
+   loop open at exit. Must be fixed before any version of this lands.
+3. **A silent behavior change in `policy-fallback.ts` that is not in the PR title.** Dev returns the
+   last upstream response when candidates are exhausted
+   ([policy-fallback.ts:161](/private/tmp/ocx-closeout.xomWAA/wt/src/server/responses/policy-fallback.ts:161):
+   `if (!next) return response;`). The PR replaces it with a synthesized 503
+   `policy_unavailable` (or 413 `policy_input_too_large`), **discarding the real upstream status and
+   body**. It also converts two `return overload` paths into `response = overload`, letting a pacing
+   overload continue the hop loop. Both are defensible, both change client-visible behavior, and
+   neither is announced. They need their own PR.
+4. `exhaustedQuotaRecoveryMs` reading cached provider quota to derive multi-day key cooldowns — a
+   31-day cooldown ceiling driven by cache is a big lever; separate review.
+5. The `cooldownKey` signature change from `keyId` to raw `apiKey` (hashed internally via
+   `apiKeyPoolEntryId`). Privacy is fine — persisted rows carry only 8-char SHA-256 prefixes, and
+   `isSafeCooldownRowKey` enforces `/^[0-9a-f]{8}$/` — but passing raw secrets through more call
+   sites is a widened surface that deserves deliberate sign-off.
+
+**Test evidence.** Substantial (+1200 test lines across 16 files) and much of it would be RED on dev.
+But 10 of those 16 files moved into 6 different domain directories on dev, so this is the worst
+rebase in the lane.
+
+**Blockers summary.** Unreffed timers (must fix); undisclosed policy-fallback status change (must
+split); `src/server/index.ts` hydration — I checked this against the AGENTS.md synchronous-activation
+invariant and it is **fine**: both hydrate calls are synchronous and sit at line ~650, far before
+`Bun.serve` at line 2367 and the `labActivationRequired` gate at 2516, so no `await` is introduced
+into the protected window. No privacy or Node-only-API violations found.
+
+**Fix list for the reimplementation.**
+
+1. Cut PR A: classification-only (the subset above) onto current dev, tests placed in their migrated
+   domains. This is reviewable and independently valuable.
+2. Cut PR B: disk persistence, **with `unref()` on both timers** and an explicit decision on the two
+   new config-dir state files.
+3. Cut PR C: the policy-fallback exhaustion/pacing semantics change, described honestly in the title
+   and description.
+4. `Co-authored-by: RHODIZSECURITY` on every carried piece.
+5. Push so the full shard matrix actually runs; the `review-ready` label is currently not backed by
+   any test evidence.
+
+---
+
+## Index re-read before verdict
+
+Re-read immediately before issuing verdicts, and **it caught two changes** — recording them rather
+than reporting a stale snapshot:
+
+1. **dev advanced** `0f27bbeb3` -> `6580694c7` ("test(oauth): restore a deleted contract test, and
+   fail when one disappears (#3530)"). That commit touches only `tests/repo-hygiene.test.ts` and
+   `tests/routing/anthropic-quorum-cache.test.ts`, so **no finding in this document is affected**:
+   no lane PR touches either file, and every cited `src/` line is unchanged between the two dev
+   commits.
+2. **#3480 was rebased by its author mid-review**, from `63623c64` (CONFLICTING, 31 behind) to
+   `74ef8faae` (MERGEABLE, 1 behind). Its section and the summary row were rewritten against the
+   new head; the disposition moved LAND_WITH_FIX -> LAND_AS_IS.
+
+Other verification state at re-read:
+
+- `git status --porcelain`: clean apart from this new file.
+- The other six head SHAs are unchanged: `dbcfde8ca`, `a4c50d104`, `e11089af8`, `38d45300a`,
+  `007076ebd`, `a64ed3250`. GitHub reported `mergeable=UNKNOWN` for them at re-read because it was
+  recomputing merge state against the new dev tip; the `CONFLICTING` states above were read on
+  `0f27bbeb3` and the conflict *causes* (the `tests/<domain>/` renames) are unchanged by `#3530`.
+- No `src/`, `tests/`, or `gui/` file was modified; no repository-wide suite was run. Focused runs
+  only: `tests/adapters/google/google-adapter.test.ts` (32 pass), `tests/server/error-fidelity.test.ts`
+  + `tests/adapters/google/google-errors.test.ts` (10 pass), plus two direct `bun -e` evaluations of
+  `classifyError` and `comboFailureDecision` on dev.

--- a/devlog/_plan/260905_open_work_closeout/003_lane_v2_and_quota.md
+++ b/devlog/_plan/260905_open_work_closeout/003_lane_v2_and_quota.md
@@ -1,0 +1,548 @@
+# Lane 3 — Encrypted V2 passthrough and quota work
+
+READ-ONLY adversarial review. Worktree `/private/tmp/ocx-closeout.xomWAA/wt`, detached at
+`origin/dev` = `0f27bbeb3ce6a92077652695e161d49b88eedc7a`. The GitHub `dev` tip was re-read
+immediately before verdict and had advanced by one commit to
+`6580694c7911cfbf78da63b6258ec1c70bd8a0e3` — `test(oauth): restore a deleted contract test, and
+fail when one disappears (#3530)`. That commit touches only `tests/repo-hygiene.test.ts` and
+`tests/routing/anthropic-quorum-cache.test.ts`, changes no `src/` surface cited below, and I
+re-ran mergeability for all five heads against `6580694c7`: #3444 and #3447 still merge clean
+(exit 0), #2956, #2783 and #2973 still conflict on the same files (exit 1). Every disposition
+below therefore holds against the current index; file:line citations are against `0f27bbeb3`,
+which is identical to `6580694c7` for every path cited.
+
+Mergeability was computed locally with `git merge-tree --write-tree origin/dev tmp-pr-<n>`
+against fetched `refs/pull/<n>/head`. This matters: GitHub's `mergeable` field disagrees with
+git for #3447, and the local three-way result is the one that reflects rename detection.
+
+## Summary
+
+| Item | Disposition | One-line reason |
+|------|-------------|-----------------|
+| #3444 | LAND_WITH_FIX | Correct, narrow, regression proven RED-on-dev; blocked only by `unsponsored_surface` on a 1-line `auth-cors.ts` policy row — needs maintainer sponsorship, not a code change. |
+| #3447 | LAND_WITH_FIX | Real Antigravity/Ollama quota feature with 359 test lines; merges clean under rename detection, but leaves a pre-existing config-`baseUrl` bearer path unfixed and the config-route regression is missing. |
+| #2956 | DEFER | 474 commits behind, zero human review, 4 real conflicts including two semantic ones in `summary.ts`/`logs-usage-routes.ts`; carry cost exceeds the lane. |
+| #2783 | LAND_WITH_FIX | Author's own PR; all three maintainer blockers are still literally present at head — each is a bounded, named fix, not a redesign. |
+| #2973 | LAND_WITH_FIX | Every substantive blocker is verified fixed at head; only staleness (152 commits) plus 4 mechanical conflicts remain. |
+
+---
+
+## #3444 — direct encrypted V2 task passthrough
+
+**Disposition: LAND_WITH_FIX** (the "fix" is a maintainer sponsorship label, plus one draft-gate box)
+
+### State
+
+| Field | Value |
+|---|---|
+| Head | `baefb1334b69e1f37ae1446b6326ae09cb0021ac` |
+| Base | `dev` |
+| Mergeable | `MERGEABLE` / `BLOCKED` (GitHub), **clean** locally (merge-tree exit 0, tree `ed79a40e8`) |
+| Review | `REVIEW_REQUIRED`, draft |
+| Drift | merge-base `2421e44ce`, 40 behind / 2 ahead |
+| CI on head | `hygiene` **fail**, `enforce-target` **fail**, `label`/`resolve-pr` pass, CodeRabbit skipped (draft) |
+| Size | +111 / -4 across 6 files |
+
+**Not conflicting.** This is the only item in the lane that merges cleanly.
+
+### Why hygiene fails
+
+The failure code is `unsponsored_surface`, from run `33872129233`:
+
+```
+##[error]PR hygiene failed: unsponsored_surface
+```
+
+The rule is `.github/scripts/pr-sponsored-surface.cjs:44` — `src/server/auth-cors.ts` is in
+`RESTRICTED_FILES`. `assessSponsoredSurface` at `.github/scripts/pr-sponsored-surface.cjs:69-80`
+returns the failure for any non-push-permission author touching that path without the
+`maintainer-sponsored` label. Author `cb8010d6` has no push permission, so the gate fires.
+
+**This is a labelling gate, not a defect signal.** The entire `auth-cors.ts` delta is one line
+adding `allowEncryptedV2AgentTasks: "editor"` to `PROVIDER_CONFIG_FIELD_POLICY` at
+`src/server/auth-cors.ts:787`. That map is an exhaustive field-classification table; the new
+entry classifies a non-secret boolean as editor-editable. It changes no authentication and no
+CORS behavior. The gate cannot tell a one-line policy-table row from a real auth change — that
+is the intended conservatism, and the documented remedy in `.github/scripts/pr-hygiene.cjs:241-242`
+is exactly "ask a maintainer to apply `maintainer-sponsored` once they have reviewed it."
+
+`enforce-target` also fails, but that is the draft readiness checklist: the fourth box
+("My PR is ready for review") is unticked in the PR body, which is the gate holding it in draft.
+
+### Is the change safe?
+
+Yes, and the trust boundary is drawn tightly. `canPassThroughEncryptedV2AgentTask`
+(`src/server/responses/core.ts:1760-1783`) requires **all** of: inbound wire is Responses, the
+provider explicitly opted in with `allowEncryptedV2AgentTasks === true`, `authMode` resolves to
+`key`, and the model's resolved wire override is still `openai-responses`. Default is off
+(`src/types/provider.ts:273-278`, optional boolean; `src/config.ts:540` schema entry is
+`.optional()`).
+
+Both call sites are guarded correctly. The recovery skip at `src/server/responses/core.ts:3122`
+adds `&& !canPassThroughEncryptedV2AgentTask(route, inboundWire)`, and the fail-closed check at
+`core.ts:3249-3255` additionally requires `!options.comboAttempt`, so combo attempts keep the
+old native-only fail-closed path. Both run against the **final** route after selection, which
+preserves the existing property that native fallback can rescue a routed primary.
+
+No privacy concern: nothing logs the task, and OpenCodex neither decrypts nor translates it —
+the ciphertext is forwarded byte-unchanged, which the test asserts.
+
+### Test evidence — proven RED on dev
+
+`tests/agent-task-recovery.test.ts`, two added blocks (+65 lines):
+
+- `trusted direct Responses routes bypass recovery and preserve encrypted tasks`
+- `trusted passthrough stays fail closed for %s` (`test.each` x 3: OAuth auth, Chat adapter, model-level Chat override)
+
+I ran this rather than trusting the PR body. Dev source + PR test file, in a scratch tree:
+
+```
+(fail) trusted direct Responses routes bypass recovery and preserve encrypted tasks
+ 22 pass / 1 fail
+```
+
+failing at `tests/agent-task-recovery.test.ts:177`. With PR source: `23 pass / 0 fail`. Dev
+baseline before the new tests: `19 pass / 0 fail`.
+
+Note the three fail-closed cases **pass on dev too** — correctly, since dev fails closed
+everywhere. They are guard tests protecting the new opt-in from widening, which is the right
+shape for a trust-boundary change.
+
+### Blockers found in the diff
+
+None. Scope is clean (no unrelated churn), docs row added at
+`docs-site/src/content/docs/reference/configuration/providers.md:73`, no Node-only APIs, no
+logging of request bodies or credentials.
+
+### Fix list
+
+1. Maintainer applies `maintainer-sponsored` after reviewing the one-line `auth-cors.ts` row — this alone clears `hygiene`.
+2. Author ticks the fourth readiness box (or a maintainer carries the branch), clearing `enforce-target` and draft state.
+3. Re-run exact-head CI; the branch is 40 behind so a rebase onto `0f27bbeb3` is advisable, but merge-tree says it is not required for correctness.
+
+If carried by a maintainer instead: `Co-authored-by: cb8010d6` is mandatory per `AGENTS.md`
+("Landing another author's work"), in the description or a branch commit so it survives the squash.
+
+### Dependencies
+
+Touches `src/config.ts` and `src/types/provider.ts`, which #2783 and #2973 also touch nearby.
+All three add distinct optional fields to different schema objects, so the overlap is additive.
+**#3444 should land first** — it is the only clean merge and the smallest diff.
+
+---
+
+## #3447 — Antigravity weekly quota + Ollama Cloud quota
+
+**Disposition: LAND_WITH_FIX**
+
+### State
+
+| Field | Value |
+|---|---|
+| Head | `745b70e1e76f6d6824557efd968f65878e4caa5b` |
+| Base | `dev` |
+| Mergeable | GitHub says `CONFLICTING`/`DIRTY`; **git merges it clean** (merge-tree exit 0, tree `7b85172d8`) |
+| Review | `CHANGES_REQUESTED` (CodeRabbit only — no human CHANGES_REQUESTED review) |
+| Drift | merge-base `52f4ffa5d`, 47 behind / 1 ahead |
+| CI on head | all pass — `hygiene`, `enforce-target`, `label`, `resolve-pr`, CodeRabbit completed |
+| Size | +567 / -9 across 3 files |
+
+### The conflict is a rename, and it resolves
+
+GitHub reports `CONFLICTING` because the PR edits `tests/provider-quota.test.ts` and
+`tests/provider-account-quota.test.ts` at the repository root, while dev moved both into
+`tests/providers/` in `8b6e4542a` ("test(layout): move providers and codex-integration into
+tests/<domain>/"). GitHub's mergeability probe does not apply rename detection the way a local
+three-way merge does.
+
+Locally, git follows the renames and produces a clean tree. I verified the content actually
+lands rather than merely merging: the merged tree's `tests/providers/provider-quota.test.ts` is
+3106 lines vs 2804 on dev — exactly the +302 the PR adds — and contains 14 matches for
+`parseOllamaCloudQuota|Ollama Cloud`.
+
+**A rebase is mechanical**, but it must be done rename-aware: the author needs to move their
+edits onto `tests/providers/`. If they instead push the old flat paths, they will trip the new
+duplicate-basename gate at `tests/repo-hygiene.test.ts:269` ("no two test files share a
+basename"), which dev added in `0f27bbeb3`.
+
+### The feature
+
+Two independent additions to `src/providers/quota.ts`:
+
+1. **Ollama Cloud quota** — `parseOllamaCloudQuota` reads `GET https://ollama.com/api/usage`, mapping `limits.session` to the 5-hour window, `limits.weekly` to weekly, `limits.monthly` to monthly, normalizing 0..1 fractions to percent. Dev has no Ollama quota support at all.
+2. **Antigravity weekly windows** — `retrieveUserQuotaSummary` parsing that produces `Gem`/`Gem (Weekly)`/`Cla`/`Cla (Weekly)` labels with a `PREFERRED_ORDER` sort. Dev's `fetchAntigravityQuota` (`src/providers/quota.ts:2362-2384`) only calls `fetchAvailableModels` and produces no weekly window.
+
+### Review threads — what remains
+
+Two CodeRabbit findings. I checked both against the head.
+
+**Finding 1 (Critical, "duplicate `seen` declarations") — FALSE POSITIVE. Retracted.**
+CodeRabbit claims `tests/provider-account-quota.test.ts:506` and `tests/provider-quota.test.ts:2796`
+redeclare `const seen` "in the same `test()` callback scope" and that "TypeScript rejects the
+test files before the suite can run." They do not. Line 470 is inside
+`test("probes each account with its own bearer...")` and line 506 is inside a **separate**
+`test("falls back to fetchAvailableModels when retrieveUserQuotaSummary returns 404")`. Distinct
+lexical scopes, legal TypeScript. The file has 10+ such per-test `const seen` declarations, a
+long-standing pattern. Confirmed by CI: all checks including `hygiene` are green on this head,
+which would be impossible if the files failed to compile. No action.
+
+**Finding 2 (Major, bearer sent to configured `baseUrl`) — PARTIALLY VALID, and the valid half is not fixed.**
+CodeRabbit's prompt is imprecise, but there is a real issue underneath. The PR has *two*
+Antigravity code paths and only one is hardened:
+
+- `fetchAntigravityUsageQuota` (per-account, PR head lines ~2484-2521) is **correct**: it pins `ANTIGRAVITY_ACCOUNT_QUOTA_BASE = "https://daily-cloudcode-pa.googleapis.com"`, routes both the summary and the `fetchAvailableModels` fallback through `providerOutboundPost`, and checks `providerRedirectError` on both. Its docstring explicitly reasons that a configured `baseUrl` "is a routing choice for requests, not a second source of Google's accounting."
+- `fetchAntigravityQuota` (provider-level, PR head lines ~2531-2555) is **not**: it computes `const baseUrl = (config.baseUrl || ANTIGRAVITY_ACCOUNT_QUOTA_BASE)` and the PR adds a **new** direct `await fetch(...)` to `${baseUrl}/v1internal:retrieveUserQuotaSummary` carrying `Authorization: Bearer ${accessToken}`, with default redirect following and no `providerRedirectError` check.
+
+The mitigating fact, and why this is not Critical: the direct-`fetch`-to-`config.baseUrl`
+pattern is **pre-existing on dev** at `src/providers/quota.ts:2371-2382`, which already sends
+the same bearer to the same operator-configured URL. The PR does not introduce the weakness;
+it adds a second request that inherits it. Still, it is a security-boundary surface per
+`AGENTS.md`, the neighbouring function in the same diff demonstrates the correct pattern, and
+extending an unpinned credential path is the kind of thing that should not grow.
+
+### Test evidence
+
+Strong: +302 lines in `provider-quota.test.ts` and +57 in `provider-account-quota.test.ts`.
+The per-account tests are genuinely adversarial — they set
+`globalThis.fetch` to a thrower ("plain fetch must not be used for account bearers") and assert
+the pinned transport is used, the exact URL is
+`https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary`, and the pinned
+address is honoured. These would be RED on dev (no `parseOllamaCloudQuota`, no
+`setAntigravityAccountQuotaTransportForTests`, no summary parsing — the symbols do not exist).
+
+**Missing coverage:** nothing exercises `fetchAntigravityQuota`'s new summary request against a
+non-canonical `config.baseUrl`. The minimal test: configure a loopback `baseUrl`, call the
+provider-level path, and assert the bearer is not sent / the request is refused.
+
+### Fix list
+
+1. Route the new `retrieveUserQuotaSummary` request in `fetchAntigravityQuota` through `providerOutboundPost` against `ANTIGRAVITY_ACCOUNT_QUOTA_BASE` with a `providerRedirectError` check, matching `fetchAntigravityUsageQuota` in the same file.
+2. Add the redirect / non-canonical-baseUrl regression described above.
+3. Rebase the two test files onto `tests/providers/` so the duplicate-basename gate stays green.
+4. Reply to CodeRabbit's Critical finding marking it a false positive with the scope reasoning, so it does not get "fixed" into a real bug.
+
+Optional, out of scope for this PR: harden the pre-existing dev-side `fetchAvailableModels`
+call the same way, as a separate change.
+
+### Dependencies
+
+Sole owner of `src/providers/quota.ts` among clean candidates — but **#2783 also modifies
+`src/providers/quota.ts` and conflicts there**. Stack order: **#3447 before #2783**. #3447 is
+one commit, currently mergeable, and carries green CI; making the larger #2783 rebase onto it
+is far cheaper than the reverse.
+
+---
+
+## #2956 — usage stats (precise time ranges, offline reports, GUI picker)
+
+**Disposition: DEFER**
+
+### State
+
+| Field | Value |
+|---|---|
+| Head | `cc6aa5f481403a2369bf1610a7b909dc7aadbf32` |
+| Base | `dev` |
+| Mergeable | `CONFLICTING` / `DIRTY` (confirmed locally, merge-tree exit 1) |
+| Review | `REVIEW_REQUIRED`, draft, **zero human reviews** (CodeRabbit skipped as draft) |
+| Drift | merge-base `47b8d1643`, **474 behind** / 7 ahead |
+| CI on head | only lightweight checks ran — `enforce-target`, `hygiene`, `label`, `resolve-pr` pass. **No test/typecheck matrix evidence exists on any head.** |
+| Size | +1261 / -114 across 34 files |
+| Last touched | 2026-08-30 |
+
+### Conflicts
+
+Four files, and two are semantic rather than mechanical:
+
+| File | Kind |
+|---|---|
+| `src/usage/summary.ts` | **semantic** |
+| `src/server/management/logs-usage-routes.ts` | **semantic** |
+| `gui/src/pages/Usage.tsx` | large positional (+217/-55) |
+| `docs-site/src/content/docs/reference/management-api.md` | mechanical |
+
+`summary.ts` is the hard one. The PR rewrites `rangeWindow` wholesale, replacing the
+`today`/`7d`/`30d` branch structure (dev: `src/usage/summary.ts:261-277`) with a
+`localCalendarDayCount` + `resolveTimeRange` model, and widens `USAGE_RANGES` to add
+`"yesterday"` (dev: `src/usage/summary.ts:16`). Dev has moved substantially underneath this
+across 474 commits — `summary.ts` now carries cost-estimation plumbing
+(`estimateAttemptCost`, `serviceTierContext`) and an `all`-range day-count path at
+`src/usage/summary.ts:1366` that the PR's rewrite does not account for. Resolving this is a
+re-derivation of the author's intent against a changed base, not a textual merge.
+
+The PR also adds `src/usage/time-range.ts` (+200) and `gui/src/usage-time-range.ts` (+20),
+neither of which exists on dev — those parts are additive and would carry cleanly.
+
+A third, quieter conflict: the PR edits `tests/usage-summary.test.ts` and
+`tests/cli-usage-report.test.ts` at the root, but dev has moved them to
+`tests/usage/usage-summary.test.ts` and `tests/cli/cli-usage-report.test.ts`. Same relocation
+trap as #3447.
+
+### The feature is real and not yet superseded
+
+Dev genuinely lacks this: `src/usage/time-range.ts` does not exist, `src/cli/observe.ts` has no
+`since`/`until`/`timeRange` flags (ripgrep returns nothing), and `USAGE_RANGES` is still the
+4-member union. So this is not SUPERSEDED — the capability gap is open.
+
+### Test evidence
+
+The PR carries `tests/usage-time-range-enhanced.test.ts` (+232) and
+`gui/tests/usage-time-filter.test.tsx` (+119), which would be RED on dev purely because
+`src/usage/time-range.ts` does not exist (import failure). That is real coverage for the new
+module, though import-failure-RED is weaker evidence than a behavioral assertion against
+existing code.
+
+### Non-blockers checked and cleared
+
+The new `readFileSync` from `node:fs` in `summary.ts` (offline `--file` reports) is **not** a
+Bun-native violation: `node:fs` is established precedent in this exact subsystem —
+`src/usage/log.ts:2`, `src/usage/ledger-scanner.ts:2`, `src/usage/debug.ts:3`, and
+`src/server/management/logs-usage-routes.ts:2` all import it. Worth noting for a future review
+round: the offline reader splits the whole file in memory with no `managementUsageMaxReadBytes`
+equivalent (dev bounds the management path at `src/server/management/logs-usage-routes.ts:185`),
+but that is a CLI-local path on an operator-supplied file, so it is a Medium, not a blocker.
+
+### Why DEFER rather than carry
+
+This is a judgment call, so here is the arithmetic. A bounded carry is not realistic in this lane:
+
+- 474 commits of drift against a file (`summary.ts`) that was actively developed in that window;
+- two semantic conflicts requiring re-derivation, one in a ~1400-line module;
+- a 217-line GUI rewrite in `Usage.tsx` that would need visual verification and a screenshot per `AGENTS.md`'s gui-screenshot rule;
+- **no human review has ever been performed**, so a carry would be simultaneously rebasing and first-reviewing 1261 lines across 34 files;
+- no test-matrix CI has ever run on it.
+
+That combination means a carry is a rewrite wearing a rebase's clothes. The honest disposition
+is DEFER with a concrete re-entry condition rather than a speculative LAND_WITH_FIX.
+
+**Re-entry condition:** ask the author to rebase onto current `dev`, split the additive
+`time-range.ts` core from the `Usage.tsx` GUI work into two PRs, move the test files to their
+`tests/<domain>/` homes, and mark ready-for-review. The `time-range.ts` half is then a
+reviewable standalone unit. If the author is unresponsive, reimplementing the range-parsing
+core fresh is cheaper than carrying this diff — with `Co-authored-by: Manson2438` per `AGENTS.md`.
+
+### Dependencies
+
+`src/server/management/logs-usage-routes.ts` and `src/usage/summary.ts` are untouched by the
+other four items. No stack ordering constraint — it is independent, which is part of why
+deferring it costs the campaign nothing.
+
+---
+
+## #2783 — quota reset detection (author's own PR)
+
+**Disposition: LAND_WITH_FIX**
+
+### State
+
+| Field | Value |
+|---|---|
+| Head | `ad74f037dcb5c47126ea7c0ca30f989b71da1afc` |
+| Base | `dev` |
+| Mergeable | `CONFLICTING` / `DIRTY` (confirmed locally) |
+| Review | `CHANGES_REQUESTED` by `Ingwannu` on this exact head |
+| Drift | merge-base `50e955604`, **675 behind** / 23 ahead |
+| CI on head | **full matrix green** — `test 1-4/4`, `macos`, `gates`, `keyring` x3, `npm-global` x3, `api usage`, `storage policy`, `react-doctor`, `hygiene`, `enforce-target` all pass |
+| Size | +6144 / -73 across 52 files |
+| Author | `lidge-jun` (maintainer, repository owner) |
+
+### Conflicts
+
+| File | Kind |
+|---|---|
+| `src/config.ts` | mechanical (additive schema section) |
+| `src/providers/quota.ts` | **semantic** — collides with #3447 |
+| `tests/lab/core-lab-boundary.test.ts` | mechanical |
+| `devlog/_plan/260827_igwanu_bug_pr_merge_round/041_wp2b_2729_supersede.md` | add/add, trivial |
+
+### The three maintainer blockers are all still present at head
+
+The `CHANGES_REQUESTED` review states "exact-head CI being green does not close these runtime
+boundaries." I verified each against `tmp-pr-2783` rather than trusting the review.
+
+**Blocker 1 — webhook SSRF / scheme. CONFIRMED.**
+`src/config.ts:866` is `webhookUrl: z.string().url().optional()` — `z.string().url()` accepts
+any scheme, including `http:`. In `src/quota/reset-sinks.ts`, `deliverWebhook` calls
+`assertUrlResolvesPublic(url)` only when `!config.allowPrivateNetwork`, and then issues
+`await fetch(url, { method: "POST", ... })` with **default redirect handling**. So the initial
+URL is validated and the redirect target is not: a public HTTPS endpoint can 302 the POST to
+loopback or a cloud metadata address, and a plain `http://` URL puts the payload and the
+credential-bearing webhook path on the wire in cleartext. The code comment correctly identifies
+the SSRF surface and then leaves the redirect hop open.
+
+**Blocker 2 — poller floor and cadence. CONFIRMED, and it is self-contradicting in source.**
+`src/quota/reset-poller.ts:16-20` documents the constant as "Above the 5-minute provider cache
+TTL and the 10-minute per-account TTL" and then declares `export const MIN_INTERVAL_MS = 60_000;`
+— 60 seconds, which is *below* both TTLs it claims to exceed. Separately,
+`src/server/background-lifecycle.ts:65` calls `startQuotaResetPoller()` with no argument, so the
+interval is always `DEFAULT_INTERVAL_MS` (15 min); the configured `pollSeconds` never reaches
+`setInterval`. `tick()` at `src/quota/reset-poller.ts:40` only checks
+`resolveQuotaResetPollMs() === 0`, i.e. it honours "off" but ignores any other configured
+cadence. An operator setting `pollSeconds: 300` silently still polls at 15 minutes. No
+single-in-flight guard and no lifecycle generation fence: `setInterval(() => void tick())` can
+overlap, and an in-flight tick can publish after `stopQuotaResetPoller()`.
+
+**Blocker 3 — claim durability. CONFIRMED.**
+`src/quota/reset-seen-store.ts:250-258`: `claimQuotaReset` does `claims.set(...)`, then
+`prune()`, then `persistNow()`, then unconditionally `return true`. `prune()`
+(`src/quota/reset-seen-store.ts:206-218`) can evict the just-added claim if its `resetAt` is
+already past and it is older than `CLAIM_MAX_AGE_MS`; `persistNow()`
+(`src/quota/reset-seen-store.ts:149-160`) swallows every write error in a bare `catch` marked
+"Best-effort persistence only." Either path returns `true` to a caller that reads it as
+"durably claimed, safe to dispatch," which is exactly the duplicate-notification-after-restart
+the docstring promises to prevent.
+
+### Test evidence
+
+Extensive — 52 files, full matrix green. But note what green CI means here: it proves the
+implemented behavior is self-consistent, not that the boundaries are right. All three blockers
+are cases where the tests assert the current (wrong) behavior or do not probe the boundary at
+all. Specifically missing:
+
+1. a redirect-to-loopback regression (sink that 302s to `127.0.0.1`, assert the POST is refused);
+2. a cadence regression (configure `pollSeconds`, assert `setInterval` receives it) plus an overlap / after-stop publish test;
+3. a claim-durability regression (force `persistNow` to throw, assert `claimQuotaReset` returns `false`).
+
+### Fix list
+
+1. `src/config.ts:866` — constrain `webhookUrl` to HTTPS at write and read validation.
+2. `src/quota/reset-sinks.ts` `deliverWebhook` — `redirect: "manual"`, then either reject redirects outright or revalidate and pin every hop; add the loopback-redirect regression.
+3. `src/quota/reset-poller.ts:20` — raise `MIN_INTERVAL_MS` above the 10-minute account TTL so the constant matches its own docstring, or correct the docstring and justify 60s.
+4. `src/server/background-lifecycle.ts:65` — pass the resolved `pollSeconds` into `startQuotaResetPoller`; make `tick()` honour cadence changes.
+5. `src/quota/reset-poller.ts` — add a single-in-flight guard and a generation counter so a tick completing after `stop` cannot publish.
+6. `src/quota/reset-seen-store.ts:250-258` — return `false` when `prune()` evicted the claim or `persistNow()` failed.
+7. Rebase onto `0f27bbeb3` **after #3447 lands**, resolving `src/providers/quota.ts` against it.
+
+### Is a bounded carry realistic?
+
+Yes, with a caveat. 6144 lines is large, but the diff is overwhelmingly *new* files under
+`src/quota/` (nine modules that do not exist on dev) plus their tests — it is additive, not a
+refactor of live code, which is why only four files conflict despite 675 commits of drift.
+The six fixes above are each localized to one function. This is the author's own PR, so there
+is no attribution or responsiveness risk and no `Co-authored-by` requirement.
+
+The caveat is sequencing: rebase after #3447, and treat the `src/providers/quota.ts` resolution
+as semantic — both PRs restructure quota fetching.
+
+### Dependencies
+
+- **#3447** — shared `src/providers/quota.ts`, real conflict. #3447 lands first.
+- **#3444, #2973** — shared `src/config.ts` / `src/types/config.ts`, additive only.
+
+---
+
+## #2973 — quota window activation (maintainer-sponsored)
+
+**Disposition: LAND_WITH_FIX**
+
+### State
+
+| Field | Value |
+|---|---|
+| Head | `b6a8792675757b5236e2675a57c0b8082c51df66` (authored 2026-09-01, committed 2026-09-02) |
+| Base | `dev` |
+| Mergeable | `CONFLICTING` / `DIRTY` (confirmed locally) |
+| Review | `CHANGES_REQUESTED`, last review `2026-09-01T15:21:15Z` on `653978f40` |
+| Drift | merge-base `bb27c26be`, **152 behind** / 9 ahead |
+| CI on head | full matrix green — `test 1-4/4`, `macos`, `gates`, `keyring` x3, `npm-global` x3, `api usage`, `storage policy`, `react-doctor`, `hygiene`, `enforce-target` |
+| Labels | `enhancement`, **`maintainer-sponsored`** (restricted-surface gate already satisfied) |
+| Size | +1025 / -60 across 33 files |
+
+### The review history is the key fact
+
+Three `CHANGES_REQUESTED` reviews, and reading them in order shows convergence:
+
+| Review | Head | Substance |
+|---|---|---|
+| 08-30 | `e131896ff` | 17 GUI failures — `CodexAccountPool` dereferenced `account.quotaAutoRefresh` on fixtures that omit it |
+| 09-01 08:42 | `cbdae0e64` | 3 blockers: type-unsafe legacy test that never injected its fixture; `registerStateSweepAfterTick` nested-server displacement; 409 doc overstatement |
+| 09-01 15:21 | `653978f40` | **"The three blockers from my previous review are fixed on this head."** Held at changes-requested explicitly "because the integration evidence is stale, not because those fixes need redesign." |
+
+The reviewer then enumerated only staleness items: base behind `dev`, PR body citing an old
+head, an unticked readiness box, and no exact-head cross-platform evidence. And the head moved
+once more after that review — `b6a879267` "fix(codex): restore displaced quota worker
+registrations" — which is precisely blocker 2's subject, and that head now carries the full
+green matrix the reviewer asked for.
+
+So: **no substantive defect is currently outstanding.** The review's own closing line is "Once
+that exact head is green, this remains a strong merge candidate," and it is green.
+
+### Conflicts — all four mechanical
+
+| File | Kind |
+|---|---|
+| `gui/src/i18n/fr.ts` | mechanical — adjacent locale-string insertion |
+| `gui/src/styles.css` | mechanical — adjacent rule blocks |
+| `src/server/management/config-routes.ts` | mechanical — adjacent route registration |
+| `tests/gui/quota-bars-rows.test.ts` | mechanical — adjacent cases |
+
+Notably the other eight `gui/src/i18n/*.ts` files auto-merged, which is the signature of a
+positional collision rather than a semantic one: `fr.ts` conflicts only because dev happened to
+add a neighbouring key. `src/config.ts`, `src/types/config.ts`, `src/server/index.ts` and
+`src/codex/quota-auto-refresh.ts` all auto-merged despite 152 commits of drift.
+
+### Test evidence
+
+Carries `gui/tests/codex-account-pool-toast-tone.test.tsx` (legacy-payload compatibility through
+the real `/api/codex-auth/accounts` normalization boundary) and lifecycle regressions covering
+registration replacement and failed-start cleanup — both added specifically in response to
+review, and both would be RED on dev since `src/codex/quota-auto-refresh.ts` does not exist
+there. The reviewer independently confirmed "9 quota-worker tests and 39 focused account-pool
+controller/behavior tests passed."
+
+### Blockers found in the diff
+
+None outstanding. The security-surface concern is pre-cleared by the `maintainer-sponsored`
+label. `src/server/index.ts` is touched — worth one check during the rebase that the
+`AGENTS.md` synchronous-activation invariant (no `await` between `Bun.serve` and the
+`labActivationRequired` gate) still holds; `tests/core-lab-boundary.test.ts` enforces this
+mechanically and is green on the head.
+
+### Fix list
+
+1. Rebase onto `0f27bbeb3`, resolving the four mechanical conflicts.
+2. Update the PR body's Verification section to the post-rebase head.
+3. Tick the remaining readiness box to clear draft.
+4. Re-run exact-head CI; confirm `tests/core-lab-boundary.test.ts` and the GUI suite stay green.
+5. If carried by a maintainer: `Co-authored-by: terrytan95`.
+
+A bounded carry here is clearly realistic — four mechanical conflicts and no open defect. Of
+the three large items in this lane, this is the one closest to landing.
+
+### Dependencies
+
+Shares `src/config.ts` and `src/types/config.ts` with #2783 and #3444, additively (distinct
+optional fields). Shares nothing with #3447. No hard ordering constraint; sequence it after
+#3444 to keep `src/config.ts` resolutions single-file-at-a-time.
+
+---
+
+## Recommended stack order
+
+```
+#3444  (clean merge; needs maintainer-sponsored label only)
+  |
+#3447  (rename-aware rebase; owns src/providers/quota.ts)
+  |
+#2783  (rebase onto #3447; 6 named boundary fixes)
+
+#2973  (independent; 4 mechanical conflicts) -- can proceed in parallel after #3444
+
+#2956  (deferred; independent, no ordering impact)
+```
+
+## Coverage ledger
+
+Every changed file in #3444 and #3447 was read. For #2956, #2783 and #2973 the `src/` surface
+and all conflicting files were read; locale/docs/asset files were skipped as mechanical, and the
+GUI files in #2956 were assessed by size and conflict status rather than line-by-line, which is
+recorded above as part of the DEFER reasoning.
+
+## Method notes
+
+- All GitHub state re-read immediately before verdict; `dev` tip `0f27bbeb3` unchanged throughout the review.
+- Mergeability from local `git merge-tree --write-tree` against fetched `refs/pull/<n>/head`, because GitHub's `mergeable` flag is wrong for #3447 (rename detection).
+- RED/GREEN for #3444 established by running the PR's test file against dev source in a scratch tree, not by trusting the PR body.
+- No repository-wide suite was run. Focused runs only: `bun test tests/agent-task-recovery.test.ts` on dev, on dev+PR-test, and on PR head.
+- No files in `src/`, `tests/`, or `gui/` were modified; scratch trees live outside the worktree.
+- One incident worth recording: an early `git fetch origin dev:refs/remotes/origin/dev --force` deleted the `origin/dev` tracking ref in the shared git dir. It was immediately restored with `git fetch origin refs/heads/dev:refs/remotes/origin/dev` and verified equal to the GitHub tip `0f27bbeb3`. No worktree content or PR ref was affected.

--- a/devlog/_plan/260905_open_work_closeout/004_lane_else_prs.md
+++ b/devlog/_plan/260905_open_work_closeout/004_lane_else_prs.md
@@ -1,0 +1,755 @@
+# Lane 4 — chore / review-ready / enhancement PRs
+
+READ-ONLY adversarial triage. Worktree `/private/tmp/ocx-closeout.xomWAA/wt`, detached at
+`origin/dev` **0f27bbeb3**. Index re-read immediately before verdict (dirty files present and
+untouched during the review: `src/oauth/index.ts`, `src/providers/model-rename-startup.ts`,
+`tests/oauth/oauth-provider-reconcile.test.ts`, `tests/providers/model-rename-migration.test.ts`).
+At the final index re-read these had been reverted by the parent; the only remaining working-tree
+entry is this untracked `devlog/_plan/260905_open_work_closeout/` directory. No verdict depends on
+those files.
+
+All PR-head verification ran against `git archive` exports under
+`/private/tmp/ocx-closeout.xomWAA/x<pr>/` with `node_modules` symlinked. No repository file was
+modified; no `bun test` ran without a file argument.
+
+## Summary
+
+| Item | Disposition | One-line reason |
+|------|-------------|-----------------|
+| #3530 | LAND_WITH_FIX | Restores a genuinely deleted contract test and adds a real anti-deletion guard; the `test 1/4` failure was a REAL layout violation already fixed on the current head, but the removal test proves the wrong seam. |
+| #3323 | LAND_AS_IS | Removes a repo-root temp-file write from a test; clean merge, full CI green on exact head, no behavior risk. |
+| #3487 | REIMPLEMENT | Correct one-line defect and correct fix, but the target file was moved by the `tests/<domain>/` reorg; the PR would resurrect a deleted path. |
+| #3508 | DEFER | Approved and green, but the module is never imported by `Logs.tsx` — it lands 175 lines of unreachable code plus a duplicate of live inline filtering. |
+| #3383 | DEFER | 121 commits behind, CONFLICTING across 15 files including `Models.tsx`/9 locales, no cross-platform CI on head, 6 unresolved review findings. |
+| #3329 | LAND_WITH_FIX | Real feature with strong tests, but carries a verified reset-metadata correctness bug and a semantic rebase over the combos test move. |
+| #3421 | LAND_WITH_FIX | Docker support with a verified runtime-identity regression (compat manifest excluded) and an all-interfaces bind default. |
+| #2716 | DEFER | 118 commits behind, CONFLICTING on `Models.tsx` + 9 locales, stacked under #3383 on the same files, no exact-head CI. |
+| #2432 | LAND_WITH_FIX | Documents a real undocumented sentinel; only blocker is staleness (88 commits) plus a trivial `src/types/provider.ts` doc-comment naming an unexported symbol. |
+| #3531 | LAND_WITH_FIX | Compact subset of #3528 rebased onto the current test layout, but it breaks a pre-existing regression test from #2960 and silently drops model-alias display. |
+| #3528 | SUPERSEDED | Its alias half is fully contained in #3531 (byte-identical src diffs) on stale test paths; the `ocx effort` half is unrelated scope that should be split. |
+
+---
+
+## Cross-cutting finding: the `tests/<domain>/` reorg is the dominant blocker
+
+Two commits moved the test tree into domain directories:
+
+- `5424ad465` — `test(layout): move cli, oauth, routing, claude-integration into tests/<domain>/ (#3497) (#3511)`
+- `8b6e4542a` — `test(layout): move providers and codex-integration into tests/<domain>/ (#3497) (#3516)`
+
+Every CONFLICTING item in this lane except #3383/#2716 (which conflict on GUI locales) conflicts
+*only* because it edits a test path that no longer exists. That makes the rebase mechanical for
+#3487 and #3528, and it is also the direct cause of the #3530 deletion this lane is cleaning up.
+
+## Cross-cutting finding: intake-only CI is not evidence
+
+#3383, #3329, #3421, #2716 and #2432 each show exactly four checks — `enforce-target`, `hygiene`,
+`label`, `resolve-pr` — plus CodeRabbit. Cross-platform CI has never run on those exact heads, so
+there is no test evidence for any of them at their current SHA. Per `AGENTS.md`, an empty required
+set is not green.
+
+---
+
+## #3530 — test(oauth): restore a deleted contract test, and fail when one disappears
+
+**Disposition: LAND_WITH_FIX**
+
+- Head `2980eaa35f7077682c5815e33b42ea6d8856f44c`, base `dev`, author `lidge-jun` (maintainer).
+- `MERGEABLE` / `BLOCKED` / `CHANGES_REQUESTED`. Merge-base is `0f27bbeb3` — level with dev tip.
+- Not conflicting. `git merge-tree` reports a clean `merged` result for `tests/repo-hygiene.test.ts`
+  and a plain add for `tests/routing/anthropic-quorum-cache.test.ts`.
+
+### CI on the exact head — the `test 1/4` question, answered
+
+**The reported `test 1/4` failure is a REAL failure, not a flake — and it is on the PREVIOUS commit,
+not the current head.**
+
+- Failing job `101177147739` belongs to sha `14fbbd187cb355fac2ce15c48982bf61204b1bee`, the head
+  before the current one.
+- The assertion, from the job log:
+
+```
+(fail) tests/ layout > every test file resolves to a domain and migrated domains hold no stragglers
+  {
+-   "misplaced": [],
++   "misplaced": [ "adapters/anthropic/anthropic-quorum-cache.test.ts -> routing" ],
+  }
+  at tests/test-layout.test.ts:47:51
+##[error]Test failure in shard 1/4 batch 21/23 (exit 1); not retrying assertion/test failures.
+```
+
+  This is deterministic and content-derived: the author first restored the file to
+  `tests/adapters/anthropic/` and `layout.json` demanded `tests/routing/`. The runner itself states
+  assertion failures are not retried, which rules out the flake classification.
+- The fix is already in: `git ls-tree` shows `tests/adapters/anthropic/anthropic-quorum-cache.test.ts`
+  at `14fbbd18` and `tests/routing/anthropic-quorum-cache.test.ts` at the current head.
+- Re-verified on the current head: `bun test tests/test-layout.test.ts` -> **2 pass / 0 fail**.
+- CI on the current head: `test 1/4` **pass (4m30s)**, `test 2/4` `3/4` `4/4` pass, `gates`,
+  `storage policy`, `api usage`, `keyring` all pass. Only `macos 1/2` and `macos 2/2` still pending
+  at time of writing.
+
+**Classification: real failure, already resolved on the current head. No flake.**
+
+### The defect is real
+
+`anthropic-quorum-cache.test.ts` is genuinely absent from dev. Tracked-name check against the index:
+
+| Required name | On dev |
+|---|---|
+| `always-on-429-failover.test.ts` | TRACKED |
+| `anthropic-quorum-cache.test.ts` | **MISSING** |
+| `generic-oauth-failover.test.ts` | TRACKED |
+| `docs-429-failover-claims.test.ts` | TRACKED |
+
+The subject it covers is live code: `src/oauth/anthropic-routing.ts:253` `QUORUM_CACHE_TTL_MS = 2_000`,
+`:255` `quorumCache`, `:278` the TTL read, and invalidations at `:626`, `:660`, `:693`. Deleted by
+`8b6e4542a` (the #3516 reorg) as a conflict resolution, with no corresponding add.
+
+### Test evidence
+
+The new guard in `tests/repo-hygiene.test.ts:290-318` is **RED on dev** — `missing` would be
+`["anthropic-quorum-cache.test.ts"]` against the current index. The restored file passes on its own
+head: **6 pass / 0 fail / 38 expect() calls**.
+
+### Blockers
+
+1. **[High] The removal test does not exercise the removal path.**
+   `tests/routing/anthropic-quorum-cache.test.ts:129-140` names itself
+   *"removing an account invalidates immediately"* but only calls
+   `clearAnthropicSessionAffinityForAccount(ids[1])`. The real DELETE route at
+   `src/server/management/oauth-account-routes.ts:551` calls `removeAccount(provider, id)` **first**,
+   then the routing cleanup at `:556`. The test never removes the credential, so the roster is
+   unchanged and the test cannot observe the transition its name claims. It asserts only that the
+   store was re-read. This is the maintainer review finding and it is correct.
+2. **[Low] The PR description is stale.** Body still says the file is restored at
+   `tests/adapters/anthropic/`; the current head correctly places it at `tests/routing/`.
+
+### Falsified: the CodeRabbit atime objection
+
+CodeRabbit argues the `atime` oracle at lines 61-77 is unreliable on `noatime` filesystems. **Not
+supported by evidence on this repository's CI.** Job `101178655718` (Linux, current head) shows all
+six tests passing, including the two that would silently pass-through if `atime` never moved:
+`a burst of requests inside the TTL window shares one store read` and
+`a rotation invalidates immediately`. The negative assertion `expect(storeWasRead()).toBe(false)`
+and the positive `expect(storeWasRead()).toBe(true)` both hold, which is only possible if `atime`
+tracks reads. Non-blocking; a read counter would be more robust but the oracle is not broken here.
+
+### Fix list
+
+1. In `tests/routing/anthropic-quorum-cache.test.ts`, make the removal test mirror the route:
+   `await removeAccount("anthropic", ids[1]!)` then `clearAnthropicSessionAffinityForAccount(ids[1]!)`,
+   and assert both `hasAnthropicFailoverQuorum(start + 1) === false` and that the store was re-read.
+2. Update the PR description to say `tests/routing/`.
+3. Let `macos 1/2` and `2/2` finish green on the fixed head.
+
+### Dependencies
+
+None on files. Conceptually it is the cleanup for the same `8b6e4542a` reorg that makes #3487 and
+#3528 conflict, so landing it first makes the lane's deletion story coherent.
+
+---
+
+## #3323 — test: isolate the route scanner probe in a unique temp directory
+
+**Disposition: LAND_AS_IS**
+
+- Head `0facdae6990716c49b793df5e237ea26354262c1`, base `dev`, author `luvs01`.
+- `MERGEABLE` / `BLOCKED` / `REVIEW_REQUIRED`. Labels `chore`, `review-ready`.
+- Not conflicting: `git merge-tree` returns a clean `merged` blob, and dev has not touched
+  `tests/management-route-registry.test.ts` since the merge-base `ff1ac6b8c`.
+
+### CI on the exact head — fully green
+
+Unlike the rest of this lane, #3323 has a complete run: `test 1/4`-`4/4` pass, `gates` (1m24s),
+`macos` (13m), `keyring macos/ubuntu/windows`, `storage policy`, `api usage`, `react-doctor`,
+`enforce-target`, `hygiene`, `label`, CodeRabbit — all pass.
+
+### The defect is real
+
+Dev still writes the probe into the repository root:
+`tests/management-route-registry.test.ts:125` — `const tmp = join(repoRoot, ".tmp-scanner-probe.ts");`.
+A crash between write and `finally` leaves `.tmp-scanner-probe.ts` in the working tree, and
+concurrent runs collide on one fixed path.
+
+### Test evidence
+
+The change *is* the test. It is not a regression test for a runtime bug, so there is no RED-on-dev
+expectation to meet. Verified on the PR head: `bun test tests/management-route-registry.test.ts` ->
+**13 pass / 0 fail**.
+
+### Quality notes (non-blocking, all improvements)
+
+- Replaces two `require("node:fs")` calls with proper ESM imports.
+- Moves `writeFileSync` **inside** the `try`, so a write failure still triggers cleanup.
+- `rmSync(tempDir, { recursive: true, force: true })` removes the whole `mkdtempSync` directory.
+
+No security-boundary, privacy, or Node-only concern: `node:fs`/`node:os` are already used throughout
+this file and are Bun-supported. No unrelated churn — one file, +6/-4.
+
+### Dependencies
+
+None. Nothing else in the lane touches this file.
+
+---
+
+## #3487 — test(kiro): prove the bounded completion fallback runs
+
+**Disposition: REIMPLEMENT**
+
+- Head `ee3b22d284b592a3a41d6d8b2db32c7e5c231b09`, base `dev`, author `Ingwannu`.
+- `CONFLICTING` / `DIRTY` / `REVIEW_REQUIRED`. 26 commits behind dev.
+- CI at the exact head was fully green (all four test shards, macOS, keyring, gates) — but that ran
+  before the reorg landed.
+
+### Why it conflicts — and why a rebase is mechanical
+
+`git merge-tree` reports `removed in local` for `tests/kiro-stream.test.ts`: dev deleted the path in
+`8b6e4542a`. The file now lives at `tests/providers/kiro/kiro-stream.test.ts`, and the target hunk is
+at line 1723 there. **Pure rename, no semantic conflict** — the surrounding test body is identical.
+The PR as-is would re-create a deleted file and leave two divergent copies, which
+`tests/test-layout.test.ts` would then fail on. That is why this is REIMPLEMENT rather than
+LAND_WITH_FIX: the patch cannot be applied to the path it names.
+
+### The defect is real
+
+At `tests/providers/kiro/kiro-stream.test.ts:1723` the stub is installed but never observed:
+
+```ts
+globalThis.fetch = (async () => new Response(streamOf(eventFrame({ content: "Final from fallback." })))) as typeof fetch;
+```
+
+The test — *"an attempt that falls back to the completion retry does not calibrate"* — asserts only
+that the estimate is unchanged. If the bounded fallback silently stopped firing, the calibration
+would also not move and the test would still pass. The added `fallbackCalls` counter with
+`expect(fallbackCalls).toBe(1)` closes exactly that false-confidence hole. This is a legitimate
+REVIEW-REGRESS-01 class fix.
+
+### Test evidence
+
+The one-line assertion is the entire change (+6/-1). It would not be RED on dev today, because the
+fallback does fire; it is a *guard* against a future silent regression. That is the correct shape for
+this defect and needs no additional test.
+
+### Blockers
+
+Only the path. No correctness, security, privacy, or Node-only issue; no unrelated churn.
+
+### Fix list (for the reimplementation)
+
+1. Apply the identical +6/-1 hunk to `tests/providers/kiro/kiro-stream.test.ts` at the
+   `Final from fallback` stub (line 1723 on current dev).
+2. Preserve authorship with a `Co-authored-by: Ingwannu <...>` trailer in a branch commit, per
+   `AGENTS.md` "Landing another author's work" — a prose mention does not count.
+3. Run `bun test tests/providers/kiro/kiro-stream.test.ts`.
+
+### Dependencies
+
+Same reorg family as #3530 and #3528. No file overlap with any other lane item.
+
+---
+
+## #3508 — feat(logs): add composable log filter engine
+
+**Disposition: DEFER**
+
+- Head `b78cadf12506df20b1e14ee42224ab4321dedbe5`, base `dev`, author `yansigit`.
+- `MERGEABLE` / **`CLEAN`** / **`APPROVED`**. Labels `enhancement`, `review-ready`,
+  `gui-screenshot-waived`.
+- Not conflicting; both files are pure adds.
+- **CI on the exact head is fully green**: `test 1/4`-`4/4`, `macos 1/2`+`2/2`, `npm-global` x3,
+  `gates`, `keyring` x3, `storage policy`, `api usage`, `react-doctor`.
+
+This is the one item where a green, approved, cleanly-mergeable PR still should not land as-is, so
+the reasoning is spelled out.
+
+### The blocker: the module is unreachable
+
+`gui/src/pages/logs-filter.ts` is imported by exactly one file — its own test:
+
+```
+gui/tests/logs-filter.test.ts:7:} from "../src/pages/logs-filter";
+```
+
+The three other `rg` hits for `logs-filter` in the PR head are the unrelated CSS class
+`logs-filter-field` in `Logs.tsx` and `styles.css`. `Logs.tsx` never imports the engine.
+
+Meanwhile the live filtering still runs inline at `gui/src/pages/Logs.tsx:516`:
+
+```ts
+const filteredLogs = logs.filter(log => (
+  logMatchesSurface(log, surfaceFilter)
+  && (!interceptedHelpersOnly || Boolean(log.shadowCallRewrittenFrom))
+  && logMatchesModelQuery(log, modelFilter)
+  && (!conversationQuery || matchesLogConversationId(log.conversationId, conversationQuery, conversationQueryHash))
+));
+```
+
+So merging adds 175 lines of dead source plus 141 lines of tests that only test the dead source, and
+creates a second, divergent definition of "how a log row is filtered" next to the real one. The new
+module also introduces behavior the page does not have (status, time window, tok/s bounds, provider
+exact-match), so the two will drift the moment either is edited.
+
+The green CI is honest but uninformative: the tests exercise a module nothing calls. The
+`gui-screenshot-waived` label is consistent with this — there is no UI change, because nothing is
+wired.
+
+### Test evidence
+
+`gui/tests/logs-filter.test.ts` is a thorough unit suite for the new module and would be RED without
+it (the import would not resolve). But it proves nothing about `Logs.tsx`. The missing test is the
+one that matters: a test asserting the **page** produces the same filtered set through the engine.
+
+### Defer reason (concrete)
+
+Land it together with the `Logs.tsx` call-site migration that deletes the inline `filteredLogs`
+block, in one PR or as an explicit two-PR stack where the child is already open. Until then the
+repository gains a maintenance liability with no user-visible behavior. If the author confirms the
+wiring PR is imminent, this flips to LAND_AS_IS as the parent of that stack.
+
+### Non-blocking quality notes
+
+The module itself is well built: injected `now` clock, defensive `attempts()` narrowing of untrusted
+log data, deterministic option ordering, no `any`. No security, privacy, or Node-only concern.
+
+### Dependencies
+
+None currently. It would become the parent of the `Logs.tsx` migration.
+
+---
+
+## #3383 — feat(models): add main picker ordering controls
+
+**Disposition: DEFER**
+
+- Head `51726d2c7c58146defdd6088aefa2b95a1e58553`, base `dev`, author `x3M3x`.
+- `CONFLICTING` / `DIRTY` / `REVIEW_REQUIRED`. 26 files, +562/-89. **121 commits behind dev.**
+- CI: intake-only (`enforce-target`, `hygiene`, `label`, `resolve-pr`) + CodeRabbit. **No
+  cross-platform CI has ever run on this head.**
+
+### Conflicts — semantic, not mechanical
+
+`git merge-tree` reports 2 textual conflict markers and `changed in both` on 15 files:
+
+`gui/src/i18n/{de,en,fr,ja,ko,ru,tr,zh-TW,zh}.ts`, `gui/src/pages/Models.tsx`,
+`src/claude/model-info.ts`, `src/codex/catalog.ts`, `src/server/index.ts`,
+`src/server/management/agent-settings-routes.ts`, `src/types/config.ts`.
+
+The locale files conflict because newer Cursor documentation and translations landed in the same
+table regions. `src/server/index.ts` is a composition root under an explicit `AGENTS.md` invariant
+(no `await` between `Bun.serve` and `labActivationRequired`), so its conflict must be resolved by
+hand, not by a merge tool.
+
+### Unresolved review findings (6, from two CodeRabbit passes)
+
+1. `src/server/management/agent-settings-routes.ts:674` — request body parsed and accessed without
+   validating it is a non-null, non-array object; null/array/primitive bodies bypass the intended 400.
+   Untrusted input at a management trust boundary.
+2. `agent-settings-routes.ts:696-713` — `pickerOrder` validation accepts only `catalogModelSlug`
+   values, rejecting the `provider/id` form.
+3. `src/codex/catalog/sync.ts:636-641` — priority bands can tie/overlap so a listed row may not stay
+   ahead of unlisted rows for partial orders longer than five entries.
+4. `gui/src/pages/Models.tsx:1601-1611` — `savePickerOrder` does not share one bounded-fetch scope
+   across both requests, so `pickerBusy` can stay stuck if a request stalls.
+5. `gui/src/i18n/ja.ts:2291` — unnatural standalone label.
+6. A regression test is requested for the >5-entry partial-order case.
+
+### Defer reason (concrete)
+
+Three independent conditions each block landing: a 121-commit semantic rebase across a protected
+composition root and nine locales; zero test evidence at the exact head; and an unvalidated
+management request body. This is not close to mergeable, and rebasing it before #2716 (which fights
+for the same `Models.tsx` and locale lines) would force the conflict to be solved twice.
+
+### Dependencies — stack order
+
+**Overlaps #2716 on exactly 10 files**: `gui/src/pages/Models.tsx` and all nine
+`gui/src/i18n/*.ts`. These two cannot be rebased independently. Recommended order: land **#2716
+first** (smaller, more self-contained GUI surface), then rebase #3383 on top; or explicitly stack
+#3383 on #2716's head. Also touches `src/types/config.ts`, shared with #3329.
+
+---
+
+## #3329 — feat(combos): per-combo cooldownMs and waitForCooldownMs
+
+**Disposition: LAND_WITH_FIX**
+
+- Head `1876d6001db50462805537f9bfea655ed97987ea`, base `dev`, author `Veritas-7`.
+- `CONFLICTING` / `DIRTY` / `CHANGES_REQUESTED`. 17 files, +819/-60. **138 commits behind dev** —
+  the stalest code item in the lane.
+- CI: intake-only + CodeRabbit. No cross-platform CI on this head.
+
+### Conflicts — mixed
+
+`git merge-tree` shows 0 textual conflict markers but `changed in both` on `src/combos/failover.ts`,
+`src/server/responses/core.ts`, `src/types/config.ts`, `tests/server-combo-failover-e2e.test.ts`,
+plus `removed in local` for three test files the reorg moved:
+
+| PR path | Current dev path |
+|---|---|
+| `tests/combos.test.ts` | `tests/codex-integration/combos.test.ts` |
+| `tests/combo-management-api.test.ts` | `tests/routing/combo-management-api.test.ts` |
+| `tests/cyber-policy-error-fidelity.test.ts` | `tests/providers/cyber-policy-error-fidelity.test.ts` |
+
+The test moves are mechanical. `src/server/responses/core.ts` is **semantic**: it is one of the three
+files `AGENTS.md` forbids from reaching `src/lab/`, and it has moved substantially in 138 commits.
+
+### The feature is real
+
+Combo failover currently has no per-combo cooldown or wait budget; the PR adds `cooldownMs` and
+`waitForCooldownMs` through `src/combos/{types,resolve,failover,index}.ts`, the management route, and
+`src/types/config.ts`. Not already fixed on dev.
+
+### Test evidence — the strongest in the lane
+
+`tests/combos.test.ts` +302, `tests/combo-management-api.test.ts` +130,
+`tests/server-combo-failover-e2e.test.ts` +98, `tests/cyber-policy-error-fidelity.test.ts` +15. These
+are genuine RED-on-dev regression tests: the config fields do not exist on dev, so they cannot compile
+against it. Coverage spans resolution, management API persistence, and end-to-end failover.
+
+### Blockers
+
+1. **[High] Reset metadata dropped for body-confirmed quota failures wrapped in 5xx.**
+   At `src/server/responses/core.ts:1645-1647` the `resetAt` metadata is retained only when the raw
+   status is 402/429. `shouldRetryCodexPoolAccountQuota` also recognizes body-confirmed quota
+   exhaustion inside HTTP 5xx and normalizes it to 429. When no alternate account exists, the raw 5xx
+   reaches `consumeComboFailure` and the status-only condition discards a valid
+   `x-codex-*-reset-at`. **Consequence: the combo target becomes eligible again before the real quota
+   reset** — the exact failure this feature exists to prevent. Independently reported by CodeRabbit
+   and the maintainer.
+2. **[Medium] Korean docs contradict the runtime.**
+   `docs-site/src/content/docs/ko/guides/combos.md:130` states every all-cooling selection returns
+   HTTP 503 immediately, directly after documenting a positive `waitForCooldownMs`. Contradicts both
+   the English source and the implementation.
+3. **[Medium] Cooldown precedence unstated across 5 locales.** English `combos.md:423-425` plus
+   ja/ko/ru/zh-cn need to say `Retry-After` and Codex reset signals take precedence over the
+   configured cooldown.
+
+### Fix list
+
+1. Preserve the effective quota classification (not the raw status) through
+   `retryCodexPoolOnAlternateAccount` -> `consumeComboFailure`, keeping the `cyberFailure` exclusion
+   and direct 402/429 handling.
+2. Add a focused regression for 5xx-body-confirmed quota retaining `resetAt`.
+3. Correct `ko/guides/combos.md:130` to bound the immediate-503 claim to a zero wait budget or an
+   earliest cooldown exceeding the budget.
+4. Synchronize the precedence wording across the five locales.
+5. Rebase: move the three test files to their `tests/<domain>/` paths and re-resolve
+   `src/server/responses/core.ts` by hand.
+6. Extend combo-update persistence assertions around `explicitDefault` (CodeRabbit).
+7. Require full cross-platform CI on the rebased head.
+
+### Dependencies
+
+Shares `src/types/config.ts` with #3383. Sequence after any core-path work in other lanes.
+
+---
+
+## #3421 — Add Docker Compose deployment support
+
+**Disposition: LAND_WITH_FIX**
+
+- Head `432016100bb8c30f212be1e6aa71816bc7f1f932`, base `dev`, author `Skyline-23`.
+- `MERGEABLE` / `BLOCKED` / `CHANGES_REQUESTED`. 16 files, +327/-89. 89 commits behind dev.
+- **Not conflicting** — `git merge-tree` shows only `added in remote`; dev has touched none of these
+  paths since the merge-base. A rebase is trivial.
+- CI: intake-only + CodeRabbit. No cross-platform CI on this head.
+
+### Blockers — both verified against dev, both real
+
+1. **[High] The container is not runtime-equivalent to the packaged artifact.**
+   `.dockerignore:9` excludes `src/generated/compatibility-version.json`, and the Dockerfile copies
+   `src` without running the package generator. `scripts/prepare-package.ts:4` imports
+   `generateCompatibilityVersionManifest`, so the normal package always has it. The runtime is
+   documented fail-closed at `src/routing/compatibility/version.ts:80`:
+   *"There is intentionally no runtime-only fallback ... live-route subject resolution fails closed
+   and follows the profile's unknown-evidence policy."* `readOpenCodexCompatibilityVersion()` returns
+   `null` (`:91`), and `src/routing/compatibility/subject.ts:96` then returns early with bare
+   `subjectIds`. **This changes routing behavior in the container versus every other install** — not
+   merely missing metadata.
+2. **[High, security boundary] Compose publishes the data port on all host interfaces.**
+   `compose.yaml:13` is `"${OPENCODEX_PORT:-10100}:10100"`, which binds `0.0.0.0` on the Docker host.
+   The admission token limits unauthenticated use, but loopback is the correct default for a local
+   Docker Desktop deployment. This is a deployment/authn-adjacent surface, so `AGENTS.md` security
+   review applies.
+3. **[Medium] Docs token-path inconsistency.** `docs-site/.../guides/remote-hub.md:175` reads the
+   token from `/run/secrets/ocx_api_token` while the bootstrap step uses the canonical `ocx-state`
+   volume path.
+
+### Test evidence
+
+`tests/container-bootstrap.test.ts` (+32) is a genuinely good boundary test for
+`docker/bootstrap-token.ts`: chunked input, exact 4096-byte maximum, and rejection of empty,
+multiline, and oversized input. It is RED on dev only in the sense that `docker/bootstrap-token.ts`
+does not exist there — appropriate for new-file work.
+
+**Missing test:** nothing asserts the container's runtime identity. The minimal addition is an
+assertion in the final runtime stage that `readOpenCodexCompatibilityVersion()` returns a valid
+SHA-256 value.
+
+### Fix list
+
+1. Generate `compatibility-version.json` during the image build via the package-owned generator and
+   copy it into the runtime stage. Do **not** commit a stale generated file.
+2. Add the runtime-stage assertion that `readOpenCodexCompatibilityVersion()` is non-null.
+3. Default the published port to loopback:
+   `"${OPENCODEX_BIND_ADDRESS:-127.0.0.1}:${OPENCODEX_PORT:-10100}:10100"`, with documented opt-in to
+   `0.0.0.0` or a LAN/Tailscale address for remote-hub use.
+4. Fix the `remote-hub.md:175` token path (and mirrored locales).
+5. Rebase onto current dev; require exact-head container build **and** normal CI.
+6. Security review before merge, per `AGENTS.md` (deployment + token handling).
+
+### Dependencies
+
+None — no file overlap with any other lane item. Can proceed in parallel.
+
+---
+
+## #2716 — feat: add discovered model display name editor
+
+**Disposition: DEFER**
+
+- Head `27ba09f405a22d7d20743f15ce25e3ecb1ac8e8f`, base `dev`, author `zigzag-007`.
+- `MERGEABLE` per the latest poll but `BLOCKED` / `CHANGES_REQUESTED`; `git merge-tree` against the
+  current tip still reports `changed in both` on 12 files. **118 commits behind dev.**
+- 17 files, +1325/-3. CI: intake-only + CodeRabbit.
+
+### Conflicts
+
+`changed in both`: `gui/src/pages/Models.tsx`, `gui/src/styles.css`, all nine `gui/src/i18n/*.ts`,
+and `docs-site/.../reference/configuration/providers.md`. Recent Cursor documentation and translation
+additions occupy the same regions. Mechanical per hunk but wide, and the maintainer's Korean review
+confirms the same finding independently.
+
+### Blockers
+
+1. **Staleness + conflicts** across 12 files, unresolved at the current head.
+2. **No exact-head CI.** Cross-platform CI and React Doctor have not run; for a +1325-line GUI change
+   with a 433-line test file, there is no evidence the tests pass anywhere.
+3. **[Low] Unrelated churn.** The PR adds `docs/superpowers/plans/...` (+253) and
+   `docs/superpowers/specs/...` (+138) — 391 lines of personal planning artifacts in a tracked
+   directory that is not `devlog/`. `AGENTS.md` designates `devlog/` for planning notes; these do not
+   belong in `docs/` and should be dropped from the diff.
+4. **[Low] Two i18n wording fixes** (`tr.ts:2399` `ör.`->`örn.`; `zh-TW.ts:2358`
+   `提供者名稱`->`供應商名稱`) and one docs hyphenation nit.
+5. GUI change => final merge needs maintainer sign-off and a refreshed screenshot.
+
+### Test evidence
+
+`gui/tests/models-display-name-editor.test.tsx` (+433) is a substantial component suite that would be
+RED on dev (`ModelDisplayNameDialog.tsx` does not exist). Coverage looks appropriate; it simply has
+never been run by CI on this head.
+
+### Defer reason (concrete)
+
+A 118-commit rebase across 12 conflicting files, zero exact-head test evidence, and 391 lines of
+out-of-scope documents. The author has been asked twice for a rebase. Deferring until a rebased head
+with green CI and a screenshot exists.
+
+### Dependencies — stack order
+
+**Overlaps #3383 on 10 files** (`Models.tsx` + nine locales) and **#2432 on
+`docs-site/.../reference/configuration/providers.md`**. Recommended: land #2716 first, then #3383,
+and keep #2432's edit to the same providers reference in mind when sequencing.
+
+---
+
+## #2432 — docs: document the `__omit__` reasoning-effort wire sentinel
+
+**Disposition: LAND_WITH_FIX**
+
+- Head `c83d8eda1ad1c4938019914c26d12b8dfeaaa74f`, base `dev`, author `mdwsk88`.
+- `MERGEABLE` / `BLOCKED` / `CHANGES_REQUESTED`. 9 files, +26/-18. 88 commits behind dev.
+- `changed in both` on all eight `providers.md` locales and `src/types/provider.ts`, but every hunk is
+  a two-line table-row replacement — **mechanical**.
+- CI: intake-only + CodeRabbit.
+
+### The gap is real
+
+The sentinel exists and is load-bearing: `src/reasoning-effort.ts:21` —
+`export const REASONING_EFFORT_OMIT_SENTINEL = "__omit__";` — consumed at `:24`, `:217`, `:228`,
+`:230`, with adapter-specific handling in `src/adapters/ollama-native.ts` and
+`src/adapters/anthropic.ts`. Dev documentation says nothing about it:
+`docs-site/.../reference/configuration/providers.md:114` reads only *"Provider-wide wire aliases for
+reasoning labels."* A user cannot discover `__omit__` from the docs. Confirmed **not** superseded.
+
+### Test evidence
+
+Docs plus two doc-comments; no runtime change, so no regression test is warranted. The behavior is
+already covered by the adapter tests referenced at `ollama-native.ts` (issue #2356). Correct scope.
+
+### Blockers
+
+1. **[Low] The doc-comment names a symbol the file cannot see.** The added comment in
+   `src/types/provider.ts` says *"Map a label to `REASONING_EFFORT_OMIT_SENTINEL`"*, but
+   `src/types/provider.ts` does not import that constant. Since it also gives the literal, this is
+   cosmetic — prefer the literal alone, or reference `src/reasoning-effort.ts` explicitly.
+2. **[Low] Locale precision (CodeRabbit).** ja/ko/ru/tr should distinguish omission of the
+   OpenAI-compatible `reasoning_effort` field from omission of Ollama's native `think` field, and the
+   English `:114` example should say which wire it targets.
+3. **[Low] French typographic apostrophe** in `l'omission` (explicitly non-blocking per reviewer).
+4. Still a draft by the checklist; 88-commit rebase and an exact-head `docs-site` build needed.
+
+The maintainer's most recent incremental review confirms the two earlier blocking issues are already
+resolved (table alignment, French attribution) and that the isolated docs build passed at 393 pages.
+
+### Fix list
+
+1. Drop the unexported-symbol reference in `src/types/provider.ts`, or point to
+   `src/reasoning-effort.ts`.
+2. Apply the ja/ko/ru/tr wire-field distinction and clarify the English example.
+3. Rebase onto current dev, re-resolve the eight locale table rows.
+4. Re-run the exact-head `docs-site` build; tick the latest-dev checklist item only after the rebase.
+
+### Dependencies
+
+Shares `docs-site/.../reference/configuration/providers.md` with **#2716**. Whichever lands second
+must re-resolve that table. Order is not important; the overlap is one file and mechanical.
+
+---
+
+## #3531 / #3528 — the `agy` alias pair
+
+### The overlap, measured
+
+Normalized `git diff` hashes (index lines stripped) for the four shared source files:
+
+| File | #3531 | #3528 | Result |
+|---|---|---|---|
+| `src/codex/catalog/sync.ts` | `04a8ac9c08da` | `04a8ac9c08da` | **identical** |
+| `src/providers/derive.ts` | `26c46b2dbdfa` | `26c46b2dbdfa` | **identical** |
+| `src/providers/registry.ts` | `ce4a119b4356` | `ce4a119b4356` | **identical** |
+| `src/router.ts` | `dc6bbbf0ae5a` | `dc6bbbf0ae5a` | **identical** |
+
+**#3531 is exactly the alias subset of #3528**, byte-for-byte on every source file, by the same author
+(`benedictusrey`), opened 10 minutes later. The only differences:
+
+- **#3528 adds unrelated scope**: `src/cli/effort.ts` (+337), `src/cli/{dispatch,help,registry}.ts`,
+  and `tests/cli-effort.test.ts` (+238) — a top-level `ocx effort` command that has nothing to do with
+  the alias.
+- **#3531 targets the current test layout**, #3528 targets the pre-reorg paths:
+
+| #3528 (stale) | #3531 (current) |
+|---|---|
+| `tests/codex-catalog.test.ts` | `tests/codex-integration/codex-catalog.test.ts` |
+| `tests/provider-model-aliases.test.ts` | `tests/providers/provider-model-aliases.test.ts` |
+
+That is precisely why #3528 is `CONFLICTING`/`DIRTY` and #3531 is `MERGEABLE`: #3531 is the same work
+rebased onto the post-`8b6e4542a` tree with the CLI scope removed.
+
+---
+
+### #3528
+
+**Disposition: SUPERSEDED**
+
+- Head `735e3f5c58e382edce06df0c684c91efed2a1ddb`, `CONFLICTING` / `DIRTY` / `REVIEW_REQUIRED`,
+  **draft**. 25 commits behind dev. CI: intake-only.
+- Superseded **for the alias half only**, by #3531, which carries the identical source diff on
+  non-conflicting test paths.
+- The `ocx effort` CLI half (+575 lines) is *not* superseded and is *not* reviewed here on its merits:
+  it is unrelated scope bundled into an alias PR. It should be re-opened as its own PR against current
+  dev, where it can get real CI and a focused review.
+- Note: closing #3528 in favor of #3531 needs no `Co-authored-by` trailer — same author.
+
+---
+
+### #3531
+
+**Disposition: LAND_WITH_FIX**
+
+- Head `f486b5d607246b068c50bf13a6c4208fcbed1388`, base `dev`, merge-base `0f27bbeb3` — level with
+  dev tip. `MERGEABLE` / `BLOCKED` / `REVIEW_REQUIRED`.
+- Left draft during this review; CodeRabbit still pending. CI: `label` and `resolve-pr` pass,
+  `enforce-target` and `hygiene` pending. **No test shard has run.**
+- Not conflicting: clean `merged` results on all six files.
+
+#### Blockers — found by running the tests, not by reading the diff
+
+1. **[High] It breaks a pre-existing regression test it does not update.**
+   Running the PR's own touched suites on its head:
+   `bun test tests/providers/provider-model-aliases.test.ts tests/codex-integration/codex-catalog.test.ts`
+   -> **276 pass, 1 fail**.
+
+   ```
+   (fail) configured CatalogModel displayName -> catalog display_name
+          > the issue reproduction uses the effective model alias for the picker label
+   at tests/codex-integration/codex-catalog.test.ts:2321
+   Expected: "google-antigravity/gemini-3.7"
+   Received: "agy/gemini-3.7"
+   ```
+
+   That test is not incidental: it was added by `0892b99d7`
+   *"fix(catalog): display effective model aliases in Codex picker (#2960)"* — it is the regression
+   proof for a previously fixed issue, and it lives at
+   `tests/codex-integration/codex-catalog.test.ts:2286`. Because `enforce-target`/`hygiene` are the
+   only checks queued, **CI would not have caught this before review.**
+
+2. **[High] The early return silently discards later display rules.**
+   The added hunk at `src/codex/catalog/sync.ts:277-279`:
+
+   ```ts
+   if (provider === "google-antigravity") {
+     return "agy/" + model;
+   }
+   ```
+
+   `routedDisplayName` is called from `:309` and `:378` with a slug whose model portion already
+   carries the effective alias (`gemini-3.7-flash` -> `gemini-3.7`). Returning early makes the
+   Antigravity branch bypass every later display rule, and the failure above shows the observable
+   result. The function's own doc-comment at `:265-271` states *"All other providers keep the raw slug
+   exactly as before"* — this adds a second provider-specific rule without updating that contract.
+
+3. **[Medium] Decide display-only vs. routing, and say so.** The PR asserts display-only relabeling
+   while also adding a routing alias in `src/router.ts` and a registry `alias` field. Both may be
+   intended, but the catalog test above shows the display half has an unintended consequence.
+
+#### What is correct
+
+The routing half is sound and well tested. `tests/providers/provider-model-aliases.test.ts` (+48)
+covers `agy/` resolution, case-insensitivity (`AGY/`), the canonical name still working, and — the
+best assertion in the change — a user-defined `alias` overriding the built-in. The `src/router.ts`
+fallback to `PROVIDER_REGISTRY` correctly preserves user precedence. Those tests are RED on dev
+(no `alias: "agy"` in the registry).
+
+#### Fix list
+
+1. Reconcile with `codex-catalog.test.ts:2286`. Either update that test **with an explicit rationale**
+   for why `agy/gemini-3.7` is now correct, or restrict the compact prefix so the effective-alias path
+   from #2960 is preserved. Do not silently rewrite a regression test from a closed issue.
+2. Move the Antigravity branch so it composes with the existing display rules instead of returning
+   before them; update the `routedDisplayName` doc-comment at `:265-271`.
+3. Add a regression test pinning Antigravity **with** a `modelAliases` entry, which is the exact case
+   that broke.
+4. Mark ready for review and require full cross-platform CI — the current four-check set cannot
+   surface this class of failure.
+5. Close #3528 in favor of this PR; re-open its `ocx effort` CLI work separately.
+
+#### Dependencies
+
+Supersedes #3528's alias half. `src/codex/catalog/sync.ts` is also touched by #3383 (picker ordering,
+`:636-641`) — if both proceed, land #3531 first, since it is level with the dev tip while #3383 needs
+a 121-commit rebase.
+
+---
+
+## Verification appendix
+
+Commands used (all read-only; network calls escalated):
+
+- `gh pr view/checks/diff`, `gh run list/view`, `gh api .../check-runs`, `.../actions/jobs/<id>/logs`
+- `git fetch origin pull/<n>/head:tmp-pr-<n>` (fetch only; `dev` never checked out)
+- `git merge-base`, `git merge-tree <base> HEAD tmp-pr-<n>`, `git ls-tree`, `git ls-files`, `git log -S`
+- `git archive tmp-pr-<n> | tar -x -C /private/tmp/.../x<n>` then focused `bun test tests/<file>.test.ts`
+
+Focused test runs performed (each with an explicit file argument):
+
+| Target | Result |
+|---|---|
+| #3530 `tests/routing/anthropic-quorum-cache.test.ts` | 6 pass / 0 fail |
+| #3530 `tests/test-layout.test.ts` | 2 pass / 0 fail (prior-head failure fixed) |
+| #3323 `tests/management-route-registry.test.ts` | 13 pass / 0 fail |
+| #3531 `provider-model-aliases` + `codex-catalog` | 276 pass / **1 fail** |
+
+`tests/repo-hygiene.test.ts` was also run against the #3530 export; its 11 failures are artifacts of
+running outside a git working tree (`git ls-files failed: not a git repository`) and are not
+attributable to the PR — the same file passes in CI on the exact head.

--- a/devlog/_plan/260905_open_work_closeout/005_lane_bug_issues.md
+++ b/devlog/_plan/260905_open_work_closeout/005_lane_bug_issues.md
@@ -1,0 +1,243 @@
+# Lane 005 — Open bug issues (read-only adversarial review)
+
+Worktree: `/private/tmp/ocx-closeout.xomWAA/wt`, detached at `origin/dev` **0f27bbeb3** (2026-09-05).
+Repo: `lidge-jun/opencodex`. Scope: READ-ONLY. No `src/`, `tests/`, `gui/` modification; no repository-wide suite run.
+
+SUPERSEDED_BY_PR is used per the lane brief for an issue whose fix is carried by an open PR; it maps to the campaign SUPERSEDED disposition.
+
+## Summary table
+
+| Item | Disposition | One-line reason |
+|---|---|---|
+| #3522 | SUPERSEDED_BY_PR #3525 | Spill health projection absent on dev (`src/responses/state.ts:2108-2152`); #3525 is MERGEABLE with 25/25 CI green on head `288506dc`. |
+| #3506 | DEFER | Upstream-owned no-progress loop; #2628 already ruled the proxy cannot infer workspace progress, and the proposed guard needs a client progress-marker contract that does not exist. |
+| #3467 | SUPERSEDED_BY_PR #3469 | `classifyGoogle` has no location branch (`src/adapters/google-errors.ts:74-76`); #3469 is APPROVED with CI green but CONFLICTING — needs a mechanical rebase. |
+| #3464 | IMPLEMENT | Version skew is warn-only (`src/cli/version-skew.ts`, `src/cli/doctor.ts`); launchd bakes package-local Bun/CLI paths (`src/service.ts:66-73,490-507`) with no stable-launcher parity. |
+| #3462 | SUPERSEDED_BY_PR #3489 (rebase required) | `isBenchmarkDnsAnswer` covers only IPv4 benchmark and explicit-zero-mapped forms (`src/lib/destination-policy.ts:135-145`); #3489 is APPROVED but went CONFLICTING on head `dbcfde8c` during this review. |
+| #3433 | DEFER | Reporter's own evidence attributes the regression to a Hermes plugin change; no dev-side defect isolated, and the remaining ask is a diagnostics feature. |
+| #3425 | IMPLEMENT | `isTerminalShortWindow` requires a future `shortResetAt` (`src/codex/routing.ts:409-422`) and 502 is classified transient (`src/codex/quota-rejection.ts`); neither #3502 nor #3529 touches the Codex pool path. |
+| #3424 | SUPERSEDED (already fixed) | Reporter ran 2.40; the `muse-spark-1.3-contributor` Responses wire default landed in `878f75417`, in v2.41.0 and not v2.40.0 — `src/providers/registry.ts:1627`. |
+| #3406 | SUPERSEDED_BY_PR #3407 | Real dashboard defect, but #3407 is DRAFT, CONFLICTING, and RED on 5 checks; carry or reimplement rather than land. |
+| #3352 | DEFER | Fail-closed entitlement projection working as designed (`src/codex/model-entitlements.ts:370,552-644`; 401 at `src/codex/auth-context.ts:413,444`); admitting unknown is a security-policy change. |
+| #3320 | DEFER | Production XML writes a locale-independent SID (`src/service.ts:1845,1909-1920`); exact UserId matching is a deliberate identity boundary. Needs redacted live XML. |
+| #3245 | DEFER | 426 is intentional (`src/server/index.ts:1144`); failure occurs before the Responses bridge, and no post-426 POST trace was captured. |
+
+---
+
+## #3522 — Windows continuation spill failures behind healthy readiness
+
+**Disposition: SUPERSEDED_BY_PR #3525**
+
+PR facts (head `288506dc6883fa8433cf89014e72d01c1675317d`, base `dev`, author Ingwannu): mergeable MERGEABLE, mergeStateStatus BLOCKED (review gate only), reviewDecision REVIEW_REQUIRED, not a draft. CI on that exact head: **25 checks pass, 0 fail** (2 skipping matrix legs), including gates, all 4 test shards, macos 1/2 and 2/2, and all three keyring and npm-global platforms. Not conflicting with current dev.
+
+**Defect proven on dev.** `responseStateMetrics()` exposes only cumulative counters: `spillWrites` and `spillWriteFailures` (`src/responses/state.ts:2108-2109`, populated at `:2151-2152`). There is no status, no failure streak, no last-error code, and no timestamp. That is exactly the observability gap the reporter hit: 1,988 successes frozen while failures climbed to 11,365, with readiness still healthy and no way to distinguish one failed response from a process that can no longer persist continuations.
+
+**Test evidence.** #3525 carries `tests/responses/responses-state.test.ts` (+124 lines) covering repeated-failure-then-success and Windows ACL exhaustion followed by a healthy runner. Those assertions are RED on dev because the fields they assert do not exist.
+
+**Blockers.** None found. The diff is 8 files, confined to `src/responses/state.ts`, `src/server/management/system-routes.ts`, docs, and tests. The projection stays on the authenticated `GET /api/system/memory` and is deliberately kept off unauthenticated `/healthz`, which is the right call for the security boundary. The error-code union is closed and raw messages, paths, and response ids are excluded, consistent with the privacy rule in AGENTS.md.
+
+**Scoping caveat, and it is the PR author's own.** This lands instrumentation, not a root-cause fix. The 2.39.0 incident has not been reproduced on 2.42/2.43. The issue should stay **open** after #3525 merges, pending an exercised snapshot. Closing #3522 on this merge would be wrong.
+
+**Dependencies.** `src/responses/state.ts` is a high-traffic file; sequence #3525 before any other campaign PR touching response state.
+
+## #3506 — Cursor/Grok 4.6 no-progress loop
+
+**Disposition: DEFER**
+
+No open PR. The issue is already labelled `upstream-tracking`, and that label is correct.
+
+**Why this is not implementable as filed.** The reporter is honest that this recurs after #2600/#2628, where the project already established that OpenCodex cannot safely infer workspace progress from protocol activity. The new evidence strengthens the diagnosis — the model ignored an explicit in-prompt no-progress policy, confirming prompt-level guidance is not enforcement — but it does not change ownership. The proxy sees read-only tool traffic and successful HTTP; nothing in that stream distinguishes productive reading from looping.
+
+The reporter's own suggested contract concedes the blocker: it requires an explicit, privacy-safe progress marker from a capable client. No such marker exists in the wire protocol today, and inventing one is a product decision with a client-side counterpart, not a bug fix. Item 3 of that proposal, allowing the guard to cancel an active Cursor stream, also collides with the existing rule against replaying potentially side-effecting tool calls.
+
+**Concrete defer reason:** requires a product decision plus an upstream/client protocol addition. Recommend keeping it open under `upstream-tracking` for discoverability, which is the fallback the reporter explicitly asked for.
+
+## #3467 — Antigravity location error misclassified as invalid_request
+
+**Disposition: SUPERSEDED_BY_PR #3469 (rebase required)**
+
+PR facts (head `e11089af85f8c1da4e67fe388b768d09078e8dcb`, base `dev`, author agentHits — the same person who filed the issue): reviewDecision **APPROVED**, not a draft, CI **25 checks pass, 0 fail** on that head. But mergeable **CONFLICTING**, mergeStateStatus DIRTY.
+
+**Defect proven on dev.** `classifyGoogle()` funnels any `status === 400`, or any message merely containing the substring invalid, into the invalid-request label (`src/adapters/google-errors.ts:74-76`). There is no location or region branch anywhere in that classifier chain (`:58-78`). A FAILED_PRECONDITION user-location rejection therefore surfaces as `invalid_request_error`, telling the operator their payload is malformed when the real cause is geography or a datacenter IP. The misdiagnosis is the whole harm: it sends people to debug their prompt instead of their egress route.
+
+**Test evidence.** #3469 adds coverage in `tests/google-errors.test.ts` (+23), `tests/error-fidelity.test.ts` (+20, including mixed-case), and `tests/google-vertex-http.test.ts` (+28). The classification assertions are RED on dev since `isLocationUnsupportedMessage` does not exist.
+
+**Conflict assessment.** Files touched: `src/lib/errors.ts`, `src/adapters/google-errors.ts`, `src/adapters/google-http.ts`, plus 3 test files. Total diff is small (+115/-3). The conflict is **mechanical**, not semantic: these are additive pattern-list and branch insertions into files that moved underneath the branch. No behavioral redesign is implied by a rebase.
+
+**Blocker to check on the rebased head.** The PR logs an actionable diagnostic warning to console in `normalizeFinalGoogleError()` (`src/adapters/google-http.ts`, +16). Confirm that warning emits no request body, URL, or account identifier — privacy:scan must stay green and AGENTS.md forbids logging request bodies or account identifiers. The described text (advising a check of TUN, proxy, or IPv6 routing) appears safe, but verify on the rebased head.
+
+**Fix list for LAND_WITH_FIX:** (1) rebase onto current dev, (2) re-run exact-head CI, (3) confirm the new console warning is privacy-clean and not spammy for a looping client.
+
+## #3464 — mise upgrade leaves launchd proxy on an old version
+
+**Disposition: IMPLEMENT**
+
+No open PR addresses this. Reporter garysassano; this is the macOS counterpart to the resolved Linux/mise issue #2898.
+
+**Defect proven on dev, two distinct halves.**
+
+*Half 1: detection is warn-only.* Version skew is computed in `src/cli/version-skew.ts` and produces a warning string (this ocx on PATH is stale). `src/cli/doctor.ts` merely reports it. Nothing in the request path refuses to route, and nothing repairs the service. So a user whose CLI is 2.42.0 and whose proxy is 2.10.1-preview keeps silently routing through the stale binary — which is exactly how the reporter's Copilot requests kept sending the private metadata field that the installed adapter would have stripped.
+
+*Half 2: the launchd plist bakes package-local paths.* `cliEntry()` resolves both the Bun runtime and the CLI entry from `import.meta.dir` (`src/service.ts:66-73`), and `buildServiceShellCommand()` bakes those absolute paths into the plist as an exec of that bun and cli (`:490-507`, `:556-558`). The comment at `:83` already acknowledges the failure mode: when a version manager deletes the old package, the unit's exec of the old bun and old cli cannot resolve. The reporter's variant is worse in one way — it did resolve, because mise kept the old package tree around, so the stale proxy kept serving. The systemd side gained a stable launcher for exactly this mise/asdf case; launchd did not.
+
+**Test evidence.** Nothing exists on dev; a PR would need to carry its own. Minimal regression: a `tests/service*.test.ts` case asserting the generated launchd plist references a stable launcher path that survives a package-directory swap, plus a version-skew test asserting the mismatch is surfaced as an actionable repair affordance rather than a passive warning.
+
+**Fix sketch.** (1) Give launchd the same stable-launcher indirection the systemd unit already uses, so the plist points at a path that survives an out-of-band package upgrade. (2) On detected skew, either auto-repair the service or fail closed with an actionable error naming `opencodex service restart` — the reporter confirmed that single command fully repaired the state. Prefer the actionable-error route by default: auto-restarting a service mid-request is a larger behavioral change than this issue authorizes.
+
+**Dependencies.** Touches `src/service.ts`, which is also implicated by #3320. Stack #3464 and any #3320 work rather than running them in parallel.
+
+## #3462 — Discovery blocked under Clash/Mihomo IPv6 fake-IP
+
+**Disposition: SUPERSEDED_BY_PR #3489**
+
+PR facts, re-read immediately before verdict (head `dbcfde8ca445c8dd04b04932904798664aae9cab`, base `dev`, author Flowershangfromthebranches): reviewDecision **APPROVED**, not a draft, CI green on the last completed run (24 pass, 0 fail, including CodeRabbit; only a skipping Windows matrix leg is non-pass). But mergeable **CONFLICTING**, mergeStateStatus **DIRTY**.
+
+**Drift warning.** An earlier read during this same review showed this PR as MERGEABLE/BLOCKED on a different head. It moved to `dbcfde8c` and went CONFLICTING while the review was in progress, and the green CI above belongs to the earlier run rather than to the current head. Re-run exact-head CI after the rebase; do not rely on the recorded pass counts.
+
+**Actual diff surface (re-read).** The change does not live in `src/lib/destination-policy.ts` at all: it touches `src/lib/provider-outbound.ts` (+54/-1, the `isCanonicalUrl` seam), `src/providers/model-discovery.ts` (+76), `src/codex/catalog/provider-fetch.ts` (+11/-2), and `src/server/management/provider-routes.ts` (+7/-2), plus `tests/command-code-fakeip-discovery.test.ts` (+378, new) and `tests/provider-model-discovery-contract.test.ts` (+60). So it admits a proven canonical destination upstream of the policy check rather than widening the policy predicate itself.
+
+**Defect proven on dev.** `isBenchmarkDnsAnswer()` (`src/lib/destination-policy.ts:135-145`) admits only (a) answers already carrying the benchmark-address detail, that is IPv4 198.18/15, canonical mapped, and NAT64 forms, and (b) the explicit-zero-mapped IPv6 spelling whose embedded quad is itself a benchmark address. A Mihomo IPv6 fake-IP answer in `fdfe:dcba:9876::/48` matches neither: it classifies as a non-global address, fails the `EXPLICIT_ZERO_MAPPED_PREFIX` check at `:141`, and is rejected. Called from `:344` and `:443`. The reporter's error text matches this path exactly.
+
+**Why #3489 supersedes rather than merely overlaps.** #3489 addresses the same admission gate (`resolvePublicAddresses` rejecting fake-IP DNS before the TUN layer can intercept) and does so with a **better security posture** than #3462's proposed patch. The issue proposes hardcoding a `startsWith("fdfe:dcba:9876:")` test — a community-convention prefix with no RFC standing, admitted purely on string shape. #3489 instead proves the final request URL against the registry's own canonical discovery URL (`isRegistryModelDiscoveryUrl`), with exact origin, path, and query matching and an `isCanonicalUrl` seam that defaults closed. That is a narrower grant: it admits a specific proven destination rather than widening the private-address allowlist for every caller.
+
+**Residual gap — must be verified before closing #3462.** #3489's writeup is framed around IPv4 fake-IP (198.18.0.0/15) and the no-proxy-env daemon case. #3462 is IPv6 (`fdfe:dcba:9876::7e`) **with** a proxy configured. The canonical-URL proof should admit the IPv6 case too, since it keys on the URL rather than the address family, but that is an inference from the design and not something I confirmed by executing the IPv6 path. **Do not auto-close #3462 on #3489's merge.** Ask the reporter to re-verify on a build carrying #3489, or add an explicit IPv6-fake-IP regression case to `tests/command-code-fakeip-discovery.test.ts`.
+
+**Blockers.** None in #3489 itself; its security-boundary section enumerates the rejections it preserves (literal benchmark IPs, RFC1918, metadata endpoints, NO_PROXY hosts, caller-modified query). Note its self-reported baseline: management-provider-validation shows 19 failures identically on unmodified dev on that host, environmental and unrelated.
+
+**Dependencies.** `src/lib/destination-policy.ts` is security-boundary code per AGENTS.md and requires explicit security review.
+
+## #3433 — Intermittent zero cache hits for Hermes
+
+**Disposition: DEFER**
+
+No open PR. Reported against 2.41.0 by Vivamisu, using a third-party Hermes Agent client.
+
+**No dev-side defect isolated.** Inbound `prompt_cache_key` forwarding demonstrably exists and is deliberate: preserved on the chat inbound path (`src/chat/inbound.ts:316`), parsed into options (`src/responses/parser.ts:827`), and forwarded to `/chat/completions` behind an explicit per-provider opt-in (`src/adapters/openai-chat.ts:156-157`, flag documented at `src/types/provider.ts:592` and `src/providers/registry.ts:303`). That opt-in is a likely partial explanation — a provider row without `promptCacheKey` set will not forward the key — but the reporter has not said which provider row they used, so it cannot be confirmed.
+
+**The reporter's own evidence points away from the proxy.** Their before/after table brackets a Hermes update (90.7% cache-read rate down to 26.0%, 0 up to 26 zero-cache requests), and they document a Hermes plugin that failed to load because it passed an unsupported `supports_codex_affinity_headers` constructor field. Cache identity that alternates between a large prefix, a small fixed prefix, and zero, then recovers to 393,728 cached tokens without any endpoint change, is the signature of a client varying its own prompt prefix rather than a proxy dropping a header.
+
+**What the issue actually asks for.** Five of its questions are documentation requests, and the sixth (question 5) is a feature request: expose redacted presence/absence diagnostics for cache key, affinity identifiers, and resolved routing cohort. That is reasonable and would settle the question empirically, but it is new observability work, not a bug fix, and it must respect the AGENTS.md privacy rule (presence/absence booleans only, never values).
+
+**Concrete defer reason:** needs reporter evidence — specifically the provider row in use and whether `promptCacheKey` forwarding is enabled on it, plus an A/B against an unchanged Hermes build. Answer their protocol questions in-thread; split the diagnostics ask into a separate feature issue.
+
+## #3425 — Routing continues to a 5h-exhausted Codex account after repeated 502s
+
+**Disposition: IMPLEMENT**
+
+**Neither suggested PR addresses this.** I checked both. #3502 (Ingwannu) is generic and Anthropic OAuth pool plus Kiro continuation credentials and docs — it touches `src/oauth/anthropic-routing.ts` and `src/oauth/generic-account-failover.ts`, not the Codex pool. #3529 (yansigit, DRAFT) is API-key failover persistence in `src/providers/key-failover.ts`. The Codex ChatGPT account pool (`src/codex/routing.ts`) is a different code path from both, so #3425 remains unowned.
+
+**Defect proven on dev, two reinforcing mechanisms.**
+
+*Mechanism 1: a 100% window only excludes an account when a future reset timestamp is present.* `isTerminalShortWindow()` (`src/codex/routing.ts:409-422`) returns false unless `shortResetAt` is a finite positive number and resolves to a moment still in the future (`:418-421`). A snapshot carrying `shortPercent: 100` with a missing or already-elapsed `shortResetAt` scores `CODEX_UNKNOWN_USAGE_SCORE` instead of `CODEX_EXHAUSTED_USAGE_PERCENT` (`:387`), so the exhausted account stays selectable. The doc comment at `:395-407` shows this is a deliberate trade — a wrongly-selected account fails one request. The reporter's data is what that trade looks like when it goes wrong: **118 consecutive HTTP 502s over 23 minutes**, not one failed request.
+
+*Mechanism 2: 502 is classified transient, so it never demotes the account.* `src/codex/quota-rejection.ts` lists 502 among `TRANSIENT_SERVER_STATUSES`, yielding a transient-server-error kind. A quota exhaustion wrapped in a 502 without a canonical message body therefore produces no quota signal at all — consistent with the reporter's log showing `sendCount: 1` and an empty `recoveryKinds` on every attempt. Nothing feeds back into selection, so the next request picks the same account again.
+
+Together: the fresh quota snapshot says 100% but cannot exclude (missing or stale `shortResetAt`), and the 502s say nothing. Account B at 3% is never reached until a human pauses A.
+
+**Test evidence.** None on dev. The reporter supplied a good regression spec; the minimal test is account A with `shortPercent: 100` and an absent `shortResetAt`, account B healthy, threshold 80, multiple admissions, asserting that new admissions select B. A second case should assert that a bare 502 with no persisted canonical message does not override a fresh snapshot already marking A at 100%. Both are RED on dev.
+
+**Fix sketch.** Let a fresh, recently-observed `shortPercent >= 100` reading exclude an account even without a future `shortResetAt`, gated on snapshot freshness rather than on reset presence. This preserves the `:395-407` intent (do not exclude on a stale reading) while closing the missing-timestamp hole. Additionally, clear or re-evaluate sticky affinity after a bounded run of consecutive failures on one account, so a 502 storm cannot pin the pool. Keep post-200 streamAborted terminal as today.
+
+**Blockers and risks.** This is account-pool and quota logic, adjacent to the security boundary. The opposite-direction regression (#3029 pointed the other way) is real: over-eager exclusion strands a recovered account. Freshness-gating is what keeps both directions safe; any patch must carry tests for both.
+
+**Dependencies.** Touches `src/codex/routing.ts` and `src/codex/quota.ts`. Independent of #3502 and #3529 — no file overlap — so it can proceed in parallel.
+
+## #3424 — opencode-go muse-spark-1.3-contributor unusable
+
+**Disposition: SUPERSEDED (already fixed on dev; needs reporter re-verify)**
+
+No PR needed. Reporter mszero, on version 2.40, Claude Code surface, HTTP 500 from upstream.
+
+**Evidence it is already fixed.** The reporter's log shows the request routed with adapter `openai-chat`, the provider-wide default, and got a provider 500. On current dev, `muse-spark-1.3-contributor` is declared `openai-responses` in `modelWireDefaults` for the `opencode-go` row (`src/providers/registry.ts:1627`). The decision-log comment immediately above (`:1616-1624`) states the exact problem: the provider is mixed-wire, but its provider-wide `openai-chat` adapter was sending these models to `/chat/completions`; the fix routes the named models to `/responses`.
+
+**Version boundary confirmed by git.** The declaration landed in `878f75417` (feat(models): add Muse Spark 1.3 on the 1.2 spec, #3317, 2026-09-03). `git merge-base --is-ancestor` confirms it **is** in v2.41.0 and **is not** in v2.40.0. The reporter ran 2.40, precisely the last release without the fix. That also explains their observation that the model works in other software (which sends it to /responses) but not through OpenCodex.
+
+**Caveat, stated plainly.** The upstream error was a 500, not a 400, so a wrong-endpoint diagnosis is strong but not airtight — a gateway-side outage could produce the same code. The issue also carries `needs-info` and the report is thin (no config, minimal repro). Recommend replying with the version boundary and asking for re-verification on 2.41.0 or later before closing. Do not close silently.
+
+## #3406 — Codex disable dialog and state are misleading
+
+**Disposition: SUPERSEDED_BY_PR #3407 — but the PR is not landable as-is**
+
+PR facts (head `38d45300a644dd0aa641a0a9b76f293169ab8ef9`, base `dev`, author turin-dev — the same person who filed the issue): isDraft **true**, mergeable **CONFLICTING**, mergeStateStatus DIRTY, reviewDecision REVIEW_REQUIRED. CI on that head is **RED**: ci, gates, macos, test 1/4, and test 2/4 all fail. The four review-readiness boxes are unticked, so the gate correctly holds it in draft.
+
+**Defect is real and proven on dev.** The issue describes three concrete faults: the Codex toggle reuses the Grok Build consequence copy, the status API reports the OpenCodex config path instead of the effective `$CODEX_HOME/config.toml`, and the card retains pre-toggle state until reload. The PR's file list corroborates where these live — `gui/src/pages/integrations/IntegrationsOverview.tsx`, `gui/src/pages/integrations/overview-clients.ts`, and `src/server/management/native-integration-routes.ts` (+4/-1, the config-path field).
+
+**Test evidence.** The PR carries `gui/tests/integrations-overview-rows.test.ts` (+61), `gui/tests/integrations-surfaces.test.tsx` (+74), and `tests/native-codex-toggle.test.ts` (+16), the last asserting the effective Codex config path, which would be RED on dev.
+
+**Blockers.**
+
+1. **RED CI on the exact head** across 5 checks, including two test shards. Whatever the author's local run showed, the repository's own gate disagrees. This alone blocks landing.
+2. **CONFLICTING** against dev. The diff spans 9 i18n locale files plus GUI components; i18n files are high-churn, so expect real conflicts. Mostly mechanical, but the `overview-clients.ts` changes (+54/-13, desired-vs-observed state separation) are **semantic** and need re-reasoning after rebase.
+3. **Screenshot hosted off-repo.** The PR embeds the required GUI screenshot from a fork-owned raw.githubusercontent.com URL. It satisfies enforce-target today but will rot if the fork disappears. The PR also adds `docs/pr-assets/3407-codex-disable-dialog.png` to the repo; confirm that binary belongs in the tree.
+4. **Draft checklist unticked** — the author has not attested readiness.
+
+**Fix list (LAND_WITH_FIX / REIMPLEMENT).** (1) Rebase onto current dev, resolving the 9 i18n files and re-reasoning `overview-clients.ts`. (2) Get CI green on the exact rebased head — diagnose the 5 failing checks first, since they may be pre-existing on that stale base rather than caused by the change. (3) Decide the docs/pr-assets binary question. (4) Have the author tick the readiness checklist, or carry the work with a `Co-authored-by: turin-dev` trailer per AGENTS.md if a maintainer reimplements it.
+
+**Dependencies.** GUI integrations surface — stack after any other campaign PR touching `gui/src/pages/integrations/` or the i18n locale files.
+
+## #3352 — Plus account entitled to GPT-5.6 gets 401 through the proxy
+
+**Disposition: DEFER** (re-verified independently against dev; prior research reached the same call)
+
+No open PR. Reported on 2.40.0 by ZhenyuXiao, with a clean A/B matrix (native succeeds, proxied 401s).
+
+**Re-verification against current dev.** The 401 originates at `src/codex/auth-context.ts:413` and `:444`, a CodexPoolAuthenticationError carrying the selected-account-does-not-support-this-model text. The entitlement projection is a three-state machine, granted / denied / unknown (`src/codex/model-entitlements.ts:370`). Every failure path — timeout, unparseable body, parsed-but-empty rows — routes to `unconfirmedAccountModels()` (`:552`, called at `:592`, `:603`, `:607`, `:618`, `:644`) on a short failure TTL, and the comment at `:965` states the policy explicitly: fail closed for unconfirmed accounts. The comment at `:206` adds that admitting these would turn an honest unknown into a cached denied.
+
+So the reported behavior is the designed behavior. The account is genuinely entitled, the roster fetch is not confirming it, and the fail-closed rule converts non-confirmation into a 401.
+
+**Why this is not a safe IMPLEMENT.** The obvious fix — let unknown through — is a security-policy change, not a bug fix: it would admit requests for accounts whose entitlement the proxy could not verify. That needs a maintainer decision, and per AGENTS.md this is auth-boundary code requiring explicit security review.
+
+**What would unblock it.** The real question is why the roster fetch returns nothing for this account. A corroborating signal sits in the reporter's own data: `/api/codex-auth/accounts` returns `plan: null` for a Plus account. If the roster call is failing or returning empty for a class of accounts, that is a fixable defect with a different shape than loosening the gate. Needs the redacted roster-fetch outcome — which of the five unconfirmed branches fired — from an affected account on a current build.
+
+**Concrete defer reason:** needs reporter evidence (which unconfirmed branch fires) plus a product and security decision on fail-closed semantics.
+
+## #3320 — Windows misclassifies a valid scheduler task for non-ASCII account names
+
+**Disposition: DEFER** (re-verified independently)
+
+No open PR. Reported on 2.40.0 by chowyuan1314; already carries `needs-info`.
+
+**Re-verification against current dev.** The report contains two separable claims.
+
+*Claim A — schtasks /create Access is denied from a non-elevated shell.* This is expected Windows behavior for task registration, not a non-ASCII defect. The reporter confirms elevated registration succeeded.
+
+*Claim B — a valid task is still reported expired or missing reboot protection.* The non-ASCII hypothesis is that the UserId comparison breaks on the account name. Current dev writes a locale-independent SID, not a name: `sessionTriggerUserId = cachedCurrentWindowsIdentity()?.sid` (`src/service.ts:1845`), and the resolver returns `identity.sid` (`:1920`), with the name available but separate (`:1909`). A SID contains no non-ASCII characters, so the stated mechanism does not hold against production-registered XML.
+
+Exact matching is also a deliberate identity boundary. The comment above `windowsTaskTriggerScopeAcceptable()` (`src/service.ts:2110-2125`) states that treating an unknown expected identity as a wildcard would let a fresh status process accept a task bound to another user's session and suppress the repair that should replace it; a prefixed UserId tag is rejected outright rather than guessed. Folding two non-ASCII identities together would be exactly the adoption bug that code prevents.
+
+**Residual possibility worth naming.** The report may still be real via a path other than the one proposed: a task registered by an older, name-based version, or schtasks output decoding — the reporter explicitly raises decoding, and console-codepage mangling of schtasks stdout on a non-ASCII system is plausible and would not be fixed by SID-based writes.
+
+**Concrete defer reason:** needs the redacted live task XML (UserId element only) plus the raw `schtasks /query /xml` bytes from the affected machine. Without knowing whether the installed task is SID-scoped or legacy name-scoped, any patch is a guess at an identity boundary.
+
+**Dependencies.** `src/service.ts` overlaps #3464. Stack, do not parallelize.
+
+## #3245 — macOS Codex 0.152.0 streams disconnect through ocx 2.39.0
+
+**Disposition: DEFER** (re-verified independently)
+
+No open PR. Already carries `upstream-tracking` and `needs-info`.
+
+**Re-verification against current dev.** The 426 the reporter sees first is intentional and correct: a 426 upgrade_required response stating the Responses WebSocket transport is disabled and HTTP should be used (`src/server/index.ts:1144`), with the comment at `:1140` explaining that codex-rs maps a connect-time UPGRADE_REQUIRED to a clean HTTP fallback. That is #324's documented behavior, and the reporter correctly identifies it as expected.
+
+The reporter's own controls are what make this a defer rather than an implement. They proved: a direct local `POST /v1/responses` with streaming completed with response.completed and [DONE]; a direct `POST /v1/chat/completions` completed; all three providers connected; the upstream HTTP proxy is reachable. So the Responses bridge and SSE delivery both work under direct load. The failure is specific to the full request shape Codex CLI emits, and per the prior lane's reading no subsequent POST was observed after the 426, which places the break before the Responses bridge rather than inside it.
+
+**What would unblock it.** A debug classification of whether the close occurs before or after upstream response.created — which the reporter proposes themselves and is the right ask. Concretely: a captured request-log entry for the failing `codex exec` on a current build (2.43.0 or later), showing whether the POST reached the proxy at all. Version drift matters here: the report is against 2.39.0 with Codex CLI 0.152.0, both several releases stale.
+
+**Concrete defer reason:** needs reporter evidence (post-426 POST trace on a current build). The configuration is also unusual — an upstream HTTP proxy at 127.0.0.1:1082 plus native Codex integration — and no maintainer reproduction exists.
+
+---
+
+## Cross-item dependency map
+
+| File / surface | Items | Stack order |
+|---|---|---|
+| `src/service.ts` | #3464 (implement), #3320 (deferred) | #3464 first; revisit #3320 only with new evidence |
+| `src/lib/destination-policy.ts` | #3462 via PR #3489 | Security-boundary review required |
+| `src/responses/state.ts` | #3522 via PR #3525 | Land before other response-state work |
+| `src/codex/routing.ts`, `src/codex/quota.ts` | #3425 (implement) | Independent of #3502/#3529 |
+| `src/adapters/google-*.ts`, `src/lib/errors.ts` | #3467 via PR #3469 | Rebase first |
+| `gui/src/pages/integrations/`, i18n locales | #3406 via PR #3407 | Blocked on green CI plus rebase |
+
+## Method note
+
+Issue and PR metadata read via `gh` on 2026-09-05 against `lidge-jun/opencodex`. CI states are from `gh pr checks` on the exact head SHAs recorded above and will drift as branches move; re-read immediately before any merge decision. All file:line citations were read in the pinned worktree at `0f27bbeb3`. No files under `src/`, `tests/`, or `gui/` were modified, and no repository-wide suite was executed.

--- a/devlog/_plan/260905_open_work_closeout/006_dispositions.md
+++ b/devlog/_plan/260905_open_work_closeout/006_dispositions.md
@@ -1,0 +1,98 @@
+# 006 — Consolidated dispositions
+
+Source: lane docs 001-005 (claude-opus-5, read-only, each re-read the index before verdict).
+Base at research: `0f27bbeb3`; `origin/dev` advanced to `6580694c7` during research (one
+commit touching two test files no candidate uses — re-checked by each plan writer).
+
+## Family 1 — bug-labelled PRs (14)
+
+| PR | Disposition | WP | Reason (evidence in lane doc) |
+|----|-------------|----|-------------------------------|
+| #3515 | LAND_AS_IS | wp1 | Green, approved; paired 499/502 regressions (001) |
+| #3529 | LAND_AS_IS | wp1 | 3 tests RED on dev → GREEN; draft checklist is the only gate (001) |
+| #3525 | LAND_AS_IS | wp1 | 6 tests RED → GREEN; exact-head CI green (001) |
+| #3490 | LAND_AS_IS | wp1 | TOML table-header comment misparse reproduced RED, fixed GREEN (001) |
+| #3484 | LAND_AS_IS | wp1 | Defect at `integration-routes.ts:379`; MERGEABLE, green (002) |
+| #3480 | LAND_AS_IS | wp1 | Author rebased mid-review; only stale CHANGES_REQUESTED remains (002) |
+| #3502 | LAND_WITH_FIX | wp2 | Three src defects live on dev; CONFLICTING; docs prose contradicts #3520 (001) |
+| #3519 | LAND_WITH_FIX | wp2 | Reviewer blockers fixed on new head; docs-site sync missing (001) |
+| #3489 | LAND_WITH_FIX | wp2 | Approved, green; conflict is `tests/providers/` rename + one comment line (002) |
+| #3469 | LAND_WITH_FIX | wp2 | Approved, green; conflict is two test renames (002) |
+| #3524 | REIMPLEMENT | wp2 | Unguarded startup `throw` reproduced; red hygiene; OAuth security surface (001) |
+| #3407 | REIMPLEMENT | wp2 | Real config-path defect; 5 failing jobs, 121 behind, 166 KB PNG tracked (002) |
+| #3348 | REIMPLEMENT | wp2 | 410/413 now fine; bundles disk persistence + undisclosed policy-fallback 503; split in three (002) |
+| #3388 | DEFER | — | Draft, 132 behind, shards never ran; 327 lines on protected `responses/core.ts` with no review (002) |
+
+## Family 2 — V2 passthrough (1)
+
+| PR | Disposition | WP | Reason |
+|----|-------------|----|--------|
+| #3444 | LAND_WITH_FIX | wp3 | Regression proven RED on dev; hygiene fail is `unsponsored_surface` on `auth-cors.ts` (one policy row), not a defect (003) |
+
+## Family 3 — usage/quota (4)
+
+| PR | Disposition | WP | Reason |
+|----|-------------|----|--------|
+| #3447 | LAND_WITH_FIX | wp4 | Merges clean under rename detection; fix unpinned bearer in `fetchAntigravityQuota` + regression; CodeRabbit "Critical" is a false positive (003) |
+| #2783 | LAND_WITH_FIX | wp4 | Three maintainer blockers still present, each localized; six bounded fixes; rebase after #3447 (003) |
+| #2973 | LAND_WITH_FIX | wp4 | No substantive defect outstanding; four mechanical conflicts (003) |
+| #2956 | DEFER | — | 474 behind, zero human review, two semantic conflicts (003) |
+
+## Family 4 — else: PRs (11)
+
+| PR | Disposition | WP | Reason |
+|----|-------------|----|--------|
+| #3323 | LAND_AS_IS | wp1 | Removes repo-root temp write; green (004) |
+| #3530 | LAND_WITH_FIX | wp5 | `test 1/4` failure was real on the previous head and is fixed; removal test exercises the wrong seam (004) |
+| #3329 | LAND_WITH_FIX | wp5 | Drops quota reset metadata for 5xx-wrapped failures (004) |
+| #3421 | LAND_WITH_FIX | wp5 | Container excludes compat manifest; Compose binds 0.0.0.0 (004) |
+| #2432 | LAND_WITH_FIX | wp5 | Real undocumented sentinel; stale + doc-comment naming unexported symbol (004) |
+| #3531 | LAND_WITH_FIX | wp5 | Compact subset of #3528; breaks #2960 regression (label bypasses alias display) (004) |
+| #3487 | REIMPLEMENT | wp5 | Correct one-line fix at a path the reorg moved (004) |
+| #3528 | SUPERSEDED | — | Alias half byte-identical to #3531; `ocx effort` half is separate scope (004) |
+| #3508 | DEFER | — | `logs-filter.ts` never imported by `Logs.tsx`; unreachable duplicate (004) |
+| #3383 | DEFER | — | 121 behind, 15 conflicting files incl. composition root, no CI (004) |
+| #2716 | DEFER | — | 118 behind, 12 conflicting files, no exact-head CI (004) |
+
+## Family 4 — else: bug issues (12)
+
+| Issue | Disposition | WP | Reason |
+|-------|-------------|----|--------|
+| #3522 | SUPERSEDED_BY_PR #3525 | wp1 | Instrumentation only; issue stays open after merge (005) |
+| #3467 | SUPERSEDED_BY_PR #3469 | wp2 | Close with landing SHA (005) |
+| #3462 | SUPERSEDED_BY_PR #3489 | wp2 | Do not auto-close; IPv6 path not executed (005) |
+| #3406 | SUPERSEDED_BY_PR #3407 | wp2 | Reimplemented in wp2; close with landing SHA (005) |
+| #3424 | SUPERSEDED (fixed) | wp6 | Fixed in `878f75417` (v2.41.0); close with that SHA (005) |
+| #3464 | IMPLEMENT | wp5 | launchd bakes package-local paths (`service.ts:66-73,490-507`); skew is warn-only (005) |
+| #3425 | IMPLEMENT | wp5 | `isTerminalShortWindow` needs future `shortResetAt` (`routing.ts:409-422`); 502 transient; unowned (005) |
+| #3506 | DEFER | — | Needs a client progress-marker contract; #2628 settled ownership (005) |
+| #3433 | DEFER | — | Reporter data brackets a Hermes plugin change; remaining ask is diagnostics (005) |
+| #3352 | DEFER | — | Fail-closed entitlement by design; security-policy change (005) |
+| #3320 | DEFER | — | Production XML writes SID; needs live XML (005) |
+| #3245 | DEFER | — | 426 intentional; break precedes the Responses bridge (005) |
+
+## Counts
+
+LAND_AS_IS 7 · LAND_WITH_FIX 13 · REIMPLEMENT 5 · IMPLEMENT 2 · SUPERSEDED 6 · DEFER 10.
+
+
+## Drift corrections from plan writers (origin/dev = `79e03643d` at plan time)
+
+- `79e03643d` (#3518) migrated `server`/`storage`/`ci-workflows` test domains: #3515, #3529,
+  #3525, #3484, #3323 flipped to CONFLICTING on relocated test files only (mechanical). wp1 is a
+  rebase-then-merge train, not a pure merge train (010 §2).
+- #3490 needs a `tests/layout.json` entry + test placed under `tests/codex-integration/`
+  or `tests/test-layout.test.ts` goes red (010).
+- #3530 merged as `6580694c7` with its removal-test gap unfixed → maintainer follow-up E0 in wp5 (050).
+- #3531's head moved; the #2960 label regression is already fixed by the author; carry as E4 (050).
+- #3528 dropped its alias half; SUPERSEDED reasoning must cite scope split, not byte identity (050).
+- #3329 moved out of wp5: hand re-resolution of `src/server/responses/core.ts` and unresolved
+  commit authorship (`" " <wj@nas-backup>`). Recorded as LAND_WITH_FIX pending a dedicated
+  layer appended after wp5 (E7) if authorship can be resolved via the PR author login; else DEFER.
+- #3489 commit email is `<opencodex-fix@local>`; trailer must use the GitHub noreply form.
+- #3502 splits into B1 (OAuth policy, needs `maintainer-sponsored`) + B2 (Kiro continuation) (020).
+- #3444: label path is insufficient (42 behind > READINESS_LATEST_DEV_BEHIND_MAX 10); maintainer
+  carry branch chosen (030).
+- Sandbox-red verifiers (EADDRINUSE on `Bun.serve({port:0})`, missing `gui/node_modules`) are
+  hosted-CI-only and must not be read as regressions (020, 040).
+

--- a/devlog/_plan/260905_open_work_closeout/007_audit_wp0.md
+++ b/devlog/_plan/260905_open_work_closeout/007_audit_wp0.md
@@ -1,0 +1,509 @@
+# 007 — wp0 adversarial plan audit (A-phase, READ-ONLY)
+
+Role: A-phase adversarial plan auditor. Skills loaded: `cxc-dev-code-reviewer`
+(REVIEW-POSTURE-01, REVIEW-FALSIFY-01, REVIEW-COVERAGE-01, REVIEW-OUTPUT-01,
+REVIEW-WORKTREE-01) and `cxc-search` (no external/current claim required a web tier;
+all evidence is repository- and `gh`-local, which is Tier-2-equivalent primary source).
+
+## Anchors (REVIEW-WORKTREE-01)
+
+| Anchor | Value |
+|---|---|
+| `pwd -P` | `/private/tmp/ocx-closeout.xomWAA/wt` |
+| Worktree `HEAD` | `0f27bbeb3ce6a92077652695e161d49b88eedc7a` (detached, unchanged; no checkout performed) |
+| `origin/dev` at audit start | `79e03643d7cfa2b6c3c4eb8afd6179a140b197a3` |
+| `origin/dev` at pre-verdict re-read | `79e03643d7cfa2b6c3c4eb8afd6179a140b197a3` (unchanged) |
+| Index at pre-verdict re-read | nothing staged; only `?? devlog/_plan/260905_open_work_closeout/` untracked |
+| Audit target | `000`, `006`, `010`, `020`, `030`, `040`, `050`, `060` (all read in full); `001`-`005` as supporting evidence |
+
+`git merge-base --is-ancestor HEAD origin/dev` -> exit 0. The worktree is **3 commits behind**
+`origin/dev` (`6580694c7`, `bdafc5191`, `79e03643d`). `git checkout` is denied in this
+sandbox (`index.lock: Operation not permitted`), so verifier runs below executed at
+`0f27bbeb3` and every `origin/dev` claim was checked through `git show origin/dev:<path>`,
+which reads the real tip tree. This is stated because it bounds what the local runs prove.
+
+## Coverage ledger (REVIEW-COVERAGE-01)
+
+| Doc | Status |
+|---|---|
+| `000_plan.md` | reviewed (full) |
+| `006_dispositions.md` | reviewed (full) |
+| `010_wp1_stack_a_land_as_is.md` | reviewed (full, 1112 lines) |
+| `020_wp2_stack_b_bug_carry.md` | reviewed (full, 1148 lines) |
+| `030_wp3_stack_c_v2_passthrough.md` | reviewed (full, 656 lines) |
+| `040_wp4_stack_d_usage_quota.md` | reviewed (full, 925 lines) |
+| `050_wp5_stack_e_else.md` | reviewed (full, 1036 lines) |
+| `060_ledger.md` | reviewed (full, 18 lines) |
+| `001`-`005` lane docs | reviewed as supporting evidence, sampled for the claims cited below |
+
+---
+
+## What the audit confirmed (so the blockers are read in proportion)
+
+This is a strong unit. Confirmed by execution, not by reading:
+
+- **Every verifier command I sampled exists and reproduces the documented count exactly.**
+  17 focused runs, zero discrepancies: `key-failover` 12, `google-adapter` 32,
+  `test-layout` 2, `management-route-registry` 13, `management-integration-journal-delete` 12,
+  `error-fidelity` 7, `google-errors` 10, `provider-model-discovery-contract` 36,
+  `oauth-provider-reconcile` 9, `always-on-429-failover` 8, `native-codex-toggle` 6,
+  `claude-cli` 34, `agent-task-recovery` 19, the `030` V2 triple 40,
+  `pr-sponsored-surface.test.cjs` 7, `provider-quota` 110, `provider-account-quota` 17,
+  `core-lab-boundary` 17, `kiro-stream` 113, `codex-catalog` 268,
+  `provider-model-aliases` 7, `codex-routing` 168, `service` 193.
+- **Every disposition defect I sampled is live on current `origin/dev`** (details in §4 below).
+- **The security-gate reasoning is correct.** `RESTRICTED_PREFIXES` = `.github/workflows/`,
+  `src/oauth/`; `RESTRICTED_FILES` includes `src/server/auth-cors.ts`
+  ([pr-sponsored-surface.cjs:24-53](../../../.github/scripts/pr-sponsored-surface.cjs)).
+  `READINESS_LATEST_DEV_BEHIND_MAX = 10` at
+  [pr-quality-state.cjs:26](../../../.github/scripts/pr-quality-state.cjs). Both are cited
+  accurately, including `030`'s central argument that the `auth-cors.ts` row is
+  compiler-forced by `satisfies Record<keyof OcxProviderConfig, ...>` at
+  [auth-cors.ts:870](../../../src/server/auth-cors.ts) — I confirmed line 870 is exactly that
+  `satisfies` clause, so the gate genuinely cannot be engineered around.
+- **Every carry author login resolves to a real GitHub account** (11/11 checked via
+  `gh api users/<login>`), so no trailer is unresolvable in principle.
+- **DIFFLEVEL-ROADMAP-01 / LEXICO-SPLIT-01 pass.** Six work-phases, six decade docs
+  (`010`-`060`), numbered filenames only, no unnumbered strays.
+
+---
+
+## Numbered blockers
+
+### 1. [High] The stack-shape claims in `010` are contradicted by `git merge-tree`: nine "must rebase" items merge CLEAN
+
+**Location:** [010_wp1_stack_a_land_as_is.md:27-78](./010_wp1_stack_a_land_as_is.md) (§0.1-0.2),
+restated at [010:1096-1112](./010_wp1_stack_a_land_as_is.md) (§10) and
+[006_dispositions.md:81-83](./006_dispositions.md).
+
+**Trigger:** `010` §0.1 asserts `79e03643d` "flipped five of seven items to CONFLICTING",
+concludes "Stack A as specified can no longer execute end-to-end today", and reduces the
+expected outcome to **2/7 merged**. That conclusion is derived from `gh`'s `mergeable` field.
+
+**Evidence (I ran this):** `git merge-tree --write-tree origin/dev refs/tmp/pr<n>` against
+the real `origin/dev` tip:
+
+```
+pr3515 CLEAN     pr3525 CLEAN     pr3484 CLEAN     pr3323 CLEAN     pr3529 CLEAN
+pr3489 CLEAN     pr3444 CLEAN     pr3447 CLEAN     pr3487 CLEAN
+pr3531 CLEAN     pr3528 CLEAN
+pr3469 CONFLICT  (tests/server/error-fidelity.test.ts, 3-stage entry)
+```
+
+Only **#3469** actually conflicts. All five Stack A items `010` calls blocked merge clean.
+
+**Impact:** the plan under-promises its own achievable outcome by five items and prescribes an
+unnecessary rebase-or-escalate decision for the parent. It also invents a hand-rebase risk the
+work-phase exists to avoid, and it burns an escalation ("this stop condition has already fired
+once", [010:209-213](./010_wp1_stack_a_land_as_is.md)) on a non-event.
+
+**Why the plan should have caught it:** `040` already documents the exact mechanism at
+[040_wp4_stack_d_usage_quota.md:182-184](./040_wp4_stack_d_usage_quota.md) — *"GitHub reports
+`CONFLICTING`; git does not. ... GitHub's probe skips rename detection; `merge-tree` exits 0."*
+`040` applies rename-awareness to #3447; `010` and `006` do not apply it to the identical
+`tests/<domain>/` rename wave, and the two docs now contradict each other on the same fact.
+
+**Concrete fix:** in `010` §0.1/§0.2 and §10, and in the `006` drift block, replace the
+`gh`-derived CONFLICTING verdict with a `git merge-tree --write-tree` result per item, using
+`040`'s wording as the precedent. State that GitHub's mergeability probe is not
+rename-aware and is therefore not the authority. Restore the expected terminal outcome to
+7/7 (subject to draft/approval gates, which are unaffected), and keep the rebase recipe only
+for #3469. Note that a squash merge through the GitHub API may still refuse a
+`CONFLICTING`-flagged PR even when git can merge it — so the fix is to re-probe and, if
+GitHub still refuses, use the local-merge carry path rather than the hand-rebase path.
+
+**verification: verified**
+
+### 2. [High] Eight documented PR heads have moved; three dispositions rest on superseded evidence
+
+**Location:** [000_plan.md:37-68](./000_plan.md) (manifest table),
+[010:33-41](./010_wp1_stack_a_land_as_is.md), [050:20-27](./050_wp5_stack_e_else.md) (D3/D4).
+
+**Trigger:** the manifest records an exact head per PR and every decade doc keys its
+RED/GREEN and CI-of-record claims to those heads.
+
+**Evidence (live `gh pr view`, taken during this audit):**
+
+| PR | Doc head | Live head | Also changed |
+|---|---|---|---|
+| #3529 | `4f103a1e7` -> `81e692313` (010 §3.7) | **`92b4eda26`** | review now `CHANGES_REQUESTED` (010 §0.1 says `REVIEW_REQUIRED`) |
+| #3531 | `f486b5d60` -> `e5137f6f2` (050 D3) | **`aef450d93`** | now **non-draft**, `CHANGES_REQUESTED` |
+| #3528 | `735e3f5c5` -> `f9f5f836d` (050 D4) | **`456bd8ed3`** | still draft |
+| #3530 | listed OPEN in the `000` manifest | **MERGED** (`6580694c7`) | already corrected in 006/050, not in 000 |
+| #3480 | `63623c640` (000) -> `74ef8faae` (010 §0.4) | `74ef8faae` | stable; 010 is right, 000 is stale |
+
+#3529 has now moved **twice** inside this unit's lifetime, and its review decision flipped to
+`CHANGES_REQUESTED` — which `010` §3.7 does not contemplate; it plans `gh pr ready` + matrix
+with no review-dismissal step. #3531's `CHANGES_REQUESTED` is likewise unaddressed by E4.
+
+**Impact:** `010` §2.3 P3 exists precisely to catch a moved head, but the *plan's* per-item
+RED/GREEN analyses, trailer table, and CI-of-record rows are keyed to heads that no longer
+exist. An implementer following `010` §3.7 or `050` E4 literally will merge against evidence
+that was never produced for the current head.
+
+**Concrete fix:** add a "head as of" column with the live SHA to the `000` manifest and mark
+#3530 MERGED there; re-read #3529/#3531/#3528 heads and re-state their review decisions; add
+an explicit review-dismissal or re-review step to `010` §3.7 and `050` E4 for the new
+`CHANGES_REQUESTED` state. Per `050`'s own standing instruction
+([050:29-31](./050_wp5_stack_e_else.md)), treat every SHA as a checkpoint — apply that rule to
+`000` and `010`, which currently do not carry it.
+
+**verification: verified**
+
+### 3. [Medium] `050` E0's patch anchors are stale: the target test sits at :144, not :122, and the quoted import line is wrong
+
+**Location:** [050_wp5_stack_e_else.md:212-257](./050_wp5_stack_e_else.md).
+
+**Trigger:** E0 quotes `tests/routing/anthropic-quorum-cache.test.ts:122-134` as "current code
+on `dev`" and prescribes an import edit at `:27`.
+
+**Evidence:** on `origin/dev` (`79e03643d`) the removal test begins at **line 144**, not 122;
+line 122 is now `test("a stale quorum cannot dispatch on a reauth-flagged account")` — added
+by `bdafc5191` (#3533). The import at `:27` is already
+`import { getAccountSet, markAccountNeedsReauth, saveCredential } from "../../src/oauth/store";`,
+not the two-symbol form the doc shows, so the prescribed `-`/`+` pair will not apply. The
+sibling test E0 cites as its unchanged-behavior guard is at `:157`, not `:136-147`.
+
+**Falsification attempt:** the doc's quoted body *is* byte-exact at `6580694c7`, so this is
+drift, not fabrication — and `050` §0 does claim plan-time tip `79e03643d`. The anchors were
+simply not re-read after `bdafc5191` landed. **The defect itself is real and still live:** the
+merged test at `:144-155` calls `clearAnthropicSessionAffinityForAccount` without
+`removeAccount`, so the roster is never reduced and the named transition is unobservable.
+`removeAccount` exists at [src/oauth/store.ts:899](../../../src/oauth/store.ts) with the
+documented signature, and the DELETE route does call `removeAccount` first
+([oauth-account-routes.ts:550](../../../src/server/management/oauth-account-routes.ts)), so
+E0's reasoning survives. Only the anchors fail.
+
+**Concrete fix:** re-quote the block from `origin/dev` at `:144-155`, change the import edit
+to add only `removeAccount` to the existing three-symbol import at `:27`, and re-point the
+sibling-guard citation to `:157`.
+
+**verification: verified**
+
+### 4. [Medium] Two conflicting `Co-authored-by` forms for the same author, and one that credits nobody
+
+**Location:** [020:243](./020_wp2_stack_b_bug_carry.md), [020:248](./020_wp2_stack_b_bug_carry.md),
+[050:178](./050_wp5_stack_e_else.md) vs [010:378](./010_wp1_stack_a_land_as_is.md).
+
+**Trigger:** `AGENTS.md` "Landing another author's work" and `missing_coauthor_credit`
+([pr-carry-attribution.cjs:212](../../../.github/scripts/pr-carry-attribution.cjs)) make the
+trailer the load-bearing artifact; GitHub matches it to an account by **email**, not login.
+
+**Evidence:** the unit prescribes two different addresses for `Ingwannu`:
+
+- `010:378` -> `Ingwannu <186453546+Ingwannu@users.noreply.github.com>` — the canonical
+  `<id>+<login>@users.noreply.github.com` form. `gh api users/Ingwannu` -> id **186453546**, so
+  this one resolves.
+- `020:243`, `020:601`, `020:668`, `050:178`, `050:387` -> `Ingwannu
+  <ingwannu@users.noreply.github.com>` — the **id-less** form. GitHub only links the id-less
+  variant for accounts created before the ID-prefixed scheme; for a modern account
+  (id 186453546) it does not attach to the contributor graph, which is exactly the
+  `CREDITS.md` failure mode this repository documents.
+- `020:248`/`020:351` -> `Flowershangfromthebranches <flowershangfromthebranches@users.noreply.github.com>`
+  — same id-less problem; the real id is **152056395**.
+
+`020:251-256` correctly diagnoses that #3489's commit email `<opencodex-fix@local>` credits
+nobody and says "use the `@users.noreply.github.com` form above, which resolves by login" —
+that premise is wrong for id-less addresses.
+
+**Impact:** a carry landed with the id-less trailer satisfies the `hygiene` regex (it only
+looks for the trailer) while still crediting nobody — the precise outcome `CREDITS.md` exists
+to prevent, dressed up as compliance.
+
+**Concrete fix:** normalize every trailer in `020` and `050` to the ID-prefixed form used in
+`010`: `Ingwannu <186453546+Ingwannu@users.noreply.github.com>`,
+`Flowershangfromthebranches <152056395+Flowershangfromthebranches@users.noreply.github.com>`.
+All eleven logins resolve (`gh api users/<login>`), so every carried item has a resolvable
+identity once the form is fixed. Correct the "resolves by login" sentence at `020:254`.
+
+**verification: verified**
+
+### 5. [Medium] `050` E4's `Co-authored-by` name and #3329's authorship gate are inconsistent with the DEFER decision
+
+**Location:** [050:181-188](./050_wp5_stack_e_else.md), [006:89-91](./006_dispositions.md).
+
+**Trigger:** E4 prescribes `Co-authored-by: benedictusrey888 <hartanto...@s.mail.nagoya-u.ac.jp>`
+while `010:374` uses `benedictusrey <hartanto...>` for the same person, and `gh` reports the
+PR author login as `benedictusrey` (id 74437942).
+
+**Evidence:** `gh api users/benedictusrey888` was **not** resolvable in my checks as a distinct
+account from `benedictusrey`; the login that owns #3531 and #3528 is `benedictusrey`. The
+doc's own justification ("that is what the contributor graph keys on") is right about commit
+identity but the graph keys on the **email**, which is identical in both rows — so the display
+name difference is cosmetic while the login mismatch invites a wrong trailer.
+
+Separately, `006:89-91` records #3329 as `LAND_WITH_FIX pending ... if authorship can be
+resolved via the PR author login; else DEFER`, while `050` §6 and the `006` Family-4 table
+list it as a straight `LAND_WITH_FIX ... wp5` and then as deferred. The `Counts` line
+(`006:76`) tallies `LAND_WITH_FIX 13 · DEFER 10`, which cannot be true under both readings.
+
+**Concrete fix:** use one identity per author across the unit (`benedictusrey` + the Nagoya
+address, or the ID-prefixed noreply form). Resolve #3329 to a single disposition and make the
+`Counts` line match; `gh` shows #3329 author `Veritas-7`, so the "resolve via PR author login"
+branch is decidable now rather than left conditional.
+
+**verification: verified**
+
+### 6. [Low] `060` is a bare skeleton with no per-work-phase rows, so wp6's stop condition is unfalsifiable
+
+**Location:** [060_ledger.md:1-18](./060_ledger.md).
+
+**Trigger:** `000:31` assigns wp6 "PR/issue closure, merge ledger, unit to `_fin`", and every
+decade doc names `060` as its memory artifact.
+
+**Evidence:** `060` is 18 lines: a header, an empty table, "(none yet)", and a verifier-policy
+paragraph. It carries no row template beyond the header, no per-item closure list, and no
+`_fin` move criteria — while `010` §7 defines a **nine**-column row format
+(`| PR | Title | Author | Head merged | Squash SHA | Ancestor proof | CI evidence | Bypass | Notes |`)
+that does not match `060`'s **eight**-column header
+(`| WP | Item | Carry branch / PR | Head SHA | CI run | Landing SHA | Ancestry proof | Original closed |`).
+
+**Impact:** two incompatible row schemas means the ledger cannot be appended consistently, and
+wp6 has no written completion criteria — unlike wp1-wp5, which all have explicit stop
+conditions. This is a diff-level gap in the one doc that is supposed to prove the campaign
+finished.
+
+**Concrete fix:** reconcile the two schemas into one, list the expected closure comments
+(#3522 stays open, #3467/#3406 close with landing SHA, #3462 do-not-auto-close, #3424 closes
+with `878f75417`, #3528 supersession) as unchecked rows, and write wp6's stop condition and
+`_fin` move criteria explicitly.
+
+**verification: verified**
+
+---
+
+## Audit checks that PASSED
+
+**PLAN-VERIFIER-REAL-01 — PASS.** I ran 23 verifier commands across all five decade docs
+(>=3 per doc as required). Every one exists, reads the change target, and reproduces the
+documented count exactly. Sampled: `010` V3/V6/V7/V8/V9; `020` V1-V8;
+`030` V1/V2/V4 plus the `auth-cors.ts:870` `satisfies` anchor; `040` V1/V2/V3;
+`050` five of six E-layer verifiers. Two documented-environment-red verifiers reproduce as
+documented: `040` V4 exits 1 in-sandbox (EADDRINUSE) exactly as
+[040:76-79](./040_wp4_stack_d_usage_quota.md) predicts, and `050`'s quorum verifier is
+unrunnable at the worktree's older HEAD but the file exists on `origin/dev`. Both docs flag
+these as hosted-CI-only and explicitly warn not to read them as regressions — correct, and
+`040:86-88`'s warning that a piped `bun test` masks the exit status is a genuinely good catch.
+
+**PHASE-SPLIT-01 / DIFFLEVEL-ROADMAP-01 / LEXICO-SPLIT-01 — PASS.** Six work-phases, six
+decade docs, all numbered. The map is dependency-ordered, not effort-bucketed: wp1 (clean
+merges) -> wp2 (carries touching `core.ts`, ordered after wp1's #3515 lands there) -> wp3
+(#3444 first because #3447/#2783/#2973 add fields to the same schema objects) -> wp4 (#3447
+before #2783 because both restructure `quota.ts`) -> wp5 (independent residue) -> wp6. Each
+ordering claim is justified by a **shared file**, and I verified the key ones
+(`core.ts` line separation ~4925 vs ~3380/6693; `quota.ts` shared by #3447/#2783).
+
+**DEV-STACK-01..03 — PASS on shape, with blocker 1 as the caveat.** `010` §2.1 correctly
+refuses to manufacture a branch stack for seven independent PRs and justifies it (disjoint
+file sets, verified — no source file appears in two Stack A PRs). `030` §2 correctly refuses
+to split #3444, and proves it: a lower `auth-cors.ts`-only layer **does not typecheck**
+because of the `satisfies` constraint. `050` §2 correctly declines to stack seven items with
+a measured zero-overlap file matrix. `020` and `040` do build real chains, each justified by
+a shared file (`src/oauth/` + `core.ts` for B1->B2; `quota.ts` for layer 1->2). Base refs form
+valid bottom-up chains and stacked children target the parent head per `AGENTS.md`. No
+independent item is falsely stacked and no stacked item is falsely independent.
+
+**Disposition sanity — PASS (>=6 LAND + >=3 DEFER sampled).** Verified live on `origin/dev`:
+#3515 (`relay.ts:1269` listener and `:1323` `onReadError` both present; `core.ts` passes only
+`clientGoneSignal: clientGone.signal`); #3525 (`state.ts:172` is exactly the three-integer
+`spillCounters`); #3490 (`project-config-warnings.ts:65` regex ends `\\s*$`, so a trailing
+comment misparses — and `layout.json` still has **no** `codex-legacy-config-keys` entry, with
+`codex-integration` in `migrated`, so the §3.4 entry+move finding holds); #3484
+(`integration-routes.ts:379` has the `if (!pruned.ok)` with no success branch; `:343` has
+`integration_operation_not_found`); #3480 (`GOOGLE_BREVITY_INSTRUCTION` is adapter-scoped per
+the `:47` comment and contains no LaTeX guidance); #3323 (the repo-root
+`.tmp-scanner-probe.ts` write is live, at `:126` — doc says `:125`, a one-line drift);
+#3444 (`config.ts` and `auth-cors.ts` rows byte-exact as quoted); #3464
+(`service.ts:66` bakes package-local paths); #3425 (`isTerminalShortWindow` at
+`codex/routing.ts:409`). DEFERs: #3388 **135** behind (doc says 132), #2956 **477** (doc says
+474), #3383 **124** (doc says 121), #2716 **121** (doc says 118) — all four drifted by exactly
+the 3 commits `origin/dev` advanced, which is internally consistent and does not change any
+rationale. #3508's `logs-filter.ts` is indeed absent from `dev` and `Logs.tsx` contains only
+CSS-class matches for `logs-filter`, never an import — the "unreachable duplicate" DEFER holds.
+
+**Security boundary — PASS.** Items touching restricted surfaces are correctly identified and
+the `MAINTAINERS.md` routing is named where it applies: #3524 and B1 (`src/oauth/`), #3444
+(`src/server/auth-cors.ts`). `030` §1 explicitly forbids routing around the gate by splitting
+`auth-cors.ts` into its own PR, citing the gate's stated purpose — correct, and it is
+reinforced by the typecheck proof. `010` §5.1 correctly finds **no** Stack A item touches a
+restricted surface and distinguishes CODEOWNERS approval routing (`core.ts`, `router.ts`
+owner-only — verified at [CODEOWNERS:46](../../../.github/CODEOWNERS)) from a security
+exception. The `--admin` bypass discipline quotes `MAINTAINERS.md` accurately ("That is a
+bypass, not an exemption") and requires it recorded on the PR. "Authors do not approve their
+own pull requests" is correctly applied to `Ingwannu`'s #3525/#3484.
+
+**C-ACTIVATION-GROUNDING-01 — PASS.** Every conditional path the plans add carries a named
+activation scenario in a table, and both branches are named rather than just the positive one:
+#3515 (2 rows, including the negative twin that must stay green — the doc explicitly says a
+merge turning it red is a regression); #3490 (6 rows, including the `existsSync`+`isFile`
+degrade-to-skip path); #3484 (4); #3525 (4, including the `cause`-chain depth-4 case); #3529
+(4); #3489 (9 rows for the new security-relevant exception, including fail-closed default,
+DNS-rebind mixed answers, and the literal-`198.18.x.x` gate). I found **no
+unreachable-by-construction branch**: the one branch that is unreachable by design —
+`providerOutboundPost`'s non-HTTPS rejection after the URL is pinned to a constant
+([040:274-277](./040_wp4_stack_d_usage_quota.md)) — is explicitly called out as unreachable
+"which is the point", rather than presented as live coverage.
+
+**PLAN-FIELD-CHAIN-01 — PASS.** The one genuinely new config field in the unit,
+`allowEncryptedV2AgentTasks`, has its full chain enumerated in `030` §3.1: declaration
+(`src/types/provider.ts`), serialization/validation (`src/config.ts` Zod row, `.optional()`
+with no `.default()` — correctly identified as what makes it default-off at the
+deserialization boundary), policy (`auth-cors.ts` row), consumer
+(`canPassThroughEncryptedV2AgentTask` + two call sites in `core.ts`), and docs. `010` §4
+correctly distinguishes #3525's **metrics** surface from a config field and explains why the
+deserialization stage is legitimately "none" (never parsed back, never written to
+`config.json`). Both are honest chains, not checkbox-filling.
+
+---
+
+## blocking_issues
+
+| # | Severity | Summary | Location |
+|---|---|---|---|
+| 1 | High | `merge-tree` contradicts the CONFLICTING claim; 9 items merge clean, plan under-promises 5 landings | 010 §0.1-0.2, §10; 006 drift block |
+| 2 | High | 8 documented PR heads moved; #3529/#3531 now `CHANGES_REQUESTED` with no dismissal step; #3530 still OPEN in the 000 manifest | 000:37-68; 010 §3.7; 050 D3/D4 |
+| 3 | Medium | E0 patch anchors stale (`:122` -> `:144`), quoted import line no longer exists | 050:212-257 |
+| 4 | Medium | Id-less `Co-authored-by` addresses credit nobody while passing the hygiene regex | 020:243/248/601/668; 050:178/387 |
+| 5 | Medium | Conflicting author identity for #3531; #3329 disposition and `Counts` line self-contradict | 050:181-188; 006:76, 89-91 |
+| 6 | Low | `060` ledger schema conflicts with 010 §7 and has no wp6 stop condition | 060:1-18 |
+
+Blockers 1 and 2 are High: each would cause an implementer to act on false state — one by
+abandoning five landable merges, the other by merging against evidence produced for a head
+that no longer exists. Both are fixable by re-running two commands
+(`git merge-tree --write-tree`, `gh pr view --json headRefOid,reviewDecision`) and editing
+prose; neither invalidates the unit's research, its verifiers, or any disposition.
+
+**Verdict:** the plan's substance is sound and unusually well-evidenced — the defects are
+real, the verifiers are real and reproduce, the security reasoning is correct, and the
+stack shapes are justified rather than assumed. What fails is **freshness**: the unit was
+written across three `origin/dev` moves and two PR-head moves, and its state layer did not
+keep up with its analysis layer. Fix the six items above and this is ready to execute.
+
+VERDICT: GO-WITH-FIXES (blockers=6)
+
+---
+
+## Round 2
+
+Re-audit of the round-1 blockers against `008_audit_synthesis.md` and the amended docs.
+
+| Anchor | Value |
+|---|---|
+| `pwd -P` | `/private/tmp/ocx-closeout.xomWAA/wt` (HEAD `0f27bbeb3`, detached, unchanged) |
+| `origin/dev` round 1 | `79e03643d` |
+| `origin/dev` round 2 (start and pre-verdict re-read) | **`6d9639165`** — one new commit, `docs(layout): closeout ... (#3534)`; delta to `src`/`tests`/`gui`/`scripts` is two one-word edits (`scripts/test.ts:463`, `tests/test-layout-tooling.test.ts:271`). No plan file:line is affected. |
+| Index at pre-verdict re-read | nothing staged; only the untracked plan directory |
+| Interdiff reviewed | 008 (new), banners atop 010/020/050, 060 schema, 000 #3530 row |
+
+The `git merge-tree` re-probe was re-run against `6d9639165` for all 26 heads. **008's table
+is exact**: CLEAN for 19, CONFLICT for #3502 (20 docs-site locale files + 2 tests), #3469
+(`tests/server/error-fidelity.test.ts`), #3388, #3348, #2956, #2783, #2973. Note for future
+re-probes: inside the sandbox `merge-tree` fails with `unable to create temporary file`
+(exit 128) — that is not a conflict (exit 1) and must not be read as one.
+
+### Per-blocker status
+
+**1 — mergeability (High) → FOLDED.** Banner atop
+[010:1](./010_wp1_stack_a_land_as_is.md) supersedes §0.1-0.2/§10 and restores 7/7;
+[020:1](./020_wp2_stack_b_bug_carry.md) narrows the rename recipe to #3469. 008's fallback
+(rename-aware `git merge origin/dev` onto the head, never a hand file-move) is the right
+one. The body text at 010:78, :215, :221, :1113 still says 2/7 — acceptable under the
+banner convention, since the banner names the superseded sections explicitly.
+
+**2 — head drift (High) → FOLDED.** [000:58](./000_plan.md) now reads `14fbbd187 → MERGED
+6580694c7`. 008's live-head table matches `gh` today (#3529 `92b4eda26`, #3531
+`aef450d93`, #3528 `dad2112a1` — #3528 moved once more since round 1, and 008 already has
+the new SHA). The per-item "re-read `headRefOid` before any merge/carry" rule is in 008
+rather than in 010 §3.7's body, and the banner points there; sufficient. One observation for
+the implementer, not a blocker: #3529's two `CHANGES_REQUESTED` reviews (Ingwannu) were
+submitted against `8b0327f4b`, two pushes ago — so "stale on the new head" is the likely
+branch of 008's dismiss-or-fold rule, but it has to be checked, not assumed.
+
+**3 — E0 anchors (Medium) → FOLDED.** [050:1](./050_wp5_stack_e_else.md) + 008 relocate to
+`:144`; confirmed on `6d9639165` (`:144` is the removal test, `:151` the affinity-only
+clear). The `rg` re-anchor instruction is the right shape for a moving file.
+
+**4 — Co-authored-by form (Medium) → FOLDED.** 008 forbids the id-less form unit-wide. The
+id-less rows still sit in the bodies (020:245, :250, :353, :603, :670; 050:180, :389) — a
+copy-paste hazard, but the banner on both docs states the rule, and the resolved form for
+Ingwannu is already written down (010:378). Accepting; the rows should be cleaned when
+those docs are next touched.
+
+**5 — #3531 identity + #3329 disposition (Medium) → split.**
+
+*#3531 half: REBUTTED-ACCEPTED, with a correction to round 1.* I wrote that
+`benedictusrey888` "was not resolvable as a distinct account". That was wrong:
+`gh api users/benedictusrey888` → id **192305729**, a real account distinct from
+`benedictusrey` (74437942), and `gh pr view 3531 --json commits` shows the Nagoya email
+is *already linked* to login `benedictusrey888`. So 050:183's trailer credits a real
+account, and 050:185-186's reasoning ("use the commit identity") was correct as written.
+008's amendment resolves the trailer to the *PR-opener* login instead; that also credits a
+real account. Either is defensible; the commit-linked email is the one GitHub will match
+without any lookup. Not a blocker. If the maintainer wants both accounts credited, two
+trailers are legal.
+
+*#3329 half: STILL OPEN (Medium).* 008 §5 decides "single disposition = LAND_WITH_FIX, wp5
+layer E7", but the amendment stops at the banner. Remaining gaps, each verified:
+
+- **No E7 exists.** `rg -n 'E7' 050_wp5_stack_e_else.md` matches only the banner (050:1).
+  There is no file change map, conflict recipe, regression test, activation table, verifier
+  list, or PR skeleton — the things DIFFLEVEL-ROADMAP-01 requires of every landing and that
+  E0–E6 all have.
+- **050's body still says DEFER in three places** ([050:113](./050_wp5_stack_e_else.md)
+  "4 deferrals (#3508, #3383, #2716, #3329)", [050:188](./050_wp5_stack_e_else.md)
+  "deferred in section 6, not landed here", [050:1024](./050_wp5_stack_e_else.md) "**DEFER
+  from wp5** (was LAND_WITH_FIX)" with a good argument for deferring). The banner asserts
+  the opposite without engaging that argument.
+- **The one named verifier does not exist.** 008:80 cites
+  `tests/core-lab-boundary.test.ts`; on `origin/dev` that path is absent — the file is
+  `tests/lab/core-lab-boundary.test.ts`. PLAN-VERIFIER-REAL-01 fails for E7 as written.
+- **The "semantic conflict" premise is not what git reports.** `git merge-tree --write-tree
+  origin/dev refs/tmp/pr-3329` → **CLEAN** (tree `47cc7a46b`). 006:89 and 050:1024 both
+  describe a hand re-resolution of `src/server/responses/core.ts`; the ten `core.ts` hunks
+  (`@@ -67`, `-1472`, `-1639`, `-2290`…`-2569`) auto-merge. That does not make the
+  change *safe* — 138 commits of drift under a protected core path still warrants the
+  lab-boundary verifier and a real review — but it is the same probe-vs-git error class as
+  blocker 1, and the plan should say what is actually true. Separately, #3329's four test
+  files are at pre-migration root paths (`tests/combos.test.ts`,
+  `tests/server-combo-failover-e2e.test.ts`, …); a pick must not recreate them at root or
+  the duplicate-basename gate fires (040 §3.1 already documents this trap for #3447).
+- Authorship is resolvable now: `Veritas-7` → id **234569343**, so
+  `Co-authored-by: Veritas-7 <234569343+Veritas-7@users.noreply.github.com>` is available.
+  The lane's High correctness finding (reset metadata dropped for body-confirmed quota
+  inside 5xx) is still present on the PR head at `core.ts:1645-1647`
+  (`...(!cyberFailure && (response.status === 429 || response.status === 402) ? {resetAt} : {})`),
+  so the LAND_WITH_FIX fix list from lane 004 is still the right starting point.
+
+**Concrete fix (either branch closes this):** (a) write E7 into 050 §3 at the same depth as
+E0–E6 — file map from the lane's fix list, the `core.ts` merge verified by
+`bun test tests/lab/core-lab-boundary.test.ts` plus `tests/routing/combo-management-api.test.ts`
+and `tests/server/server-combo-failover-e2e.test.ts` (hosted-CI-only per 020), the
+Veritas-7 trailer, and a root-file check after the pick — and change 050:113/:188/:1024 to
+match; **or** (b) keep 050's own DEFER argument, revert 008 §5 to DEFER, and correct
+006:76 to `LAND_WITH_FIX 12 · DEFER 11`. The plan must not carry both.
+
+**6 — ledger schema + wp6 stop condition (Low) → STILL OPEN (Low).** 060 now has a
+nine-column header ([060:6](./060_ledger.md)) and it matches 008 §6 — good. But 008:85
+says this is "the nine-column form from 010 §7", and it is not: 010 §7
+([010:1008](./010_wp1_stack_a_land_as_is.md)) still specifies
+`PR | Title | Author | Head merged | Squash SHA | Ancestor proof | CI evidence | Bypass | Notes`,
+a different nine columns, and 010 carries no banner about it. Two schemas still coexist,
+and the wp6 stop condition lives only in 008 — `rg -in 'stop condition|_fin|privacy:scan'
+060_ledger.md` returns nothing. **Fix:** one line in 010 §7 deferring to 060's header, and
+paste 008 §6's stop condition into 060 so the ledger doc is self-describing.
+
+### Summary
+
+| # | Round 1 | Round 2 status | Residual severity |
+|---|---|---|---|
+| 1 | High | FOLDED | — |
+| 2 | High | FOLDED | — |
+| 3 | Medium | FOLDED | — |
+| 4 | Medium | FOLDED | — |
+| 5a | Medium | REBUTTED-ACCEPTED (my evidence was wrong; 050's trailer is valid) | — |
+| 5b | Medium | STILL OPEN — E7 has no plan body, 050 contradicts itself, verifier path wrong, conflict premise false | Medium |
+| 6 | Low | STILL OPEN — 010 §7 schema not reconciled, stop condition not in 060 | Low |
+
+No High remains. One Medium (5b) and one Low (6), both docs-only edits in the same unit.
+
+VERDICT: GO-WITH-FIXES (blockers=2)

--- a/devlog/_plan/260905_open_work_closeout/008_audit_synthesis.md
+++ b/devlog/_plan/260905_open_work_closeout/008_audit_synthesis.md
@@ -1,0 +1,104 @@
+# 008 — Audit synthesis and plan amendments (wp0, round 1)
+
+Reviewer: claude-opus-5 auditor, report `007_audit_wp0.md`, verdict GO-WITH-FIXES (blockers=6).
+Main-agent judgment: near-pass → all six folded as amendments below. Live re-probe run at
+`origin/dev` = `79e03643d` on 2026-09-05 (this doc supersedes the conflicting sections).
+
+## Blocker 1 (High) — mergeability re-probe with `git merge-tree --write-tree origin/dev <head>`
+
+GitHub's `mergeable` probe skips rename detection; `merge-tree` is the authority. Result:
+
+| PR | Head | merge-tree |
+|----|------|------------|
+| #3529 | 92b4eda26 | CLEAN |
+| #3525 | 288506dc6 | CLEAN |
+| #3524 | cf0b3fe0a | CLEAN |
+| #3519 | 6b92ab7db | CLEAN |
+| #3515 | 4f09faf5d | CLEAN |
+| #3502 | 6671a1623 | CONFLICT |
+| #3490 | 3fbe8a2c7 | CLEAN |
+| #3489 | dbcfde8ca | CLEAN |
+| #3484 | a4c50d104 | CLEAN |
+| #3480 | 74ef8faae | CLEAN |
+| #3469 | e11089af8 | CONFLICT |
+| #3407 | 38d45300a | CLEAN |
+| #3388 | 007076ebd | CONFLICT |
+| #3348 | a64ed3250 | CONFLICT |
+| #3444 | baefb1334 | CLEAN |
+| #3447 | 745b70e1e | CLEAN |
+| #2956 | cc6aa5f48 | CONFLICT |
+| #2783 | ad74f037d | CONFLICT |
+| #2973 | b6a879267 | CONFLICT |
+| #3323 | 0facdae69 | CLEAN |
+| #3487 | ee3b22d28 | CLEAN |
+| #3329 | 1876d6001 | CLEAN |
+| #3421 | 432016100 | CLEAN |
+| #2432 | c83d8eda1 | CLEAN |
+| #3531 | aef450d93 | CLEAN |
+| #3528 | dad2112a1 | CLEAN |
+
+**Amendment to 010 §0.1-0.2 and §2:** wp1 expected outcome is restored to 7/7. #3323, #3515,
+#3484, #3525, #3529 need no rebase; a GitHub-side "CONFLICTING" flag on any of them is a
+rename-detection artifact. If GitHub refuses the squash button, the fallback is a maintainer
+carry branch created by `git merge origin/dev` onto the PR head (rename-aware) and pushed
+with `--no-verify`, never a manual file-move rebase. #3490 keeps its `layout.json` +
+`tests/codex-integration/` placement fix (a real gate, independent of mergeability).
+**Amendment to 020:** #3489 needs no rebase; only #3469 keeps the two-test-rename recipe.
+
+## Blocker 2 (High) — head drift
+
+| PR | Manifest head | Live head | Consequence |
+|----|---------------|-----------|-------------|
+| #3529 | 4f103a1e7 | 92b4eda26 | review now CHANGES_REQUESTED → 010 §3.7 adds "re-read review threads; dismiss if stale on the new head, else fold the requested change" before ready/merge |
+| #3480 | 63623c640 | 74ef8faae | already handled in 002/010 (author rebase) |
+| #3531 | f486b5d60 | aef450d93 | non-draft; #2960 regression fixed by author (050 E4 stands) |
+| #3528 | 735e3f5c5 | dad2112a1 | alias half removed; SUPERSEDED reasoning = scope split only |
+| #3530 | 14fbbd187 | MERGED 6580694c7 | 000 manifest row marked MERGED; E0 follow-up in wp5 stands |
+
+Rule carried into every implementation P: re-read `gh pr view <n> --json headRefOid`
+immediately before any merge/carry action; a moved head restarts that item's pre-merge checks.
+
+## Blocker 3 (Medium) — E0 anchors
+
+050 E0: target test now at `tests/routing/anthropic-quorum-cache.test.ts:144` (`bdafc5191`
+inserted a test at `:122`); the quoted import line is gone. Implementer re-anchors at B by
+`rg -n "removeAccount|quorum" tests/routing/anthropic-quorum-cache.test.ts` before patching.
+
+## Blocker 4 (Medium) — Co-authored-by form
+
+All trailers use the ID-prefixed noreply form `<id>+<login>@users.noreply.github.com` resolved
+via `gh api users/<login> --jq .id` at B, or the author's real commit email when the PR commits
+carry one. The id-less `<login>@users.noreply.github.com` form is forbidden in this unit.
+Known: Ingwannu → `186453546+Ingwannu@users.noreply.github.com` (010 §3). #3489's
+`<opencodex-fix@local>` and #3329's `" " <wj@nas-backup>` are replaced by the login-resolved form.
+
+## Blocker 5 (Medium) — #3531 identity and #3329 disposition
+
+- #3531: author is `benedictusrey`; trailer resolved per Blocker 4 at B (050 §E4 identity line replaced).
+- #3329: single disposition = **LAND_WITH_FIX, wp5 layer E7**, appended after E0-E6; requires hand
+  re-resolution of `src/server/responses/core.ts` under the lab-boundary invariant
+  (`tests/core-lab-boundary.test.ts` is a verifier for E7) and the trailer per Blocker 4.
+  006 Counts stay: LAND_WITH_FIX 13 includes #3329.
+
+## Blocker 6 (Low) — ledger schema and wp6 stop condition
+
+060 ledger schema is the nine-column form from 010 §7:
+`| WP | Item | Disposition | Carry branch / PR | Head SHA | CI run id | Landing SHA | Ancestry proof (cmd + exit) | Original closed (comment URL) |`.
+wp6 stop condition: every LAND/REIMPLEMENT/IMPLEMENT row has a landing SHA with ancestry
+exit 0 and an original-closure link (or an explicit "keep open" rider: #3522, #3462), every
+DEFER/SUPERSEDED has a closure or comment link, and `bun run privacy:scan` exit 0 on the
+closeout commit; then the unit moves to `devlog/_fin/`.
+
+
+## Round 2 synthesis
+
+| Blocker | Status | Action |
+|---------|--------|--------|
+| 1-4 | FOLDED | none |
+| 5a #3531 identity | REBUTTED-ACCEPTED | 050 original trailer (`benedictusrey888`, id 192305729) stands |
+| 5b #3329 | FOLDED (round 2) | E7 written in full at the end of 050 (file map, field chain, activation scenarios, verifiers incl. `tests/lab/core-lab-boundary.test.ts`, trailer `234569343+Veritas-7`); merge-tree CLEAN so carry = merge, not hand-resolution. Body DEFER mentions in 050 are superseded by the E7 section. |
+| 6 ledger | FOLDED (round 2) | 010 §7 row format replaced with the 060 nine-column schema; wp6 stop condition written into 060 |
+
+Main-agent judgment: **near-pass** → exit A>B for wp0 (docs-only). Residuals: none blocking.
+
+DOCEOF; rg -n 'Author \| Head merged' /private/tmp/ocx-closeout.xomWAA/wt/devlog/_plan/260905_open_work_closeout/010_wp1_stack_a_land_as_is.md | head -2; tail -3 /private/tmp/ocx-closeout.xomWAA/wt/devlog/_plan/260905_open_work_closeout/060_ledger.md

--- a/devlog/_plan/260905_open_work_closeout/010_wp1_stack_a_land_as_is.md
+++ b/devlog/_plan/260905_open_work_closeout/010_wp1_stack_a_land_as_is.md
@@ -1,0 +1,1114 @@
+> **Amended by 008 (audit round 1):** `git merge-tree` shows all seven items merge clean at `79e03643d`; the "CONFLICTING" rows in §0 and the 2/7 outcome are superseded — expected outcome is 7/7. #3529 head is now `92b4eda26` with CHANGES_REQUESTED; see 008 Blocker 2.
+
+# 010 — wp1 / Stack A: the LAND_AS_IS merge train
+
+Work-phase: **wp1**. Unit `devlog/_plan/260905_open_work_closeout`.
+Scope: **#3515, #3529, #3525, #3490, #3484, #3480, #3323** — seven independent open pull
+requests whose code is correct as written. This is a **merge-train recipe**, not a rebase
+or reimplementation plan: no `src/`, `tests/`, or `gui/` file is authored in this
+work-phase except the one layout-registry line forced by #3490 (§3.4).
+
+Source lanes: `001_lane_bug_prs_a.md` (#3515 #3529 #3525 #3490),
+`002_lane_bug_prs_b.md` (#3484 #3480), `004_lane_else_prs.md` §#3323.
+
+## 0. Re-verification against current `dev` (drift check)
+
+> **Read this section before touching anything.** `origin/dev` moved **twice while this doc
+> was being written**, and the second move changed the shape of the entire work-phase. The
+> per-item sections below are correct on the merits; this section overrides their
+> *mergeability* status.
+
+Lane research ran at `origin/dev` = `0f27bbeb3`. Current `origin/dev` = **`79e03643d`**:
+
+```
+79e03643d test(layout): move server, storage, ci-workflows into tests/<domain>/ (#3497) (#3518)
+bdafc5191 test(oauth): prove the unobservable quorum staleness window is harmless (#3533)
+6580694c7 test(oauth): restore a deleted contract test, and fail when one disappears (#3530)
+```
+
+### 0.1 `79e03643d` flipped five of seven items to CONFLICTING
+
+`79e03643d` migrated the **`server`**, **`storage`** and **`ci-workflows`** domains into
+`tests/<domain>/`, adding all three to `layout.migrated`. Every Stack A PR that edits a test
+file which just moved is now `CONFLICTING / DIRTY`. Re-read with `gh pr view` after the move:
+
+| PR | Head now | Mergeable | Draft | Review |
+|----|----------|-----------|-------|--------|
+| #3515 | `4f09faf5d` | **CONFLICTING** | no | REVIEW_REQUIRED |
+| #3529 | **`81e692313`** (moved) | **CONFLICTING** | yes | REVIEW_REQUIRED |
+| #3525 | `288506dc6` | **CONFLICTING** | no | REVIEW_REQUIRED |
+| #3484 | `a4c50d104` | **CONFLICTING** | no | REVIEW_REQUIRED |
+| #3323 | `0facdae69` | **CONFLICTING** | no | REVIEW_REQUIRED |
+| #3490 | `3fbe8a2c7` | MERGEABLE / BLOCKED | yes | REVIEW_REQUIRED |
+| #3480 | `74ef8faae` | MERGEABLE / BLOCKED | **no** (exited draft) | **CHANGES_REQUESTED** |
+
+**The conflict is mechanical in every case, and provably so.** For each PR I compared its
+changed-file list against `origin/dev` and asked whether each path still exists. Exactly the
+relocated test files are `GONE`; **every source, GUI, and docs path is `OK`**:
+
+| PR | Conflicting path(s) — all test-only | New path on `dev` | Source conflicts |
+|----|--------------------------------------|--------------------|------------------|
+| #3515 | `tests/server-auth.test.ts` | `tests/server/server-auth.test.ts` | **none** |
+| #3484 | `tests/management-integration-journal-delete.test.ts` | `tests/server/…` | **none** |
+| #3323 | `tests/management-route-registry.test.ts` | `tests/server/…` | **none** (it is the only file in the PR) |
+| #3525 | `tests/memory-watchdog.test.ts` | `tests/server/…` | **none**; its two `tests/responses/` files are still `OK` |
+| #3529 | `tests/server-combo-failover-e2e.test.ts`, `tests/terminal-guard-server.test.ts` | `tests/server/…` both | **none**; `tests/adapters/` and `tests/providers/` files still `OK` |
+
+No two PRs conflict with each other, and no PR conflicts with `dev` on a source file. This is
+the same `tests/<domain>/` migration lane 002 already identified as "the dominant blocker" —
+it has now reached the `server` domain and swept up Stack A.
+
+### 0.2 What this means for the work-phase
+
+A merge train requires `MERGEABLE` heads. Five items no longer have one, so **Stack A as
+specified can no longer execute end-to-end today.** The disposition of every item is unchanged
+— the code is still correct and the defects are still live — but five of them now need a
+mechanical rebase first, which §1 explicitly places out of scope.
+
+Two paths, and the choice belongs to the parent, not to this doc (§1 escalation):
+
+- **(A) Ask each author to rebase.** Preferred: attribution stays native, the merge stays a
+  plain squash, and the rebase is a file move plus a specifier rewrite
+  (`../src/` -> `../../src/`). #3529's author is already responsive — that head moved from
+  `4f103a1e7` to `81e692313` during this session.
+- **(B) Move the five rebases into wp2** (`020`), which already owns mechanical
+  `tests/<domain>/` rebases for #3489, #3469, #3487 and #3528. Stack A then lands only what
+  is still mergeable.
+
+**Executable today, unchanged:** #3480 (step 2) and #3490 (step 6, with its §3.4 fix).
+Everything else waits on a rebase. The merge order in §2.2 stays valid as the order to use
+*once* heads are mergeable again.
+
+**Rebase recipe** (identical for all five; this is the whole of it):
+
+```
+git rebase origin/dev                      # conflicts land as delete/modify on the moved file
+git mv-equivalent: re-apply the PR's test hunk onto tests/server/<file>.test.ts
+rewrite relative specifiers one level deeper:  ../src/  ->  ../../src/
+bun test tests/server/<file>.test.ts        # must be GREEN with the src half applied
+bun test tests/test-layout.test.ts          # must stay 2 pass / 0 fail
+```
+
+Do **not** re-run the lanes' red/green analysis after the rebase: the RED-on-dev arguments in
+§3 are about source behavior and are unaffected by a file move.
+
+### 0.3 A baseline an implementer will otherwise misread
+
+On `0f27bbeb3`, `bun test tests/test-layout-tooling.test.ts` was **14 pass / 1 fail**
+(`membership oracle > the live tree and the fixture agree entry by entry`,
+`missingFromTree: ["anthropic-quorum-cache.test.ts"]`). `6580694c7` adds that file at
+`tests/routing/`, so the failure is **already repaired by the drift**. If it is red after
+checkout, the checkout is stale — it is not a Stack A regression.
+
+Likewise, `bun test tests/server/<file>.test.ts` fails with *"Tests need .test..."* in a
+worktree still detached at `0f27bbeb3`, because those paths only exist from `79e03643d`
+onward. The verifier table in §1 lists pre-migration paths as executed; **on a checkout at
+`79e03643d` or later, prefix them with `tests/server/`** — V2, V5, V6, V8.
+
+### 0.4 State captured before the drift (still the CI evidence of record)
+
+These are the heads and exact-head CI results the dispositions rest on. They remain valid *for
+those heads*; a rebase invalidates the run and requires a fresh one.
+
+| PR | Author | Head | Draft | +/- | Exact-head CI at capture |
+|----|--------|------|-------|-----|--------------------------|
+| #3515 | VXNCXNX | `4f09faf5d` | no | 87/1 | **full green** (26 checks) |
+| #3525 | Ingwannu | `288506dc6` | no | 305/43 | **full green** (27 checks) |
+| #3484 | Ingwannu | `a4c50d104` | no | 187/1 | **full green** (25 checks) |
+| #3323 | luvs01 | `0facdae69` | no | 6/4 | **full green** (22 checks) |
+| #3529 | yansigit | `4f103a1e7` | yes | 165/68 | intake only (4) |
+| #3490 | yxr1995-maker | `3fbe8a2c7` | yes | 159/1 | intake only (4) |
+| #3480 | benedictusrey | `74ef8faae` | yes -> **no** | 11/0 | intake only (4) |
+
+**Three corrections to the lane docs**, all established by execution:
+
+1. **#3480's draft state changed twice.** Lane 002 recorded non-draft; mid-session it was
+   `isDraft: true`; at final re-read it is **non-draft** again with `CHANGES_REQUESTED` still
+   standing. Treat only the stale review as the blocker (§3.2) and re-check draft state at P1.
+2. **#3490 is NOT mergeable as-is — it fails a `dev` gate that did not exist when it was
+   branched.** Overrides lane 001's clean `LAND_AS_IS`. See §3.4. Still true at
+   `79e03643d`: `origin/dev:scripts/test-layout/layout.json` has **no** entry for the file.
+3. **Five items are now CONFLICTING** (§0.1), which lane 001 and 002 could not have seen.
+
+Drift/behind measurements (`git rev-list --count <head>..origin/dev`), all seven heads
+fetched read-only into `refs/tmp/pr<n>`:
+
+| PR | merge-base | behind `dev` | ahead | `pr-quality` latest-dev box (max 10 behind) |
+|----|-----------|--------------|-------|---------------------------------------------|
+| #3480 | `0f27bbeb3` | 1 | 1 | passes |
+| #3529 | `0f27bbeb3` | 1 | 1 | passes |
+| #3525 | `99fc38c39` | 3 | 1 | passes |
+| #3515 | `6edc56328` | 14 | 2 | **fails** (>10) |
+| #3490 | `85e42117c` | 24 | 3 | **fails** (>10) |
+| #3484 | `066146980` | 28 | 1 | **fails** (>10) |
+| #3323 | `ff1ac6b8c` | **152** | 2 | **fails** (>10) |
+
+`READINESS_LATEST_DEV_BEHIND_MAX = 10` at
+[pr-quality-state.cjs:26](/private/tmp/ocx-closeout.xomWAA/wt/.github/scripts/pr-quality-state.cjs:26).
+This matters only for the *draft-checklist* path (§2.4): a maintainer merging directly
+is not gated by it. It is recorded because an implementer who tries to drive #3323 or
+#3490 through the contributor checklist will be bounced by a box the author cannot tick.
+
+---
+
+## 1. Loop-spec header
+
+**Archetype.** Spec-satisfaction repair — every item's *specification* (the defect and its
+regression test) is already satisfied by an open PR head. The repair is to the repository
+state (the defects are live on `dev`), not to the diffs. One item (#3490) additionally
+needs a one-line spec-satisfaction fix against a gate introduced after it branched.
+
+**Trigger.** Seven open PRs are `MERGEABLE` with correct, test-backed diffs and are blocked
+only on procedure: missing approval, draft status, or a stale review. Their defects are all
+confirmed live on `origin/dev` = `6580694c7` (per-item evidence in §3).
+
+**Goal.** All seven landed on `dev` by squash merge, each proven an ancestor of
+`origin/dev`, with attribution preserved and a ledger row per PR in `060`.
+
+**Non-goals.**
+
+- No rebase, carry, or reimplementation. Any PR that turns `CONFLICTING` mid-train leaves
+  Stack A and is handed to wp2 (`020`) — do not resolve conflicts here.
+- No `main`/`preview` promotion, no release, no version bump.
+- No repository-wide `bun run test` or bare `bun test`. Focused files only (AGENTS.md).
+- No edits to `src/`, `tests/`, or `gui/` beyond §3.4's single `layout.json` line.
+- No re-review of code the lanes already cleared; this phase re-verifies **state**, not merit.
+
+**Verifier commands.** Every command below was executed in
+`/private/tmp/ocx-closeout.xomWAA/wt` at `0f27bbeb3` and reads the change target of at
+least one item. Exit codes are recorded as observed.
+
+| # | Command | Reads | Observed result |
+|---|---------|-------|-----------------|
+| V1 | `git fetch origin dev && git rev-parse --short origin/dev` | drift | exit 0 -> `6580694c7` |
+| V2 | `bun test tests/server/server-auth.test.ts` | #3515 target | file existed at `tests/server-auth.test.ts` (183327 B) pre-migration; **path moved by `79e03643d`** (§0.3) |
+| V3 | `bun test tests/adapters/key-failover.test.ts` | #3529 target | file exists (11183 B); exit 0 |
+| V4 | `bun test tests/responses/responses-state.test.ts` | #3525 target | file exists (159759 B); exit 0 |
+| V5 | `bun test tests/server/memory-watchdog.test.ts` | #3525 second target | file existed at root (15259 B) pre-migration; **path moved** (§0.3) |
+| V6 | `bun test tests/server/management-integration-journal-delete.test.ts` | #3484 target | **12 pass / 0 fail**, exit 0 (at the pre-migration root path) |
+| V7 | `bun test tests/adapters/google/google-adapter.test.ts` | #3480 target | **32 pass / 0 fail**, exit 0 |
+| V8 | `bun test tests/server/management-route-registry.test.ts` | #3323 target | **13 pass / 0 fail**, exit 0 (at the pre-migration root path) |
+| V9 | `bun test tests/test-layout.test.ts` | #3490 gate | **2 pass / 0 fail**, exit 0 (clean dev) |
+| V10 | `bun test tests/lab/core-lab-boundary.test.ts` | #3529 import-graph invariant | file exists (21129 B) |
+| V11 | `gh pr checks <n>` | exact-head CI | exit 0 for all seven |
+| V12 | `git merge-base --is-ancestor <squash-sha> FETCH_HEAD` | landing proof | run per merge |
+
+`tests/codex-legacy-config-keys.test.ts` is deliberately **absent** from this table:
+`ls` returns `No such file or directory` on `dev` (exit 1). It arrives with #3490 and is
+only runnable after that merge — which is precisely the §3.4 finding.
+
+**Path caveat.** V2, V5, V6 and V8 were executed at `0f27bbeb3`, where these files sat at the
+`tests/` root; `79e03643d` moved all four into `tests/server/`. The table lists the
+**post-migration** paths, which are the ones to use on any current checkout. Running the old
+root path on a current checkout produces Bun's *"Tests need .test..."* message — that is a
+wrong path, not a missing test.
+
+**Stop condition.** All seven PRs `MERGED`, each squash SHA proven by V12, seven ledger rows
+written to `060`, and `origin/dev` green. Stop early and escalate on any of: a PR flipping
+to `CONFLICTING`; a required check failing on an exact head; a squash merge that does not
+become an ancestor of `origin/dev`.
+
+**This stop condition has already fired once** — `79e03643d` flipped five items to
+`CONFLICTING` mid-planning (§0.1). Per the rule above that is an escalation, not something to
+work around inside this work-phase. The parent decides between §0.2 option (A) author rebase
+and option (B) hand the five to wp2. Until that decision, the achievable terminal state is
+**2/7 merged** (#3480, #3490), which is a legitimate *partial* outcome, not a failure.
+
+**Memory artifact.** This doc plus the merge ledger in `060` (row format in §7).
+
+**Expected terminal outcomes.**
+
+- *Success:* 7/7 merged, 7 ledger rows, `dev` green. **Not reachable today** — see §0.2.
+- *Partial (the expected outcome as of `79e03643d`):* #3480 and #3490 merged; the other five
+  carry a one-line reason (`CONFLICTING on the `server` test migration`) and a target
+  (author rebase, or wp2). Partial is legitimate here — the items are independent by
+  construction (§2.1), so a blocked item blocks nothing else.
+- *Failure:* a merged change turns `dev` red -> revert that squash commit immediately
+  (§6), do not attempt a forward fix inside this work-phase.
+
+**Escalation.** Stop and hand back to the parent when: (a) any item needs a code change
+beyond §3.4's one line; (b) a security-boundary approval is required that the operator
+cannot self-grant (§6.2); (c) a contributor must act and has not (draft exit, stale-review
+dismissal) — that is external coordination, not a blocker to work around.
+
+---
+
+## 2. Stack map (DEV-STACK-01..03)
+
+### 2.1 There is no branch stack in this work-phase — and that is the finding
+
+DEV-STACK-01..03 govern *dependent* work split across a chain of reviewable PRs. Stack A has
+**no dependency chain**. Every item is already an open PR targeting `dev`, every one is
+`MERGEABLE`, and the file sets are disjoint. Building a branch stack here would mean
+re-creating seven contributor PRs as maintainer branches — discarding attribution, discarding
+seven exact-head CI runs (four of them full-matrix green), and manufacturing the rebase risk
+this work-phase exists to avoid.
+
+**So Stack A is a merge train: seven direct squash merges into `dev`, ordered by risk.**
+DEV-STACK-01..03 are satisfied vacuously (depth 1, no upper layers). The ordering below is a
+*sequencing* discipline, not a branch topology.
+
+Disjointness, verified from the `gh pr view --json files` output — no source file appears
+in two PRs:
+
+| PR | Source files touched |
+|----|----------------------|
+| #3515 | `src/server/relay.ts`, `src/server/responses/core.ts` |
+| #3529 | `src/providers/key-failover.ts` |
+| #3525 | `src/responses/state.ts`, `src/server/management/system-routes.ts` |
+| #3490 | `src/cli/doctor.ts`, `src/codex/legacy-config-keys.ts` (new), `src/codex/project-config-warnings.ts` |
+| #3484 | `src/server/management/integration-routes.ts`, 3 `gui/src/pages/integrations/` files |
+| #3480 | `src/adapters/google.ts` |
+| #3323 | none (test-only) |
+
+Re-verified against `79e03643d`: for every PR, each changed **source**, **GUI**, and **docs**
+path still exists on `dev` — only relocated *test* paths are missing (§0.1). This
+disjointness table is therefore unaffected by the migration.
+
+The single **near**-collision is `src/server/responses/core.ts`: #3515 edits it at line 4925.
+Lane 001 flags #3502 (wp2) as also touching that file at ~3364/6693 — 1,500 lines away, and
+#3502 is not in Stack A. Landing #3515 first is what makes that separation trivial, which is
+why #3515 is first in the train regardless of its other properties.
+
+Two **docs** files are shared and are append-only in both PRs, so ordering is irrelevant but
+the second merge must be re-checked for mergeability:
+`docs-site/src/content/docs/reference/management-api.md` is touched by **#3525** (1/-1, the
+spill-health field) and **#3484** (+10, the 404 reconcile code) — different sections. Verify
+with V11 after the first of the two lands; if GitHub reports `CONFLICTING`, that is a
+one-hunk docs conflict and the PR leaves Stack A for wp2.
+
+### 2.2 Merge order (risk-ascending, and why)
+
+Ordered so that anything capable of destabilizing `dev` lands while the train is shortest,
+and so that each merge's blast radius is understood before the next begins. **As of
+`79e03643d` only steps 2 and 6 have a mergeable head** (§0.1); the rest of the order applies
+once the five conflicting items are rebased.
+
+| Step | PR | Why here |
+|------|----|----------|
+| 1 | **#3323** | Test-only, +6/-4, one file, no runtime reachability. Zero-risk train warm-up: proves the merge/ancestry/ledger loop works before any runtime change. |
+| 2 | **#3480** | Smallest runtime delta in the set: one string appended to a prompt constant. No control flow. |
+| 3 | **#3515** | Full-matrix green, maintainer-approved, 4 lines of runtime change — but it lands on `src/server/responses/core.ts`, the owner-only proxy-core boundary. Land it early so #3502 (wp2) rebases against a known state. |
+| 4 | **#3484** | Full-matrix green, 2-line server change + GUI. Larger surface than #3515 but confined to the integrations subsystem. |
+| 5 | **#3525** | Full-matrix green, but the largest diff in the train (+305/-43) and it rewrites the spill-counter shape in `src/responses/state.ts`. Land after the small items so a regression is unambiguously attributable. |
+| 6 | **#3490** | Needs the §3.4 registry line before it can go green. Land after everything that is merge-ready today. |
+| 7 | **#3529** | Last by risk: 429 key-failover rotation with persistence semantics, +165/-68, six test files, and **no full-matrix run has ever executed on this head**. It also adds a `src/router` import to a module on the request path — cleared by lane 001 against `core-lab-boundary`, but it is the one item whose CI evidence must be created from scratch. |
+
+Steps 1-5 were mergeable at capture time (§0.4) and are **now blocked on a mechanical rebase**
+(§0.1-0.2). Steps 6-7 always required author or maintainer action first (§2.4). Net today:
+**#3480 and #3490 are executable; the other five are not.**
+
+### 2.3 Per-PR pre-merge checks (run for every item, in this order)
+
+```
+P1  gh pr view <n> --json headRefOid,mergeable,mergeStateStatus,reviewDecision,isDraft
+      -> mergeable == "MERGEABLE"; record headRefOid as HEAD_N
+P2  gh pr checks <n>          -> every required check "pass" on HEAD_N; no pending, no fail
+P3  gh pr view <n> --json headRefOid   -> re-read; MUST still equal HEAD_N
+      (a push between P1 and P4 invalidates both the CI evidence and any ticked checklist)
+P4  gh pr merge <n> --squash --admin --body-file <ledger-body>
+P5  git fetch origin dev && git merge-base --is-ancestor <squash-sha> FETCH_HEAD; echo $?
+      -> 0 is the landing proof; anything else stops the train
+P6  append the §7 ledger row to 060
+```
+
+P3 is not ceremony. `pr-quality` resets the readiness checklist and re-drafts a PR on any new
+push ([pr-quality-messages.cjs:272](/private/tmp/ocx-closeout.xomWAA/wt/.github/scripts/pr-quality-messages.cjs:272)),
+so a head that moved has neither valid CI nor a valid checklist.
+
+**On `--admin`.** `MAINTAINERS.md` records that ruleset `Protect dev` (id 20763889) requires
+one approving review plus code-owner review, and that the `maintain`/`admin` role holds a
+`pull_request` bypass —
+[MAINTAINERS.md:172](/private/tmp/ocx-closeout.xomWAA/wt/MAINTAINERS.md:172): *"That is a
+bypass, not an exemption ... an owner who uses the bypass should record it on the pull
+request rather than leave it to be inferred from a merge timestamp."* Therefore **every
+`--admin` merge in this train must leave a comment on the PR stating that the bypass was
+used and why** (author-approval unavailable / maintainer-authorized closeout). The ledger row
+(§7) carries the same fact. Squash is the correct method: rebase merges are disabled on this
+repository.
+
+**Authors do not approve their own pull requests.** #3525 and #3484 are authored by
+`Ingwannu`, a maintainer — so `Ingwannu` cannot supply their approval. Those two land on the
+owner's bypass or on a second maintainer's review.
+
+### 2.4 Drafts with an 0/4 checklist
+
+Three items are drafts: **#3529, #3490, #3480**. Their heavy CI is draft-gated — each shows
+exactly `enforce-target`, `hygiene`, `label`, `resolve-pr` and a CodeRabbit *"Review skipped:
+draft pull request"*. Per AGENTS.md, an empty required set is not green.
+
+The maintainer-authorized path, which does **not** require the author to act:
+
+```
+D1  gh pr ready <n>                     # maintainer marks ready; unblocks the full matrix
+D2  wait for the matrix to complete on the unchanged head:
+      gh pr checks <n> --watch
+D3  require: test 1/4..4/4, gates, macos, keyring x3, npm-global x3,
+             storage policy, api usage, react-doctor, enforce-target, hygiene  -> all pass
+D4  then run P1..P6 from §2.3
+```
+
+`gh pr ready` is the mechanism because the four-box checklist is a *contributor* gate: the
+local-CI box is an author attestation the gate never disproves, and for #3490 (24 behind) and
+#3323 (152 behind) the latest-dev box cannot be ticked at all under the 10-commit rule. The
+maintainer marking ready and admin-merging is the authorized substitute, and it is why D2/D3
+exist — **the exact-head matrix is the evidence the checklist was standing in for.** Do not
+skip D3 and merge on intake checks alone.
+
+If marking ready flips the PR back to draft (the gate re-drafts on a new push), the head
+moved: return to P1.
+
+### 2.5 Carried contributor work
+
+**None in Stack A.** Every item merges from its own PR head, so GitHub records authorship
+natively and no `Co-authored-by` trailer is required —
+`missing_coauthor_credit` in `.github/scripts/pr-carry-attribution.cjs` applies to
+reimplementation and carry, which this work-phase forbids (§1 non-goals).
+
+Trailers are needed **only** on the contingency in §6.3 (a PR is closed and its content
+carried onto a maintainer branch). Emails resolved now so the contingency is executable
+without further lookup — `gh pr view <n> --json commits` gives the commit email; where that
+email is unusable the GitHub `id` gives the canonical noreply form:
+
+| PR | Author | Trailer to use |
+|----|--------|----------------|
+| #3529 | yansigit | `Co-authored-by: yansigit <44089734+yansigit@users.noreply.github.com>` |
+| #3480 | benedictusrey | `Co-authored-by: benedictusrey <hartanto.benedictus.reynaldo.w0@s.mail.nagoya-u.ac.jp>` |
+| #3490 | yxr1995-maker | `Co-authored-by: yxr1995-maker <257504378+yxr1995-maker@users.noreply.github.com>` (commit email is `earan@localhost`, unusable) |
+| #3515 | VXNCXNX | `Co-authored-by: VXNCXNX <93332837+VXNCXNX@users.noreply.github.com>` |
+| #3323 | luvs01 | `Co-authored-by: luvs01 <27862058+luvs01@users.noreply.github.com>` |
+| #3525, #3484 | Ingwannu | `Co-authored-by: Ingwannu <186453546+Ingwannu@users.noreply.github.com>` |
+
+---
+
+## 3. Per-item execution
+
+Each item below states the live defect (re-verified on `6580694c7`), the file change map,
+the RED/GREEN argument, the focused verifier, and accept criteria. **No file map is a work
+instruction except §3.4** — for the other six the diff already exists on the PR head, and the
+map is what the reviewer confirms is what merged.
+
+### 3.1 #3515 — fix(responses): keep caller cancellations out of upstream failure logs
+
+Head `4f09faf5d3e08275476b31f4b6a8ed30d04a8a66` · VXNCXNX · +87/-1 · 4 files · **full-matrix
+green** · `bug`, `review-ready` · not draft · REVIEW_REQUIRED.
+**Now `CONFLICTING`** on `tests/server-auth.test.ts` -> `tests/server/server-auth.test.ts`
+(§0.1). Source files are clean; rebase per §0.2 before P1.
+
+**Defect, live on `6580694c7`.** The inspection pump learns the client is gone only via the
+listener at [relay.ts:1269](/private/tmp/ocx-closeout.xomWAA/wt/src/server/relay.ts:1269):
+
+```ts
+  clientGoneSignal?.addEventListener("abort", markClientGone, { once: true });
+```
+
+and its `catch` reaches `options.onReadError?.()` at
+[relay.ts:1323](/private/tmp/ocx-closeout.xomWAA/wt/src/server/relay.ts:1323) whenever
+`clientGone` is still false. Bun can settle the body read before dispatching every abort
+listener, so a caller abort lands there. The call site compounds it —
+[core.ts:4925](/private/tmp/ocx-closeout.xomWAA/wt/src/server/responses/core.ts:4925) passes
+only the synthetic signal:
+
+```ts
+        clientGoneSignal: clientGone.signal,
+```
+
+never the inbound `options.abortSignal` available on the same object. Result: a client cancel
+logs 502 and increments the account-pool failure streak.
+
+**File change map (confirm, do not author).**
+
+| Path | Change |
+|------|--------|
+| `src/server/relay.ts` | +4: treat a read rejection as a caller cancel when the inbound signal is aborted, before the `onReadError` classification |
+| `src/server/responses/core.ts` | +4/-1 at ~4925: widen `clientGoneSignal` to include `options.abortSignal` (`AbortSignal.any`) |
+| `tests/server-auth.test.ts` -> **`tests/server/server-auth.test.ts`** | +75: the two regressions below; re-target on rebase |
+| `docs-site/src/content/docs/reference/proxy-formats.md` | +4: documents 499 vs 502 |
+
+**Regression tests** (`tests/server-auth.test.ts`), both confirmed present in the head diff:
+
+- `native passthrough caller abort logs cancellation without penalizing the pool` — asserts
+  499, `closeReason: "client_cancel"`, `consecutiveFailures === 0`. **RED on dev**: the
+  `catch` classifies the abort as an upstream fault, so the log is 502 and the streak
+  increments. **GREEN after**: the inbound signal is consulted first.
+- `native passthrough upstream reset still logs 502 and penalizes the pool` — asserts 502,
+  `streamAborted: true`, `consecutiveFailures === 1`. Green both before and after **by
+  design**: it is the negative twin proving the fix narrows classification instead of
+  suppressing 502 wholesale. A merge that turns this one red is a regression, not a pass.
+
+**Verifier.** `bun test tests/server/server-auth.test.ts` (V2; root path pre-`79e03643d`).
+
+**Accept criteria + activation scenarios (C-ACTIVATION-GROUNDING-01).** Both branches of the
+new conditional must be exercised, and both are:
+
+| Path | Activation scenario | Expected |
+|------|--------------------|----------|
+| inbound signal aborted | client disconnects mid-stream | 499, `client_cancel`, streak unchanged |
+| inbound signal not aborted | upstream resets the connection | 502, `streamAborted`, streak +1 |
+
+**Docs sync.** Satisfied in-PR (`proxy-formats.md`). No locale twin required — the PR touches
+only the English reference and `hygiene` passes.
+
+**Security boundary.** `src/server/responses/core.ts` is **owner-only** in
+[CODEOWNERS:46](/private/tmp/ocx-closeout.xomWAA/wt/.github/CODEOWNERS:46) (proxy-core
+boundary, `@lidge-jun` alone). Not an auth/OAuth/workflow surface, so no
+`maintainer-sponsored` label is needed — but the merge requires the owner, not any
+maintainer. No `src/lab/` import is added; the core/lab invariant is untouched.
+
+**PR body.** Already conformant; do not rewrite. Add only the §2.3 bypass comment at merge.
+
+### 3.2 #3480 — fix(google): steer Google models away from unrendered LaTeX math
+
+Head `74ef8faaed94d61835a6ffbade7bdc345829408b` · benedictusrey · +11/-0 · 2 files ·
+**CHANGES_REQUESTED (stale)** · **still `MERGEABLE` after `79e03643d`** — its test lives in
+`tests/adapters/google/`, an already-migrated domain, so the `server` move did not touch it.
+Draft state flapped during the session and was **non-draft** at final re-read (§0.4); confirm
+at P1. One of only two items executable today.
+
+**Defect, live on `6580694c7`.** `GOOGLE_BREVITY_INSTRUCTION` at
+[google.ts:49](/private/tmp/ocx-closeout.xomWAA/wt/src/adapters/google.ts:49) has four
+bullets — output style, internal reasoning, tool preference, final-answer exemption — and
+says nothing about math delimiters. Google models emit `$...$` / `\\(...\\)` / `\\text{}`,
+which the Codex desktop renderer shows raw.
+
+**File change map.** `src/adapters/google.ts` +1 (a fifth bullet);
+`tests/adapters/google/google-adapter.test.ts` +10.
+
+**Regression test.** `systemInstruction includes formatting guidance against unrendered
+LaTeX math` — asserts `toContain` on `String.raw`does not support LaTeX math delimiters
+($...$, $$...$$, \(...\), \[...\])`` and `String.raw`\text{}, \times, \le, \ge``.
+**RED on dev**: I ran V7 on clean dev — **32 pass / 0 fail**, and dev's instruction contains
+no LaTeX text at all, so both `toContain` calls cannot match. **GREEN after**: the bullet
+supplies both substrings. The `String.raw` usage is what makes the assertion independent of
+source-level escaping — which is exactly the reviewer's original objection, now moot.
+
+**Stale review — the reason it is dismissible.** The objection was that a single-backslash
+`\text{}` in a normal JS string becomes a tab at runtime. Lane 002 verified byte-exactly that
+the current head uses doubled escapes and that the test asserts via `String.raw`. The
+requested change is in; only the review state was never refreshed.
+
+**Verifier.** `bun test tests/adapters/google/google-adapter.test.ts` (V7, exit 0, 32/0 on dev).
+
+**Accept criteria + activation.** Single unconditional code path — the bullet is appended to
+every `google`-adapter `systemInstruction`. No conditional, so C-ACTIVATION-GROUNDING-01 is
+satisfied by the one scenario: any Google-adapter request carries the guidance; non-Google
+adapters are untouched because the constant is adapter-scoped
+([google.ts:47](/private/tmp/ocx-closeout.xomWAA/wt/src/adapters/google.ts:47) comment).
+
+**Docs sync.** None. An internal prompt constant is not user-facing configuration.
+
+**Security boundary.** `/src/adapters/` is maintainer-owned (CODEOWNERS:5), not a security
+surface. No exception needed.
+
+**Pre-merge, in addition to §2.3.** (a) `Ingwannu` dismisses the stale
+`CHANGES_REQUESTED` — `gh pr review 3480 --approve` or an explicit dismissal; (b) `gh pr
+ready 3480`; (c) D2/D3 full matrix. **This head has never run the shards** — it is the first
+that will.
+
+**Judgment note carried from lane 002.** This steers Google models globally, including
+clients that *can* render LaTeX. The maintainer endorsed that tradeoff in-thread. Recorded,
+not re-litigated.
+
+### 3.3 #3323 — test: isolate the route scanner probe in a unique temp directory
+
+Head `0facdae6990716c49b793df5e237ea26354262c1` · luvs01 · +6/-4 · 1 file · **full-matrix
+green** · `chore`, `review-ready` · 152 behind `dev`.
+**Now `CONFLICTING`**: its single file moved to
+`tests/server/management-route-registry.test.ts` (§0.1). The PR's whole content is that one
+file, so the rebase *is* re-applying the +6/-4 hunk at the new path.
+
+**Defect, live on `6580694c7`.**
+[management-route-registry.test.ts:125](/private/tmp/ocx-closeout.xomWAA/wt/tests/management-route-registry.test.ts:125)
+still writes the probe into the repository root:
+
+```ts
+    const tmp = join(repoRoot, ".tmp-scanner-probe.ts");
+```
+
+A crash between the write and the `finally` leaves `.tmp-scanner-probe.ts` in the working
+tree; concurrent runs collide on the fixed path. Target: `mkdtempSync` +
+`rmSync(tempDir, { recursive: true, force: true })`, `writeFileSync` moved **inside** the
+`try`, and two `require("node:fs")` calls converted to ESM imports.
+
+**Regression test.** N/A by construction — the change *is* the test. There is no RED-on-dev
+expectation; the pass/fail semantics of the suite are unchanged and only the temp-file
+location moves. Accept criterion is that the suite still passes and no repo-root artifact
+remains.
+
+**Verifier.** `bun test tests/server/management-route-registry.test.ts` (V8, exit 0,
+**13 pass / 0 fail** measured at the pre-migration root path). After merge, re-run and
+additionally confirm `git status --porcelain | rg 'tmp-scanner-probe'` is empty.
+
+**Accept criteria + activation.** The `finally` cleanup path is the only conditional and it
+activates on both scenarios: normal completion, and a throw inside the `try` (the case the
+change exists for — write failure now also triggers cleanup because `writeFileSync` moved
+inside).
+
+**Staleness note.** 152 commits behind, merge-base `ff1ac6b8c`. It stayed `MERGEABLE` for
+152 commits because `dev` never touched this file — and then `79e03643d` moved it, which is
+exactly the "if P1 returns `CONFLICTING`" branch this note anticipated. Its green CI (run
+33717654059) remains valid for its head but a rebase invalidates it. Hand to wp2 or ask
+`luvs01` to re-apply at `tests/server/`.
+
+**Docs sync / security.** None; test-only, no runtime reachability.
+
+### 3.4 #3490 — fix(codex): diagnose invalid persistent instructions config
+
+Head `3fbe8a2c760016fcd7c0d8aafa0ad0fe060060a5` · yxr1995-maker · +159/-1 · 4 files ·
+**draft** · intake-only CI · merge-base `85e42117c`.
+**Still `MERGEABLE` after `79e03643d`** — none of its four paths moved. One of only two
+items executable today, and the layout fix below is still required: re-checked at
+`79e03643d`, `origin/dev:scripts/test-layout/layout.json` has **no** entry for
+`codex-legacy-config-keys.test.ts`.
+
+**Disposition change vs lane 001: LAND_AS_IS -> LAND_AS_IS + one registry line.** Lane 001
+cleared this on the merits and was right about the code. It could not have caught what
+follows, because the gate post-dates the PR's merge-base.
+
+**Defect, live on `6580694c7`.** The hand-rolled TOML table matcher at
+[project-config-warnings.ts:65](/private/tmp/ocx-closeout.xomWAA/wt/src/codex/project-config-warnings.ts:65):
+
+```ts
+    const table = line.match(/^\s*\[([^\]]+)\]\s*$/);
+```
+
+The trailing `\s*$` rejects a trailing comment, so `[model_messages] # templates` never
+matches, `current` is never switched, and every key under that header is attributed to the
+document root. Target: tolerate a trailing `#` comment. Valid TOML, misparsed today.
+
+**BLOCKER — the new test file does not resolve under `dev`'s layout guard.** The PR adds
+`tests/codex-legacy-config-keys.test.ts` **at the tests root**. Between the PR's merge-base
+and today, `5df664cda` introduced `tests/test-layout.test.ts`, which requires every
+`*.test.ts` to resolve to a domain. Verified three ways:
+
+1. `git cat-file -e 85e42117c:tests/test-layout.test.ts` -> **ABSENT** at the merge-base.
+   The guard did not exist when this branch was cut.
+2. Running the repository's own resolver against the filename:
+   `resolveTarget(layout, "codex-legacy-config-keys.test.ts")` -> **`null`**, and
+   `keepAtRoot` -> `false`. The `codex-integration` regex seed matches
+   `^(?:active|app|bearer|catalog|combos...|native|parallel|project|...)-`; `codex-` is not a
+   seed, and every existing `codex-*` file is mapped through the `explicit` map instead.
+   `git show refs/tmp/pr3490:scripts/test-layout/layout.json` contains **no** entry for it.
+3. **Executed the failure.** I copied the PR's test file to the tests root on clean dev, ran
+   V9, and got `1 pass / 1 fail` with `unresolved` non-empty; removing the file restored
+   `2 pass / 0 fail`. The worktree was left clean (`git status --porcelain` shows only the
+   untracked devlog directory).
+
+So merging #3490 unchanged turns `tests/test-layout.test.ts` **red on `dev`**. Its
+intake-only CI cannot reveal this: the shard that runs the guard is draft-gated.
+
+**File change map.**
+
+| Path | Change | Origin |
+|------|--------|--------|
+| `src/codex/project-config-warnings.ts` | +1/-1 at line 65: regex tolerates a trailing comment | PR |
+| `src/codex/legacy-config-keys.ts` | **new**, +66: legacy-key detection | PR |
+| `src/cli/doctor.ts` | +10: surface the diagnostic | PR |
+| `tests/codex-legacy-config-keys.test.ts` | **new**, +82, at tests root | PR |
+| `scripts/test-layout/layout.json` | **+1 — authored in this work-phase**: `"codex-legacy-config-keys.test.ts": "codex-integration"` in the `explicit` map | **this doc** |
+
+**The one authored line.** Add to the `explicit` object in
+`scripts/test-layout/layout.json`, in its alphabetical slot among the `codex-*` keys (they
+run from `codex-log-guard-*` at lines 406-415; `codex-legacy-config-keys.test.ts` sorts
+immediately before `codex-log-guard-coderabbit.test.ts`):
+
+```json
+    "codex-legacy-config-keys.test.ts": "codex-integration",
+```
+
+Verified sufficient: with that entry injected, the resolver returns **`"codex-integration"`**
+instead of `null`.
+
+**Which resolution, and why this one.** Two options exist and they are not equivalent:
+
+- *(chosen)* **Keep the file at the tests root, add the explicit entry.** `resolveTarget`
+  returns `codex-integration`, which **is** in `layout.migrated`, so the guard's straggler
+  rule fires for a root file resolving to a migrated domain — meaning the file must **also**
+  move to `tests/codex-integration/`. Read the guard precisely: a root file whose target is a
+  migrated domain is a *straggler*. So the complete fix is **entry + move**:
+  `tests/codex-integration/codex-legacy-config-keys.test.ts`, with import specifiers
+  rewritten one level deeper (`../src/` -> `../../src/`).
+- *(rejected)* Adding the file to `keepAtRoot`. That list is for support files
+  (`preload.ts`, `fake-codex-server.ts`, the layout tests themselves), not domain tests.
+  Using it would satisfy the guard while lying about the file's nature.
+
+**Therefore the authored change is: the `layout.json` explicit entry, plus the file placed at
+`tests/codex-integration/codex-legacy-config-keys.test.ts` with `../../src/` specifiers.**
+Ask the author to do this on their branch (preferred — keeps attribution native and the merge
+a plain squash); if they do not respond, it is a two-line maintainer commit pushed to the PR
+branch, which is still not a carry and still needs no trailer.
+
+After the move, confirm the tooling oracle agrees:
+`bun test tests/test-layout-tooling.test.ts` — expect **15 pass / 0 fail** on a checkout at
+`6580694c7` (see §0: 14/1 at `0f27bbeb3` is the stale-checkout signature, not this change).
+
+**Regression tests** (in the PR's new file, names read from the head):
+
+- `a table header with a trailing comment does not leak fields into root` — **RED on dev**,
+  and lane 001 isolated it by applying the test file and the new module while *withholding*
+  the one-line regex fix: `5 pass, 1 fail`, `Expected length: 0, Received length: 1`. That
+  isolation is what proves the regex is load-bearing rather than incidental.
+- `flags top-level persistent_instructions as an unsupported legacy key`,
+  `ignores a table-scoped key with the same name`, `formats one doctor line per legacy key`,
+  `does not flag a clean config`, `reports unavailable when the config path is not a regular
+  file` — new-module coverage; RED on dev only in the trivial sense that the module does not
+  exist.
+
+**Verifiers.**
+
+```
+bun test tests/test-layout.test.ts                              # V9 — the gate; MUST stay 2 pass / 0 fail
+bun test tests/codex-integration/codex-legacy-config-keys.test.ts   # post-merge only; absent on dev (ls -> exit 1)
+bun test tests/codex-integration/project-config-warnings.test.ts    # shared-parser consumer, must not regress
+```
+
+Lane 001 measured the last two together at **27 pass / 0 fail** with the full patch.
+
+**Accept criteria + activation (C-ACTIVATION-GROUNDING-01).** The diff adds several
+conditionals; each needs a named scenario:
+
+| Conditional | Activation scenario | Expected |
+|-------------|--------------------|----------|
+| regex matches a commented header | `[model_messages] # templates` | section switches; root gains no key |
+| regex matches a plain header | `[model_messages]` | unchanged from dev |
+| top-level legacy key present | `persistent_instructions` at root | one doctor line |
+| same key table-scoped | `persistent_instructions` under a table | **not** flagged |
+| config path is not a regular file | path is a directory / missing | `unavailable`, check skipped, doctor still runs |
+| clean config | no legacy keys | no output |
+
+The `existsSync` + `statSync().isFile()` guard degrading to a skipped check (rather than
+failing doctor) is the behavior the fifth row pins.
+
+**Docs sync.** None required: a doctor diagnostic string is not documented configuration.
+
+**Security boundary.** `/src/codex/` and `/src/cli/` are maintainer-owned; `src/codex/
+auth-context.ts` is the only security-listed file in that tree and is not touched. `node:fs`
+is acceptable here — `doctor.ts` and neighbouring `src/codex/` modules already use it, and
+the Bun-native rule targets the server request path. No exception needed.
+
+**Pre-merge.** layout fix -> `gh pr ready 3490` -> D2/D3 full matrix -> §2.3 P1-P6.
+
+### 3.5 #3484 — fix(integrations): reconcile journal deletion cleanup
+
+Head `a4c50d104778d2ac11fc4c91b29b3e505cb68c2a` · Ingwannu · +187/-1 · 14 files ·
+**full-matrix green** (25 checks, macOS 16m1s) · `bug`, `gui-screenshot-waived` · not draft.
+**Now `CONFLICTING`** on `tests/management-integration-journal-delete.test.ts` ->
+`tests/server/…` (§0.1). All 13 other paths — server, GUI, and 8 locales — are clean.
+
+**Defects, both live on `6580694c7`.**
+
+1. Stale prune-failure marker at
+   [integration-routes.ts:379](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/integration-routes.ts:379):
+
+   ```ts
+       const pruned = store.pruneSnapshots(operation.clientId);
+       if (!pruned.ok) store.markPruneFailure(operation.clientId, pruned.error);
+   ```
+
+   No success branch, so a later successful prune never clears an earlier marker and
+   `retentionDegraded` latches forever. It is an oversight, not a design choice: the other two
+   call sites already pair the clear with the prune —
+   [journal.ts:180](/private/tmp/ocx-closeout.xomWAA/wt/src/integrations/journal.ts:180) and
+   [store.ts:97](/private/tmp/ocx-closeout.xomWAA/wt/src/integrations/store.ts:97).
+2. `integration_operation_not_found` exists at
+   [integration-routes.ts:343](/private/tmp/ocx-closeout.xomWAA/wt/src/server/management/integration-routes.ts:343)
+   but no client predicate consumes it, so a second tab completing the same delete leaves the
+   first tab offering a retry that can only 404 again.
+
+**File change map.** `src/server/management/integration-routes.ts` +2/-1 (the `pruned.ok`
+clear); `gui/src/pages/integrations/{IntegrationsOverview.tsx,FileIntegrationPage.tsx}` +9
+each; `gui/src/pages/integrations/integration-api.ts` +7 (`isMissingJournalEntry`);
+`gui/tests/integrations-surfaces.test.tsx` +69; `management-api.md` +10 in **8 locales**.
+
+**Regression tests.**
+
+- `tests/management-integration-journal-delete.test.ts`: `a successful delete-triggered prune
+  clears an older failure marker` — marks a failure, deletes, asserts `pruneFailures.hermes`
+  is `undefined`. **RED on dev**: nothing clears the marker. **GREEN after**: the success
+  branch clears it. V6 on clean dev is **12 pass / 0 fail**; the merged file adds this 13th.
+- `gui/tests/integrations-surfaces.test.tsx` +69 covers the 404 reconcile path.
+
+**Verifier.** `bun test tests/server/management-integration-journal-delete.test.ts` (V6,
+exit 0 at the pre-migration root path). The GUI test runs under the `react-doctor` / GUI job,
+already green on the head.
+
+**Accept criteria + activation.**
+
+| Conditional | Activation scenario | Expected |
+|-------------|--------------------|----------|
+| `pruned.ok` true | delete succeeds after an earlier prune failure | marker cleared, `retentionDegraded` false |
+| `pruned.ok` false | prune fails | marker set (dev behavior preserved) |
+| `isMissingJournalEntry` true | second tab already completed the delete | dialog reconciles to "already gone", no retry |
+| `isMissingJournalEntry` false | genuine transient error | retry still offered |
+
+The post-commit ordering documented in the comment above line 379 is preserved — the clear is
+added, the sequence is not reordered.
+
+**Docs sync.** Satisfied: all 8 locales updated in-PR, matching the repo rule.
+
+**Security boundary.** `/src/server/` is maintainer-owned. `integration-routes.ts` is **not**
+in the auth/credential CODEOWNERS block and is not `management-auth.ts` or
+`management-api.ts`, so no `maintainer-sponsored` label is required. The `gui` screenshot
+gate is already satisfied by the `gui-screenshot-waived` label.
+
+**Cross-PR note.** Shares `docs-site/.../reference/management-api.md` with #3525 (§2.1) and
+`IntegrationsOverview.tsx` with #3407 (wp2, not in this train) — land #3484 first so #3407
+rebases onto it.
+
+### 3.6 #3525 — fix(responses): expose continuation spill write health
+
+Head `288506dc6883fa8433cf89014e72d01c1675317d` · Ingwannu · +305/-43 · 8 files ·
+**full-matrix green** (27 checks) · CodeRabbit "No actionable comments".
+**Now `CONFLICTING`** on `tests/memory-watchdog.test.ts` -> `tests/server/…` only; its two
+`tests/responses/` files and all source/docs paths are clean (§0.1).
+
+**Defect, live on `6580694c7`.** `spillCounters` at
+[state.ts:172](/private/tmp/ocx-closeout.xomWAA/wt/src/responses/state.ts:172):
+
+```ts
+const spillCounters = { writes: 0, writeFailures: 0, readFailures: 0 };
+```
+
+Three cumulative integers. An operator cannot distinguish "failed 10,000 times and is still
+failing" from "failed 10,000 times an hour ago and recovered" — which is exactly the #3522
+Windows report (successful spills frozen at 1,988 while failures climbed past 10,000, and
+`/healthz` still reporting healthy). Observability, not a crash fix: it does **not** close
+#3522, and the author says so. Do not write `Closes #3522` on this merge.
+
+**File change map.** `src/responses/state.ts` +124/-28 (streak/last-failure shape +
+`classifySpillWriteFailure`); `src/server/management/system-routes.ts` +3/-2 (expose on
+`/api/system/memory`); `tests/responses/responses-state.test.ts` +124/-1;
+`tests/memory-watchdog.test.ts` +26/-6; `tests/responses/continuation-dedup.test.ts` +3/-2;
+`structure/05_gui-and-management-api.md` +9/-1;
+`docs-site/.../reference/management-api.md` +1/-1;
+`docs-site/.../troubleshooting/windows-memory.md` +15/-2.
+
+**Regression tests**, names read from the head diff:
+
+- `a successful spill clears a repeated failure streak without erasing the last failure`
+  (`tests/responses/responses-state.test.ts`) — **RED on dev**: with three cumulative
+  integers there is no streak to clear and no last-failure to retain.
+- `Windows spill reports exhausted ACL retry and recovers after a healthy runner`
+  (`tests/memory-watchdog.test.ts`) — RED on dev for the same reason.
+- `response-state management metrics keep every added field finite scalar and privacy-safe` —
+  the privacy guard on the new fields.
+
+Lane 001 measured tests-only on clean dev at **137 pass / 6 fail**, and the full patch across
+`responses-state` + `memory-watchdog` + `continuation-dedup` at **172 pass / 0 fail**.
+
+**Verifiers.** `bun test tests/responses/responses-state.test.ts` (V4);
+`bun test tests/server/memory-watchdog.test.ts` (V5, moved by `79e03643d`);
+`bun test tests/responses/continuation-dedup.test.ts`.
+
+**Accept criteria + activation.**
+
+| Conditional | Activation scenario | Expected |
+|-------------|--------------------|----------|
+| spill succeeds after failures | healthy runner follows an ACL-exhausted streak | streak resets; last-failure retained |
+| spill fails repeatedly | Windows ACL retry exhausted | streak increments; classification recorded |
+| `cause` chain up to 4 deep | nested error carrying a path/username | collapses to the fixed 9-member enum; no message or path surfaces |
+| unclassifiable failure | unknown error shape | falls to the enum's catch-all, still a scalar |
+
+**Privacy — the reason this is safe to expose.** `classifySpillWriteFailure` walks up to four
+`cause` levels and collapses everything to a fixed 9-member enum, so no message or filesystem
+path can leak; the diff's own comment names the nested-`cause` username/path risk. The new
+fields are scalars on the **authenticated** `/api/system/memory` and explicitly **not** on
+`/healthz`. `privacy:scan` passes on the head.
+
+**Docs sync.** Satisfied in-PR: `structure/05`, the management-API reference, and the Windows
+memory troubleshooting page.
+
+**Known non-blocking nit (do not fix here).** `windows-memory.md` adds "run `ocx observe
+memory --json`". The command resolves — `observe` with a `memory` subcommand at
+[registry.ts:237](/private/tmp/ocx-closeout.xomWAA/wt/src/cli/registry.ts:237) and an alias at
+line 264 — but line 264's summary reads "Alias of `ocx n memory`" while the canonical name is
+`observe`. **That inconsistency is pre-existing on `dev`, not introduced by this PR.** Out of
+scope (§8).
+
+**Security boundary.** `/src/server/` maintainer-owned; `system-routes.ts` is not in the
+auth block. Author is `Ingwannu`, so the approval must come from the owner or a second
+maintainer (§2.3).
+
+### 3.7 #3529 — fix(providers): rebase key failover on persisted state
+
+Head **`81e692313`** (was `4f103a1e71bd8712fc31e856ca105864811d8b7f`; the author pushed
+during this session) · yansigit · +165/-68 · 6 files · **draft** · intake-only CI.
+**Now `CONFLICTING`** on two moved files — `tests/server-combo-failover-e2e.test.ts` and
+`tests/terminal-guard-server.test.ts`, both -> `tests/server/…` (§0.1). Its
+`tests/adapters/` and `tests/providers/` files and `src/providers/key-failover.ts` are clean.
+**Re-read the head before any action** — the moving head is exactly why P3 exists (§2.3).
+
+**Defects, both live on `6580694c7`.**
+
+1. `rotateKeyOn429` mutates the request's in-memory config and writes the whole object —
+   [key-failover.ts:221-222](/private/tmp/ocx-closeout.xomWAA/wt/src/providers/key-failover.ts:221):
+
+   ```ts
+         provider.apiKey = candidate.key;
+         saveConfigPreservingClaudeCode(config);
+   ```
+
+   A key deleted from the pool through the management API between request start and rotation
+   is **resurrected** by that whole-object write.
+2. `rotateProviderTransportOn429` at
+   [key-failover.ts:280](/private/tmp/ocx-closeout.xomWAA/wt/src/providers/key-failover.ts:280)
+   spreads `{ ...routedProvider, apiKey: rotated.apiKey }`, so a concurrent edit to any other
+   persisted provider field is dropped on the retry. The module's own doc comment at line 176
+   already warns not to assign a routed provider wholesale.
+
+**File change map.** `src/providers/key-failover.ts` +62/-46;
+`tests/adapters/key-failover.test.ts` +62/-7;
+`tests/terminal-guard-server.test.ts` +33/-15 -> **`tests/server/terminal-guard-server.test.ts`**;
+`tests/server-combo-failover-e2e.test.ts` +4 -> **`tests/server/server-combo-failover-e2e.test.ts`**;
+`tests/adapters/openai/openai-chat-native-policy.test.ts` +2;
+`tests/providers/openrouter-provider-routing.test.ts` +2.
+The two `-> tests/server/` re-targets are the whole of this PR's rebase.
+
+**Regression tests**, names read from the head diff (`tests/adapters/key-failover.test.ts`):
+
+- `rebases over a concurrent pool edit without resurrecting a removed key`
+- `inherits routed-only backfills while persisted fields stay authoritative`
+- `unavailable persistence does not publish a tentative cooldown`
+- `two stale handlers adopt one committed rotation without rotating twice`
+
+Lane 001 executed the tests-only half on clean dev: **12 pass / 3 fail**, with the
+persisted-field case failing `Expected: "https://api.example.com/v1" Received:
+"https://registry-pinned.example/v1"` — the routed value winning over the persisted one, which
+*is* defect 2. Adding the `src/` half gives **15 pass / 0 fail**. Honestly RED on dev.
+
+**Verifier.** `bun test tests/adapters/key-failover.test.ts` (V3). Also run
+`bun test tests/lab/core-lab-boundary.test.ts` (V10) — see the invariant note below.
+
+**Accept criteria + activation.**
+
+| Conditional | Activation scenario | Expected |
+|-------------|--------------------|----------|
+| key removed from pool mid-request | management API deletes the key, then a 429 rotates | removed key stays removed |
+| other provider field edited mid-request | `baseUrl` changed concurrently, then a 429 | persisted `baseUrl` wins over the routed backfill |
+| persistence unavailable | config write fails | **no** tentative cooldown published |
+| two stale handlers race | two in-flight requests both see the pre-rotation key | one committed rotation adopted; no double rotation |
+
+**Invariant cleared, and worth re-checking after any rebase.** The diff adds
+`import { routedProviderConfig } from "../router"` to a module that
+`src/server/responses/core.ts` and `compact.ts` import. Lane 001 verified `src/router.ts`
+does **not** import `key-failover` (checked against router.ts:1-47), so there is no cycle,
+and `tests/lab/core-lab-boundary.test.ts` passed **17/17** with the patch applied. `src/
+router.ts` is one of the four owner-only proxy-core files, so if the head is ever rebased,
+re-run V10 before merging.
+
+**Docs sync.** None — internal rotation semantics, no user-facing surface change.
+
+**Security boundary.** `/src/providers/` is maintainer-owned. Key logging stays id-only (lane
+001 verified), so `privacy:scan` is unaffected. Not an auth/OAuth surface: no
+`maintainer-sponsored` label needed.
+
+**Pre-merge.** `gh pr ready 3529` -> D2/D3. This is the **highest-risk item in the train** and
+the one whose CI evidence must be created from nothing: rotation + persistence semantics with
+zero full-matrix history. Merge last, and treat any shard failure as a stop, not a flake,
+unless the same test is independently shown failing on `dev`.
+
+---
+
+## 4. Field / enum chains for new config fields
+
+**N/A for six of seven items** — #3515, #3490, #3484, #3480, #3323, #3529 add no persisted
+configuration field, no serialized enum, and no new wire key. #3529 changes *how* an existing
+`provider.apiKey` write is composed, not the field's shape or type.
+
+**#3525 is the one item with a new serialized surface**, and it is a **metrics** surface
+rather than a config field — nothing is read back or persisted to `config.json`, so there is
+no deserialization consumer:
+
+| Stage | Where | Note |
+|-------|-------|------|
+| creation | `src/responses/state.ts` — `spillCounters` gains streak / last-failure fields alongside `writes`, `writeFailures`, `readFailures` | in-memory only, process-lifetime |
+| classification | `classifySpillWriteFailure` -> fixed **9-member enum** | walks <=4 `cause` levels; collapses to the enum so no message or path escapes |
+| serialization | `src/server/management/system-routes.ts` -> `GET /api/system/memory` | authenticated; finite scalars only; **not** `/healthz` |
+| deserialization | **none** | never parsed back; not written to `config.json` |
+| consumer | operator / dashboard; documented in `structure/05` and `reference/management-api.md` | the `windows-memory.md` runbook is the human consumer |
+
+The enum is closed by construction — that is what makes the privacy guarantee hold, and the
+`...keep every added field finite scalar and privacy-safe` test is what enforces it. Any
+future member must be added at the classification site and nowhere else.
+
+---
+
+## 5. Risk and rollback
+
+Rollback is per-merge and uniform, because each item is one squash commit:
+
+```
+git revert --no-edit <squash-sha>     # then open the revert as a PR to dev
+```
+
+Never force-push `dev`: the `Protect dev` ruleset blocks non-fast-forward pushes and
+deletion, so revert-forward is the only available path.
+
+| Step | PR | Risk | Blast radius if wrong | Rollback |
+|------|----|------|----------------------|----------|
+| 1 | #3323 | **negligible** | test-only; cannot affect runtime | revert; nothing depends on it |
+| 2 | #3480 | **low** | every Google-adapter request gets one extra prompt line; worst case is prompt-quality regression, not failure | revert restores the 4-bullet constant |
+| 3 | #3515 | **medium** | proxy-core: a misclassification could hide a genuine 502 or mislabel a cancel | revert; the negative-twin test is the tripwire — if it goes red post-merge, revert immediately |
+| 4 | #3484 | **low-medium** | integrations delete flow + GUI dialog; failure is a stuck dialog, not data loss (ordering preserved: journal retired before prune) | revert server + GUI together (one squash) |
+| 5 | #3525 | **medium** | largest diff; `state.ts` is on the continuation path. A shape error surfaces as bad metrics, but the module is request-path adjacent | revert; `/api/system/memory` returns to the 3-integer shape |
+| 6 | #3490 | **low** | doctor diagnostics + a shared TOML parser used by `collectProjectCodexConfigWarnings`. Parser regression would mis-attribute config keys | revert; **also** revert the `layout.json` line if it was a separate commit |
+| 7 | #3529 | **highest** | 429 rotation + config persistence. A wrong rebase could drop a concurrent config edit or fail to rotate under load | revert immediately; do not forward-fix. Re-run V3 and V10 on `dev` after the revert |
+
+**Train-level risk.** The only cross-item coupling is the two docs files in §2.1. If the
+second of #3525/#3484 reports `CONFLICTING` at P1, stop that item and hand it to wp2 — do not
+resolve a docs conflict inside a merge train.
+
+### 5.1 Security-boundary items and the MAINTAINERS.md exception needed
+
+No item in Stack A touches `src/oauth/`, `auth-cors.ts`, `management-auth.ts`,
+`admin-secrets.ts`, `.github/` workflows, or release automation. **No `maintainer-sponsored`
+label and no security review is required for any of the seven.** For contrast, the
+`unsponsored_surface` hygiene failure that blocks #3524 (wp2) —
+*"This changes an authentication, workflow, release-automation, or dependency surface"*,
+[pr-hygiene.cjs:242](/private/tmp/ocx-closeout.xomWAA/wt/.github/scripts/pr-hygiene.cjs:242) —
+has **no analogue here**: `hygiene` passes on all seven heads.
+
+Two ownership constraints do apply, and they are approval routing, not security exceptions:
+
+| Item | Path | Constraint |
+|------|------|-----------|
+| #3515 | `src/server/responses/core.ts` | **owner-only** ([CODEOWNERS:46](/private/tmp/ocx-closeout.xomWAA/wt/.github/CODEOWNERS:46)) — proxy-core boundary; `@lidge-jun` must approve or merge |
+| #3529 | imports `src/router.ts` | `router.ts` is owner-only; the import is cleared by V10 but a rebase must re-run it |
+| #3525, #3484 | authored by `Ingwannu` | *"Authors do not approve their own pull requests"* — needs the owner or a second maintainer |
+
+Every `--admin` merge needs the bypass recorded on the PR (§2.3).
+
+---
+
+## 6. Contingencies
+
+**6.1 A PR turns `CONFLICTING` mid-train.** Stop that item, leave it open, record it in the
+ledger as `DEFERRED -> wp2` with the conflicting paths. Do not rebase inside this
+work-phase.
+
+**6.2 An approval cannot be obtained.** If the owner is unavailable for #3515's proxy-core
+approval, or no second maintainer exists for #3525/#3484, stop and escalate (§1). Do not
+widen the bypass beyond what `MAINTAINERS.md` already grants.
+
+**6.3 A contributor is unreachable and the PR must be closed.** Only then does carry apply:
+create `codex/260905-<slug>` from the PR head (`git checkout -b codex/260905-<slug>
+refs/tmp/pr<n>`), keep the author's commits, add the §2.5 trailer so it survives the squash,
+and open a new PR crediting the original. This is a wp2-shaped action; prefer waiting.
+
+**6.4 `dev` goes red after a merge.** Revert that squash (§5) before merging the next item.
+A red `dev` invalidates the CI evidence of every remaining head.
+
+---
+
+## 7. Ledger row format (for `060`)
+
+One row per PR, appended in merge order:
+
+```
+| WP | Item | Disposition | Carry branch / PR | Head SHA | CI run id | Landing SHA | Ancestry proof (cmd + exit) | Original closed (comment URL) |
+```
+
+- **Head merged** — the `headRefOid` confirmed at P3, not P1.
+- **Ancestor proof** — `git merge-base --is-ancestor <squash> FETCH_HEAD` exit code, plus the
+  `origin/dev` SHA it was checked against.
+- **CI evidence** — `full-matrix green (N checks)` or `ready+matrix run <id>` for a draft
+  released via D1-D3. Never `intake-only`.
+- **Bypass** — `admin-squash (recorded on PR)` or `approved by <login>`.
+- **Notes** — one line; for #3490 record the `layout.json` entry and the test relocation.
+
+Worked example (illustrative shape, SHAs filled at execution):
+
+```
+| #3323 | test: isolate the route scanner probe... | luvs01 | 0facdae69 | <squash> | 0 vs <dev-sha> | full-matrix green (22) | admin-squash (recorded) | 152 behind; file untouched on dev since merge-base |
+```
+
+---
+
+## 8. Out of scope / deferred (evidence carried from the lanes)
+
+- **#3502** (LAND_WITH_FIX, wp2) — `CONFLICTING`; its docs prose contradicts #3520 which
+  already landed, and three of its four test files no longer exist on `dev`.
+- **#3519** (LAND_WITH_FIX, wp2) — both reviewer blockers are genuinely fixed, but the
+  behavior change ships with no `docs-site/` update and carries an unresolved
+  `CHANGES_REQUESTED`.
+- **#3524** (REIMPLEMENT, wp2) — adds an unguarded `throw` on the `startServer` path,
+  reproduced live as a boot failure, and is `hygiene`-blocked on `unsponsored_surface` for
+  `src/oauth/index.ts`.
+- **#3489, #3469** (LAND_WITH_FIX, wp2) — approved and green, but both conflict on the
+  `tests/<domain>/` migration and need a mechanical test-path rebase. **`79e03643d` has now
+  put five Stack A items in the same position (§0.1)** — if the parent chooses option (B),
+  wp2 should handle all of them with one recipe rather than two.
+- **#3407** (REIMPLEMENT, wp2) — 5 failing CI jobs on its exact head, 121 commits behind, and
+  a tracked 166 KB PNG that does not belong in the tree.
+- **#3388** (DEFER) — draft, 132 commits behind, shards never ran, and a 327-line stream
+  rewriter lands on the protected `responses/core.ts` path with no maintainer review.
+- **#3348** (REIMPLEMENT) — the 2165-line diff bundles unrelated disk persistence and a silent
+  policy-fallback status change; only a classification-only subset should land.
+- **The `ocx observe memory` alias-summary inconsistency** (`registry.ts:264` says "Alias of
+  `ocx n memory`" while the canonical name at line 237 is `observe`) — pre-existing on
+  `dev`, surfaced by #3525's docs but not caused by it; fix separately.
+- **#3522 remains open after #3525 lands** — #3525 is observability only and does not fix the
+  Windows spill failure it diagnoses. Do not write `Closes #3522`.
+
+---
+
+## 9. PR body skeleton
+
+Stack A merges **existing contributor PRs**, so no new PR is authored and no new body is
+written. Do not rewrite contributor descriptions — `enforce-target` already passes on all
+seven, and editing a body can reset the readiness checklist.
+
+The skeleton below applies **only** to the §6.3 carry contingency or to the #3490
+`layout.json` fix if it is opened as its own PR rather than pushed to the author's branch.
+It follows `.github/PULL_REQUEST_TEMPLATE.md` (Summary / Verification / Checklist):
+
+```markdown
+## Summary
+
+<what changed and why, in prose; name the defect and the file:line it lives at>
+
+| Layer | Branch | Targets | Proves alone |
+|-------|--------|---------|--------------|
+| 1 | codex/260905-<slug> | dev | <the single verifiable claim> |
+
+Closes #<issue>   <!-- only if a real issue is fixed; PRs target dev, so close manually -->
+
+## Verification
+
+- \`bun test tests/<file>.test.ts\` — N pass / 0 fail
+- \`bun run typecheck\` — exit 0
+- exact-head CI: <run id>, all required checks green
+
+## Checklist
+
+- [x] Local CI green
+- [x] Branch on the latest \`dev\` commit
+- [x] Codex and CodeRabbit findings fixed
+- [x] Ready for review
+
+Co-authored-by: <login> <email>
+```
+
+For the #3490 layout fix specifically: title
+`test(layout): map codex-legacy-config-keys to codex-integration`, no `Closes` line, and the
+`yxr1995-maker` trailer only if it is carried rather than pushed to the author's branch.
+
+---
+
+## 10. Stack map table
+
+All rows target `dev` directly — Stack A is depth-1 by construction (§2.1), so no branch
+targets another PR's head. `Mergeable` is as of `origin/dev` = `79e03643d`.
+
+| Step | PR | Branch (head) | Targets | Proves alone | Mergeable now | CI of record | Pre-merge action | Risk |
+|------|----|---------------|---------|--------------|---------------|--------------|------------------|------|
+| 1 | #3323 | `test/route-scanner-private-temp` | `dev` | the route-scanner probe no longer writes into the repo root | **CONFLICTING** — file moved to `tests/server/` | full green (22) | rebase test path (§0.2); then approve + admin squash | negligible |
+| 2 | #3480 | `fix/google-latex-formatting` | `dev` | Google `systemInstruction` carries LaTeX-avoidance guidance | **MERGEABLE** | intake only (4) | dismiss stale `CHANGES_REQUESTED`; confirm draft state; `gh pr ready`; full matrix | low |
+| 3 | #3515 | `fix/native-caller-cancel-502` | `dev` | a caller abort logs 499 without penalizing the pool, while an upstream reset still logs 502 | **CONFLICTING** — `server-auth.test.ts` moved | full green (26) | rebase test path; **owner** approval (proxy-core); admin squash | medium |
+| 4 | #3484 | `ingw/fix-journal-delete-followup-3477` | `dev` | a successful prune clears a stale failure marker; the GUI reconciles a 404 | **CONFLICTING** — journal-delete test moved | full green (25) | rebase test path; owner/2nd-maintainer approval (author is a maintainer) | low-medium |
+| 5 | #3525 | `fix/3522-spill-health-diagnostics` | `dev` | spill health distinguishes an active failure streak from a recovered one | **CONFLICTING** — `memory-watchdog.test.ts` moved | full green (27) | rebase test path; owner/2nd-maintainer approval; **no `Closes #3522`** | medium |
+| 6 | #3490 | `fix/doctor-legacy-codex-config` | `dev` | a TOML table header with a trailing comment no longer leaks keys into root | **MERGEABLE** | intake only (4) | **add `layout.json` entry + place test at `tests/codex-integration/`** (§3.4); `gh pr ready`; full matrix | low |
+| 7 | #3529 | `codex/upstream-key-failover-rebase` (head `81e692313`) | `dev` | 429 rotation rebases on persisted state instead of resurrecting a removed key | **CONFLICTING** — two `tests/server/` moves | intake only (4) | rebase both test paths; `gh pr ready`; full matrix; re-run `core-lab-boundary` | highest |
+
+**Executable today: steps 2 and 6.** Steps 1, 3, 4, 5, 7 need the §0.2 mechanical rebase
+first — author-driven (A) or handed to wp2 (B); that call belongs to the parent.

--- a/devlog/_plan/260905_open_work_closeout/020_wp2_stack_b_bug_carry.md
+++ b/devlog/_plan/260905_open_work_closeout/020_wp2_stack_b_bug_carry.md
@@ -1,0 +1,1150 @@
+> **Amended by 008 (audit round 1):** #3489 merges clean under `git merge-tree` (no rebase); only #3469 keeps the test-rename recipe. Co-authored-by trailers use the ID-prefixed noreply form resolved via `gh api users/<login>`.
+
+# 020 — wp2 / Stack B: bug PRs needing carry or reimplementation
+
+Unit: `devlog/_plan/260905_open_work_closeout`. Work-phase: **wp2**.
+Sources: `001_lane_bug_prs_a.md` (#3502, #3519, #3524) and `002_lane_bug_prs_b.md`
+(#3489, #3469, #3407, #3348, #3388), both read in full.
+
+Planning worktree: `/private/tmp/ocx-closeout.xomWAA/wt` (detached at `0f27bbeb3`).
+`git fetch origin dev` at plan time: `origin/dev` = **`6580694c7`**
+("test(oauth): restore a deleted contract test, and fail when one disappears (#3530)").
+
+> **Second fetch, immediately before finalizing: `origin/dev` moved again to `79e03643d`.**
+> Two commits, and unlike the first drift **both affect this doc**. The corrections are
+> folded in below and marked "(drift-corrected)". Re-fetch before you branch; if
+> `origin/dev` has moved past `79e03643d`, re-run the two drift commands in this section
+> before trusting any line number or test path here.
+>
+> 1. `79e03643d` "test(layout): move server, storage, ci-workflows into tests/<domain>/
+>    (#3497) (#3518)" — `server` and `storage` are **now migrated domains** with real
+>    directories. Every "stays at `tests/` root" instruction below is inverted: those files
+>    now live in `tests/server/` and `tests/storage/` at depth 1.
+> 2. `bdafc5191` "test(oauth): prove the unobservable quorum staleness window is harmless
+>    (#3533)" — adds 13 lines to `src/oauth/anthropic-routing.ts`, shifting B1's target line
+>    from `:662` to **`:675`**. The line's text is unchanged, so the conflict stays
+>    mechanical; the anchor moved, not the content.
+
+**Drift check against the lane snapshot (`0f27bbeb3`).** One commit, and it touches
+nothing this work-phase owns:
+
+```
+git log --oneline 0f27bbeb3..origin/dev
+  6580694c7 test(oauth): restore a deleted contract test, and fail when one disappears (#3530)
+git log --oneline 0f27bbeb3..origin/dev -- src/oauth src/cli/claude.ts src/lib/errors.ts \
+  src/lib/provider-outbound.ts src/server/responses/core.ts src/combos \
+  src/server/management/native-integration-routes.ts src/codex/catalog/provider-fetch.ts \
+  src/adapters/google-errors.ts gui/src/pages/integrations
+  (empty)
+```
+
+Every `src/` line cited below was re-read on the tree at plan time, so all line numbers are
+current. **Branch from `origin/dev` = `6580694c7`, not the lane snapshot.**
+
+## Corrections to the lane docs (verified at plan time)
+
+Three lane claims are wrong or stale, and an implementer following them literally would
+produce a broken branch. Each was re-verified against the tree:
+
+1. **001 says three of #3502's four test files "do not exist on dev".** They exist, in
+   their migrated domains: `tests/oauth/adapter-event-oauth-failover.test.ts`,
+   `tests/oauth/generic-oauth-failover.test.ts`, `tests/routing/always-on-429-failover.test.ts`
+   (`ls` exit 0 on all three). The conflict is the `tests/<domain>/` migration described in
+   002, not a deletion. The test half is replayable at the new paths.
+2. **002's rebase recipe ("apply the hunk to the file's new path") is necessary but not
+   sufficient for NEW test files.** `tests/test-layout.test.ts` and
+   `tests/test-layout-tooling.test.ts` require every new basename to *resolve* to a domain
+   through `scripts/test-layout/layout.json`, and `tests/test-layout-tooling.test.ts:250`
+   asserts `layout.explicit` equals `tests/fixtures/test-layout-expected.json` byte for byte.
+   A new file whose name matches no regex seed fails `unresolvedNew` even if placed correctly.
+   Verified with the repo's own resolver — every new basename prescribed below resolves:
+
+   | New basename | `resolveTarget` | Directory |
+   |---|---|---|
+   | `command-code-fakeip-discovery.test.ts` | `providers` | `tests/providers/` |
+   | `server-startup-reconcile-resilience.test.ts` | `server` | `tests/server/` (drift-corrected) |
+   | `router-combo-failover-classification.test.ts` | `routing` | `tests/routing/` |
+   | `policy-fallback-exhaustion.test.ts` | `routing` | `tests/routing/` |
+   | `storage-cooldown-disk.test.ts` | `storage` | `tests/storage/` (drift-corrected) |
+
+   **(drift-corrected at `79e03643d`.)** At the lane snapshot `server` and `storage` were
+   unmigrated, so files resolving to them stayed at `tests/` root. `79e03643d` migrated
+   `server`, `storage`, and `ci-workflows`, so `layout.migrated` on `79e03643d` is:
+   adapters, ci-workflows, claude-integration, cli, clients, codex-integration, config, gui,
+   lab, lib, oauth, providers, responses, routing, **server**, service, **storage**, update,
+   usage, vision, web-search, windows. Both directories now exist, so these files go **in
+   them**, at depth 1 (`../src/` → `../../src/`). The rule itself is unchanged — a file
+   resolving to a *migrated* domain may not sit at root (the guard's `stragglers` branch), and
+   a file resolving to an unmigrated one may not sit in a directory (`misplaced`). Only the
+   membership moved. Re-read `layout.migrated` at branch time rather than trusting this list.
+3. **002's #3348 subset lists `AttemptRecoveryKind` and `COOLDOWN_RECOVERY_KINDS` as one
+   item.** They live in two different modules — the type at `src/usage/log.ts:45` with its
+   runtime set at `src/usage/log.ts:256`, and the analytics set at
+   `src/routing/analytics.ts:117`. Adding `key-401` is a four-site chain (§4), not one edit.
+
+## 1. Loop-spec header
+
+**Archetype:** spec-satisfaction repair. Each layer restores behavior the repository already
+documents or already implements elsewhere; none of it invents product surface. The two
+exceptions are called out where they occur (#3519 is a deliberate UX change; #3489 widens a
+security exception).
+
+**Trigger:** wp1 (Stack A, doc `010`) has merged into `dev`, or has been confirmed to touch
+none of this phase's files. The only cross-phase file overlap is
+`src/server/responses/core.ts`: wp1 lands #3515 near line 4925, this phase lands #3502's Kiro
+fix near lines 3380/6693. ~1,500 and ~3,300 lines apart, so the overlap is ordering hygiene,
+not a conflict.
+
+**Goal:** land the six carryable bug fixes in this family on `dev` as a reviewable stack plus
+two independent merges, with the two contributor reimplementations reduced to the bounded,
+defensible subsets the lane research identified, and every carried piece credited.
+
+**Non-goals:**
+
+- No `main`/`preview` promotion, no release, no version bump.
+- No repository-wide suite. `bun run test` and bare `bun test` with no file argument are
+  forbidden here; `bun run test:changed` and named files only.
+- Not landing #3388 (deferred, §6), #3348's disk persistence beyond PR B, #3348's
+  policy-fallback semantics beyond PR C, or #3407's tracked PNG.
+- No `git reset --hard`, no force-push to a shared branch, no rewriting a contributor's
+  branch in place. Carried work goes on **new** `codex/260905-*` branches.
+
+**Verifier commands.** Every one of these was run at plan time in the worktree at
+`0f27bbeb3`; the file exists and the command reads the change target. Exit codes are the
+**baseline on unmodified dev**, which is what makes the RED/GREEN claims per item falsifiable.
+
+| # | Command | Baseline on dev | Reads |
+|---|---|---|---|
+| V1 | `bun test tests/server/error-fidelity.test.ts` | 7 pass / 0 fail, exit 0 | `classifyError` (#3469) |
+| V2 | `bun test tests/adapters/google/google-errors.test.ts` | 10 pass / 0 fail, exit 0 | google classifier (#3469) |
+| V3 | `bun test tests/adapters/google/google-vertex-http.test.ts` | 24 pass / 0 fail, exit 0 | vertex retry fetch (#3469) |
+| V4 | `bun test tests/providers/provider-model-discovery-contract.test.ts` | 36 pass / 0 fail, exit 0 | discovery contract (#3489) |
+| V5 | `bun test tests/claude-integration/claude-cli.test.ts` | 34 pass / 0 fail, exit 0 | `src/cli/claude.ts` (#3519) |
+| V6 | `bun test tests/oauth/oauth-provider-reconcile.test.ts` | 9 pass / 0 fail, exit 0 | `reconcileOAuthProviders` (#3524) |
+| V7 | `bun test tests/routing/always-on-429-failover.test.ts` | 8 pass / 0 fail, exit 0 | 429 failover (#3502) |
+| V8 | `bun test tests/codex-integration/native-codex-toggle.test.ts` | 6 pass / 0 fail, exit 0 | codex toggle route (#3407) |
+| V9 | `bun run typecheck` | exit 0 | whole tree |
+| V10 | `bun run test:changed` | resolves against merge-base | import graph of the touched set |
+
+Note V1 **(drift-corrected)**: V1 was executed at `tests/error-fidelity.test.ts`, which is
+where the file sat at the lane snapshot. `79e03643d` moved it to
+`tests/server/error-fidelity.test.ts`; the 7-pass baseline is unaffected by the move. Same for
+V-adjacent combo files: `tests/server-combo-failover-e2e.test.ts` is now
+`tests/server/server-combo-failover-e2e.test.ts`.
+
+**Two verifiers are environment-red and must not be used as gates.** Re-run at plan time on
+**unmodified** dev:
+
+- `bun test tests/server/server-combo-failover-e2e.test.ts` → 36 pass / **45 fail**
+  (path drift-corrected; executed at its pre-move root path)
+- `bun test tests/routing/combo-management-api.test.ts` → 27 pass / **3 fail**
+
+Every failure is `error: Failed to start server. Is port 0 in use? code: "EADDRINUSE"` from
+`Bun.serve({ port: 0 })` — a sandbox restriction, not a regression. Treat both as
+**hosted-CI-only** verifiers for B6. Do not "fix" these failures.
+
+**Stop condition.** Stop when every branch below is either merged into `dev` (proven by
+`git fetch origin dev && git merge-base --is-ancestor <squash-sha> FETCH_HEAD`) or explicitly
+recorded as deferred in `060` with a reason. A layer whose exact-head CI is not green does not
+merge; it stops the stack above it and is reported, not forced.
+
+**Memory artifact.** This doc plus the merge ledger in `060`. Each landing appends: PR number,
+branch, squash SHA, ancestry proof output, and the exact-head CI conclusion.
+
+**Expected terminal outcomes.**
+
+- Merged: #3489, #3469 (independent of the stack), #3502 (split into B1 + B2), #3519 (B3),
+  #3524-reimplementation (B4), #3407-reimplementation (B5), #3348 PR A (B6).
+- Closed with a pointer to the replacement: #3524, #3407, #3348 (superseded by
+  reimplementations, each carrying `Co-authored-by`).
+- Deferred: #3388 (§6).
+
+**Escalation — stop the phase and report rather than improvising:**
+
+1. `hygiene` reports `unsponsored_surface` on a branch you authored and you lack the
+   `maintainer-sponsored` label (B1, B4 — see §5).
+2. A test the lane calls RED-on-dev passes on dev. That invalidates the defect claim; report
+   it instead of adjusting the test.
+3. A rebase conflict is **semantic** where this doc says mechanical.
+4. #3519's `Ingwannu` `CHANGES_REQUESTED` cannot be cleared — a reimplementation does not
+   dismiss another PR's review state.
+5. Exact-head CI fails for a reason not explained here.
+
+## 2. Stack map (DEV-STACK-01..03)
+
+Two independent merges first, then one six-layer stack. The split is driven by shared files,
+not by convenience.
+
+**Merged directly (not restacked).** #3489 and #3469 are `APPROVED` with fully green
+exact-head CI, and their only conflict is the `tests/<domain>/` migration. They share no file
+with the stack: #3489 touches `src/lib/provider-outbound.ts`, `src/providers/model-discovery.ts`,
+`src/codex/catalog/provider-fetch.ts`, `src/server/management/provider-routes.ts`; #3469 touches
+`src/lib/errors.ts`, `src/adapters/google-errors.ts`, `src/adapters/google-http.ts`. Neither
+file appears in any stack layer.
+
+*Caveat that changes the plan:* both are `CONFLICTING/DIRTY` at plan time (re-read immediately
+before writing this doc), and a conflicting PR cannot be squash-merged. Since these are
+contributor branches you cannot push to, each becomes a maintainer carry branch (§3.1, §3.2)
+that closes the original with credit. The "direct merge" path applies only if the author
+rebases first. Both routes are specified.
+
+Pre-merge checks, in order, for either route:
+
+1. `gh pr view <n> --json headRefOid,mergeable,mergeStateStatus,reviewDecision,isDraft` — head
+   must be MERGEABLE and not draft.
+2. Dismiss any review that is stale against the current head:
+   `gh api -X PUT repos/lidge-jun/opencodex/pulls/<n>/reviews/<review_id>/dismissals -f message=...`.
+   Neither #3489 nor #3469 needs this (both APPROVED against the reviewed head); it applies to
+   #3519 in B3.
+3. Mark ready if draft: `gh pr ready <n>`.
+4. Exact-head CI: `gh pr checks <n>` and confirm every row's SHA equals `headRefOid`. A row
+   from an older SHA is not evidence.
+5. Admin squash: `gh pr merge <n> --squash --admin --body-file <file>`, body carrying the
+   `Co-authored-by` trailer when the head is not the contributor's own commit.
+
+**Stack (bottom targets `dev`; each upper targets the branch below).**
+
+| Layer | Branch | Targets | Proves alone |
+|---|---|---|---|
+| B1 | `codex/260905-oauth-failover-policy-boundaries` | `dev` | Disabled pools stop reactivating proactive strategy; per-provider `true` beats global `false` |
+| B2 | `codex/260905-kiro-continuation-auth-context` | B1 | A rotated Kiro bearer carries its own region/profile into the terminal continuation |
+| B3 | `codex/260905-claude-native-fallback` | B2 | `ocx claude` launches native Claude when routing is explicitly off, without leaking a loopback credential |
+| B4 | `codex/260905-startup-reconcile-persistence` | B3 | Startup reconciliation rebases on the persisted config and **cannot** kill boot |
+| B5 | `codex/260905-codex-toggle-truthful` | B4 | The Codex dashboard row shows Codex's own config path and the user's setting |
+| B6 | `codex/260905-combo-failure-classification` | B5 | Cooldown scope and hop/stop verdicts match the failure's actual blast radius |
+
+**Why this order.**
+
+- **B1 → B2** is a hard dependency: both come from #3502 and B2 edits
+  `src/server/responses/core.ts`. B1 carries the OAuth policy halves
+  (`src/oauth/anthropic-routing.ts`, `src/oauth/generic-account-failover.ts`, `src/types/*`,
+  docs); B2 carries the Kiro `applyFailoverSnapshot` change alone. Splitting isolates the
+  `src/oauth/` security surface (§5) from a `core.ts` change that needs no sponsorship —
+  exactly the lane's fix-list item 5.
+- **B2 → B3** is ordering only, no shared file. B3 sits above B2 so the `core.ts` region
+  settles before a large `src/cli/claude.ts` diff enters review.
+- **B3 → B4**: no shared file, but B4 changes startup (`src/oauth/index.ts`,
+  `src/providers/model-rename-startup.ts`, called from `src/server/index.ts`) and B3's
+  `ensureProxyForClaude` path spawns the proxy. Reviewing a startup-failure-mode change under
+  a launcher change that depends on startup succeeding is the wrong order.
+- **B4 → B5**: no shared file. B5 is GUI + management routes. Placed above B4 because #3407's
+  reimplementation must rebase after **#3484** lands (wp1/Stack A, shared
+  `gui/src/pages/integrations/IntegrationsOverview.tsx`, per 002). If #3484 has not merged when
+  you reach B5, stop and report — do not reimplement on top of an unlanded #3484.
+- **B5 → B6**: no shared file. B6 is last because it is the largest carry and the only one
+  whose local verifiers are environment-blocked; a failure there should not hold five clean
+  layers behind it.
+
+**Carried contributor work.** Every branch below is created **from `origin/dev`** with the
+contributor's hunks cherry-picked or reapplied by hand (their heads are too far behind to
+branch from). Each needs a `Co-authored-by` trailer in a branch commit so it survives the
+squash. Emails read at plan time via `gh pr view <n> --json commits`:
+
+| Layer | Source PR | Trailer |
+|---|---|---|
+| B1, B2 | #3502 | `Co-authored-by: Ingwannu <ingwannu@users.noreply.github.com>` |
+| B3 | #3519 | `Co-authored-by: everton-dgn <evertondgn@hotmail.com>` |
+| B4 | #3524 | `Co-authored-by: yansigit <44089734+yansigit@users.noreply.github.com>` |
+| B5 | #3407 | `Co-authored-by: turin-dev <koomj5258@gmail.com>` |
+| B6 | #3348 | `Co-authored-by: RHODIZSECURITY <info.rhodiz@gmail.com>` |
+| carry-3489 | #3489 | `Co-authored-by: Flowershangfromthebranches <flowershangfromthebranches@users.noreply.github.com>` — see note |
+| carry-3469 | #3469 | `Co-authored-by: agentHits <zvercombat26rus@icloud.com>` |
+
+**#3489's commit email is unusable.** `gh pr view 3489 --json commits` returns an empty login
+and `<opencodex-fix@local>` — a local placeholder, not a GitHub-linked address, so it credits
+nobody. Use the `@users.noreply.github.com` form above, which resolves by login. If the carry
+route is taken, ask the author for their preferred address on the PR before merging; do not
+guess a personal email.
+
+## 3. Per item
+
+### 3.1 #3489 — fake-IP TUN discovery exception (LAND_WITH_FIX)
+
+Head `dbcfde8ca`, APPROVED by Ingwannu after explicit security review, 24 green checks on the
+exact head, `CONFLICTING/DIRTY`.
+
+**File change map.** Take the PR's `src/` half unchanged — it applies cleanly and no dev
+commit touched these files since. Concretely, `src/lib/provider-outbound.ts:157` is currently:
+
+```ts
+      allowBenchmarkAddresses: proxyConfigured && !noProxyMatches(parsed),
+```
+
+and becomes:
+
+```ts
+      allowBenchmarkAddresses: (proxyConfigured && !noProxyMatches(parsed))
+        || transparentFakeIpException(url, parsed, isCanonicalUrl, name),
+```
+
+with `isCanonicalUrl?: (name: string, url: string) => boolean` added to
+`ProviderOutboundDependencies` (defaulted at the `providerOutboundRequest` destructure as
+`dependencies.isCanonicalUrl ?? (() => false)` — fail-closed), `transparentFakeIpException`
+added above `normalizeProxyHostname`, and `isRegistryModelDiscoveryUrl` added in
+`src/providers/model-discovery.ts` then wired at the call sites in
+`src/codex/catalog/provider-fetch.ts` (~1669) and `src/server/management/provider-routes.ts`
+(~1237).
+
+**Conflict resolution recipe — mechanical, two items only.**
+
+1. `src/codex/catalog/provider-fetch.ts`: dev's `8b6e4542a` rewrote a **comment** at line 720
+   (a test path). The PR's hunk is at ~1669. Take dev's side of the comment; the PR hunk
+   applies untouched.
+2. Tests: `tests/provider-model-discovery-contract.test.ts` is now
+   `tests/providers/provider-model-discovery-contract.test.ts`. The new
+   `command-code-fakeip-discovery.test.ts` must be **created at `tests/providers/`**
+   (resolver: `providers`, which is migrated). In both files rewrite `../src/` →
+   `../../src/`. `../helpers/` specifiers stay as-is: `helpers` is anchored to `tests/` and
+   `rewriteSpecifier` leaves it unchanged at depth 1 (`tests/test-layout-tooling.test.ts:58`).
+
+**Regression tests.**
+
+- `tests/providers/command-code-fakeip-discovery.test.ts` (new, ~304 lines). RED on dev because
+  `isRegistryModelDiscoveryUrl` does not exist there — `rg -n "isRegistryModelDiscoveryUrl" src`
+  returns nothing, so the import fails outright. GREEN after: the symbol exists and the
+  transport consults it.
+- `tests/providers/provider-model-discovery-contract.test.ts` (+60). RED on the new assertions
+  for the same reason; the existing 36 stay green.
+
+**Focused verifier:** V4 (dev baseline 36 pass / exit 0) plus
+`bun test tests/providers/command-code-fakeip-discovery.test.ts`, then V9.
+
+**Accept criteria, with activation scenario per conditional path (C-ACTIVATION-GROUNDING-01).**
+The exception is a new security-relevant branch, so every path needs a named scenario:
+
+| Path | Activation scenario | Expected |
+|---|---|---|
+| `isCanonicalUrl` default `() => false` | Any caller that does not inject the seam | Exception never granted (fail-closed) |
+| `noProxyMatches(parsed)` true | `NO_PROXY=api.example.com`, TUN active | Exception refused, benchmark answer rejected |
+| Canonical URL, no proxy env, all answers 198.18.x.x | Clash TUN, discovery to the registry's fixed URL | Exception granted, fetch proceeds |
+| Canonical origin+path, extra/missing query | `?token=…` appended | Rejected (`candidate.search === expected.search` exact) |
+| `http:`, or embedded `username`/`password`, or `hash` | Retargeted custom row | Rejected outright |
+| Literal `198.18.x.x` URL | `baseUrl` set to the fake IP | Rejected by the literal gate before DNS answers are read |
+| Renamed custom row pointing at attacker host | OAuth/forward name matches any `baseUrl` | Rejected — proof is on the URL, not the name |
+| Mixed public + benchmark answers | DNS rebind attempt | Rejected — exception requires every answer benchmark |
+| `privateNetwork` destination | Image/Lab fetch | Unchanged; those paths never pass the flag |
+
+**Docs-site sync:** none. The PR ships no user-facing config surface; the exception is
+internal transport policy.
+
+**PR skeleton (carry route).** Title:
+`fix(discovery): allow canonical model endpoints through fake-IP TUN DNS`
+
+```
+## Summary
+Carries #3489 onto current dev. Model discovery to a registry's own fixed discovery URL is
+rejected under Clash/Surge/Mihomo TUN mode, because the fake-IP (198.18.0.0/15) DNS answer is
+only tolerated when an outbound proxy env is configured (src/lib/provider-outbound.ts:157).
+TUN intercepts the fake-IP destination itself, so the request would succeed.
+
+The exception is proven on the FINAL request URL, injected as a dependency defaulting to
+"not canonical" so a caller that forgets the seam fails closed.
+
+## Verification
+- bun test tests/providers/command-code-fakeip-discovery.test.ts
+- bun test tests/providers/provider-model-discovery-contract.test.ts
+- bun run typecheck
+
+## Checklist
+(all four boxes)
+
+Stack: independent of the wp2 stack; shares no file with B1-B6.
+
+Co-authored-by: Flowershangfromthebranches <flowershangfromthebranches@users.noreply.github.com>
+```
+
+No `Closes #` line — this carries #3489; close #3489 manually with a pointer once the carry
+lands on `dev` (GitHub auto-close only fires on `main`).
+
+### 3.2 #3469 — classify "User location is not supported" (LAND_WITH_FIX)
+
+Head `e11089af8`, APPROVED, 25 green checks on the exact head, `CONFLICTING/DIRTY`.
+
+**File change map.**
+
+`src/lib/errors.ts` — add after `isPermissionMessage` (currently ends at line 128):
+
+```ts
+export const LOCATION_UNSUPPORTED_PATTERNS = [
+  "location is not supported", "location not supported", "unsupported location",
+  "region is not supported", "unsupported region", "country is not supported",
+  "not supported in your country", "not supported in your region",
+] as const;
+
+export function isLocationUnsupportedMessage(text: string): boolean {
+  const lower = text.toLowerCase();
+  return LOCATION_UNSUPPORTED_PATTERNS.some(needle => lower.includes(needle));
+}
+```
+
+The PR's own second commit **removed** `"not supported for the api use"` from this list. Keep
+it removed: it is the broad pattern CodeRabbit worried about, and the PR's negative test
+asserts `isLocationUnsupportedMessage("not supported for the api use") === false`.
+
+In `classifyError`, insert **before** the generic invalid-request branch that currently begins
+at `src/lib/errors.ts:271` (`text.includes("validationexception") || text.includes("invalid request") || …`)
+and after the `subscription_required` branch:
+
+```ts
+  if (type === "location_not_supported" || isLocationUnsupportedMessage(text)) {
+    return { message, type: "permission_error", code: "location_not_supported" };
+  }
+```
+
+Placement is load-bearing: dev's stop-list at :271 matches `"invalid request"` first, which is
+exactly why a geo-block is reported as a malformed request today.
+
+`src/adapters/google-errors.ts` — replace the local copies with re-exports so adapter and lib
+cannot drift:
+
+```ts
+export const GOOGLE_LOCATION_UNSUPPORTED_PATTERNS = LOCATION_UNSUPPORTED_PATTERNS;
+export const isGoogleLocationUnsupportedText = isLocationUnsupportedMessage;
+```
+
+`src/adapters/google-http.ts` — in `normalizeFinalGoogleError`, wrap `formatMessage` to
+`console.warn` a static TUN/IPv6-leak hint when `isGoogleLocationUnsupportedText(payloadText)`.
+Static string only — no payload, key, or account id, so `privacy:scan` is unaffected.
+
+**Conflict resolution recipe — mechanical, tests only.** No `src/` file overlaps dev.
+
+- `tests/google-errors.test.ts` → `tests/adapters/google/google-errors.test.ts`
+- `tests/google-vertex-http.test.ts` → `tests/adapters/google/google-vertex-http.test.ts`
+- `tests/error-fidelity.test.ts` → `tests/server/error-fidelity.test.ts` **(drift-corrected:
+  `server` was migrated by `79e03643d`; it no longer stays at root)**
+
+For the two Google files rewrite `../src/` → `../../../src/` (depth 2). For
+`tests/server/error-fidelity.test.ts` rewrite `../src/` → `../../src/` (depth 1) — the file
+already carries the rewritten specifiers on `79e03643d`, so only the PR's added hunk needs care.
+
+**Regression tests.** Three, all RED on dev:
+
+- `tests/server/error-fidelity.test.ts` — asserts `code: "location_not_supported"`. Dev returns
+  `invalid_request_error`; the lane executed it directly:
+  `classifyError(400, "upstream_error", "User location is not supported for the API use.")`
+  → `{ type: "invalid_request_error", code: "invalid_request_error" }`. GREEN once the new
+  branch precedes the stop-list.
+- `tests/adapters/google/google-errors.test.ts` — imports `isGoogleLocationUnsupportedText`;
+  compiles only after the re-export exists.
+- `tests/adapters/google/google-vertex-http.test.ts` — positive and negative warning
+  assertions; the warning does not exist on dev.
+
+**Focused verifier:** V1, V2, V3 (dev baselines 7 / 10 / 24 pass, exit 0) then V9.
+
+**Accept criteria + activation scenarios.**
+
+| Path | Scenario | Expected |
+|---|---|---|
+| `type === "location_not_supported"` | Adapter already classified it | `permission_error` / `location_not_supported` |
+| Message match, status 400 | Vertex "User location is not supported for the API use." | `permission_error`, not `invalid_request_error` |
+| Negative: `"not supported for the api use"` alone | Model-capability rejection with no geo cue | Falls through to the generic branch |
+| Warning path | Geo rejection through `normalizeFinalGoogleError` | One `console.warn`, static text |
+| Warning negative | Any other Google error | No warning |
+| Shard coverage | Lane noted only shards 1/4 and 2/4 ran | Confirm all four shards on the rebased head |
+
+**Docs-site sync:** none required (error-classification internals).
+
+**PR skeleton.** Title: `fix(google): classify "User location is not supported" as a location error`.
+Same three-section body shape as §3.1; Verification lists V1-V3 + V9; trailer
+`Co-authored-by: agentHits <zvercombat26rus@icloud.com>`; no `Closes #`, close #3469 manually.
+
+### 3.3 B1 — #3502 OAuth failover policy boundaries (LAND_WITH_FIX, split 1 of 2)
+
+Head `6671a1623`, `CONFLICTING/DIRTY`, CI green but on stale base `2fb11f4a0`.
+**Security surface: `src/oauth/` — see §5.**
+
+**File change map.**
+
+`src/oauth/anthropic-routing.ts:675` **(drift-corrected: `:662` at the lane snapshot;
+`bdafc5191` added 13 lines above it — the line text is unchanged)** — current:
+
+```ts
+  const next = pickAlternateAnthropicAccount(config, failedAccountId, now);
+```
+
+target:
+
+```ts
+  // The pool's strategy is a PROACTIVE policy. When the pool is disabled, reactive
+  // presence-only recovery must not silently reactivate round-robin/fill-first merely
+  // because those dormant values remain in config. The quota picker is the neutral
+  // recovery policy already used by the default strategy.
+  const next = isAnthropicAccountPoolEnabled(config)
+    ? pickAlternateAnthropicAccount(config, failedAccountId, now)
+    : pickLowestUsage(config, failedAccountId, now);
+```
+
+Both helpers already exist in this file (`isAnthropicAccountPoolEnabled` at :83,
+`pickLowestUsage` at :334 as of `0f27bbeb3`; both shift down by `bdafc5191`'s 13 lines on
+`79e03643d`) — no import needed. Locate them by name, not by line.
+
+`src/oauth/generic-account-failover.ts:189` — inside `isProactivePreferenceEnabled`, current:
+
+```ts
+  if (provider.oauthAccountFailover?.enabled === false) return false;
+  if (config.oauthAccountFailover?.enabled === false) return false;
+  return hasFailoverAccountQuorum(providerName, now);
+```
+
+target:
+
+```ts
+  const perProvider = provider.oauthAccountFailover?.enabled;
+  // Preserve the published narrow-over-broad precedence. A provider-specific true may
+  // opt this provider into proactive preference even when the global default is false;
+  // a provider-specific false refuses it even when the global setting is true.
+  if (typeof perProvider === "boolean") {
+    return perProvider && hasFailoverAccountQuorum(providerName, now);
+  }
+  if (config.oauthAccountFailover?.enabled === false) return false;
+  return hasFailoverAccountQuorum(providerName, now);
+```
+
+The `typeof … === "boolean"` guard is what keeps a malformed value falling through rather than
+taking a provider out of service — preserve it exactly.
+
+`src/types/config.ts:794` and `src/types/provider.ts:433` — doc-comment only. Replace
+"only `false` is meaningful — `true` adds nothing over presence" with "per provider in either
+direction; reactive 429 rotation remains presence-driven". **No field is added or removed**
+(see §4).
+
+`structure/04_transports-and-sidecars.md` — add the "OAuth account failover" row to the owner
+table and the Decision Log block; applies cleanly.
+
+**Conflict resolution recipe.**
+
+- `src/oauth/anthropic-routing.ts`: **mechanical.** The PR's hunk anchors at old line 621; dev
+  inserted `quorumCache = null;` above it (at :660 on `6580694c7`, :673 on `79e03643d`), and
+  `bdafc5191` then added a comment block in the same function. The target line itself is
+  byte-identical on dev in both. Re-apply below the `quorumCache = null;` that immediately
+  precedes the `const next = pickAlternateAnthropicAccount(...)` call — anchor on that pair,
+  not on a line number.
+- Docs: **semantic, and this is the real work.** #3520 (`5d10a1900`) already landed
+  "stop promising a 429 failover kill switch that no longer exists" and rewrote this prose. Do
+  **not** replay the PR's docs hunks. Write a fresh delta on top of #3520's current text
+  describing per-provider precedence in both directions, and remove the enabled-only opening
+  condition CodeRabbit named: `fr/reference/configuration/providers.md` ~:207,
+  `zh-cn/reference/configuration/providers.md` ~:172, and the English pair at
+  `reference/configuration/providers.md` ~:437-438. Re-read each file first; those line
+  numbers are from the PR's base, not dev.
+- `docs-site/**/guides/claude-code.md` (en, fr, tr, zh-tw) hunks in #3502 are unrelated to this
+  split and overlap B3's docs work. **Drop them from B1**; B3 owns that guide.
+
+**Regression tests.** Replay at migrated paths — all three exist on dev, contrary to the lane
+doc:
+
+- `tests/routing/always-on-429-failover.test.ts` — RED on dev for the disabled-pool case: dev
+  calls `pickAlternateAnthropicAccount` unconditionally (`:675` on `79e03643d`), so a disabled pool still
+  applies round-robin/fill-first. GREEN after the branch.
+- `tests/oauth/generic-oauth-failover.test.ts` — RED for "provider-specific `true` opts in
+  under a global `false`": dev returns `false` at the global check. GREEN after.
+- `tests/oauth/adapter-event-oauth-failover.test.ts` — replay as-is.
+- `tests/adapters/anthropic/anthropic-sidecar-account-failover.test.ts` — new (+277). Resolver
+  confirms `adapters/anthropic`, which is migrated and exists, so create it **there**.
+
+Rewrite specifiers by depth: `tests/routing/` and `tests/oauth/` are depth 1
+(`../src/` → `../../src/`); `tests/adapters/anthropic/` is depth 2 (`../../../src/`).
+
+**Focused verifier:** V7 (dev baseline 8 pass / exit 0), plus
+`bun test tests/oauth/generic-oauth-failover.test.ts tests/oauth/adapter-event-oauth-failover.test.ts`,
+plus the new anthropic file, then V9 and V10.
+
+**Accept criteria + activation scenarios.** Every conditional path added here is a policy
+branch, so each needs a scenario:
+
+| Path | Scenario | Expected |
+|---|---|---|
+| Anthropic pool **enabled**, 429 | pool enabled, strategy round-robin, 2 accounts | `pickAlternateAnthropicAccount` — unchanged behavior |
+| Anthropic pool **disabled**, 429 | pool disabled, dormant `strategy: "fill-first"` left in config, 2 eligible accounts | `pickLowestUsage` — recovery happens, strategy does **not** reactivate |
+| Disabled pool, all accounts cooled | same, both in cooldown | `null` → existing 429 + `[anthropic-pool]` warn |
+| Per-provider `true`, global `false` | `providers.x.oauthAccountFailover.enabled = true`, `oauthAccountFailover.enabled = false` | Proactive preference **on** for x (quorum permitting) |
+| Per-provider `false`, global unset/true | inverse | Proactive preference **off** for x |
+| Per-provider unset, global `false` | only the global key written | Off — unchanged from dev |
+| Per-provider malformed (`"yes"`) | hand-edited config | `typeof` guard falls through to global; provider stays in service |
+| Quorum absent | per-provider `true`, 1 account | Off — presence still governs |
+
+**Docs-site sync:** required, and it is the semantic conflict above. English +
+`fr/ja/ko/ru/tr/zh-cn/zh-tw` copies of `reference/configuration/providers.md` and
+`reference/cli/providers-accounts.md`. Locales must not contradict the English source.
+
+**PR skeleton.** Title: `fix(oauth): repair proactive-failover policy boundaries`
+
+```
+## Summary
+Carries the policy half of #3502 onto current dev, rebased, with docs rewritten on top of
+#3520 rather than replayed.
+
+1. src/oauth/anthropic-routing.ts consults the pool's proactive strategy even when the
+   pool is disabled, so a disabled pool silently reactivates round-robin/fill-first on the
+   reactive 429 path.
+2. src/oauth/generic-account-failover.ts:189 honours only enabled === false per provider, so
+   a provider-specific true cannot opt back in when the global default is false.
+
+The Kiro continuation half of #3502 is split into the next PR in the stack.
+
+## Verification
+- bun test tests/routing/always-on-429-failover.test.ts
+- bun test tests/oauth/generic-oauth-failover.test.ts tests/oauth/adapter-event-oauth-failover.test.ts
+- bun test tests/adapters/anthropic/anthropic-sidecar-account-failover.test.ts
+- bun run typecheck
+
+## Checklist
+(all four boxes)
+
+| Layer | Branch | Targets |
+|---|---|---|
+| B1 (this) | codex/260905-oauth-failover-policy-boundaries | dev |
+| B2 | codex/260905-kiro-continuation-auth-context | B1 |
+| B3 | codex/260905-claude-native-fallback | B2 |
+| B4 | codex/260905-startup-reconcile-persistence | B3 |
+| B5 | codex/260905-codex-toggle-truthful | B4 |
+| B6 | codex/260905-combo-failure-classification | B5 |
+
+Co-authored-by: Ingwannu <ingwannu@users.noreply.github.com>
+```
+
+No `Closes #`; close #3502 manually once B2 also lands.
+
+### 3.4 B2 — #3502 Kiro continuation auth context (split 2 of 2)
+
+**File change map.** `src/server/responses/core.ts` only — no `src/oauth/` file, so **no
+sponsorship needed** (§5). That isolation is the point of the split.
+
+At `core.ts:3364`, widen the closure signature:
+
+```ts
+  const applyFailoverSnapshot = (
+    snapshot: OAuthAccessSnapshot,
+    retryParsed: OcxParsedRequest = parsed,
+  ): boolean => {
+```
+
+At `core.ts:3380`, current:
+
+```ts
+    if (route.providerName === "kiro") parsed._kiroAuthContext = { ...(snapshot.kiro ?? {}) };
+```
+
+target:
+
+```ts
+    if (route.providerName === "kiro") {
+      const kiroContext = { ...(snapshot.kiro ?? {}) };
+      // Terminal-guard continuations are rebuilt from a shallow clone. Updating only the
+      // outer request pairs the new bearer with the failed account's region/profile on
+      // the retry. Keep both owners synchronized; for ordinary paths they are identical.
+      parsed._kiroAuthContext = kiroContext;
+      if (retryParsed !== parsed) retryParsed._kiroAuthContext = { ...kiroContext };
+    }
+```
+
+At `core.ts:6693`, current `if (applyFailoverSnapshot(snapshot)) {` becomes
+`if (applyFailoverSnapshot(snapshot, nextParsed)) {`.
+
+**Conflict resolution recipe:** mechanical. The default parameter keeps all other call sites
+source-compatible, so only the terminal-guard site changes. If wp1's #3515 landed first, its
+edit is at ~4925 — no overlap with 3380 or 6693.
+
+**Regression test.** New: `tests/providers/kiro/kiro-auth-context-continuation.test.ts`
+(resolver: `providers/kiro`, migrated, directory exists; specifiers `../../../src/`). Asserts
+that after a 429 rotation on the terminal-guard path, the object passed to the retry carries
+the **rotated** account's region/profile. RED on dev: dev writes only `parsed`, so `nextParsed`
+keeps the failed account's context. GREEN after.
+
+**Focused verifier:** `bun test tests/providers/kiro/kiro-auth-context-continuation.test.ts`
+then V9. Add `bun test tests/providers/kiro/` for the sibling Kiro files.
+
+**Accept criteria + activation scenarios.**
+
+| Path | Scenario | Expected |
+|---|---|---|
+| `retryParsed === parsed` (default) | Ordinary rotation, non-terminal | One write; behavior identical to dev |
+| `retryParsed !== parsed` | Terminal-guard continuation with `nextParsed` | Both objects carry the rotated context |
+| Non-Kiro provider | Anthropic/Google rotation | Branch not entered; no `_kiroAuthContext` written |
+| `snapshot.kiro` undefined | Kiro account with no stored region/profile | `{}` on both, never the failed account's values |
+
+**Docs-site sync:** none (internal retry plumbing).
+
+**PR skeleton.** Title: `fix(responses): carry rotated Kiro auth context into the terminal continuation`.
+Body: same shape; stack table with B2 marked "(this)"; trailer
+`Co-authored-by: Ingwannu <ingwannu@users.noreply.github.com>`.
+
+### 3.5 B3 — #3519 native Claude launch fallback (LAND_WITH_FIX)
+
+Head `6b92ab7db`, draft, `CHANGES_REQUESTED` (Ingwannu, against an older head — the lane
+verified both blockers are fixed on `6b92ab7db`).
+
+**Route decision.** #3519 is `MERGEABLE` and the author is active. Prefer asking the author to
+exit draft, tick 4/4, and get the review re-run — then merge #3519 directly with the three
+fixes below pushed by the author. Only if that stalls, carry it as B3. Either way the three
+fixes are required, so they are specified as changes.
+
+**File change map (fixes on top of the PR's head).**
+
+1. **Docs (High, AGENTS.md "Docs sync").** `docs-site/src/content/docs/guides/claude-code.md`
+   plus `fr/ja/ko/ru/tr/zh-cn/zh-tw` twins (all eight verified present) still describe
+   `ocx claude` as proxy-only. Add: when `claudeCode.enabled` is explicitly `false` — in
+   config or reported live by `GET /api/claude-code` — `ocx claude` launches the native
+   `claude` binary instead of erroring, and what happens to `ANTHROPIC_BASE_URL`.
+2. **Silent `readPickerDefaultModel` failure (Medium).** The PR adds:
+
+   ```ts
+   function readPickerDefaultModel(configDir: string): string | null {
+     try {
+       const parsed = JSON.parse(readFileSync(join(configDir, "settings.json"), "utf8")) as Record<string, unknown>;
+       return typeof parsed.model === "string" && parsed.model.trim() !== "" ? parsed.model.trim() : null;
+     } catch { return null; }
+   }
+   ```
+
+   A corrupt `settings.json` is indistinguishable from an absent one, so the
+   "saved model requires the proxy" warning disappears exactly when the file is broken.
+   Distinguish absent (`ENOENT` → `null`, silent) from unparseable (`console.warn` naming the
+   file, no contents echoed). Keep the repo's `no-excuse-ok` marker convention on the catch.
+3. **Restore the deleted `#764 / SERVICE_STOP_LIVENESS` rationale comment** above
+   `ensureProxyForClaude`. The diff deletes it while keeping the behavior, discarding the
+   reason the 3-attempt budget exists.
+
+For orientation, dev's current behavior is the hard error at `src/cli/claude.ts:420`:
+
+```ts
+  if (config.claudeCode?.enabled === false) {
+    console.error("Claude inbound is disabled (config.claudeCode.enabled=false — flip the Claude ON toggle in the GUI or edit config).");
+    return 1;
+  }
+```
+
+**Conflict resolution recipe:** none — `MERGEABLE`, and its test already sits at
+`tests/claude-integration/claude-cli.test.ts` (migrated, correct).
+
+**Regression tests.** `tests/claude-integration/claude-cli.test.ts` (+6 unit tests: plan
+matrix, preflight ordering, env scrubbing, the `http://localhost:8080` loopback negative,
+`isProxyOnlyModelId` incl. an AWS Bedrock ARN false-positive guard, root opt-in). These are
+RED on dev by **compile failure** — `claudeLaunchPlan`, `buildNativeClaudeEnv`,
+`claudeLaunchPreflight`, `isProxyOnlyModelId` do not exist on dev. That is the honest state
+for new behavior. Add a seventh: corrupt `settings.json` produces a warning and still returns
+`null` (RED against the PR's own head, GREEN after fix 2).
+
+**Focused verifier:** V5 (dev baseline 34 pass / exit 0) then V9.
+
+**Accept criteria + activation scenarios.** This layer adds the most branches in the phase:
+
+| Path | Scenario | Expected |
+|---|---|---|
+| `claudeCode.enabled` absent | Default install | Routed launch, exactly as dev |
+| Config `enabled: false` | User flipped Claude OFF | Native launch + `CLAUDE_NATIVE_ROUTING_OFF` notice |
+| Live `enabled: false` from `GET /api/claude-code` | Toggle flipped in GUI while proxy runs | Native launch + `CLAUDE_NATIVE_LIVE_DISABLED` |
+| Older proxy omitting `enabled` | Proxy predates the field | Stays routed (only explicit `false` disables) |
+| Proxy absent, routing on | Proxy not started | `ensureProxyForClaude` still spawns — **not** native fallback |
+| Env scrub: owned admission + loopback + exact port | `ANTHROPIC_BASE_URL=http://127.0.0.1:<config.port>` | Deleted |
+| Env scrub negative | `ANTHROPIC_BASE_URL=http://localhost:8080` + user credential | **Preserved** (both) |
+| Preflight ordering | Invalid/mismatched client state | Preflight errors **before** any native fallback |
+| `settings.json` absent | Fresh install | `null`, silent |
+| `settings.json` corrupt | Truncated JSON | `null` + one warning naming the file |
+| Root + `--dangerously-skip-permissions` | Root shell | Existing `rootSkipPermissionsNotice` unchanged |
+
+The env-scrub guard is `hasOwnedAdmission && targetsLocalClaudeProxy(baseUrl, config.port)`;
+dev's `targetsLocalClaudeProxy` (`src/cli/claude.ts:60`) already requires http + loopback host
++ exact configured port + no embedded credentials.
+
+**Docs-site sync:** required — the eight `guides/claude-code.md` files above.
+
+**PR skeleton.** Title: `fix(claude): fall back to native launch when routing is off`.
+Body must state the behavior change plainly (dev hard-errors at `src/cli/claude.ts:420`), list
+the three fixes, carry the stack table, and — if carried — the
+`Co-authored-by: everton-dgn <evertondgn@hotmail.com>` trailer.
+**Pre-merge:** the stale `CHANGES_REQUESTED` must be dismissed by Ingwannu or superseded by a
+fresh review; a maintainer merge does not clear it.
+
+### 3.6 B4 — #3524 reimplementation: startup reconciliation persistence
+
+**Why REIMPLEMENT.** The defect is real: `reconcileOAuthProviders` at `src/oauth/index.ts:1250`
+mutates the in-memory config then `saveConfig(config)`, so a startup snapshot can overwrite an
+operator edit made after load. But the PR's rewrite adds an **unguarded `throw` on the boot
+path** (lane reproduced it live: "THREW: OAuth provider reconciliation persistence unavailable:
+missing"). `reconcileOAuthProviders(config)` is called with no try/catch at
+`src/server/index.ts:663`, and `runModelRenameStartupMigration` at `:651` has the same shape.
+Both are inside `startServer`, which is synchronous by design.
+
+**File change map.**
+
+`src/oauth/index.ts` — take the PR's projection/adopt refactor
+(`projectOAuthProviderReconciliation`, `adoptOAuthReconciliation`,
+`withOAuthReconciliationTouchedKeys`, `reconcileOAuthProviders(config, persist = true)` using
+`mutatePersistedConfig`), but **replace** the PR's:
+
+```ts
+  if (outcome.status === "unavailable") {
+    throw new Error(`OAuth provider reconciliation persistence unavailable: ${outcome.reason}`);
+  }
+```
+
+with the degrade-and-warn shape every other `mutatePersistedConfig` consumer already uses
+(`src/storage/policy.ts:473`, `src/codex/plan-from-token.ts:92`, `src/codex/auth-api.ts:1089`,
+`src/server/management/agent-settings-routes.ts:124`): warn once with the reason, adopt the
+in-memory projection so the running process is still correct, and return `true`. Same change in
+`src/providers/model-rename-startup.ts` for
+`"model rename startup persistence unavailable: …"`.
+
+`src/server/index.ts` — no change required once the throws are gone. Do **not** add an
+`await` anywhere near `Bun.serve`; AGENTS.md's synchronous-activation invariant is scanned by
+the guard in `tests/lab/core-lab-boundary.test.ts`. Both call sites (`:651`, `:663`) sit far
+above `Bun.serve` and stay synchronous.
+
+`adoptConfig` in `src/providers/model-rename-startup.ts` deletes every key of the caller's
+object and re-assigns from a `structuredClone`. Object identity survives, but a live reference
+to a nested sub-object held elsewhere is silently detached. Reimplement as a key-by-key assign
+over the touched keys only (the projection already tracks `touchedProviders` and
+`touchedAntigravityVersion`).
+
+**Split.** The PR bundles OAuth and model-rename. Keep both here — same failure mode, same
+helper — but if sponsorship (§5) stalls, the model-rename half
+(`src/providers/model-rename-startup.ts`, not a restricted path) can ship alone.
+
+**Regression tests.**
+
+- `tests/oauth/oauth-provider-reconcile.test.ts` — carry the PR's coverage, but **invert the
+  throw assertion**: the PR asserts the throw string at its `:81`; the reimplementation asserts
+  `status: "unavailable"` degrades, warns, and returns without throwing. RED against the PR's
+  head, GREEN here.
+- `tests/providers/model-rename-migration.test.ts` — same inversion.
+- **New:** `tests/server/server-startup-reconcile-resilience.test.ts` **(drift-corrected:
+  `server` became a migrated domain in `79e03643d`, so this goes in `tests/server/` at depth 1
+  with `../../src/` specifiers — at the lane snapshot it would have stayed at root)**.
+  This is the gap the lane named: the PR proves the new failure mode in
+  isolation and never checks where it matters. Assert `startServer` completes and serves
+  `/healthz` when the config file disappears between `loadConfig()` and reconcile.
+  RED against the PR's head (throws), GREEN here.
+
+  Reproduction recipe from the lane: isolated `OPENCODEX_HOME`, load a valid config, remove
+  `config.json`, then reconcile. Benign paths that must stay `changed=false`: fresh install with
+  no `config.json`, malformed JSON, unreadable file.
+
+**Focused verifier:** V6 (dev baseline 9 pass / exit 0),
+`bun test tests/providers/model-rename-migration.test.ts`,
+`bun test tests/server/server-startup-reconcile-resilience.test.ts`, then V9.
+
+**Accept criteria + activation scenarios.**
+
+| Path | Scenario | Expected |
+|---|---|---|
+| `status: "unchanged"` | Nothing to reconcile | No write, no warn, returns `false` |
+| Committed mutation | Preset gained a model | Persisted via rebase; concurrent operator edit preserved |
+| `status: "unavailable"` | `config.json` removed between load and reconcile | Warn once, adopt in-memory, **`startServer` completes** |
+| Fresh install, no config | First run | `changed=false`, no warn |
+| Malformed JSON | Hand-edited broken config | `changed=false`, degrade |
+| Unreadable file | Permissions / unmounted volume | `changed=false`, degrade |
+| `persist = false` | Callers that manage their own write | In-memory adopt only |
+| Rebase contention | Competing writer during the mutation | Retries within `CONFIG_MUTATION_MAX_REBASE_ATTEMPTS`, then degrades |
+
+**Docs-site sync:** none (startup internals, no user-facing surface).
+
+**PR skeleton.** Title: `fix(oauth): rebase startup reconciliation on the persisted config`.
+Summary must state explicitly that reconciliation **degrades and warns** rather than throwing,
+and that a startup-path regression covers it. Trailer
+`Co-authored-by: yansigit <44089734+yansigit@users.noreply.github.com>`. Close #3524 manually
+with a pointer. Needs `maintainer-sponsored` (§5) and a clean `enforce-target`.
+
+### 3.7 B5 — #3407 reimplementation: truthful Codex dashboard toggle
+
+**Precondition:** #3484 must be on `dev` (shared
+`gui/src/pages/integrations/IntegrationsOverview.tsx`). If not, stop and report.
+
+**Why REIMPLEMENT.** Five CI jobs fail on the PR's exact head (`ci`, `gates`, `macos`,
+`test 1/4`, `test 2/4`), it is 121 commits behind, and it tracks a 166 KB PNG at
+`docs/pr-assets/3407-codex-disable-dialog.png` — confirmed present in the PR's file list. The
+`gui` gate wants a screenshot **in the description**, not a binary in the tree.
+
+**File change map.**
+
+`src/server/management/native-integration-routes.ts:686` — current:
+
+```ts
+      clients: [claudeStatus(config, getConfigPath()), grokStatus(config), codexStatus(config, getConfigPath()), desktopStatus(config)],
+```
+
+`codexStatus` writes its `configPath` parameter straight into the row (`:164`), so the Codex
+row reports **opencodex's** config file. Target: pass `join(getCodexHome(), "config.toml")` for
+the Codex row only; `claudeStatus` legitimately keeps `getConfigPath()`. `getCodexHome` is
+already exported and used across `src/codex/` (`src/codex/inject.ts:68`).
+
+`gui/src/pages/integrations/IntegrationsOverview.tsx` — the switch renders `row.applied`
+(observed routing) rather than the user's setting, so the toggle can contradict what the user
+chose. Target: `toggleOn = row.toggleOn ?? row.applied`. Also add `codexResource.refresh()`
+after a successful toggle and the `"codex"` case in `blockedText`.
+
+`gui/src/i18n/{en,ko,ja,zh,zh-TW,fr,de,ru,tr}.ts` — add `CODEX_DISABLE_COPY` and its 6 keys
+across **all nine** locales, applied to current dev's files (the PR's versions are 121 commits
+stale and i18n files are append-heavy).
+
+**Explicitly dropped from the carry:** the tracked PNG, and the
+`nativeSettled === undefined` backward-compatibility branch — update the callers directly
+instead.
+
+**Conflict resolution recipe:** do not rebase the PR. Reapply the four changes above by hand
+onto current dev. The i18n files are the only high-friction part; add keys at the current end
+of each locale object rather than replaying positional hunks.
+
+**Regression tests.**
+
+- `tests/codex-integration/native-codex-toggle.test.ts` — already exists on dev (164 lines,
+  6 tests, V8 baseline 6 pass / exit 0) at the migrated path. Add a config-path assertion: the
+  Codex row's `configPath` ends with the Codex home `config.toml`, not opencodex's config
+  file. RED on dev (dev passes `getConfigPath()`), GREEN after.
+  `rg -n "configPath" tests/codex-integration/native-codex-toggle.test.ts` returns nothing
+  today, so this assertion is genuinely new rather than a rename of an existing one.
+- `gui/tests/integrations-surfaces.test.tsx` and `gui/tests/integrations-overview-rows.test.ts`
+  — toggle reflects `toggleOn`, refresh fires, `blockedText` covers `"codex"`. (GUI tests live
+  outside `tests/`, so the layout guard does not apply to them.)
+
+**Focused verifier:** V8 then V9. GUI: `bun run lint:gui` and the GUI runner for the two files
+above.
+
+**Accept criteria + activation scenarios.**
+
+| Path | Scenario | Expected |
+|---|---|---|
+| `clientIntegrations.codex` unset | Default | Row `current`, toggle on, path = Codex `config.toml` |
+| `clientIntegrations.codex === false` | User turned Codex off | Row `absent`, toggle **off** even if routing still observed |
+| `row.toggleOn` undefined | Row from an older payload | Falls back to `row.applied` — no crash |
+| Toggle succeeds | User flips it in the GUI | `codexResource.refresh()` runs; row updates without reload |
+| Toggle blocked | Codex disable blocked by admission | `blockedText` returns the `"codex"` copy, not a blank |
+| Locale coverage | App in each of 9 locales | Every new key resolves; no raw key text |
+
+**Docs-site sync:** `docs-site/src/content/docs/guides/codex-integration.md` — describe what
+the Codex row's config path now points at and that the toggle reflects the user's setting.
+
+**PR skeleton.** Title: `fix(integrations): make the Codex dashboard toggle truthful`.
+Body must include the **screenshot in the description** (not a tracked file) because the title
+mentions `gui`; trailer `Co-authored-by: turin-dev <koomj5258@gmail.com>`. Close #3407
+manually with a pointer.
+
+### 3.8 B6 — #3348 PR A: combo failure classification only
+
+**Why REIMPLEMENT and split.** 2165/196 across 35 files, only 5 checks ever ran (no shards, no
+gates, no macOS) despite a `review-ready` label, and 10 of 16 test files moved into 6 domains.
+The lane's 410/413 concern is resolved — re-verified at plan time: `comboFailureDecision`
+(`src/combos/failover.ts:323`) has no 410/413 in its hop list (`[401, 403, 404, 408, 429]` plus
+`>= 500`), and `isModelLifecycleGone` still requires `status === 410` **and** a structured
+lifecycle code.
+
+**PR A file change map (this layer).**
+
+`src/combos/failover.ts:256` — widen the scope type:
+
+```ts
+export type ComboFailureCooldownScope = "target" | "provider";          // current
+export type ComboFailureCooldownScope = "none" | "target" | "provider"; // target
+```
+
+`src/combos/failover.ts:280-286` — current body:
+
+```ts
+  return isProviderScopedQuotaCap(status, message, options?.code) ? "provider" : "target";
+```
+
+Target: return `"none"` for request-shape failures (413, `input_admission_refused`,
+`context_length_exceeded`, `tool_catalog_too_large`, `cursor_root_envelope_limit`,
+`target_incompatible`) — an oversized request must not cool a healthy target — and
+`"provider"` for 401/402/403 and credential/billing codes, before the existing quota-cap check.
+
+`src/combos/failover.ts:323` `comboFailureDecision` — recognize
+`model_not_found`/`model_unavailable`/`unsupported_model` as target-local hops, and add 402 and
+425 to the hop status list.
+
+Move `free_rate_limited` out of provider-scoped quota into a request-local free-prompt cap.
+Today `isProviderScopedQuotaCap` (`:275`) returns true for `free_rate_limited` /
+`err_free_prompt_cap` / "free tier"+"single request", so a **per-request** cap cools an entire
+provider. Introduce `isRequestLocalFreePromptCap` and remove those three needles from the
+provider-scoped predicate.
+
+`src/lib/errors.ts:365` `inferHttpStatusFromAdapterMessage` — `"malformed upstream"` currently
+falls into the `invalid`/`not found`/`unsupported`/`malformed` group returning a 4xx. Map it to
+**502**: upstream garbage is a provider failure, not a client error. Scope the match to
+"malformed upstream" specifically so plain `"malformed"` keeps its current verdict.
+
+`src/combos/resolve.ts` — the standalone bug. `pickComboTarget`'s `eligible` predicate (`:155`)
+checks provider usability, cached quota exhaustion, and exclusion — but **not** cooldown, so a
+target cooled a moment ago is picked anyway. `isComboTargetInCooldown` is already imported at
+`resolve.ts:4` and already used in a *different* code path at `:299`. Add to the predicate:
+
+```ts
+    && !isComboTargetInCooldown(comboId, target, now)
+```
+
+**Field/enum chain for `key-401`** — see §4; it is four sites, not one.
+
+**Conflict resolution recipe.** Do not rebase #3348. Reapply the six changes above by hand.
+Tests: place each new/edited file at its resolved domain —
+`tests/routing/router-combo-failover-classification.test.ts` (new; resolver `routing`,
+migrated), `tests/routing/combo-management-api.test.ts` (exists),
+`tests/codex-integration/combos.test.ts` (exists),
+`tests/providers/cyber-policy-error-fidelity.test.ts` (exists),
+`tests/server/error-fidelity.test.ts` (exists, drift-corrected). Rewrite specifiers by depth.
+
+**Regression tests.**
+
+- `tests/routing/router-combo-failover-classification.test.ts` (new). RED on dev for four
+  claims: (a) `comboFailureCooldownScope(413, …) === "none"` — dev returns `"target"`;
+  (b) `free_rate_limited` does not cool the provider — dev's `isProviderScopedQuotaCap` at
+  `:275` returns true; (c) `comboFailureDecision(402|425, …) === "hop"` — dev's list is
+  `[401, 403, 404, 408, 429]`; (d) a cooled target is not picked — dev's `eligible` omits the
+  cooldown check. Must **also** assert the invariants that must not move:
+  `comboFailureDecision(410, "resource is gone") === "stop"` and
+  `comboFailureDecision(413, "request too large") === "stop"`, both green on dev and after.
+- `tests/server/error-fidelity.test.ts` — `"malformed upstream"` → 502. RED on dev.
+
+**Focused verifier:** `bun test tests/routing/router-combo-failover-classification.test.ts`,
+V1, `bun test tests/codex-integration/combos.test.ts`, then V9 and V10.
+**Not local gates:** `tests/server/server-combo-failover-e2e.test.ts` and
+`tests/routing/combo-management-api.test.ts` — both are EADDRINUSE-red on unmodified dev in
+this sandbox (45 and 3 failures). Read them on hosted CI only.
+
+**Accept criteria + activation scenarios.**
+
+| Path | Scenario | Expected |
+|---|---|---|
+| `"none"` scope | 413 oversized request against a healthy target | No cooldown recorded; target stays selectable |
+| `"none"` via code | `input_admission_refused` / `context_length_exceeded` | No cooldown |
+| `"provider"` scope | 401 invalid key / 402 billing | Whole provider cooled |
+| `"target"` scope | Ordinary 500 from one target | Only that target cooled |
+| Free-prompt cap | `free_rate_limited` on one request | Request-local; provider **not** cooled |
+| Model-local hop | `model_not_found` | `hop` to next combo target |
+| 402 / 425 | Payment required / too early | `hop` |
+| Invariant: generic 410 | `"resource is gone"` | `stop` (unchanged) |
+| Invariant: generic 413 | `"request too large"` | `stop` (unchanged) |
+| Lifecycle 410 | Structured `model_end_of_life` | `hop` (unchanged) |
+| Cooldown predicate | Target cooled 5 s ago, cooldown 60 s | Not picked |
+| Cooldown expired | Cooled 5 s ago, cooldown 1 s | Picked; `isComboTargetInCooldown` self-evicts |
+| `"malformed upstream"` | Upstream returns garbage | 502, not 4xx |
+| `key-401` recovery kind | Key-pool 401 rotation | Recorded and round-trips through the usage log |
+
+**Docs-site sync:** if the combos reference documents cooldown scope, update it and its
+locales. Verify with `rg -n "cooldown" docs-site/src/content/docs/reference/` before writing —
+if nothing describes scope, no docs change is required and the PR should say so.
+
+**PR skeleton.** Title: `fix(combos): scope failover cooldowns to the failure's blast radius`.
+Summary must state that generic 410/413 remain terminal (with the two assertions named), that
+disk persistence and policy-fallback semantics are **separate** PRs, and carry
+`Co-authored-by: RHODIZSECURITY <info.rhodiz@gmail.com>`.
+
+**PRs B and C (cut here, not required to land in wp2).**
+
+- **PR B — disk persistence.** `src/combos/cooldown-disk.ts` and
+  `src/providers/key-cooldown-disk.ts` (~177 lines) plus `startServer` hydration and shutdown
+  flush. **Both debounce timers must `unref()`** — the PR does
+  `persistTimer = setTimeout(..., 250)` with none, and a pending 250 ms timer can hold the
+  event loop open at exit. Copy the established shape from `src/responses/state.ts:1573`:
+  `(persistTimer as { unref?: () => void }).unref?.();`. New test at
+  `tests/storage/storage-cooldown-disk.test.ts` (**drift-corrected: `storage` became a
+  migrated domain in `79e03643d`**). Hydration must stay synchronous and far above `Bun.serve`; the lane
+  verified the PR's placement (~line 650 vs `Bun.serve` at 2367) does not violate the
+  synchronous-activation invariant.
+- **PR C — policy-fallback semantics.** Dev returns the last upstream response when candidates
+  are exhausted (`src/server/responses/policy-fallback.ts:160`: `if (!next) return response;`).
+  The PR replaces it with a synthesized 503 `policy_unavailable` (or 413
+  `policy_input_too_large`), discarding the real upstream status and body, and converts two
+  `return overload` paths into `response = overload` so a pacing overload continues the hop
+  loop. Both are client-visible and unannounced in the PR title. Title them honestly; new test
+  at `tests/routing/policy-fallback-exhaustion.test.ts` (resolver `routing`, migrated).
+  **Explicitly excluded from wp2's stop condition.**
+
+Also excluded from all three: `exhaustedQuotaRecoveryMs` deriving multi-day key cooldowns from
+cached provider quota (a 31-day ceiling driven by cache), and the `cooldownKey` signature
+change from `keyId` to raw `apiKey`. Privacy is fine (persisted rows carry 8-char SHA-256
+prefixes, `isSafeCooldownRowKey` enforces `/^[0-9a-f]{8}$/`), but passing raw secrets through
+more call sites is a widened surface needing deliberate sign-off.
+
+## 4. Field/enum chains
+
+**No new config field is introduced anywhere in wp2.** Two things look like fields and are not,
+plus one real enum chain:
+
+**`oauthAccountFailover.enabled` (B1) — N/A, existing field.** It already exists at
+`src/types/config.ts:796` (global) and `src/types/provider.ts:435` (per provider), both
+`{ enabled?: boolean }`. B1 changes only how the **existing** value is read
+(`isProactivePreferenceEnabled`) and the doc comment. Creation (GUI/CLI/hand-edit),
+serialization, and deserialization are untouched, so there is no new chain to trace. What does
+change is consumer precedence, which is why §3.3's scenario table enumerates all four
+global × per-provider combinations plus the malformed case.
+
+**`_kiroAuthContext` (B2) — N/A, request-local.** It lives on the in-memory parsed request, is
+never persisted, and is not a config field. The change is which object owns it during a retry.
+
+**`key-401` on `AttemptRecoveryKind` (B6) — a real four-site chain.** The lane treats this as
+one item; it is not. Verified locations:
+
+| Stage | Site | Change |
+|---|---|---|
+| Type | `src/usage/log.ts:45` `AttemptRecoveryKind` union | Add `\| "key-401"` |
+| Runtime validation | `src/usage/log.ts:256` `ATTEMPT_RECOVERY_KINDS` set | Add `"key-401"` — this set is the deserialization filter at `:394-395`, so a value missing here is silently dropped on read-back |
+| Production | `src/server/responses/core.ts` rotation sites (pattern: `nextContinuationRecoveryKind = "oauth-account-429"` at ~`core.ts:6694`) | Emit `"key-401"` on the key-pool 401 rotation path |
+| Consumer | `src/routing/analytics.ts:117` `COOLDOWN_RECOVERY_KINDS` | Add `"key-401"` so `:155` counts it as a cooldown recovery |
+
+Serialization needs no change (`recoveryKinds: AttemptRecoveryKind[]` at `src/usage/log.ts:73`
+writes the string as-is), but **deserialization does**: `:394` filters through
+`ATTEMPT_RECOVERY_KINDS`, so adding the type without the set produces a value that writes fine
+and vanishes on read. The regression must round-trip a persisted attempt, not merely typecheck.
+
+**`ComboFailureCooldownScope` gaining `"none"` (B6) — type-only, no persistence.** Declared at
+`src/combos/failover.ts:256`, consumed in-process via `src/combos/resolve.ts:4` and
+`src/combos/index.ts:37`. Never serialized in PR A. If PR B lands, it becomes persisted state
+and needs its own chain review — one more reason PR B is separate.
+
+## 5. Risk, rollback, and security boundaries
+
+| Layer | Primary risk | Rollback |
+|---|---|---|
+| carry-3489 | Widens a DNS/SSRF exception. Blast radius bounded to the registry's own fixed discovery URL | Single squash revert; `isCanonicalUrl` defaults to `() => false`, so reverting the seam alone restores dev behavior |
+| carry-3469 | A too-broad matcher could reclassify unrelated 400s as permission errors | Squash revert. Mitigated by requiring an explicit location/region/country cue and the negative test |
+| B1 | Changes who may fail over. A precedence bug could route to an account the operator refused | Revert B1; B2+ depend on its position, not its behavior |
+| B2 | Touches the shared `core.ts` retry path | Revert; the default parameter means all other call sites are unchanged |
+| B3 | Largest behavior change: an error becomes a native launch. Worst case is a credential reaching an unintended base URL | Revert. Guarded by `hasOwnedAdmission && targetsLocalClaudeProxy(baseUrl, config.port)` and the `localhost:8080` negative test |
+| B4 | Boot path. A mistake here fails startup — exactly the defect being fixed | Revert. The new startup-survival regression is the standing guard |
+| B5 | GUI + i18n across 9 locales | Revert. Contained to the integrations page and one route line |
+| B6 | Changes when a target is cooled and when a failure hops | Revert. The invariant assertions (410/413 stay `stop`) are the tripwire |
+
+**Security-boundary items requiring the MAINTAINERS.md exception.** The gate is code:
+`.github/scripts/pr-sponsored-surface.cjs` defines
+`RESTRICTED_PREFIXES = [".github/workflows/", "src/oauth/"]` plus a `RESTRICTED_FILES` set, and
+`assessSponsoredSurface` returns `{ code: "unsponsored_surface" }` unless the author has push
+permission **or** the PR carries the `maintainer-sponsored` label.
+
+| Layer | Restricted paths | Requirement |
+|---|---|---|
+| B1 | `src/oauth/anthropic-routing.ts`, `src/oauth/generic-account-failover.ts` | `maintainer-sponsored` unless the author has push permission. This is what failed #3524's `hygiene` (`unsponsored_surface`, "Paths: src/oauth/index.ts") |
+| B4 | `src/oauth/index.ts` | Same. `src/providers/model-rename-startup.ts` is **not** restricted, which is the fallback if sponsorship stalls |
+| B2, B3, B5, B6 | none | `src/server/responses/core.ts`, `src/cli/claude.ts`, GUI, `src/combos/`, `src/lib/errors.ts` are all unrestricted |
+| carry-3489 | none by path | But it **is** a security-relevant change (SSRF/DNS boundary). MAINTAINERS.md requires explicit security review regardless of the automated gate. #3489 already has Ingwannu's; a carry branch should reference it and request re-confirmation |
+
+If a maintainer authors B1/B4 with push permission the gate is satisfied by their own review —
+but MAINTAINERS.md's "authors do not approve their own pull requests" and
+"security-sensitive changes should be reviewed by both maintainers when practical" still apply.
+
+## 6. Out of scope / deferred
+
+| Item | Reason (carried from the lane) |
+|---|---|
+| **#3388** — Grok sparse terminal repair | 327 new lines land on `src/server/responses/core.ts`, one of three files AGENTS.md names as carrying every user's request path, and the head has **never run a single test shard**; draft, 132 behind, no human review, CodeRabbit skipped. The gate is `logCtx.surface === "grok"`, a client marker rather than a provider opt-in, which needs an explicit maintainer ruling. A "not yet": the 481 lines of new tests are thorough and RED on dev. Unblock = onto current dev, out of draft, both tests to `tests/responses/`, maintainer ruling on the marker gate. |
+| #3348 PR B — cooldown disk persistence | Two new on-disk state files in the config dir are their own design decision, and the debounce timers are not `unref()`'d, which can hold the event loop open at exit. |
+| #3348 PR C — policy-fallback exhaustion/pacing | Discards the real upstream status and body for a synthesized 503, and lets a pacing overload continue the hop loop — both client-visible and unannounced in the PR title. |
+| #3348 — `exhaustedQuotaRecoveryMs` multi-day key cooldowns | A 31-day cooldown ceiling driven by cached provider quota is a big lever needing separate review. |
+| #3348 — `cooldownKey` raw `apiKey` signature | Privacy is fine (8-char SHA-256 prefixes, `isSafeCooldownRowKey` enforces the hex-8 shape), but passing raw secrets through more call sites is a widened surface needing deliberate sign-off. |
+| #3407 — tracked 166 KB PNG | The `gui` gate asks for a screenshot in the PR description, not a binary in the repository. |
+| #3407 — `nativeSettled === undefined` compat branch | Dead weight in a reimplementation that can update the callers directly. |
+| #3484, #3480 (lane B); #3515, #3529, #3525, #3490 (lane A) | LAND_AS_IS — owned by wp1 / Stack A, doc `010`. #3484 is a **precondition** for B5. |
+| `tests/server/server-combo-failover-e2e.test.ts` local failures | 45 failures on **unmodified** dev, all `EADDRINUSE` from `Bun.serve({ port: 0 })` in this sandbox. Environmental; do not investigate or "fix". |
+
+## Verification notes for this doc
+
+- `git fetch origin dev` run at plan time; `origin/dev` = `6580694c7`; drift scoped to this
+  phase's files is empty.
+- Verifiers V1-V8 executed on unmodified dev; baselines recorded in §1. V9/V10 named but not
+  run (V10 needs a change set).
+- Every `src/` line number re-read at plan time on the current tree.
+- Test-path targets resolved with the repository's own resolver
+  (`scripts/test-layout/schema.ts`), not by pattern-matching the lane docs.
+- PR head/mergeable state and co-author emails re-read via `gh pr view` immediately before
+  writing; `gh` reported `UNKNOWN` mergeable for #3502/#3519/#3524 while recomputing against the
+  new dev tip, and `CONFLICTING/DIRTY` for #3489/#3469/#3407/#3348/#3388.
+- No `src/`, `tests/`, or `gui/` file was modified; no repository-wide suite was run.

--- a/devlog/_plan/260905_open_work_closeout/030_wp3_stack_c_v2_passthrough.md
+++ b/devlog/_plan/260905_open_work_closeout/030_wp3_stack_c_v2_passthrough.md
@@ -1,0 +1,656 @@
+# 030 — wp3 / Stack C: #3444 direct encrypted V2 task passthrough
+
+Unit: `devlog/_plan/260905_open_work_closeout`. Work-phase: **wp3**. Lane source:
+[`003_lane_v2_and_quota.md`](./003_lane_v2_and_quota.md) (#3444 section).
+
+Re-verified against `origin/dev` = `6580694c7911cfbf78da63b6258ec1c70bd8a0e3`
+(`test(oauth): restore a deleted contract test, and fail when one disappears (#3530)`),
+fetched at plan time. The lane doc was researched at `0f27bbeb3`.
+
+**Drift check (executed, empty result):**
+
+~~~
+git log --oneline 0f27bbeb3..origin/dev -- src/config.ts src/types/provider.ts \
+  src/server/auth-cors.ts src/server/responses/core.ts \
+  tests/agent-task-recovery.test.ts \
+  docs-site/src/content/docs/reference/configuration/providers.md
+  -> (no output)
+~~~
+
+Zero commits in that range touch any of the six files #3444 changes. The single commit
+`6580694c7` touches `tests/repo-hygiene.test.ts` and
+`tests/routing/anthropic-quorum-cache.test.ts` only. **Every file:line citation in the lane
+doc and in this plan is valid at the current `origin/dev`.**
+
+---
+
+## 1. Loop-spec header
+
+| Field | Value |
+|---|---|
+| **Archetype** | spec-satisfaction repair |
+| **Trigger** | PR #3444 is functionally complete and merges clean, but is held by two repository gates that no code change can clear: `hygiene / unsponsored_surface` (contributor touched `src/server/auth-cors.ts`) and `enforce-target` (contributor readiness checklist box 4 unticked, PR in draft). |
+| **Goal** | Land the `allowEncryptedV2AgentTasks` opt-in on `dev` with author attribution to `cb8010d6` preserved, the security-boundary review recorded on the PR, and the regression coverage in `tests/agent-task-recovery.test.ts` green at the exact merged head. |
+| **Non-goals** | (a) Changing the trust-boundary logic in `canPassThroughEncryptedV2AgentTask` — it was reviewed and is correct; (b) rebasing the contributor's fork branch on their behalf; (c) widening `RESTRICTED_FILES` or altering `.github/scripts/pr-sponsored-surface.cjs`; (d) any `main`/`preview` promotion; (e) landing #3447, #2783, #2973, #2956 (separate work-phases). |
+| **Stop condition** | `git fetch origin dev && git merge-base --is-ancestor <squash-sha> FETCH_HEAD` exits 0, AND the merged PR's checks are green at the exact pre-merge head SHA, AND #3444 is closed with the merge recorded. |
+| **Memory artifact** | This document + the merge ledger in `060_closeout.md`. |
+| **Expected terminal outcomes** | `MERGED_AS_CARRY` (selected path) or `MERGED_AS_IS` (label path). Failure outcome: `BLOCKED_ON_MAINTAINER_LABEL` if neither the label nor a push-permission author is available. |
+| **Escalation** | The `maintainer-sponsored` label and the admin squash bypass both require the maintainer. If the executing agent lacks label-write or merge permission, stop at "CI green on exact head" and hand off. Do **not** route around the sponsorship gate by splitting `auth-cors.ts` into a separate PR — that defeats the gate's stated purpose (`pr-sponsored-surface.cjs:14-18`). |
+
+### Verifier commands (each proven to exist and to read the change target)
+
+| # | Command | Proof it exists / reads the target | Observed exit |
+|---|---|---|---|
+| V1 | `bun test tests/agent-task-recovery.test.ts` | File present (`ls -la` -> 21050 bytes). Exercises `canPassThroughEncryptedV2AgentTask` through `post(config, "relay/gpt-5.6-luna", ...)`. | **0** on dev (19 pass / 0 fail); **1** on dev source + PR test file (22 pass / 1 fail); **0** on PR head (23 pass / 0 fail) |
+| V2 | `bun test tests/agent-task-recovery-combo.test.ts tests/v2-agent-message-failfast.test.ts tests/agent-task-recovery-security.test.ts` | All three present. Cover the `options.comboAttempt` branch and the fail-closed guard this change must not widen. | **0** (40 pass / 0 fail) on dev |
+| V3 | `bun run typecheck` (`bun x tsc --noEmit`, `package.json:43`) | Load-bearing: `PROVIDER_CONFIG_FIELD_POLICY` is `satisfies Record<keyof OcxProviderConfig, ProviderConfigFieldPolicy>` at `src/server/auth-cors.ts:870`. | **0** on dev. **Proven non-vacuous:** deleting the `auth-cors.ts` row from a PR-head tree yields `src/server/auth-cors.ts(870,12): error TS2741`. |
+| V4 | `node --test .github/scripts/pr-sponsored-surface.test.cjs` | Directly covers `assessSponsoredSurface` — the function producing the block. | **0** (7 pass / 0 fail) |
+| V5 | `gh pr checks <n>` filtered to the exact head SHA | Hosted CI: `test 1..4/4`, `gates`, `storage policy`, `api usage`, `hygiene`, `enforce-target`. | must be green pre-merge |
+| V6 | `git fetch origin dev && git merge-base --is-ancestor <sha> FETCH_HEAD` | Landing proof. | must be 0 |
+| V7 | `bun run privacy:scan` (`package.json:45`) | Security-boundary item: confirms no new body/credential logging on a ciphertext-forwarding path. | must be 0 |
+
+**Do not run** `bun run test` or a bare `bun test`. The repository-wide suite is forbidden for
+this campaign (000 plan), and the pre-push hook that would run it is bypassed with `--no-verify`.
+
+---
+
+## 2. Stack map (DEV-STACK-01..03)
+
+**Stack C is a single-layer stack.** #3444 is the only lane-3 item that merges cleanly, is the
+smallest diff (+111/-4 across 6 files), and every other lane-3 item benefits from it landing
+first (they add distinct optional fields to the same schema objects). Under DEV-STACK-01 work is
+stacked only when it splits into 2+ parts with a real dependency order **and** one PR would be
+too large to review. Neither holds: one config field, one policy row, one guard function, two
+call-site conditions, one docs row, one test block is a single cohesive thesis. Splitting it
+would produce a lower layer (`auth-cors.ts` row alone) that **does not typecheck** — the
+`satisfies Record<keyof OcxProviderConfig, ...>` constraint at `src/server/auth-cors.ts:870`
+requires the field to exist on `OcxProviderConfig` first, and the field is inert without its
+consumer. That is a slicing failure, and DEV-STACK-01's "do not stack when the change is one
+cohesive thesis" applies directly.
+
+| Layer | Branch | Targets | Item | Proves alone |
+|---|---|---|---|---|
+| C1 (bottom, only) | `codex/260905-v2-passthrough-3444` *(carry path only)* | `dev` | #3444 | A direct key-auth Responses provider that opts in with `allowEncryptedV2AgentTasks: true` forwards an opaque encrypted V2 sub-agent task byte-unchanged, while every other route (OAuth, Chat adapter, model-level Chat override, combo attempt) keeps the existing recovery or fail-closed behavior. |
+
+### Ordering relative to the rest of lane 3
+
+~~~
+#3444  (Stack C — this doc)          <- lands FIRST
+   |
+   +-- #3447  (wp4, owns src/providers/quota.ts)
+   |      |
+   |      +-- #2783  (rebase onto #3447)
+   |
+   +-- #2973  (independent after #3444; 4 mechanical conflicts)
+
+#2956  (DEFER — no ordering impact)
+~~~
+
+Rationale carried from the lane doc: #3444, #2783 and #2973 all add **distinct optional fields**
+to `src/config.ts` / `src/types/provider.ts`. The overlap is additive, so the only real cost is
+conflict-resolution surface; landing the smallest clean one first keeps every later resolution
+single-file-at-a-time.
+
+### Direct-merge candidates (not restacked)
+
+#3444 is **already an open PR that merges clean** — the lane's local
+`git merge-tree --write-tree origin/dev refs/pull/3444/head` returned exit 0 (tree `ed79a40e8`).
+Under the campaign rule such an item is merged directly rather than restacked, **provided the
+label path is viable**. §3.2 shows it is not, for a reason unrelated to sponsorship.
+
+### Carried contributor work
+
+The carry branch is created from the PR head, not retyped:
+
+~~~
+git fetch origin dev
+git fetch origin +refs/pull/3444/head:refs/tmp/pr3444
+git switch -c codex/260905-v2-passthrough-3444 origin/dev
+git cherry-pick b487dc794ce72fffd1a5d2295ffbcd6a8ed10a81 baefb1334b69e1f37ae1446b6326ae09cb0021ac
+~~~
+
+Attribution trailer — the author's commit email was read from
+`gh pr view 3444 --json commits` (`commits[].authors[].email`):
+
+~~~
+Co-authored-by: cb8010d6 <53855466+cb8010d6@users.noreply.github.com>
+~~~
+
+Both PR commits (`b487dc794`, `baefb1334`) carry that identical author identity, so one trailer
+covers the carry. It must be in the **squash body or a branch commit**, per `AGENTS.md`
+("Landing another author's work") and `.github/scripts/pr-carry-attribution.cjs`. Note that
+`assessCarryAttribution` reads the PR *text*, not its diff (`pr-carry-attribution.cjs:20-22`):
+a carry PR whose body says "carries #3444" without the trailer fails `hygiene` with
+`missing_coauthor_credit`.
+
+---
+
+## 3. The item: #3444
+
+### 3.0 State at plan time
+
+| Field | Value |
+|---|---|
+| Head | `baefb1334b69e1f37ae1446b6326ae09cb0021ac` |
+| Branch | `feat/direct-encrypted-v2-provider-passthrough` on fork `cb8010d6/opencodex` |
+| `maintainerCanModify` | `true` |
+| Author | `cb8010d6` (no push permission) |
+| Base | `dev` |
+| Labels | `enhancement`, `intake: hygiene-blocked` |
+| Draft | yes |
+| Merge-base | `2421e44ceb24b12666fad668923c6705d4a19ee1` — **42 behind / 2 ahead** of `6580694c7` |
+| Blocking checks | `hygiene` (`unsponsored_surface`), `enforce-target` (readiness box 4) |
+
+**42 behind is the number that decides the path.** See §3.2.
+
+### 3.1 File change map
+
+Six files. Current `origin/dev` lines quoted, then the target state.
+
+#### (a) `src/types/provider.ts` — declare the field
+
+Current, `src/types/provider.ts:268-278`:
+
+~~~ts
+  /**
+   * Explicit opt-in for a relay that genuinely fronts OpenAI and can decode native
+   * compaction blobs. Absent or false degrades foreign blobs to an opaque note.
+   */
+  decodesNativeCompactionBlobs?: boolean;
+  /**
+   * Explicit opt-in for non-registry private-network destinations such as localhost, RFC1918,
+   * link-local, or unique-local upstreams. Metadata endpoints remain blocked.
+   */
+  allowPrivateNetwork?: boolean;
+~~~
+
+Target — insert between the two:
+
+~~~ts
+  decodesNativeCompactionBlobs?: boolean;
+  /**
+   * Trust this direct key-auth Responses provider to consume or relay opaque encrypted
+   * V2 agent tasks. OpenCodex does not decrypt, translate, or recover an eligible task.
+   * Absent or false keeps the existing recovery/fail-closed behavior.
+   */
+  allowEncryptedV2AgentTasks?: boolean;
+  /**
+   * Explicit opt-in for non-registry private-network destinations ...
+   */
+  allowPrivateNetwork?: boolean;
+~~~
+
+#### (b) `src/config.ts` — Zod schema row
+
+Current, `src/config.ts:538-540`:
+
+~~~ts
+  preserveResponsesReasoningContent: z.boolean().optional(),
+  decodesNativeCompactionBlobs: z.boolean().optional(),
+  allowPrivateNetwork: z.boolean().optional(),
+~~~
+
+Target:
+
+~~~ts
+  decodesNativeCompactionBlobs: z.boolean().optional(),
+  allowEncryptedV2AgentTasks: z.boolean().optional(),
+  allowPrivateNetwork: z.boolean().optional(),
+~~~
+
+`.optional()` with no `.default()` is what makes the feature default-off at the
+deserialization boundary.
+
+#### (c) `src/server/auth-cors.ts` — field-policy row **(SECURITY BOUNDARY / the gate trigger)**
+
+Current, `src/server/auth-cors.ts:785-787`:
+
+~~~ts
+  preserveResponsesReasoningContent: "editor",
+  decodesNativeCompactionBlobs: "editor",
+  allowPrivateNetwork: "editor",
+~~~
+
+Target — one line inserted after `decodesNativeCompactionBlobs`:
+
+~~~ts
+  allowEncryptedV2AgentTasks: "editor",
+~~~
+
+This row is **compiler-forced, not discretionary**: the map closes with
+`} as const satisfies Record<keyof OcxProviderConfig, ProviderConfigFieldPolicy>;` at
+`src/server/auth-cors.ts:870`. Verified by deleting the row from a PR-head scratch tree and
+running `bun x tsc --noEmit`:
+
+~~~
+src/server/auth-cors.ts(870,12): error TS2741: Property 'allowEncryptedV2AgentTasks'
+  is missing in type '{ ... }' but required in type
+  'Record<keyof OcxProviderConfig, ProviderConfigFieldPolicy>'.
+~~~
+
+There is therefore **no version of this change that avoids touching `auth-cors.ts`**, which is
+why the sponsorship gate cannot be engineered around and must be cleared by §3.2.
+
+#### (d) `src/server/responses/core.ts` — the guard and its two call sites
+
+**(d1) New predicate**, inserted after `unreadableEncryptedAgentTaskResponse()`, which currently
+ends at `src/server/responses/core.ts:1759`:
+
+~~~ts
+/**
+ * Keep this trust boundary deliberately narrow: only a key-auth Responses route may consume
+ * opaque child-task ciphertext, and the model's final wire override must still be Responses.
+ * Callers keep combo attempts on their existing native-only recovery/fail-closed behavior.
+ */
+function canPassThroughEncryptedV2AgentTask(
+  route: RouteResult,
+  inboundWire: InboundWire,
+): boolean {
+  const provider = route.provider;
+  if (
+    inboundWire !== "responses"
+    || provider.allowEncryptedV2AgentTasks !== true
+    || (provider.authMode ?? "key") !== "key"
+  ) return false;
+
+  return resolveWireProtocolOverride(
+    route.providerName,
+    route.modelId,
+    provider,
+    inboundWire,
+  ).adapter === "openai-responses";
+}
+~~~
+
+All four conjuncts are load-bearing. `authMode ?? "key"` matches the documented default at
+`src/types/provider.ts:425`. `resolveWireProtocolOverride` (`src/server/adapter-resolve.ts:20`)
+is what makes a **model-level** `modelAdapters` Chat override defeat a provider-level
+`openai-responses` declaration — scenario A5 in §3.5.
+
+**(d2) Recovery-skip call site.** Current, `src/server/responses/core.ts:3089-3097`:
+
+~~~ts
+  // Native fallback can consume ciphertext, so recover only after final route selection.
+  if (
+    inboundWire === "responses"
+    &&
+    threadSpawn
+    && unreadableEncryptedAgentTask
+    && agentTaskRecovery
+    && !isCanonicalOpenAiForwardProvider(route.provider)
+    && !options.comboAttempt
+  ) {
+~~~
+
+Target — comment updated, one conjunct appended:
+
+~~~ts
+  // Native fallback and explicitly trusted direct Responses routes can consume ciphertext,
+  // so recover only after final route selection.
+  if (
+    inboundWire === "responses"
+    &&
+    threadSpawn
+    && unreadableEncryptedAgentTask
+    && agentTaskRecovery
+    && !isCanonicalOpenAiForwardProvider(route.provider)
+    && !options.comboAttempt
+    && !canPassThroughEncryptedV2AgentTask(route, inboundWire)
+  ) {
+~~~
+
+**(d3) Fail-closed call site.** Current, `src/server/responses/core.ts:3221-3225`:
+
+~~~ts
+  // Encrypted child tasks may only reach the canonical native backend. This check
+  // runs against the FINAL route so native-only fallback can rescue a routed primary.
+  if (!isCanonicalOpenAiForwardProvider(route.provider) && unreadableEncryptedAgentTask) {
+    return unreadableEncryptedAgentTaskResponse();
+  }
+~~~
+
+Target:
+
+~~~ts
+  // Encrypted child tasks may reach the canonical native backend or an explicitly trusted
+  // direct Responses route. This runs against the FINAL route so native-only fallback can
+  // rescue an incompatible primary without weakening combo behavior.
+  const finalRouteCanPassThroughEncryptedTask = !options.comboAttempt
+    && canPassThroughEncryptedV2AgentTask(route, inboundWire);
+  if (
+    !isCanonicalOpenAiForwardProvider(route.provider)
+    && !finalRouteCanPassThroughEncryptedTask
+    && unreadableEncryptedAgentTask
+  ) {
+    return unreadableEncryptedAgentTaskResponse();
+  }
+~~~
+
+The `!options.comboAttempt` conjunct is what keeps the combo path
+(`src/server/responses/core.ts:2299-2313`, which returns `unreadableEncryptedAgentTaskResponse()`
+when no target `canDecryptUnreadableAgentTask`) on its existing native-only behavior.
+**Do not drop it during conflict resolution** — it is the difference between an opt-in on a
+single named route and one that silently widens combo dispatch.
+
+#### (e) `docs-site/src/content/docs/reference/configuration/providers.md` — one table row
+
+Insert after the `responsesPath?` row (line 72 on dev; the PR adds at line 73):
+
+| `allowEncryptedV2AgentTasks?` | `boolean` | Disabled by default. Trust a direct key-auth `openai-responses` provider to consume or relay opaque encrypted V2 sub-agent tasks unchanged. Eligible routes skip `agentTaskRecovery`; all other routes keep the existing recovery or fail-closed behavior. OpenCodex does not decrypt, translate, or recover tasks sent through this opt-in. |
+
+#### (f) `tests/agent-task-recovery.test.ts` — +65 lines, two blocks
+
+Inserted after the existing block ending at line 147. Content unchanged from the PR head;
+RED/GREEN ledger in §3.4.
+
+---
+
+### 3.2 Conflict resolution recipe / path selection
+
+There is **no merge conflict**. `git merge-tree --write-tree origin/dev refs/pull/3444/head`
+returned exit 0 (lane doc, tree `ed79a40e8`), and the drift query at the top of this document
+confirms none of the six files moved since. The 42-commit lag touches `src/config.ts`,
+`src/types/provider.ts`, `src/server/responses/core.ts` and the docs file, but every hunk is
+additive and lands in a different region. The conflict to resolve is **procedural**, and the two
+candidate paths were evaluated against `.github/scripts/pr-sponsored-surface.cjs`:
+
+~~~js
+function assessSponsoredSurface({ authorHasPushPermission = false, changedFiles = [], labels = [] }) {
+  if (authorHasPushPermission) return [];            // :75
+  const restricted = changedFiles.filter(isRestrictedPath);
+  if (restricted.length === 0) return [];            // :77
+  if (hasSponsorship(labels)) return [];             // :78
+  return [{ code: "unsponsored_surface", paths: restricted }];
+}
+~~~
+
+`src/server/auth-cors.ts` is in `RESTRICTED_FILES` (`pr-sponsored-surface.cjs:44`), so exactly
+three exits clear the gate. Removing the file from the diff is impossible (§3.1c), leaving:
+
+| Path | Mechanism | Evidence | Cost |
+|---|---|---|---|
+| **P1 — label** | Maintainer applies `maintainer-sponsored`. `hasSponsorship` (`:60-64`) accepts a string or `{name}`; the label is in `HYGIENE_GATE_LABELS` (`pr-hygiene.cjs:259`) so `pr-hygiene.yml` wakes on `labeled`, and `enforce-pr-target.yml:43` wakes on it too. The label is auto-created if absent (`pr-hygiene.yml:89`). | `node --test .github/scripts/pr-sponsored-surface.test.cjs` → "passes once a maintainer sponsors it", exit 0 | Contributor keeps native authorship; **but** `enforce-target` still needs box 4, which only the author can tick (`enforce-pr-target.yml:912-914`: "The tickable checklist lives in the PR body, because only the PR author can edit it"). |
+| **P2 — maintainer carry** | Maintainer opens a branch from the PR head. `authorHasPushPermission` is true (`pr-quality.cjs:88-90`: `admin`/`maintain`/`write`), so `assessSponsoredSurface` returns `[]` at `:75` and `checklistRequired` is false (`enforce-pr-target.yml:766-768`). | `node --test` → "exempts an author who can already push", exit 0 | Requires the `Co-authored-by` trailer; adds one PR to close out. |
+
+**Selected: P2 (maintainer carry). P1 is the preferred fallback only if the contributor is
+actively responding.**
+
+The deciding evidence is not the sponsorship gate — both paths clear it — it is the **readiness
+claim verifier**, which P1 cannot satisfy without contributor action:
+
+- `readinessClaimViolations` (`.github/scripts/pr-quality-state.cjs:213-223`) pushes
+  `"latest_dev"` when `behindBase > READINESS_LATEST_DEV_BEHIND_MAX`.
+- `READINESS_LATEST_DEV_BEHIND_MAX = 10` (`pr-quality-state.cjs:26`).
+- `behindBase` comes from `compareCommitsWithBasehead` (`enforce-pr-target.yml:580-587`).
+- Measured: `git rev-list --count refs/tmp/pr3444..origin/dev` → **42**.
+
+So even if the author ticks box 4 today, the gate unticks the "latest dev" box and holds the PR
+in draft. **P1 requires the contributor to rebase onto `dev` *and* re-tick all four boxes**, and
+every push resets the checklist again. P2 removes the checklist entirely
+(`checklistRequired = !authorIsMaintainer`), and the maintainer's own review *is* the
+sponsorship — the documented intent at `pr-sponsored-surface.cjs:20-22` ("A maintainer with push
+permission is exempt because their own review is the sponsorship").
+
+P2 is also what `AGENTS.md` anticipates here: `maintainerCanModify: true` makes the carry
+mechanical, and the lane doc already flags the trailer as mandatory.
+
+**P2 recipe — mechanical, no semantic resolution.** Branch creation is in §2. If either
+cherry-pick reports a conflict (it should not — merge-tree is clean), the resolution for every
+one of the six files is **take both sides**: all six hunks are pure insertions into lists or
+tables. The single exception is `src/server/responses/core.ts` (d2)/(d3), where the rule is:
+keep every conjunct `dev` has, and add the new one. Losing `!options.comboAttempt` at (d3) is
+the only resolution error that would be semantically dangerous rather than merely wrong.
+
+Then:
+
+~~~
+git commit --amend --no-edit --trailer "Co-authored-by: cb8010d6 <53855466+cb8010d6@users.noreply.github.com>"
+git push --no-verify -u origin codex/260905-v2-passthrough-3444
+~~~
+
+`--no-verify` per the campaign constraint: the pre-push hook runs the forbidden suite.
+
+### 3.3 Pre-merge checks (exact sequence)
+
+Applies to whichever PR is merged — the carry PR under P2, or #3444 itself under P1.
+
+1. **Refresh state immediately before acting.** `gh pr view <n> --json headRefOid,mergeable,mergeStateStatus,labels,isDraft,reviewDecision`. Record the head SHA; every later check is bound to it.
+2. **Dismiss stale reviews.** #3444 carries `REVIEW_REQUIRED` and CodeRabbit was skipped as draft. Under P2 the carry PR is new, so nothing is stale; under P1 any `CHANGES_REQUESTED` predating the sponsorship label must be dismissed with a reason, not silently overridden.
+3. **Mark ready.** P2: the maintainer PR opens ready (`checklistRequired` false). P1: the *author* ticks box 4 and the gate calls `markPullRequestReadyForReview` itself (`enforce-pr-target.yml:495`).
+4. **Apply `maintainer-sponsored` if P1.** Not required under P2, but applying it anyway is harmless and makes the security review visible on the PR — the stated point of the gate (`pr-sponsored-surface.cjs:16-18`).
+5. **Exact-head CI.** `gh pr checks <n>`, confirming each conclusion belongs to the recorded head SHA. Required green: `test 1/4`–`4/4`, `gates`, `storage policy`, `api usage`, `hygiene`, `enforce-target`. An **empty** `gh pr checks --required` output is not green evidence.
+6. **Security-boundary review recorded.** Post the note in §5 as a PR comment.
+7. **Admin squash merge**, bottom-up (single layer here). The `Protect dev` ruleset (id 20763889) permits merge and squash only; rebase merges are off (`MAINTAINERS.md`). The `maintain`/`admin` `pull_request` bypass is what allows merging without the second approval, and `MAINTAINERS.md` requires that use of the bypass be **recorded on the pull request**, not inferred from a merge timestamp. Confirm the squash body carries the `Co-authored-by` trailer *in the confirm dialog*, before merging.
+8. **Landing proof.** `git fetch origin dev && git merge-base --is-ancestor <squash-sha> FETCH_HEAD` → exit 0.
+9. **Close #3444** (P2) with a comment naming the carry PR and the squash SHA. PRs here target `dev`, so GitHub will not auto-close it (`AGENTS.md`, branch policy).
+
+### 3.4 Regression tests
+
+**File:** `tests/agent-task-recovery.test.ts`
+
+| Test name | RED on dev? | Why |
+|---|---|---|
+| `trusted direct Responses routes bypass recovery and preserve encrypted tasks` | **YES — verified** | Dev has no `allowEncryptedV2AgentTasks` path, so the fail-closed check at `core.ts:3223` fires for the routed `relay` provider. Observed: `tests/agent-task-recovery.test.ts:177:31 — expect(response.status).toBe(200), Received: 400`. |
+| `trusted passthrough stays fail closed for OAuth authentication` | no (passes on dev) | Guard test — dev fails closed everywhere, so it passes before and after. Protects the new opt-in from widening. |
+| `trusted passthrough stays fail closed for a Chat Completions adapter` | no (passes on dev) | Same. |
+| `trusted passthrough stays fail closed for a model-level Chat override` | no (passes on dev) | Same. |
+
+**Ledger (executed in scratch trees outside the worktree, `node_modules` symlinked):**
+
+| Tree | Result |
+|---|---|
+| dev source, dev tests | 19 pass / 0 fail |
+| **dev source + PR test file** | **22 pass / 1 fail** ← RED proof |
+| PR head (source + tests) | 23 pass / 0 fail ← GREEN proof |
+
+The three `test.each` guard cases passing on dev is the **correct** shape for a trust-boundary
+change and must not be mistaken for missing coverage: the RED test proves the feature works, and
+the three GREEN-on-both tests prove the boundary did not move for anything else.
+
+**Focused verifier commands:**
+
+~~~
+bun test tests/agent-task-recovery.test.ts
+bun test tests/agent-task-recovery-combo.test.ts tests/v2-agent-message-failfast.test.ts tests/agent-task-recovery-security.test.ts
+bun run typecheck
+bun run privacy:scan
+~~~
+
+The second command covers the combo and fail-closed neighbours the change must not disturb; it
+was run on dev and returned 40 pass / 0 fail, exit 0. `bun run test:changed` alone is
+insufficient here — name the combo/failfast files explicitly rather than relying on the module
+graph to select them.
+
+### 3.5 Accept criteria — activation scenario per conditional path (C-ACTIVATION-GROUNDING-01)
+
+| # | Condition | Activating scenario | Expected | Covered by |
+|---|---|---|---|---|
+| A1 | `inboundWire !== "responses"` | A Chat-wire inbound request to an opted-in provider. | predicate false → existing behavior | **No activating test.** Structurally unreachable at the (d2) site, which is already gated on `inboundWire === "responses"` (`core.ts:3091`); the conjunct is defence-in-depth for (d3). Accept as unverified-by-test **with this reason carried into the PR body**. |
+| A2 | `allowEncryptedV2AgentTasks !== true` | Any provider without the opt-in — i.e. every existing config. | fail closed, HTTP 400 `unreadable_encrypted_agent_task` | The whole 19-test dev baseline, e.g. `leaves native encrypted passthrough unchanged`. |
+| A3 | `(authMode ?? "key") !== "key"` | `providers.relay = { adapter: "openai-responses", authMode: "oauth", allowEncryptedV2AgentTasks: true }` | 400, `fetchCalls === 0` | `trusted passthrough stays fail closed for OAuth authentication` |
+| A4 | resolved adapter !== `openai-responses` (provider-level) | `{ adapter: "openai-chat", allowEncryptedV2AgentTasks: true }` | 400, `fetchCalls === 0` | `... for a Chat Completions adapter` |
+| A5 | resolved adapter !== `openai-responses` (**model override defeats provider level**) | `{ adapter: "openai-responses", modelAdapters: { "gpt-5.6-luna": "openai-chat" }, allowEncryptedV2AgentTasks: true }` | 400, `fetchCalls === 0` | `... for a model-level Chat override` — the case `resolveWireProtocolOverride` exists to catch |
+| A6 | predicate **true**, provider-level Responses | `{ adapter: "openai-responses", authMode: "key", apiKey, allowEncryptedV2AgentTasks: true }` | 200; exactly 1 fetch; URL contains `relay.example.test` and not `chatgpt.com`; `forwardedInput` deep-equals the original ciphertext | `trusted direct Responses routes ...` (loop iteration 1) |
+| A7 | predicate **true**, reached via a model override *up* to Responses | `{ adapter: "openai-chat", modelAdapters: { "gpt-5.6-luna": "openai-responses" }, ... }` | same as A6 | same test (loop iteration 2) |
+| A8 | `options.comboAttempt === true` at (d3) | A combo target resolving to an opted-in provider. | `finalRouteCanPassThroughEncryptedTask` false → combo keeps native-only fail-closed | `fails closed after a single failed combo recovery pass` + `tests/agent-task-recovery-combo.test.ts` |
+| A9 | `isCanonicalOpenAiForwardProvider(route.provider)` | The canonical ChatGPT backend route. | unchanged native passthrough; opt-in never consulted | `allows the canonical ChatGPT route to forward the encrypted task` (`tests/v2-agent-message-failfast.test.ts`) |
+| A10 | `agentTaskRecovery` configured **and** opt-in set | `routedConfig()` (recovery enabled) + opted-in relay | recovery **skipped**, ciphertext forwarded unchanged — this is (d2) | `trusted direct Responses routes ...` uses `routedConfig()` with recovery **on**, which is precisely what makes it exercise (d2) and not only (d3) |
+
+### 3.6 docs-site sync
+
+- **English source — required, already in the diff:** `docs-site/src/content/docs/reference/configuration/providers.md:73`.
+- **Locales — not required, do not add.** Seven locale copies exist (`fr`, `ja`, `ko`, `ru`, `tr`, `zh-cn`, `zh-tw`) and each already lags the English table. `AGENTS.md` requires only that translated locales not *contradict* the English source; an absent row does not contradict. Machine-translated rows would exceed scope.
+- **`agents.md` cross-reference — optional.** `docs-site/src/content/docs/reference/configuration/agents.md:125-137` presents `agentTaskRecovery` as *the* compatibility path for encrypted v2 tasks. One sentence noting that `allowEncryptedV2AgentTasks` is the opposite disposition (forward rather than recover) would stop an operator reading them as alternatives to the same problem. Safe as a follow-up: docs are not a `BEHAVIOR_PREFIX` (`pr-hygiene.cjs:73-75`), so a docs-only PR does not owe a regression test.
+- **`structure/` — no change.** `structure/04_transports-and-sidecars.md:245` documents `decodesNativeCompactionBlobs` because that flag participates in the compaction-blob decision; this field touches no transport invariant.
+
+---
+
+### 3.7 PR title / body skeleton
+
+**Title (P2 carry)** — keep the contributor's original verbatim:
+
+~~~
+feat(providers): allow direct encrypted V2 task passthrough
+~~~
+
+Do not put a carry verb in the title; `CARRY_VERB_RE` (`pr-carry-attribution.cjs:24-25`) scans
+title and body, and while the trailer satisfies it either way, keeping the declaration in the
+body alone is tidier.
+
+**Body:**
+
+~~~md
+## Summary
+
+- Add a default-off `allowEncryptedV2AgentTasks` provider option for direct key-auth
+  `openai-responses` routes.
+- Skip `agentTaskRecovery` only when the selected model's final wire override is still
+  Responses, then forward the opaque encrypted task byte-unchanged.
+- Keep canonical ChatGPT forwarding, combo attempts, OAuth/forward/local providers, and every
+  non-opted route on the existing recovery or fail-closed path.
+
+Carries #3444 by @cb8010d6 onto current `dev`. The fork branch was 42 commits behind, so the
+contributor readiness checklist could not be completed against a current head.
+
+The one-line `src/server/auth-cors.ts` change adds the new non-secret boolean to the
+exhaustive `PROVIDER_CONFIG_FIELD_POLICY` table as editor-editable. It is compiler-forced by
+the `satisfies Record<keyof OcxProviderConfig, ...>` constraint at auth-cors.ts:870 and
+changes no authentication or CORS behavior. No GUI change.
+
+### Stack
+
+| Layer | PR | Base | Status |
+|---|---|---|---|
+| C1 (bottom, only) | this PR | `dev` | ready |
+
+Lane 3 ordering: this lands before #3447, #2783 and #2973, which add distinct optional fields
+to the same schema objects.
+
+## Verification
+
+- `bun test tests/agent-task-recovery.test.ts` — 23 pass / 0 fail
+  (RED on dev without the source change: 22 pass / 1 fail at line 177)
+- `bun test tests/agent-task-recovery-combo.test.ts tests/v2-agent-message-failfast.test.ts
+  tests/agent-task-recovery-security.test.ts` — 40 pass / 0 fail
+- `bun run typecheck`
+- `bun run privacy:scan`
+- `cd docs-site && bun run build`
+
+The `inboundWire !== "responses"` conjunct in `canPassThroughEncryptedV2AgentTask` has no
+activating test: the recovery call site is already gated on `inboundWire === "responses"`, so
+the conjunct is defence-in-depth for the second call site.
+
+## Checklist
+
+- [x] Scope stays focused and avoids unrelated cleanup.
+- [x] Docs or release notes were updated when needed.
+- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
+
+Closes #3444
+
+Co-authored-by: cb8010d6 <53855466+cb8010d6@users.noreply.github.com>
+~~~
+
+`Closes #3444` will not auto-close: this PR targets `dev`, and GitHub auto-closes only on the
+default branch (`main`). Close #3444 manually after the squash lands.
+
+---
+
+## 4. Field / enum chain
+
+One new config field: `allowEncryptedV2AgentTasks: boolean | undefined`. No new enum, no GUI
+surface (the dashboard renders editor fields generically).
+
+| Stage | Location | Behavior |
+|---|---|---|
+| **Type declaration** | `src/types/provider.ts`, new, after `decodesNativeCompactionBlobs` (:272) | `allowEncryptedV2AgentTasks?: boolean` on `OcxProviderConfig`. Optional — absence *is* the default-off state. |
+| **Creation (operator, file)** | `providers.<name>.allowEncryptedV2AgentTasks` in the config file | Hand-written, or written by the dashboard. |
+| **Creation (operator, API)** | `POST`/`PATCH /api/providers` | Accepted **because** of the policy row: `PROVIDER_CONFIG_FIELD_SET` (`auth-cors.ts:913`) is built from the policy map's keys, and `parseProviderEditorConfig` (`auth-cors.ts:974-982`) rejects any field outside that set as `invalid_provider_editor_field`. |
+| **Deserialization** | `src/config.ts` `providerConfigSchema`, new row after :539 | `z.boolean().optional()`. No `.default()`, no `.nullish()` — unlike `upstreamHttpVersion` (:544-546) this field has no "clear to null" API contract, so a literal `null` on disk is a schema error. Matches `decodesNativeCompactionBlobs` and `allowPrivateNetwork` immediately around it. |
+| **Serialization / redaction** | `src/server/auth-cors.ts:787`, policy `"editor"` | `"editor"` means: not in `REDACTED_PROVIDER_FIELDS` (:879-881), not in `RUNTIME_PROVIDER_FIELDS` (:882-884), therefore not in `PROVIDER_EDITOR_DENIED_FIELDS` (:895-898) — so `providerEditorProviderDTO` (:926-929) emits it to the dashboard unredacted. Correct: a non-secret boolean. |
+| **Consumer** | `src/server/responses/core.ts`, `canPassThroughEncryptedV2AgentTask` (new, after :1759) | Read as `provider.allowEncryptedV2AgentTasks !== true`. **Strict `!== true`, not a falsy check** — a hand-edited `"true"` string does not activate the trust boundary. |
+| **Registry default** | **none — deliberately** | Contrast `preserveResponsesReasoningContent`, which carries a registry seed (`src/providers/registry.ts:257,1978`) merged in `src/router.ts:403-404` and `src/providers/derive.ts:538`. This field has **no registry path**, so no built-in preset can turn it on; only an explicit operator opt-in can. That is the right default for a trust boundary and must be preserved if the field is ever extended. |
+
+---
+
+## 5. Risk, rollback, and the security boundary
+
+### Security-boundary classification — REQUIRED REVIEW
+
+`src/server/auth-cors.ts` is:
+
+- in `RESTRICTED_FILES` (`.github/scripts/pr-sponsored-surface.cjs:44`);
+- owned by both maintainers in `.github/CODEOWNERS` under "Authentication, credentials, and management API" (`/src/server/auth-cors.ts @lidge-jun @Ingwannu`);
+- covered by `MAINTAINERS.md`: "Authentication, credential handling, GitHub Actions, release automation, dependency installation, and other security-boundary changes require explicit security review", plus "Security-sensitive and release-related changes should be reviewed by both maintainers when practical."
+
+**MAINTAINERS.md exception needed:** the `maintain`/`admin` `pull_request` bypass on the
+`Protect dev` ruleset, used to squash-merge without the second approving review. `MAINTAINERS.md`
+is explicit that this is "a bypass, not an exemption" and that "an owner who uses the bypass
+should record it on the pull request rather than leave it to be inferred from a merge timestamp."
+**Post that record as a PR comment before merging**, naming the reviewed surface. Under P1 the
+`maintainer-sponsored` label is a second, separate requirement; under P2 it is optional but
+recommended as a visible marker.
+
+### Security review note to record on the PR
+
+> Security-boundary review — `src/server/auth-cors.ts`. The change is a single row in
+> `PROVIDER_CONFIG_FIELD_POLICY` classifying a new non-secret boolean as `"editor"`. It is
+> compiler-forced: the map closes with
+> `satisfies Record<keyof OcxProviderConfig, ProviderConfigFieldPolicy>` (auth-cors.ts:870), and
+> omitting the row fails `bun run typecheck` with TS2741. It adds nothing to
+> `REDACTED_PROVIDER_FIELDS` and removes nothing; no credential, token, or secret becomes
+> readable or writable through the management API that was not already. No CORS origin, no auth
+> mode, and no session check is touched.
+>
+> The runtime trust boundary lives in `src/server/responses/core.ts` and is narrow by
+> construction: passthrough requires the inbound wire to be Responses, an explicit provider
+> opt-in (strict `!== true`), `authMode` resolving to `key`, and the model's **final** resolved
+> wire override still being `openai-responses`. Default is off, with no registry seed, so no
+> built-in preset can enable it. OpenCodex neither decrypts nor translates the task — the
+> ciphertext is forwarded byte-unchanged, asserted by `expect(forwardedInput).toEqual(input)`.
+> Nothing logs the task; `bun run privacy:scan` is green.
+>
+> Combo dispatch is explicitly excluded via `!options.comboAttempt`, so the native-only
+> fail-closed path at core.ts:2299-2313 is unchanged.
+
+### Risk register
+
+| Risk | Likelihood | Impact | Mitigation / rollback |
+|---|---|---|---|
+| Conflict resolution silently drops `!options.comboAttempt` at (d3) | low | **high** — would widen the opt-in into combo dispatch | `tests/agent-task-recovery-combo.test.ts` and `fails closed after a single failed combo recovery pass` are the tripwire; both are in verifier V2. |
+| Operator enables the flag on a relay that cannot actually consume V2 ciphertext | medium | medium — the child task fails upstream instead of being recovered locally | Documented default-off with an explicit caveat in the docs row. No code mitigation is possible or desirable: this is the operator's declared trust. |
+| The field is later given a registry default | low | high — would silently enable a trust boundary for preset users | Recorded in §4 as a deliberate absence; any future registry seed is a security-boundary change in its own right. |
+| `maintainer-sponsored` applied without an actual review | low | high — defeats the gate's purpose | The review note above is the artifact; §3.3 step 6 makes posting it a merge precondition. |
+| Carry lands without the `Co-authored-by` trailer | medium | medium — contributor becomes invisible and `CREDITS.md` grows | `hygiene` fails with `missing_coauthor_credit` before merge; §3.3 step 7 re-checks the squash body at the confirm dialog. |
+
+### Rollback
+
+Single squash commit, one layer, no migration and no persisted-state change. Rollback is
+`git revert <squash-sha>` via a PR into `dev`. The one non-inert consequence: an operator who
+had set the flag would see the key rejected by `providerConfigSchema` after the revert — call
+that out in any revert PR.
+
+---
+
+## 6. Out of scope / deferred (this family)
+
+- **#3447 (Antigravity weekly + Ollama Cloud quota)** — deferred to **wp4**: merges clean under rename detection, but `fetchAntigravityQuota` still adds a direct `fetch` of `${config.baseUrl}/v1internal:retrieveUserQuotaSummary` carrying `Authorization: Bearer` with no `providerRedirectError` check, while the neighbouring `fetchAntigravityUsageQuota` pins `ANTIGRAVITY_ACCOUNT_QUOTA_BASE` correctly; the config-route regression test is missing.
+- **#2783 (author's own PR)** — deferred to **wp4** and must land after #3447: all three maintainer blockers are still literally present at head, and it conflicts with #3447 on `src/providers/quota.ts`.
+- **#2973** — deferred to **wp5**: every substantive blocker is verified fixed at head, leaving only 152-commit staleness and four mechanical conflicts; independent of #3444 apart from additive `src/config.ts` overlap.
+- **#2956 (usage stats)** — **DEFER, no landing planned**: 474 commits behind, zero human review, no test/typecheck matrix evidence on any head, and four real conflicts including two semantic ones in `src/usage/summary.ts` and `src/server/management/logs-usage-routes.ts`.
+- **Locale docs rows for `allowEncryptedV2AgentTasks`** — out of scope: the seven locale provider tables already lag the English source, and an absent row does not contradict it.
+- **Hardening the pre-existing dev-side `fetchAvailableModels` bearer path** (`src/providers/quota.ts:2371-2382`) — out of scope for lane 3: it predates every PR here and is a separate security-boundary change.
+- **Widening `RESTRICTED_FILES` or adjusting the sponsorship gate** — out of scope: the gate behaved exactly as designed on #3444, and the conservatism that cannot distinguish a policy-table row from a real auth change is the intended trade (`pr-sponsored-surface.cjs:14-22`).
+
+---
+
+## 7. Method notes
+
+- `origin/dev` re-fetched at plan time: `6580694c7`. The drift query over all six changed files returned empty.
+- PR head fetched locally as `refs/tmp/pr3444` = `baefb1334b69e1f37ae1446b6326ae09cb0021ac`; `git rev-list --count` confirms 2 ahead / 42 behind, merge-base `2421e44ce`.
+- RED/GREEN established by running the suite in three scratch trees under `/private/tmp` (`git archive` plus a symlinked `node_modules`), not by trusting the PR body. Exact failure line captured: `tests/agent-task-recovery.test.ts:177:31`.
+- The `auth-cors.ts` row's compiler-forced status was proven by deleting it from a scratch PR-head tree and observing TS2741 at line 870.
+- `node --test .github/scripts/pr-sponsored-surface.test.cjs` was run to confirm both gate exits (label, push-permission) behave as read.
+- No files under `src/`, `tests/`, or `gui/` in the worktree were modified; all scratch trees live outside it.
+- `git merge-tree --write-tree` could not be re-run in this sandbox (`unable to create temporary file: Operation not permitted` — the shared git dir is not writable here). The clean-merge result is carried from the lane doc and cross-checked by the empty drift query, which is the stronger evidence for these six files.
+

--- a/devlog/_plan/260905_open_work_closeout/040_wp4_stack_d_usage_quota.md
+++ b/devlog/_plan/260905_open_work_closeout/040_wp4_stack_d_usage_quota.md
@@ -1,0 +1,925 @@
+# 040 — wp4 / Stack D: usage and quota
+
+Diff-level implementation plan for one PABCD work-phase. Written to be executable by an
+implementer with no other context: every change site is quoted from the tree, every conflict has
+a mechanical-or-semantic verdict, and every verifier was run before this doc was written.
+
+Unit: `devlog/_plan/260905_open_work_closeout`. Lane research: `003_lane_v2_and_quota.md`.
+
+## Base state (re-read immediately before writing)
+
+`git fetch origin dev` -> `origin/dev` = **`6580694c7`**
+(`test(oauth): restore a deleted contract test, and fail when one disappears (#3530)`).
+
+Research-time tip was `0f27bbeb3`. Drift check for this lane's files:
+
+```
+$ git log --oneline 0f27bbeb3..origin/dev -- src/providers/quota.ts src/config.ts \
+    src/types/config.ts src/types/provider.ts src/server/background-lifecycle.ts \
+    src/server/management/config-routes.ts gui/src/i18n/fr.ts gui/src/styles.css
+(empty)
+```
+
+`git diff --stat 0f27bbeb3 6580694c7` touches only `tests/repo-hygiene.test.ts` (+29) and
+`tests/routing/anthropic-quorum-cache.test.ts` (+146). **Zero drift affecting any item below.**
+Every `file:line` citation in the lane doc still resolves.
+
+Mergeability re-verified against `6580694c7` with `git merge-tree --write-tree`:
+
+| PR | Head | merge-tree exit | Conflicting paths |
+|----|------|-----------------|-------------------|
+| #3447 | `745b70e1e` | **0** (clean, tree `43d11d5e9`) | none — rename detection resolves the `tests/providers/` move |
+| #2783 | `ad74f037d` | 1 | `src/config.ts`, `src/providers/quota.ts`, `tests/lab/core-lab-boundary.test.ts`, `devlog/_plan/260827_igwanu_bug_pr_merge_round/041_wp2b_2729_supersede.md` |
+| #2973 | `b6a879267` | 1 | `gui/src/i18n/fr.ts`, `gui/src/styles.css`, `src/server/management/config-routes.ts`, `tests/gui/quota-bars-rows.test.ts` |
+
+All three heads are unchanged from the lane snapshot (`gh pr view --json headRefOid`).
+
+---
+
+## 1. Loop-spec header
+
+**Archetype:** spec-satisfaction repair. Each layer has a written specification — a docstring, a
+neighbouring correct implementation, or a maintainer review — that the code at head does not
+satisfy. The work is to close the gap named in that spec, not to redesign the feature.
+
+**Trigger:** wp4 of the `260905_open_work_closeout` campaign, after wp3 (#3444) lands.
+
+**Goal:** land #3447, then #2783, then #2973 on `dev` as a bottom-up stack, with each layer's
+named defects fixed and covered by a regression that is RED without the fix.
+
+**Non-goals:**
+
+- #2956 — deferred; see section 6.
+- Hardening the **pre-existing** `fetchAvailableModels` unpinned-bearer path on `dev`
+  (`src/providers/quota.ts:2371-2382`). Real, but out of scope: the lane doc records it as a
+  separate change, and widening #3447 past its own delta breaks the RED/GREEN story.
+- `main`/`preview` promotion, releases, credential or account changes.
+- Any repository-wide suite run.
+
+**Verifier commands.** Each was executed in `/private/tmp/ocx-closeout.xomWAA/wt` at
+`6580694c7` before this doc was written; each reads the change target of the layer it is
+attached to.
+
+| # | Command | Exit | Observed | Reads |
+|---|---------|------|----------|-------|
+| V1 | `bun test tests/providers/provider-quota.test.ts` | **0** | 110 pass / 0 fail, 365 expects | `src/providers/quota.ts` — provider-level path (#3447) |
+| V2 | `bun test tests/providers/provider-account-quota.test.ts` | **0** | 17 pass / 0 fail, 80 expects | `src/providers/quota.ts` — per-account path (#3447) |
+| V3 | `bun test tests/lab/core-lab-boundary.test.ts` | **0** | 17 pass / 0 fail, 48 expects | runtime import graph (#2783 conflict file) |
+| V4 | `bun test tests/server-background-lifecycle.test.ts` | **0 unsandboxed** | 3 pass / 0 fail | `src/server/background-lifecycle.ts` (#2783 blocker 2) |
+| V5 | `bun test tests/gui/quota-bars-rows.test.ts` | see note | — | `gui/src/components/QuotaBars.tsx` (#2973 conflict file) |
+| V6 | `bun run typecheck` | run per layer | — | whole `src/` graph |
+| V7 | `git fetch origin dev && git merge-base --is-ancestor <sha> FETCH_HEAD` | 0 = landed | — | landing proof |
+
+**Two environment-only failures — do not investigate them as defects.** Both were diagnosed
+before this doc was written:
+
+- **V4** exits 1 *inside the Codex sandbox* with
+  `error: Failed to start server. Is port 0 in use? code: "EADDRINUSE"` at
+  `src/server/index.ts:2367`. The sandbox denies loopback bind. Re-run with escalated
+  permissions: **exit 0, 3 pass / 0 fail**. Verified both ways.
+- **V5** exits 1 with
+  `error: Cannot find module 'react/jsx-dev-runtime' from '.../gui/src/components/QuotaBars.tsx'`
+  because `gui/node_modules` is absent in this worktree (`ls -d gui/node_modules` -> not found).
+  Run `cd gui && bun install` first, per `AGENTS.md`'s container section. This is not a #2973
+  regression.
+
+A piped invocation (`bun test ... | tail`) reports the **pipeline's** exit status and will mask a
+failure as 0. Capture the status directly (`bun test <file> >/dev/null 2>&1; echo $?`) when the
+exit code is the thing being asserted. Both false-green readings above were caught that way.
+
+**Stop condition.** All three of:
+
+1. #3447, #2783, #2973 each squash-merged into `dev`, proven by V7 on each merge SHA;
+2. every fix in sections 3.1-3.3 present in the merged tree, each with its regression;
+3. exact-head hosted CI green on each PR head at merge time (`gh pr checks <n>` filtered to the
+   head SHA — an empty `--required` list is **not** green evidence).
+
+**Memory artifact:** this doc plus the merge ledger in `060`. Record per layer: PR number, final
+head SHA, merge SHA, V7 result, and the exact-head CI run id.
+
+**Expected terminal outcomes:** three PRs merged; #2956 left open with the re-entry condition
+posted; CodeRabbit's false-positive thread on #3447 answered so it is not "fixed" into a real bug.
+
+**Escalation — stop the phase and report, do not improvise:**
+
+- `src/providers/quota.ts` conflict in layer 2 resolves to anything other than "both functions
+  present, both pinned" (semantic; see 3.2);
+- `bun run typecheck` fails after a conflict resolution;
+- exact-head CI fails on a **non**-environment check;
+- a fix in 3.2 requires touching a file outside the layer's map;
+- any `origin/dev` movement that touches `src/providers/quota.ts`, `src/config.ts`, or
+  `src/quota/` — re-run the drift check before continuing.
+
+---
+
+## 2. Stack map (DEV-STACK-01..03)
+
+A real dependency chain: #3447 and #2783 both restructure `src/providers/quota.ts`, and #2783's
+conflict there is semantic.
+
+| Layer | Branch | Targets | PR | Proves alone |
+|-------|--------|---------|----|--------------|
+| 1 | `codex/260905-antigravity-ollama-quota` | `dev` | #3447 (carried) | Antigravity weekly + Ollama Cloud quota parse, with **both** Antigravity paths pinned |
+| 2 | `codex/260905-quota-reset-detection` | layer 1 branch | #2783 | Reset detection is boundary-safe: no redirect SSRF, honest cadence, honest claim durability |
+| 3 | `codex/260905-quota-window-activation` | `dev` | #2973 (carried) | Codex quota windows auto-activate; GUI renders them |
+
+**Why this order.**
+
+- **1 before 2 — hard, shared-file.** Both edit `src/providers/quota.ts`; #2783 conflicts there
+  against `6580694c7`. #3447 is one commit, +567/-9 across 3 files, merges clean, and carries
+  green CI. #2783 is 23 commits, +6144/-73 across 52 files. Rebasing the large diff onto the
+  small one is strictly cheaper than the reverse, and it means the semantic quota.ts resolution
+  is done once, by the layer that understands both sides.
+- **3 is independent.** #2973 shares nothing with #3447 and only touches `src/config.ts` /
+  `src/types/config.ts` additively with #2783 (distinct optional fields, auto-merged despite 152
+  commits of drift). It targets `dev` directly and may proceed in parallel once wp3's #3444 has
+  landed — sequencing it after #3444 keeps `src/config.ts` resolutions single-file-at-a-time.
+
+```
+dev (6580694c7)
+ +- codex/260905-antigravity-ollama-quota   #3447   [layer 1]
+     +- codex/260905-quota-reset-detection  #2783   [layer 2]
+
+dev (6580694c7)
+ +- codex/260905-quota-window-activation    #2973   [layer 3, independent]
+```
+
+Per `AGENTS.md`, a stacked child targets its parent's **head branch** while the parent is open,
+and is retargeted to `dev` after the parent lands. `enforce-target` skips the wrong-base gate
+for those children.
+
+### Merged-directly items (not restacked)
+
+**None in this lane.** No Stack D item is LAND_AS_IS: all three need code or conflict work.
+For reference, the pre-merge sequence used elsewhere in the campaign is: dismiss the stale
+review, mark ready, confirm exact-head CI, then admin squash-merge.
+
+### Carried contributor work — attribution is mandatory
+
+#3447 and #2973 are contributor PRs. Landing them via a maintainer branch requires a
+`Co-authored-by` trailer **in a branch commit or the PR description**, so it survives the squash.
+Prose naming the author is not equivalent — GitHub reads the trailer, and `CREDITS.md` exists
+because 27 landings got this wrong.
+
+Emails resolved with `gh pr view <n> --json commits --jq '[.commits[].authors[]|{name,email,login}]|unique'`:
+
+| PR | Login | Trailer |
+|----|-------|---------|
+| #3447 | `hualiny` | `Co-authored-by: yhualin <hualiny233@gmail.com>` |
+| #2973 | `terrytan95` | `Co-authored-by: Terry Tan <tmy1995hflc@gmail.com>` |
+| #2783 | `lidge-jun` | **not required** — author is the maintainer running this campaign |
+
+---
+
+## 3. Per-item plans
+
+### 3.1 Layer 1 — #3447 Antigravity weekly + Ollama Cloud quota
+
+**Head:** `745b70e1e` · **Author:** `hualiny` · **Labels:** `enhancement`, `review-ready` ·
+**Draft:** no · **Review:** `CHANGES_REQUESTED` (CodeRabbit only; no human changes-requested) ·
+**Size:** +567/-9 across 3 files · **CI on head:** all green.
+
+GitHub reports `CONFLICTING`; git does not. The PR edits `tests/provider-quota.test.ts` and
+`tests/provider-account-quota.test.ts` at the repository root, and `dev` moved both into
+`tests/providers/` in `8b6e4542a`. GitHub's probe skips rename detection; `merge-tree` exits 0.
+
+#### Branch creation
+
+```bash
+cd <clean worktree at origin/dev>
+git fetch origin dev
+git fetch origin refs/pull/3447/head:tmp-pr-3447
+git switch -c codex/260905-antigravity-ollama-quota origin/dev
+git cherry-pick 745b70e1e        # single commit
+```
+
+The cherry-pick is where the rename lands. Git applies the test hunks to
+`tests/providers/*.test.ts` via rename detection. **Verify no root-level test file was
+recreated** — if `tests/provider-quota.test.ts` exists at the repository root after the pick, the
+duplicate-basename gate at `tests/repo-hygiene.test.ts:269` ("no two test files share a
+basename") fails:
+
+```bash
+git status --porcelain
+ls tests/provider-quota.test.ts tests/provider-account-quota.test.ts 2>&1   # must be "No such file"
+git mv tests/provider-quota.test.ts tests/providers/provider-quota.test.ts  # only if recreated
+```
+
+Then append the trailer:
+
+```bash
+git commit --amend --no-verify --trailer "Co-authored-by: yhualin <hualiny233@gmail.com>"
+```
+
+#### File change map
+
+**F1 — `src/providers/quota.ts`, `fetchAntigravityQuota` (PR head lines 2524-2573): pin the new summary request.**
+
+This is the one real defect. The PR adds a **new** direct `fetch` carrying a bearer to an
+operator-configured `baseUrl`, with default redirect following and no redirect check — while the
+function immediately above it, added in the same diff, does the same job correctly.
+
+Current code (PR head, `src/providers/quota.ts:2533-2547`):
+
+```ts
+  const baseUrl = (config.baseUrl || ANTIGRAVITY_ACCOUNT_QUOTA_BASE).replace(/\/+$/, "");
+
+  try {
+    const summaryResponse = await fetch(`${baseUrl}/v1internal:retrieveUserQuotaSummary`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": antigravityUserAgent(),
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ project: credential.projectId }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (summaryResponse.status === 401 || summaryResponse.status === 403) return null;
+```
+
+Target code — mirror `fetchAntigravityUsageQuota` (`src/providers/quota.ts:2483-2497`) exactly:
+
+```ts
+  const summaryUrl = `${ANTIGRAVITY_ACCOUNT_QUOTA_BASE}/v1internal:retrieveUserQuotaSummary`;
+
+  try {
+    const summaryResponse = await providerOutboundPost(
+      "google-antigravity",
+      { baseUrl: ANTIGRAVITY_ACCOUNT_QUOTA_BASE },
+      summaryUrl,
+      {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "User-Agent": antigravityUserAgent(),
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ project: credential.projectId }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+      antigravityOutboundDependencies,
+    );
+    if (await providerRedirectError(summaryResponse, summaryUrl)) return null;
+    if (summaryResponse.status === 401 || summaryResponse.status === 403) return null;
+```
+
+Notes that make this mechanical rather than a judgment call:
+
+- `providerOutboundPost` and `providerRedirectError` are **already imported** at
+  `src/providers/quota.ts:17`. No import change.
+- `ANTIGRAVITY_ACCOUNT_QUOTA_BASE` (`:2468`) and `antigravityOutboundDependencies` (`:2469`)
+  are module-level and in scope.
+- `providerOutboundPost` is POST-only and rejects non-HTTPS at
+  `src/lib/provider-outbound.ts:115-118` (`ProviderOutboundPolicyError: "provider POST URL must
+  use HTTPS"`). Since the URL is now the pinned constant, that branch is unreachable here — which
+  is the point.
+- Passing the pinned base as the `provider` config (not `config`) is what drops `config.baseUrl`
+  from the destination decision. This is the documented rationale in the sibling docstring:
+  a configured `baseUrl` "is a routing choice for requests, not a second source of Google's
+  accounting."
+- **Leave the `fetchAvailableModels` fallback at `:2558` alone.** It is unchanged from `dev`
+  (`src/providers/quota.ts:2371-2382`), so touching it moves the diff outside the PR's delta.
+  Non-goal, recorded above.
+
+The `const baseUrl = ...` binding at `:2533` is still consumed by the fallback at `:2558`; keep it.
+
+**F2 — `tests/providers/provider-quota.test.ts`: add the missing regression.**
+
+#### Conflict resolution recipe
+
+| Path | Kind | Recipe |
+|------|------|--------|
+| `tests/provider-quota.test.ts` -> `tests/providers/provider-quota.test.ts` | **mechanical (rename)** | Cherry-pick applies it; confirm no root file remains |
+| `tests/provider-account-quota.test.ts` -> `tests/providers/provider-account-quota.test.ts` | **mechanical (rename)** | Same |
+| `src/providers/quota.ts` | **none** | Clean against `6580694c7` |
+
+#### Regression test
+
+- **File:** `tests/providers/provider-quota.test.ts`
+- **Name:** `fetchAntigravityQuota does not send the account bearer to a configured baseUrl`
+- **Shape:** configure a provider with `baseUrl: "http://127.0.0.1:1/"`; install a pinned
+  transport via `setAntigravityAccountQuotaTransportForTests`; set `globalThis.fetch` to a
+  thrower (`"plain fetch must not be used for account bearers"` — the existing idiom in
+  `tests/providers/provider-account-quota.test.ts`); assert the summary request URL is exactly
+  `https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary` and that no
+  request carried an `Authorization` header to the loopback host.
+- **Second case:** `fetchAntigravityQuota refuses a redirected summary response` — pinned
+  transport returns `302` with a `location` of `http://127.0.0.1/`; assert the result is `null`
+  and the redirect target was never fetched.
+- **RED on layer-1-without-F1:** the thrower fires, because `fetchAntigravityQuota` calls
+  `globalThis.fetch` directly at `:2536`. **GREEN after F1:** the request goes through the pinned
+  transport against the constant base, and `providerRedirectError` short-circuits the 302.
+- **RED on `dev`:** stronger still — `parseAntigravityQuotaSummary`,
+  `setAntigravityAccountQuotaTransportForTests` and `parseOllamaCloudQuota` do not exist, so the
+  file fails to resolve.
+
+#### Focused verifier
+
+```bash
+bun test tests/providers/provider-quota.test.ts          # V1 — baseline 110 pass / 0 fail
+bun test tests/providers/provider-account-quota.test.ts  # V2 — baseline 17 pass / 0 fail
+bun run typecheck
+```
+
+#### Accept criteria, with activation scenario per conditional path (C-ACTIVATION-GROUNDING-01)
+
+Every branch below is named with the configuration that reaches it. A path no test can activate
+is not accepted.
+
+| # | Path | Activation scenario | Expected |
+|---|------|---------------------|----------|
+| A1 | `fetchAntigravityQuota` summary success | `google-antigravity` credential with `projectId`; pinned transport returns a valid summary body | `report(provider, "google-antigravity:retrieveUserQuotaSummary", quota)` |
+| A2 | Summary 401/403 | Pinned transport returns 401 | `null` — no fallback, no partial row |
+| A3 | Summary redirect | Pinned transport returns 302 -> loopback | `null`; `providerRedirectError` fires; bearer never re-sent |
+| A4 | Summary throws | Transport rejects | falls through to `fetchAvailableModels` (unchanged dev behaviour) |
+| A5 | Configured non-canonical `baseUrl` | `baseUrl: "http://127.0.0.1:1/"` | Summary still goes to `daily-cloudcode-pa.googleapis.com`; `globalThis.fetch` thrower never fires |
+| A6 | No credential / no `projectId` | credential absent | `null` before any request |
+| A7 | Ollama Cloud canonical base | `ollama-cloud` provider, canonical `baseUrl`, api key present | `report(provider, "ollama-cloud:usage", quota)` |
+| A8 | Ollama Cloud non-canonical base | `baseUrl` not canonical | `null` before any request — `isCanonicalOllamaCloudBaseUrl` guard at `:715` |
+| A9 | Ollama legacy vs migrated plan | body with `limits.session`+`limits.weekly`; then `limits.monthly` | five-hour + weekly percents; then monthly percent |
+| A10 | Ollama zero windows | `limits` present but no parsable usage | `null` (`windows > 0` guard at `:710`) |
+| A11 | Ollama 404 vs 4xx | 404; then 403 | `null`; then `TERMINAL_QUOTA_FAILURE` |
+
+A7-A11 are already covered by the PR's +302 test lines; re-assert they still pass post-rename.
+A3 and A5 are the **new** obligations from F1/F2.
+
+#### Docs-site sync
+
+Required — this adds a user-visible provider capability. `docs-site/` currently documents no
+Ollama quota and no Antigravity weekly window (`rg -i 'ollama' providers.md` returns only
+adapter/base-url rows). Add to
+`docs-site/src/content/docs/reference/configuration/providers.md`: Ollama Cloud reads
+`GET https://ollama.com/api/usage` only when `baseUrl` is canonical, and Antigravity now reports
+`Gem`/`Gem (Weekly)`/`Cla`/`Cla (Weekly)` windows. State that quota probes always go to Google's
+own host regardless of a configured `baseUrl` — that is now a documented guarantee, not an
+implementation detail.
+
+#### Review-thread obligation
+
+Reply to CodeRabbit's **Critical** "duplicate `seen` declarations" finding marking it a false
+positive: `tests/provider-account-quota.test.ts:470` and `:506` are in two **different**
+`test()` callbacks, so the declarations are in distinct lexical scopes and are legal TypeScript.
+Green `hygiene` on the head corroborates it — a file that failed to compile could not pass.
+Say so explicitly, so a later pass does not "fix" it into a real bug.
+
+#### PR skeleton
+
+> **Title:** `feat(quota): support Google Antigravity weekly quota and Ollama Cloud quota`
+>
+> **Summary**
+> Adds Ollama Cloud quota (`GET /api/usage`, canonical-base-only) and Antigravity weekly
+> windows via `retrieveUserQuotaSummary`. Carries #3447 by `@hualiny`, rebased rename-aware onto
+> `tests/providers/`, plus one fix: the provider-level summary request is pinned to Google's own
+> host through `providerOutboundPost` with a redirect check, matching `fetchAntigravityUsageQuota`
+> in the same file. Without it the PR added a second bearer-carrying request to an
+> operator-configured `baseUrl` with default redirect following.
+>
+> **Verification**
+> `bun test tests/providers/provider-quota.test.ts` · `bun test tests/providers/provider-account-quota.test.ts` · `bun run typecheck` · exact-head CI.
+>
+> **Stack**
+>
+> | Layer | PR | Targets |
+> |---|---|---|
+> | 1 (this) | #3447 carry | `dev` |
+> | 2 | #2783 | layer 1 |
+>
+> **Checklist** — all boxes ticked.
+>
+> `Co-authored-by: yhualin <hualiny233@gmail.com>`
+
+No `Closes #` line: `gh pr view 3447 --json body` shows no issue reference. Close #3447 manually
+once this lands on `dev` (GitHub auto-closes only on merge into `main`).
+
+---
+
+### 3.2 Layer 2 — #2783 quota reset detection
+
+**Head:** `ad74f037d` · **Author:** `lidge-jun` (maintainer) · **Draft:** no ·
+**Review:** `CHANGES_REQUESTED` by `Ingwannu` on this exact head · **Size:** +6144/-73 across 52
+files · **Drift:** 675 behind · **CI on head:** full matrix green.
+
+Green CI here proves the implemented behaviour is self-consistent — not that the boundaries are
+right. All three maintainer blockers are cases where tests assert current behaviour or do not
+probe the boundary. Each was re-verified against `tmp-pr-2783` for this doc; **all three are
+still literally present at head.**
+
+The diff is overwhelmingly additive — nine new modules under `src/quota/` — which is why only
+four files conflict despite 675 commits.
+
+#### Branch creation (after layer 1 exists)
+
+```bash
+git fetch origin refs/pull/2783/head:tmp-pr-2783
+git switch -c codex/260905-quota-reset-detection codex/260905-antigravity-ollama-quota
+git merge tmp-pr-2783            # resolve the four conflicts below
+```
+
+A merge is preferable to `rebase` for 23 commits across 675 commits of drift: it resolves each
+conflicting file **once** instead of once per commit. Squash-merge flattens it anyway.
+
+#### Conflict resolution recipe
+
+| Path | Kind | Recipe |
+|------|------|--------|
+| `src/config.ts` | **mechanical** | Additive schema section. Keep both sides: dev's neighbours and the PR's `quotaResetNotifySchema` (PR `:861-869`) plus its `configSchema` entry (`:921`). No shared key. |
+| `src/providers/quota.ts` | **semantic — the one that needs judgment** | See below. |
+| `tests/lab/core-lab-boundary.test.ts` | **mechanical** | Both sides add entries to the boundary allow/deny lists. Union them; `src/quota/` must stay off the core path. |
+| `devlog/_plan/260827_igwanu_bug_pr_merge_round/041_wp2b_2729_supersede.md` | **mechanical (add/add)** | Historical devlog note; take `dev`'s copy. No runtime effect. |
+
+**`src/providers/quota.ts` — semantic resolution.** Both PRs restructure quota fetching. #3447
+(now in the base) adds `parseOllamaCloudQuota`, `fetchOllamaCloudQuota`,
+`parseAntigravityQuotaSummary`, `fetchAntigravityUsageQuota`, and rewrites
+`fetchAntigravityQuota`. #2783 adds reset-observation hooks into the report path.
+
+The resolution invariant: **both features survive, and every Antigravity request stays pinned.**
+Concretely — keep #3447's pinned `providerOutboundPost` call sites verbatim; graft #2783's
+observation hook onto the **result** of `report(...)`, not into the request construction. If a
+resolution deletes a `providerRedirectError` call or reintroduces a `config.baseUrl`-derived URL
+for a bearer-carrying request, it is wrong — that is layer 1's whole delta. Re-read F1 above
+before resolving, and re-run V1/V2 immediately after, since they are layer 1's guard.
+
+#### File change map — six bounded fixes, each localized to one function
+
+**B1 — `src/config.ts:865`: constrain `webhookUrl` to HTTPS.**
+
+Current: `webhookUrl: z.string().url().optional(),` — `z.string().url()` accepts **any** scheme,
+including `http:`, putting the payload and the credential-bearing webhook path in cleartext.
+
+Target:
+
+```ts
+  webhookUrl: z.string().url().refine(
+    value => { try { return new URL(value).protocol === "https:"; } catch { return false; } },
+    { message: "webhookUrl must use https" },
+  ).optional(),
+```
+
+The schema is `.strict()` and feeds both write validation and the read path via
+`quotaResetNotifyError` (`src/config.ts:2117-2124`) and the ignore-reason reporter (`:1705-1709`),
+so one edit covers both. Verify the `schema_invalid:` message still renders.
+
+**B2 — `src/quota/reset-sinks.ts`, `deliverWebhook` (`:88-126`): close the redirect hop.**
+
+The initial URL is validated and the redirect target is not. Current:
+
+```ts
+  if (!config.allowPrivateNetwork) {
+    try {
+      await assertUrlResolvesPublic(url);
+    } catch {
+      return { sink: "webhook", ok: false, reason: "blocked-destination" };
+    }
+  }
+
+  const timeout = signalWithTimeout(config.timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: json,
+      signal: timeout.signal,
+    });
+```
+
+A public HTTPS endpoint can `302` the POST to loopback or a cloud metadata address. Target: add
+`redirect: "manual"` to the `fetch` init, then treat any 3xx as a refusal:
+
+```ts
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: json,
+      redirect: "manual",
+      signal: timeout.signal,
+    });
+    if (response.status >= 300 && response.status < 400) {
+      cancelResponseBodyBestEffort(response);
+      return { sink: "webhook", ok: false, reason: "blocked-destination" };
+    }
+```
+
+Refuse rather than re-validate-and-follow: the operator can configure the final URL directly,
+which is the same stance `providerRedirectError` takes
+(`src/lib/provider-outbound.ts:94-104`: "configure the final provider URL directly"). Reuse the
+existing `"blocked-destination"` reason so no new enum member is needed — see section 4.
+
+**B3 — `src/quota/reset-poller.ts:20`: make `MIN_INTERVAL_MS` match its own docstring.**
+
+The source contradicts itself. The docstring at `:16-19` says "Above the 5-minute provider cache
+TTL and the 10-minute per-account TTL", then:
+
+```ts
+export const MIN_INTERVAL_MS = 60_000;
+```
+
+60 s is below both TTLs it claims to exceed. Target: `export const MIN_INTERVAL_MS = 10 * 60_000;`
+(above the 10-minute per-account TTL, as documented).
+
+Coupling to check: `src/quota/reset-notify-config.ts:35` has `const MIN_POLL_SECONDS = 60`, and
+`resolveQuotaResetPollMs` clamps with it (`:89-91`). After B4 the resolver's value reaches
+`setInterval`, so leaving `MIN_POLL_SECONDS = 60` while raising `MIN_INTERVAL_MS` means the
+poller floor silently overrides an accepted config value. Raise `MIN_POLL_SECONDS` to `600` to
+match, and keep the `pollSeconds === 0` passive-only escape (`:89`) intact.
+
+**B4 — `src/server/background-lifecycle.ts:65`: pass the configured cadence.**
+
+Current: `startQuotaResetPoller();` — no argument, so the interval is always
+`DEFAULT_INTERVAL_MS` (15 min) and the configured `pollSeconds` never reaches `setInterval`.
+`tick()` (`src/quota/reset-poller.ts:40`) only checks `resolveQuotaResetPollMs() === 0`, so it
+honours "off" and ignores every other cadence. An operator setting `pollSeconds: 300` silently
+polls at 15 minutes.
+
+Target: resolve the configured value and pass it —
+`startQuotaResetPoller(resolveQuotaResetPollMs() || undefined);` — and in `tick()`, compare the
+resolved cadence against the live interval, restarting the timer when it changed. That preserves
+the module's stated "toggling takes effect on the next tick without a restart" property, which is
+the reason the config gate lives in the callee.
+
+**B5 — `src/quota/reset-poller.ts`: single-in-flight guard and generation fence.**
+
+`setInterval(() => void tick(), bounded)` (`:59`) can overlap, and an in-flight tick can publish
+after `stopQuotaResetPoller()`. Target: a module-level `let inFlight = false` returning early
+while set, and a `let generation = 0` incremented in both `start` and `stop`, captured at tick
+entry and re-checked before publishing. Drop the result when the generation moved.
+
+**B6 — `src/quota/reset-seen-store.ts:250-258`: stop returning `true` for a lost claim.**
+
+Current:
+
+```ts
+export function claimQuotaReset(key: string, at: number, resetAt?: number): boolean {
+  hydrate();
+  if (claims.has(key)) return false;
+  claims.set(key, { at, ...(resetAt !== undefined ? { resetAt } : {}) });
+  prune();
+  persistNow();
+  return true;
+}
+```
+
+Two ways this lies to its caller. `prune()` (`:206-218`) can evict the just-added claim when its
+`resetAt` is already past and it is older than `CLAIM_MAX_AGE_MS`. `persistNow()` (`:149-160`)
+swallows every write error in a bare `catch` marked "Best-effort persistence only." Either way the
+caller reads `true` as "durably claimed, safe to dispatch" — producing exactly the
+duplicate-notification-after-restart the docstring promises to prevent.
+
+Target: make `persistNow()` report success (return `boolean`, or set a module flag), then:
+
+```ts
+  claims.set(key, { at, ...(resetAt !== undefined ? { resetAt } : {}) });
+  prune();
+  if (!claims.has(key)) return false;   // prune() evicted it: not durably claimed
+  return persistNow();                  // false when the write failed
+```
+
+Keep `persistNow`'s `catch` — the change is reporting the failure, not throwing. The
+"no await inside" property that makes the check-and-set indivisible under Bun's single-threaded
+turn semantics (docstring `:243-248`) must survive: all three additions are synchronous.
+
+#### Regression tests
+
+| Fix | File | Test name | RED before / GREEN after |
+|-----|------|-----------|--------------------------|
+| B1 | `tests/quota-reset-notify-config.test.ts` | `an http webhookUrl is rejected as schema_invalid` | RED: `z.string().url()` accepts `http://...`, so the config validates. GREEN: refinement rejects it. |
+| B2 | `tests/quota-reset-notify.test.ts` | `a webhook that redirects to loopback is refused` | RED: default redirect following POSTs the payload to `127.0.0.1` and returns `ok: true`. GREEN: 3xx -> `blocked-destination`, loopback never receives a request. |
+| B3+B4 | `tests/server-background-lifecycle.test.ts` | `the configured pollSeconds reaches the poller interval` | RED: `startQuotaResetPoller()` takes no argument; the spy sees `DEFAULT_INTERVAL_MS`. GREEN: sees the resolved value. |
+| B5 | `tests/quota-reset-observation.test.ts` | `an overlapping tick is skipped and a tick completing after stop does not publish` | RED: two concurrent ticks both run; a post-`stop` tick publishes. GREEN: second returns early; generation fence drops the late publish. |
+| B6 | `tests/quota-reset-seen-store.test.ts` | `claimQuotaReset returns false when the claim is not durable` | RED: returns `true` in both the pruned-immediately and `persistNow`-throws cases. GREEN: `false` in both. |
+
+All five files ship in the PR (`git diff --name-only 6580694c7...tmp-pr-2783`), so these are
+additions to existing suites. `tests/server-background-lifecycle.test.ts` already exists on
+`dev`; the other four arrive with the PR.
+
+Note the RED baseline: these are RED **on the PR head**, not on `dev` — the modules do not exist
+on `dev`, so a dev-side run is an import failure, which is weaker evidence. Establish RED by
+running each test against the merged branch **before** applying its fix. Do that explicitly; it
+is the only way the six fixes are proven load-bearing.
+
+#### Focused verifier
+
+```bash
+bun test tests/quota-reset-notify-config.test.ts
+bun test tests/quota-reset-notify.test.ts
+bun test tests/quota-reset-seen-store.test.ts
+bun test tests/quota-reset-observation.test.ts
+bun test tests/quota-reset-detector.test.ts
+bun test tests/server-background-lifecycle.test.ts     # V4 — needs unsandboxed loopback bind
+bun test tests/lab/core-lab-boundary.test.ts           # V3 — conflict file
+bun test tests/providers/provider-quota.test.ts        # V1 — layer 1 guard after the semantic resolution
+bun run typecheck
+```
+
+`bun run test:changed` is appropriate here too — the touch set spans 52 files. Per `AGENTS.md`
+it follows Bun's parsed module graph and cannot see subprocess dependencies:
+`tests/helpers/quota-reset-burst-child.ts` is spawned as a child process, so
+`tests/quota-reset-observation.test.ts` must be run explicitly.
+
+#### Accept criteria, with activation scenario per conditional path
+
+| # | Path | Activation scenario | Expected |
+|---|------|---------------------|----------|
+| B1a | https webhook | `quotaResetNotify.webhookUrl: "https://example.com/hook"` | accepted |
+| B1b | http webhook | `"http://example.com/hook"` | `schema_invalid: quotaResetNotify.webhookUrl`; section rejected at write |
+| B2a | Public 2xx | sink returns 200 | `{ ok: true }` |
+| B2b | Redirect to loopback | sink returns 302 -> `http://127.0.0.1:9/` | `{ ok: false, reason: "blocked-destination" }`; loopback never contacted |
+| B2c | Private with opt-in | `allowPrivateNetwork: true`, direct loopback URL | delivered — the documented self-hosted-receiver opt-in still works |
+| B2d | Timeout | sink never responds past `timeoutMs` | `{ ok: false, reason: "timeout" }` |
+| B3a | Below-floor cadence | `pollSeconds: 60` | clamped to the 10-minute floor; no timer faster than the account TTL |
+| B4a | Configured cadence | `pollSeconds: 900` | `setInterval` receives 900 000 ms |
+| B4b | Passive-only | `pollSeconds: 0` | no timer; passive detection still runs |
+| B4c | Cadence changed live | config edited from 900 -> 1800 between ticks | next tick adopts it without a restart |
+| B5a | Overlapping tick | tick 1 still awaiting when the interval fires | tick 2 returns immediately; no second probe |
+| B5b | Tick after stop | `stopQuotaResetPoller()` during an in-flight tick | result discarded; nothing published |
+| B6a | Normal claim | fresh key, writable state file | `true`, one notification |
+| B6b | Write failure | `atomicWriteFile` throws | `false`; caller does not dispatch |
+| B6c | Pruned immediately | claim with a past `resetAt` older than `CLAIM_MAX_AGE_MS` | `false` |
+| B6d | Duplicate claim | same key twice | second returns `false` (unchanged) |
+
+#### Docs-site sync
+
+The PR already updates `docs-site/src/content/docs/reference/configuration/server.md`,
+`reference/management-api.md` and `reference/cli/providers-accounts.md` (all auto-merged). Update
+for the fixes: `webhookUrl` must be `https` (B1); webhook redirects are refused, configure the
+final URL (B2); the `pollSeconds` floor is 600 s with 0 meaning passive-only (B3/B4).
+
+#### Security-boundary flag
+
+**B1 and B2 are security-boundary changes** (outbound credential-bearing request destination,
+SSRF). Per `AGENTS.md` and `MAINTAINERS.md` these require explicit security review. The author
+is the maintainer, so this is a self-review the merge ledger must record rather than a delegated
+approval — note the reviewer and the exact head reviewed. The layer-1 quota.ts resolution
+inherits the same flag.
+
+#### PR skeleton
+
+> **Title:** `feat(quota): detect usage-window resets and notify on them`
+>
+> **Summary**
+> Adds `src/quota/` reset detection with webhook and command sinks. Rebased onto layer 1 and
+> resolves `src/providers/quota.ts` semantically against the Antigravity/Ollama work. Six fixes
+> for the three review blockers: HTTPS-only `webhookUrl`; `redirect: "manual"` with 3xx refused;
+> `MIN_INTERVAL_MS` raised to match its docstring; the configured `pollSeconds` now reaches
+> `setInterval`; single-in-flight plus generation fence; `claimQuotaReset` returns `false` when
+> the claim was pruned or the write failed.
+>
+> **Verification** — the focused list above, plus `bun run test:changed` and exact-head CI.
+>
+> **Stack**
+>
+> | Layer | PR | Targets |
+> |---|---|---|
+> | 1 | #3447 carry | `dev` |
+> | 2 (this) | #2783 | layer 1 branch -> retarget to `dev` after layer 1 lands |
+>
+> **Checklist** — all boxes ticked.
+
+No `Closes #` line — no issue reference in the PR body.
+
+---
+
+### 3.3 Layer 3 — #2973 quota window activation (independent)
+
+**Head:** `b6a879267` · **Author:** `terrytan95` · **Draft:** yes ·
+**Labels:** `enhancement`, **`maintainer-sponsored`** (restricted-surface gate already satisfied) ·
+**Review:** `CHANGES_REQUESTED` (last review `2026-09-01T15:21:15Z`, on the **older** head
+`653978f40`) · **Size:** +1025/-60 across 33 files · **Drift:** 152 behind · **CI on head:** full
+matrix green.
+
+**No substantive defect is outstanding.** The review history converges: the 09-01 15:21 review
+says "The three blockers from my previous review are fixed on this head" and holds at
+changes-requested explicitly "because the integration evidence is stale, not because those fixes
+need redesign." The head then moved once more — `b6a879267`, "fix(codex): restore displaced quota
+worker registrations", which is precisely blocker 2's subject — and that head carries the full
+green matrix the reviewer asked for. The work here is staleness plus four mechanical conflicts.
+
+#### Branch creation
+
+```bash
+git fetch origin refs/pull/2973/head:tmp-pr-2973
+git switch -c codex/260905-quota-window-activation origin/dev
+git merge tmp-pr-2973          # resolve the four conflicts below
+git commit --amend --no-verify --trailer "Co-authored-by: Terry Tan <tmy1995hflc@gmail.com>"
+```
+
+Targets `dev` directly — no stack dependency on layers 1-2.
+
+#### Conflict resolution recipe — all four mechanical
+
+| Path | Kind | Recipe |
+|------|------|--------|
+| `gui/src/i18n/fr.ts` | **mechanical** | Adjacent locale-key insertion. Keep both keys, preserve alphabetical/positional order. The other **eight** `gui/src/i18n/*.ts` files auto-merged — the signature of a positional collision, not a semantic one: `fr.ts` conflicts only because `dev` added a neighbouring key. |
+| `gui/src/styles.css` | **mechanical** | Adjacent rule blocks. Keep both; no selector overlap. |
+| `src/server/management/config-routes.ts` | **mechanical** | Adjacent route registration. Keep both routes; check for no duplicate path. |
+| `tests/gui/quota-bars-rows.test.ts` | **mechanical** | Adjacent cases. Union them. |
+
+`src/config.ts`, `src/types/config.ts`, `src/server/index.ts` and `src/codex/quota-auto-refresh.ts`
+**auto-merged** despite 152 commits of drift — confirmed by `merge-tree`, which lists only the
+four paths above.
+
+#### Test-path relocation — check before pushing
+
+The PR edits `tests/quota-bars-rows.test.ts`, `tests/codex-quota-auto-refresh.test.ts`,
+`tests/server-background-lifecycle.test.ts` and `tests/state-store-sweeper.test.ts`. On `dev`:
+
+| PR path | Path on `dev` |
+|---|---|
+| `tests/quota-bars-rows.test.ts` | `tests/gui/quota-bars-rows.test.ts` |
+| `tests/state-store-sweeper.test.ts` | `tests/oauth/state-store-sweeper.test.ts` |
+| `tests/server-background-lifecycle.test.ts` | unchanged (still at root) |
+| `tests/codex-quota-auto-refresh.test.ts` | new file — place under `tests/codex/` |
+
+The merge already resolves the first two by rename detection (the conflict is reported at the
+`tests/gui/` path). Confirm no root-level duplicate survives, or
+`tests/repo-hygiene.test.ts:269` fails:
+
+```bash
+git ls-files 'tests/**/*.test.ts*' | xargs -n1 basename | sort | uniq -d   # must be empty
+```
+
+#### Invariant to re-check during the merge
+
+`src/server/index.ts` is touched. `AGENTS.md` requires that `startServer` stay synchronous
+between the `Bun.serve` call and the `labActivationRequired` gate — no `await` may be introduced
+there, and `startServer` must not become `async`. `tests/lab/core-lab-boundary.test.ts` enforces
+this mechanically and is green on the head; re-run it after resolving (V3).
+
+#### Regression tests (already in the PR — verify, do not re-derive)
+
+| File | Test | RED on `dev` because |
+|------|------|----------------------|
+| `gui/tests/codex-account-pool-toast-tone.test.tsx` | legacy-payload compatibility through the real `/api/codex-auth/accounts` normalization boundary | `src/codex/quota-auto-refresh.ts` does not exist on `dev` |
+| `tests/codex-quota-auto-refresh.test.ts` | worker registration replacement and failed-start cleanup | same |
+| `tests/server-background-lifecycle.test.ts` | nested-server registration displacement | the displaced-registration path does not exist on `dev` |
+
+Both were added specifically in response to review. The reviewer independently confirmed
+"9 quota-worker tests and 39 focused account-pool controller/behavior tests passed."
+
+#### Focused verifier
+
+```bash
+cd gui && bun install && cd ..                      # required for V5 — see the environment note
+bun test tests/gui/quota-bars-rows.test.ts          # V5
+bun test tests/codex/codex-quota-auto-refresh.test.ts
+bun test tests/server-background-lifecycle.test.ts  # V4 — unsandboxed
+bun test tests/lab/core-lab-boundary.test.ts        # V3
+bun run lint:gui
+bun run typecheck
+```
+
+#### Accept criteria, with activation scenario per conditional path
+
+| # | Path | Activation scenario | Expected |
+|---|------|---------------------|----------|
+| C1 | Auto-refresh enabled | account with `quotaAutoRefresh: true` | worker registered; window refreshes on schedule |
+| C2 | Field absent (legacy payload) | account fixture **omitting** `quotaAutoRefresh` | no dereference error — this is the 08-30 review's 17 GUI failures; the toast-tone test covers it |
+| C3 | Explicitly disabled | `quotaAutoRefresh: false` | no worker registered |
+| C4 | Nested server start | second `startServer` while the first is live | the newer registration does not displace the older server's process-wide work |
+| C5 | Failed start cleanup | `startServer` throws after registration | registrations cleaned up; no orphan worker |
+| C6 | Config route write | POST the new config route | value persisted; `.strict()` rejects unknown keys |
+| C7 | GUI locale coverage | switch to `fr` | new keys render; no missing-key fallback |
+
+C2 is the one to actually exercise by hand — it is the regression that produced the first review
+round, and it activates only through a payload shape the normalization boundary must tolerate.
+
+#### Docs-site sync
+
+The PR already updates `getting-started/how-it-works.mdx`,
+`reference/configuration/providers.md`, `reference/management-api.md`,
+`structure/05_gui-and-management-api.md` and `structure/08_openai-provider-tiers.md` — all
+auto-merged. Re-read `providers.md` after the merge for a stale statement about quota windows
+not auto-activating.
+
+#### GUI screenshot obligation
+
+`enforce-target` rejects a PR whose title or description mentions `gui` without a screenshot of
+the UI change. The PR carries `.github/pr-assets/quota-window-auto-refresh.png`; ensure it is
+referenced in the carried description, and re-capture it if the merge changes the rendering.
+
+#### PR skeleton
+
+> **Title:** `feat(codex): auto-activate quota reset windows`
+>
+> **Summary**
+> Carries #2973 by `@terrytan95`, rebased onto `6580694c7` with four mechanical conflicts
+> resolved (`gui/src/i18n/fr.ts`, `gui/src/styles.css`,
+> `src/server/management/config-routes.ts`, `tests/gui/quota-bars-rows.test.ts`). All three
+> blockers from the review series are fixed on the carried head; this rebase supplies the
+> exact-head evidence the last review asked for.
+>
+> **Verification** — the focused list above, plus `bun run lint:gui` and exact-head CI.
+> ![quota window auto refresh](.github/pr-assets/quota-window-auto-refresh.png)
+>
+> **Stack**
+>
+> | Layer | PR | Targets |
+> |---|---|---|
+> | 3 (this) | #2973 carry | `dev` — independent of layers 1-2 |
+>
+> **Checklist** — all boxes ticked.
+>
+> `Closes #2969.`
+> `Co-authored-by: Terry Tan <tmy1995hflc@gmail.com>`
+
+`Closes #2969` is carried from the original PR body. Because these PRs target `dev` and GitHub
+auto-closes only on merge into `main`, close #2969 manually once this lands.
+
+---
+
+## 4. Field and enum chains
+
+**Layer 1 (#3447) — N/A.** No new config field. `fetchOllamaCloudQuota` and
+`fetchAntigravityQuota` read the **existing** `config.baseUrl` and `config.apiKey`; the new
+outputs (`fiveHourPercent`, `weeklyPercent`, `monthlyPercent`, `customWindows`) are existing
+`ProviderQuota` members. The only new module-level constants —
+`ANTIGRAVITY_ACCOUNT_QUOTA_BASE` (`:2468`) and `OLLAMA_CLOUD_USAGE_URL` — are internal, not
+serialized. F1 **removes** a config read rather than adding one.
+
+**Layer 2 (#2783) — one new config section.** Full chain, verified end to end:
+
+| Stage | Site | Content |
+|---|---|---|
+| **Creation** | `src/types/config.ts:477` | `quotaResetNotify?: OcxQuotaResetNotifyConfig;` on `OcxConfig` |
+| **Schema / validation** | `src/config.ts:861-869` | `quotaResetNotifySchema` = `{ enabled, kinds, pollSeconds, webhookUrl, allowPrivateNetwork, timeoutMs, command }`, `.strict()` |
+| **Registration** | `src/config.ts:921` | `quotaResetNotify: quotaResetNotifySchema.optional().catch(undefined)` |
+| **Serialization** | standard config write path | `.strict()` — an unknown key is a rejected write, not a silent drop |
+| **Deserialization** | `src/config.ts:1705-1709`, `:2117-2124` | ignore-reason reporter and `quotaResetNotifyError` -> `schema_invalid: quotaResetNotify.<field>` |
+| **Resolution** | `src/quota/reset-notify-config.ts:47-102` | `RawNotify` -> frozen resolved shape; `pollSeconds` -> `pollMs`; `positiveInt` clamps with `MIN_POLL_SECONDS=60`, `DEFAULT_POLL_SECONDS=900`, `timeoutMs` bounded `[100, 30 000]` |
+| **Consumers** | `isQuotaResetNotificationEnabled()` `:148`; `resolveQuotaResetPollMs()` `:151`; `src/quota/reset-poller.ts:40`; `src/server/background-lifecycle.ts:65`; `src/quota/reset-sinks.ts:175` | |
+
+**Enum chain — `kinds`:** `z.enum(["scheduled", "surprise"])` (`src/config.ts:863`) ->
+`ALL_KINDS` default in the resolver -> `Set<QuotaResetKind>` -> filter in `reset-sinks.ts`. **B1-B6
+add no enum member.** B2 deliberately reuses the existing `"blocked-destination"` delivery reason
+rather than adding `"blocked-redirect"`, so the `QuotaResetDeliveryResult` union is unchanged and
+no consumer needs a new case. If a future change does need to distinguish them, the union is the
+one place to extend.
+
+**Fields changed by fixes:** `webhookUrl` gains an HTTPS refinement (B1) — same field, narrower
+domain, no chain change. `pollSeconds` gains a higher floor (B3) — the clamp lives in the
+resolver, so a hand-edited low value degrades to the floor instead of discarding the section.
+
+**Layer 3 (#2973) — new field, but the chain is already merged and reviewed.** `quotaAutoRefresh`
+flows `src/types/config.ts` -> `src/config.ts` schema -> `src/server/management/config-routes.ts`
+(the conflict file) -> `src/codex/quota-auto-refresh.ts` -> `gui/src/hooks/useCodexAccountPool.ts`
+-> `gui/src/components/CodexAccountPool.tsx`. The **absent-field** case (C2) is the one that broke
+once and is now covered by `gui/tests/codex-account-pool-toast-tone.test.tsx`. All chain files
+except `config-routes.ts` auto-merged.
+
+---
+
+## 5. Risk and rollback
+
+| Layer | Risk | Likelihood | Rollback |
+|---|---|---|---|
+| 1 | F1 pins the summary request; an operator relying on a proxying `baseUrl` for quota loses it | Low — matches the per-account path already merged, and `fetchAvailableModels` still honours `baseUrl` | `git revert <squash-sha>`; single commit, 3 files |
+| 1 | Rename-aware pick recreates a root-level test file | Medium — the trap that made GitHub call this CONFLICTING | Caught pre-push by the `uniq -d` check and by `tests/repo-hygiene.test.ts:269` |
+| 2 | Semantic `src/providers/quota.ts` resolution silently drops layer 1's pinning | **Medium — highest risk in the phase** | V1/V2 immediately after resolving; they are layer 1's guard. Escalate rather than improvise |
+| 2 | B3's higher floor breaks an operator running a deliberately fast poll | Low — the docstring already claimed this floor; `pollSeconds: 0` still disables | Revert B3+B4 together; they are coupled through the resolver |
+| 2 | B2 refuses a legitimately redirecting webhook receiver | Low-Medium — some receivers 302 to a CDN | Documented remedy: configure the final URL. `allowPrivateNetwork` unchanged |
+| 2 | 6144 lines, 52 files, 675 commits of drift | Medium, but additive — nine new modules, only four conflicts | Revert the squash; `src/quota/` is new, so removal is clean |
+| 3 | GUI merge changes rendering; screenshot goes stale | Low | Re-capture; `enforce-target` blocks a `gui` PR without one |
+| 3 | `src/server/index.ts` merge introduces an `await` in the synchronous activation window | Low | `tests/lab/core-lab-boundary.test.ts` fails mechanically; revert the hunk |
+
+**Security-boundary items requiring the `MAINTAINERS.md` explicit-security-review exception:**
+
+| Item | Surface | Exception needed |
+|---|---|---|
+| Layer 1 F1 | Outbound destination for a credential-bearing request (`src/providers/quota.ts`) | Security review. Note: this **narrows** the surface |
+| Layer 2 B1 | Credential-bearing webhook URL scheme (`src/config.ts`) | Security review |
+| Layer 2 B2 | SSRF via redirect (`src/quota/reset-sinks.ts`) | Security review |
+| Layer 2 quota.ts resolution | Inherits F1's surface | Same review as F1 |
+| Layer 3 | `maintainer-sponsored` label **already applied** | Pre-cleared |
+
+No workflow, OAuth, CORS or release-automation file is touched by this phase. No item requires a
+`.github/workflows/` change.
+
+**Security-note handling.** Per `AGENTS.md`, pre-disclosure security material does not go in
+`devlog/`. Everything in this doc describes weaknesses in **open, public pull requests** whose
+diffs are already visible — B2's redirect gap is public in #2783's diff, and F1's is public in
+#3447's — so this is not pre-disclosure material. If the work surfaces a defect on **shipped**
+`dev` code that is not already public, write it to `.tmp/` or a `mktemp -d` path and say where,
+not into this unit.
+
+---
+
+## 6. Out of scope / deferred
+
+| Item | Reason (carried from `003_lane_v2_and_quota.md`) |
+|---|---|
+| **#2956** usage stats (time ranges, offline reports, GUI picker) | DEFER — 474 commits behind with two **semantic** conflicts (`src/usage/summary.ts`, `src/server/management/logs-usage-routes.ts`), a 217-line `Usage.tsx` rewrite needing visual verification, **zero human review ever**, and no test-matrix CI on any head: a carry would be simultaneously rebasing and first-reviewing 1261 lines across 34 files. Independent of every other item, so deferring costs the campaign nothing. **Re-entry:** ask the author to rebase, split the additive `src/usage/time-range.ts` core from the GUI work into two PRs, move the test files to their `tests/<domain>/` homes, and mark ready. If unresponsive, reimplementing the range-parsing core fresh is cheaper than carrying the diff, with `Co-authored-by: Manson2438`. Not SUPERSEDED — `src/usage/time-range.ts` does not exist on `dev` and `USAGE_RANGES` is still the 4-member union. |
+| Pre-existing unpinned bearer in `fetchAvailableModels` (`src/providers/quota.ts:2371-2382` on `dev`) | Real but out of scope — it predates #3447, which only inherits it. Widening the PR past its own delta breaks the RED/GREEN story. Lane doc records it as a separate change. |
+| #2956's unbounded offline reader (`readFileSync` with no `managementUsageMaxReadBytes` equivalent) | Medium, not a blocker — a CLI-local path over an operator-supplied file. Rides with #2956's re-entry. |
+| #3444 (V2 passthrough) | Belongs to wp3, not this phase. Sequence #2973 after it so `src/config.ts` resolutions stay single-file-at-a-time. |
+| CodeRabbit's "duplicate `seen`" Critical on #3447 | Not a fix — a **false positive** to answer in-thread: `:470` and `:506` are separate `test()` scopes, and green `hygiene` on the head proves the file compiles. Recorded so a later pass does not "fix" it into a real bug. |
+
+---
+
+## 7. Stack map (summary)
+
+| Layer | Branch | Targets | PR | Author | Trailer | Conflicts | Gate |
+|---|---|---|---|---|---|---|---|
+| 1 | `codex/260905-antigravity-ollama-quota` | `dev` | #3447 | `hualiny` | `Co-authored-by: yhualin <hualiny233@gmail.com>` | none (rename-aware) | V1, V2, typecheck |
+| 2 | `codex/260905-quota-reset-detection` | layer 1 | #2783 | `lidge-jun` | not required | 4 (1 semantic: `src/providers/quota.ts`) | V1, V3, V4 + 5 quota suites |
+| 3 | `codex/260905-quota-window-activation` | `dev` | #2973 | `terrytan95` | `Co-authored-by: Terry Tan <tmy1995hflc@gmail.com>` | 4 mechanical | V3, V4, V5, lint:gui |

--- a/devlog/_plan/260905_open_work_closeout/050_wp5_stack_e_else.md
+++ b/devlog/_plan/260905_open_work_closeout/050_wp5_stack_e_else.md
@@ -1,0 +1,1097 @@
+> **Amended by 008 (audit round 1):** E0 anchors re-locate to `tests/routing/anthropic-quorum-cache.test.ts:144`; all Co-authored-by trailers use the ID-prefixed noreply form; #3329 is appended as layer E7 (LAND_WITH_FIX, `core.ts` hand-resolution + lab-boundary verifier).
+
+# 050 — wp5 / Stack E: remaining ready PRs and implementable bug issues
+
+Unit: `devlog/_plan/260905_open_work_closeout`. Work-phase **wp5**, one PABCD cycle.
+Worktree: `/private/tmp/ocx-closeout.xomWAA/wt` (detached).
+Sources: `004_lane_else_prs.md` (#3530 #3487 #3508 #3383 #3329 #3421 #2716 #2432 #3531 #3528),
+`005_lane_bug_issues.md` (#3464, #3425).
+
+## 0. Drift since lane research — READ THIS FIRST
+
+Lane research ran at `origin/dev` = `0f27bbeb3`. The brief said dev had moved to `6580694c7`.
+**It has moved twice more since.** Verified at plan time:
+
+```
+$ git fetch origin dev && git log --oneline 0f27bbeb3..origin/dev
+79e03643d test(layout): move server, storage, ci-workflows into tests/<domain>/ (#3497) (#3518)
+bdafc5191 test(oauth): prove the unobservable quorum staleness window is harmless (#3533)
+6580694c7 test(oauth): restore a deleted contract test, and fail when one disappears (#3530)
+```
+
+**Plan-time dev tip: `79e03643d`.** Four consequences, each of which changes the lane's instructions:
+
+| # | Drift | Consequence for this work-phase |
+|---|---|---|
+| D1 | **#3530 is MERGED** as `6580694c7` | It is no longer a landing in this stack. Its `LAND_WITH_FIX` item — the removal test that does not remove — **merged unfixed** and is carried here as **E0**, a new maintainer-authored follow-up. |
+| D2 | **A third reorg wave landed** (#3518: `server`, `storage`, `ci-workflows`) | `tests/repo-hygiene.test.ts` -> `tests/ci-workflows/repo-hygiene.test.ts`; `tests/management-route-registry.test.ts` -> `tests/server/`; `tests/server-combo-failover-e2e.test.ts` -> `tests/server/`. Every path below is re-verified against `79e03643d`, not against the lane docs. |
+| D3 | **#3531's head moved** `f486b5d60` -> `e5137f6f2` | The lane's headline blocker (**#2960 regression RED**) **is already fixed by the author.** Reproduced and disproved below — the fix list changes materially. |
+| D4 | **#3528's head moved** `735e3f5c5` -> `f9f5f836d` and **dropped its alias half entirely** | The lane's `SUPERSEDED` reasoning (byte-identical src diffs) no longer describes the current head. Disposition stays SUPERSEDED-for-alias, but the evidence is now "alias half removed by author", and the residual `ocx effort` half is a stale pre-#3518 test-layout rewrite. Do **not** close it citing byte-identity. |
+
+**Standing instruction for the implementer:** re-run the D-block `git log --oneline <plan-sha>..origin/dev` and
+`gh pr view <n> --json headRefOid,mergeable,reviewDecision` immediately before each layer. This unit has observed
+**three** dev moves and **two** PR head moves inside ~24h. Treat every SHA below as a checkpoint, not a fact.
+
+---
+
+## 1. Loop-spec header
+
+**Archetype:** spec-satisfaction repair. Every item below has a written contract (a regression test, an
+`AGENTS.md` invariant, a doc-comment, or an issue-reported behavior) that the tree currently fails to satisfy.
+No item invents new product surface.
+
+**Trigger:** wp1–wp4 complete or independently landed; this work-phase owns the residue of lane 004 plus the two
+IMPLEMENT issues from lane 005.
+
+**Goal:** land E0–E6 into `dev`, and close/defer the rest of the family with recorded evidence.
+
+**Non-goals (do not do these in wp5):**
+
+- No `main`/`preview` promotion, no release, no version bump.
+- No repository-wide suite: **never** run bare `bun test` or `bun run test` for a scoped change.
+- No `src/lab/` reachability from `src/router.ts`, `src/server/lifecycle.ts`, `src/server/responses/core.ts`.
+- No auto-restart of a running service (E5 explicitly chooses the actionable-error route).
+- No loosening of the Codex entitlement fail-closed gate (that is #3352, DEFER).
+- Do not rewrite the #2960 regression test (E4) or the #3029 freshness assertions (E6).
+
+**Verifier commands.** Each was executed against a `git archive origin/dev` export at `79e03643d`
+(`/private/tmp/ocx-wp5-dev`, `node_modules` symlinked). All exist and are green **before** any change:
+
+| Command | Exit | Result at `79e03643d` | Reads which change target |
+|---|---|---|---|
+| `bun test tests/routing/anthropic-quorum-cache.test.ts` | 0 | 6 pass / 0 fail | E0 removal test |
+| `bun test tests/providers/kiro/kiro-stream.test.ts` | 0 | 113 pass / 0 fail | E1 fallback guard |
+| `bun test tests/codex-integration/codex-catalog.test.ts` | 0 | 268 pass / 0 fail | E4 #2960 contract |
+| `bun test tests/providers/provider-model-aliases.test.ts` | 0 | 7 pass / 0 fail | E4 alias routing |
+| `bun test tests/codex-integration/codex-routing.test.ts` | 0 | 168 pass / 0 fail | E6 usage score / #3029 |
+| `bun test tests/service/service.test.ts` | 0 | 193 pass / 0 fail | E5 launchd plist |
+| `bun test tests/test-layout.test.ts` | 0 | 2 pass / 0 fail | **every new test file** (see 1.1) |
+| `bun run typecheck` | 0 | strict `tsc --noEmit` | all `src/` layers |
+| `bun run test:changed` | 0 | import-graph vs `dev` merge base | all layers |
+| `bun run privacy:scan` | 0 | credential/privacy gate | E5, E6 (log lines) |
+| `gh pr checks <n>` filtered to exact head | — | hosted cross-platform CI | every PR |
+
+Existence proof for the two paths the lane docs cite at **stale** locations (both moved by #3518):
+
+```
+$ ls tests/ci-workflows/repo-hygiene.test.ts tests/server/management-route-registry.test.ts
+tests/ci-workflows/repo-hygiene.test.ts
+tests/server/management-route-registry.test.ts
+```
+
+### 1.1 The layout gate is a landmine for every new test file
+
+`tests/test-layout.test.ts:20` fails when a `*.test.ts` file does not resolve to a domain. This is exactly what
+made #3530's `test 1/4` go red. Resolution was probed through the repo's own resolver
+(`scripts/test-layout/schema.ts` -> `resolveTarget`) for every filename this plan proposes:
+
+```
+codex-pool-502-exhaustion.test.ts        -> null      # WOULD FAIL CI
+service-launchd-stable-launcher.test.ts  -> service   # ok
+container-bootstrap.test.ts              -> null      # WOULD FAIL CI  (#3421 adds this name)
+codex-catalog-antigravity-alias.test.ts  -> null      # WOULD FAIL CI
+combos-cooldown.test.ts                  -> null      # WOULD FAIL CI
+```
+
+**Rule for this work-phase:** prefer extending an existing, already-mapped test file. When a new file is
+unavoidable, add its basename to the `"explicit"` map in `scripts/test-layout/layout.json` **in the same commit**,
+and place the file in the mapped directory. `resolveTarget` consults `explicit` first (`schema.ts:47`), so an
+explicit entry always wins over the name-pattern fallbacks.
+
+**Stop condition.** E0–E4 merged into `dev` with exact-head CI green and ancestry proven; E5 and E6 either merged
+or, if security review is unavailable, left as open PRs with green CI and the review request recorded; every
+DEFER/SUPERSEDED item has its comment posted. Ancestry proof per landing:
+
+```
+git fetch origin dev && git merge-base --is-ancestor <merge-sha> FETCH_HEAD
+```
+
+**Memory artifact.** This document plus the merge ledger in `060_closeout.md`. Every landing appends one row:
+item, branch, PR, merge SHA, ancestry check exit, CI conclusion at exact head.
+
+**Expected terminal outcomes.** 7 landings (E0–E6, of which E1–E4 carry contributor work and E5/E6 are new
+maintainer implementations), 1 supersession closure (#3528), 4 deferrals (#3508, #3383, #2716, #3329) with
+reasons recorded.
+
+**Escalation.** Stop and report, do not improvise, when: (a) E6 or E3 needs a `MAINTAINERS.md` security review
+that is not available; (b) any exact-head CI failure is not reproducible locally with a focused verifier; (c) a
+contributor rebases a head mid-flight (already happened twice — D3, D4); (d) resolving #3329's
+`src/server/responses/core.ts` conflict would require touching the `src/lab/` boundary.
+
+---
+
+## 2. Stack map (DEV-STACK-01..03)
+
+The governing question is **shared files**, not thematic similarity. Measured overlap across the seven landings:
+
+| File | E0 | E1 | E2 | E3 | E4 | E5 | E6 |
+|---|---|---|---|---|---|---|---|
+| `tests/routing/anthropic-quorum-cache.test.ts` | X | | | | | | |
+| `tests/providers/kiro/kiro-stream.test.ts` | | X | | | | | |
+| `docs-site/.../providers.md` (+7 locales) | | | X | | | | |
+| `src/types/provider.ts` | | | X | | | | |
+| `Dockerfile`, `compose.yaml`, `docker/` | | | | X | | | |
+| `src/codex/catalog/sync.ts`, `src/router.ts`, `src/providers/{derive,registry}.ts` | | | | | X | | |
+| `src/service.ts` | | | | | | X | |
+| `src/codex/routing.ts`, `src/codex/quota.ts` | | | | | | | X |
+
+**No file is shared by any two landings.** Therefore Stack E is not a stack: it is **seven independent PRs, all
+targeting `dev` directly**, mergeable in any order and reviewable in parallel. Forcing them into a
+`DEV-STACK-01..03` chain would create artificial rebase coupling with no shared-file justification, which is
+precisely the failure mode `DEV-STACK` exists to avoid.
+
+The one true ordering constraint is **E0 before E4**, and it is a review-semantics constraint rather than a file
+one: both concern "a test that asserts less than its name claims", and landing E0 first makes the deletion story
+of the #3516/#3518 reorg family coherent before E4 touches the #2960 contract. It costs nothing to honor.
+
+### 2.1 Branch table
+
+| Layer | Branch (`codex/260905-` prefix) | Base | Item | What it proves alone |
+|---|---|---|---|---|
+| E0 | `codex/260905-quorum-removal-contract` | `dev` | #3530 follow-up | The DELETE route's removal path is actually exercised, not just its cache invalidation. |
+| E1 | `codex/260905-kiro-fallback-guard` | `dev` | #3487 REIMPLEMENT | The Kiro bounded completion fallback demonstrably fires, closing a false-confidence hole. |
+| E2 | `codex/260905-omit-sentinel-docs` | `dev` | #2432 carry | `__omit__` is discoverable from the docs; no runtime change. |
+| E3 | `codex/260905-docker-compose` | `dev` | #3421 carry | A container runtime-identical to the packaged artifact that binds loopback by default. |
+| E4 | `codex/260905-antigravity-agy-alias` | `dev` | #3531 carry | `agy/` routes and relabels **without** displacing the #2960 effective-alias label. |
+| E5 | `codex/260905-launchd-stable-launcher` | `dev` | #3464 IMPLEMENT | A launchd plist that survives a version-manager package swap. |
+| E6 | `codex/260905-codex-pool-502-wedge` | `dev` | #3425 IMPLEMENT | A fresh 100% burst reading excludes an account without stranding a recovered one. |
+
+### 2.2 Already-open PRs: merge directly, do not restack
+
+**None of the wp5 items is LAND_AS_IS.** The lane's only LAND_AS_IS (#3323) belongs to another work-phase. Every
+open PR here is LAND_WITH_FIX or REIMPLEMENT, so each needs a maintainer-authored commit and therefore a carried
+branch. For completeness, the pre-merge sequence when a PR does reach as-is quality:
+
+1. `gh pr view <n> --json headRefOid,mergeable,mergeStateStatus,reviewDecision` — confirm the head has not moved.
+2. `gh pr ready <n>` if it is a draft.
+3. Dismiss the stale review only when the finding is demonstrably addressed:
+   `gh pr review <n> --dismiss -m "<reason>"` (a `CHANGES_REQUESTED` from a fixed finding otherwise blocks).
+4. `gh pr checks <n>` — every required check green **on the exact head SHA**, not a previous run.
+5. `gh pr merge <n> --squash --admin`, then the ancestry proof from section 1.
+
+### 2.3 Carried contributor work — `Co-authored-by` is mandatory
+
+`AGENTS.md` "Landing another author's work": a prose mention is read by nothing; the trailer is what GitHub reads.
+`missing_coauthor_credit` in `.github/scripts/pr-carry-attribution.cjs` enforces it. Emails read from
+`gh pr view <n> --json commits` at plan time:
+
+| Layer | PR | Author login | Trailer to place in a branch commit (survives squash) |
+|---|---|---|---|
+| E1 | #3487 | `Ingwannu` | `Co-authored-by: Ingwannu <ingwannu@users.noreply.github.com>` |
+| E2 | #2432 | `mdwsk88` | `Co-authored-by: mdwsk88 <924038395@qq.com>` |
+| E3 | #3421 | `Skyline-23` | `Co-authored-by: Skyline-23 <flight@skyline23.com>` |
+| E4 | #3531 | `benedictusrey` | `Co-authored-by: benedictusrey888 <hartanto.benedictus.reynaldo.w0@s.mail.nagoya-u.ac.jp>` |
+
+Note for E4: the PR author is displayed as `benedictusrey` but the **commit** author is `benedictusrey888` with the
+Nagoya University address. Use the commit identity — that is what the contributor graph keys on.
+
+For #3329 (deferred in section 6, not landed here) the commit authorship is `" " <wj@nas-backup>` plus
+`claude <noreply@anthropic.com>` — an empty display name and a machine address. If it is ever carried, resolve the
+human identity with the author first; do not invent one.
+
+Branch creation for a carry:
+
+```bash
+git fetch origin pull/<n>/head:pr-<n>
+git checkout -b codex/260905-<slug> origin/dev
+git cherry-pick <sha>          # or apply the hunks by hand when the path moved
+# then the maintainer fix commit, carrying the trailer
+```
+
+Push with `--no-verify` (the pre-push hook runs the forbidden repository-wide suite).
+
+---
+
+## 3. Per-item plans
+
+### E0 — #3530 follow-up: the removal test that never removes
+
+**Disposition:** new maintainer PR. #3530 **merged** as `6580694c7` with this High finding unaddressed; verified by
+reading the merged file on `dev`, not the PR diff.
+
+**File change map.**
+
+`tests/routing/anthropic-quorum-cache.test.ts:122-134` — current code on `dev`:
+
+```ts
+  test("removing an account invalidates immediately, not after the TTL", async () => {
+    // The management DELETE route calls clearAnthropicSessionAffinityForAccount for Anthropic.
+    // Without invalidation there, deleting the second account would leave quorum true for up to
+    // 2s -- long enough for a request to record an id whose credential is already gone.
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    clearAnthropicSessionAffinityForAccount(ids[1]!);
+    markStoreUnread();
+    hasAnthropicFailoverQuorum(start + 1);
+    expect(storeWasRead()).toBe(true);
+  });
+```
+
+Target code:
+
+```ts
+  test("removing an account invalidates immediately, not after the TTL", async () => {
+    // Mirror the real DELETE route: src/server/management/oauth-account-routes.ts removes the
+    // credential FIRST (:550, removeAccount) and only then clears routing state (:553-554).
+    // Clearing affinity alone leaves the roster at 2, so the predicate cannot observe the
+    // transition this test is named for -- it could only ever assert that the store was re-read.
+    const start = Date.now();
+    const ids = await seed(2);
+    expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    expect(await removeAccount("anthropic", ids[1]!)).toBe(true);
+    clearAnthropicSessionAffinityForAccount(ids[1]!);
+    markStoreUnread();
+    expect(hasAnthropicFailoverQuorum(start + 1)).toBe(false);
+    expect(storeWasRead()).toBe(true);
+  });
+```
+
+Import change at `tests/routing/anthropic-quorum-cache.test.ts:27`:
+
+```ts
+-import { getAccountSet, saveCredential } from "../../src/oauth/store";
++import { getAccountSet, removeAccount, saveCredential } from "../../src/oauth/store";
+```
+
+Signature verified: `src/oauth/store.ts:899` — `export async function removeAccount(provider: string, accountId: string): Promise<boolean>`.
+Route order verified: `oauth-account-routes.ts:550` `removeAccount(provider, id)`, then `:553-554`
+`clearAnthropicAccountCooldown` / `clearAnthropicSessionAffinityForAccount`.
+
+**Conflict recipe:** none. `dev` owns this file as of `6580694c7`; nothing else in wp5 touches it.
+
+**Regression test.** The changed test *is* the regression. RED-on-dev demonstration: with the current body,
+deleting the `removeAccount` call from the route would leave the test green — that is the defect. After the change,
+the added `expect(hasAnthropicFailoverQuorum(start + 1)).toBe(false)` fails if the roster is not actually reduced.
+Drive it red once by commenting out the `removeAccount` line and confirming the new assertion fails; that proof is
+required before commit, the same discipline #3530's own hygiene guard used.
+
+**Focused verifier:** `bun test tests/routing/anthropic-quorum-cache.test.ts` — 6 pass / 0 fail on dev today;
+must stay 6 pass after the change.
+
+**Accept criteria (C-ACTIVATION-GROUNDING-01).** Two paths, both grounded in a scenario:
+
+- *Removal path active*: 2 accounts seeded -> `removeAccount` returns `true` -> roster is 1 -> quorum `false`,
+  store re-read `true`.
+- *Removal path inactive* (unchanged-behavior guard): the sibling test "a manual account selection invalidates
+  immediately" (`:136-147`) still passes with 2 accounts intact, proving the new assertion did not simply make
+  every path return `false`.
+
+**Docs-site sync:** none — test-only.
+
+**PR skeleton.**
+
+```
+title: test(oauth): exercise the account-removal path the quorum test is named for
+
+## Summary
+#3530 restored the quorum cache contract test, and its removal case asserts the store was
+re-read but never removes the credential -- so the roster is unchanged and the transition the
+test is named for cannot be observed. Mirror the DELETE route: removeAccount first, then the
+routing cleanup, and assert quorum actually drops.
+
+## Verification
+- bun test tests/routing/anthropic-quorum-cache.test.ts (6 pass / 0 fail)
+- Driven red by removing the removeAccount call before committing.
+- bun run typecheck
+
+## Checklist
+- [x] Focused tests pass
+- [x] No repository-wide suite run
+- [x] No docs-site change needed (test-only)
+
+Follows up #3530.
+```
+
+---
+
+### E1 — #3487 REIMPLEMENT: prove the Kiro bounded fallback runs
+
+**Disposition:** REIMPLEMENT. The PR is `CONFLICTING`/`DIRTY` only because it names `tests/kiro-stream.test.ts`,
+a path deleted by the reorg. Applying it as-is would resurrect a deleted file and fail `tests/test-layout.test.ts`.
+
+**File change map.** Target is `tests/providers/kiro/kiro-stream.test.ts:1723` (line re-verified at `79e03643d`;
+the same string also occurs at `:313` and `:333` — **do not** patch those, they belong to a different test).
+
+Current code, inside `test("an attempt that falls back to the completion retry does not calibrate")`:
+
+```ts
+    resetKiroCalibration();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(streamOf(eventFrame({ content: "Final from fallback." })))) as typeof fetch;
+    try {
+```
+
+Target code:
+
+```ts
+    resetKiroCalibration();
+    const originalFetch = globalThis.fetch;
+    // Observe the stub, do not merely install it. The assertion below is that the estimate did
+    // not move -- which stays true if the bounded fallback silently stopped firing at all. The
+    // counter is what separates "did not calibrate" from "did not run".
+    let fallbackCalls = 0;
+    globalThis.fetch = (async () => {
+      fallbackCalls += 1;
+      return new Response(streamOf(eventFrame({ content: "Final from fallback." })));
+    }) as typeof fetch;
+    try {
+```
+
+and after the `finally` block restores `globalThis.fetch` (before the `after` adapter is constructed):
+
+```ts
+    expect(fallbackCalls).toBe(1);
+```
+
+**Conflict recipe:** mechanical, path-only. Do **not** `git cherry-pick` — the source path does not exist. Apply
+the hunk by hand to the new path, then commit with the `Ingwannu` trailer.
+
+**Regression test.** Honestly characterized: this is **not** RED on dev, because the fallback does fire today. It
+is a guard against silent regression, the correct shape for a REVIEW-REGRESS-01 defect. Proof that the guard has
+teeth: stub the Kiro completion path to a no-op and confirm `expect(fallbackCalls).toBe(1)` fails while the
+pre-existing `expect(afterEstimate).toBe(baseline)` still passes — that divergence is the whole argument for the
+change and belongs in the PR body.
+
+**Focused verifier:** `bun test tests/providers/kiro/kiro-stream.test.ts` — 113 pass / 0 fail on dev; must stay
+113 pass with one added `expect()` call.
+
+**Accept criteria (C-ACTIVATION-GROUNDING-01).**
+
+- *Fallback active*: tool-carrying request with a context percentage and no private completion call ->
+  `fallbackCalls === 1` and calibration unchanged.
+- *Fallback inactive*: the sibling non-fallback calibration tests in the same describe block are untouched and
+  still pass, proving the counter did not leak into the ordinary path.
+
+**Docs-site sync:** none.
+
+**PR skeleton.**
+
+```
+title: test(kiro): prove the bounded completion fallback actually runs
+
+## Summary
+The fallback test asserts only that the calibration estimate did not move, which stays true if
+the bounded fallback stopped firing entirely -- a false-confidence hole. Count the stubbed
+fetch and assert it ran exactly once. Reimplementation of #3487 at the post-reorg path: the
+original patch targets tests/kiro-stream.test.ts, deleted by #3516/#3518.
+
+## Verification
+- bun test tests/providers/kiro/kiro-stream.test.ts (113 pass / 0 fail)
+- bun run typecheck
+
+## Checklist
+- [x] Focused tests pass
+- [x] Original authorship preserved via trailer
+
+Closes #3487.
+
+Co-authored-by: Ingwannu <ingwannu@users.noreply.github.com>
+```
+
+---
+
+### E2 — #2432 carry: document the `__omit__` sentinel
+
+**Disposition:** LAND_WITH_FIX, carried (88+ commits behind, mechanical locale conflicts).
+
+**File change map.**
+
+1. `docs-site/src/content/docs/reference/configuration/providers.md:114` — current row:
+
+```md
+| `reasoningEffortMap?` | `Record<string, string>` | Provider-wide wire aliases for reasoning labels. |
+```
+
+   Target: extend that row (and the `modelReasoningEffortMap?` row at `:115`) to name the sentinel and say
+   **which wire field** it suppresses:
+
+```md
+| `reasoningEffortMap?` | `Record<string, string>` | Provider-wide wire aliases for reasoning labels. The reserved value `__omit__` drops the field from the upstream request entirely — `reasoning_effort` on an OpenAI-compatible wire, and Ollama's native `think` field on the Ollama native adapter (#2356). |
+```
+
+2. Mirror into the seven locales, all verified present:
+   `docs-site/src/content/docs/{fr,ja,ko,ru,tr,zh-cn,zh-tw}/reference/configuration/providers.md`.
+   Per the lane's CodeRabbit finding, ja/ko/ru/tr must carry the OpenAI-vs-Ollama wire distinction, not a generic
+   "omit" verb.
+
+3. `src/types/provider.ts` doc-comment — **apply the lane's fix**: the PR's comment references
+   `REASONING_EFFORT_OMIT_SENTINEL`, which this file does not import. Verified: no such import exists in
+   `src/types/provider.ts`, and the constant lives at `src/reasoning-effort.ts:21`. Use the literal plus a file
+   reference. Current line `src/types/provider.ts:174` area carries `alias?: string;` and its neighbors; the
+   sentinel comment attaches to the `reasoningEffortMap` declaration:
+
+```ts
+  /** Provider-wide wire aliases for reasoning labels. The reserved value `"__omit__"` drops the
+   *  field from the upstream request (see `REASONING_EFFORT_OMIT_SENTINEL` in src/reasoning-effort.ts). */
+```
+
+**Conflict recipe:** mechanical. Every hunk is a two-line table-row replacement across eight files. Do not
+cherry-pick the stale branch; re-apply the eight rows onto current `dev`, which is faster and avoids resurrecting
+pre-reorg context.
+
+**Regression test:** none warranted, and that is the correct call — docs plus two doc-comments, zero runtime
+change. The behavior is already covered by the adapter tests for #2356. Do not manufacture a test to satisfy a
+checklist.
+
+**Focused verifier:** `bun run typecheck` (it is still a `.ts` edit) plus an exact-head `docs-site` build. The lane
+records an isolated docs build passing at 393 pages; re-run it on the rebased head.
+
+**Accept criteria (C-ACTIVATION-GROUNDING-01).** The conditional path here is the sentinel itself:
+
+- *Sentinel active*: `reasoningEffortMap = { high: "__omit__" }` -> field absent from the upstream body
+  (`isReasoningEffortOmitted`, `src/reasoning-effort.ts:23-25`).
+- *Sentinel inactive*: any other string maps normally.
+  Both must be readable from the documentation row alone — that is the acceptance bar for a docs change.
+
+**Docs-site sync:** this item *is* the docs sync. English is the source; the seven locales must not contradict it.
+
+**PR skeleton.**
+
+```
+title: docs: document the `__omit__` reasoning-effort wire sentinel
+
+## Summary
+REASONING_EFFORT_OMIT_SENTINEL (src/reasoning-effort.ts:21) is load-bearing and undiscoverable:
+the providers reference described reasoningEffortMap only as "wire aliases for reasoning
+labels". Document the sentinel in English and seven locales, naming which wire field it
+suppresses on each adapter.
+
+## Verification
+- Exact-head docs-site build
+- bun run typecheck
+
+## Checklist
+- [x] Docs updated (English source + 7 locales)
+- [x] No runtime change, so no regression test
+
+Closes #2432.
+
+Co-authored-by: mdwsk88 <924038395@qq.com>
+```
+
+---
+
+### E3 — #3421 carry: Docker Compose, made runtime-identical and loopback by default
+
+**Disposition:** LAND_WITH_FIX, carried. `MERGEABLE` today (no file overlap with `dev` churn), but it carries a
+routing-behavior regression and a security-boundary default.
+
+**File change map.**
+
+1. **Runtime identity [High].** `.dockerignore:9` excludes `src/generated/compatibility-version.json`, and the
+   Dockerfile copies `src` without running the package generator. The runtime is documented fail-closed at
+   `src/routing/compatibility/version.ts:80` — "There is intentionally no runtime-only fallback" —
+   `readOpenCodexCompatibilityVersion()` returns `null` (`:91`) and `src/routing/compatibility/subject.ts:96` then
+   returns early with bare `subjectIds`. **This is a routing difference, not missing metadata.**
+   Fix: run the package-owned generator during the image build (`scripts/prepare-package.ts:4` imports
+   `generateCompatibilityVersionManifest`) and copy the result into the runtime stage. **Do not commit a generated
+   file** — a stale manifest is worse than an absent one.
+
+2. **Bind default [High, security boundary].** `compose.yaml:13`:
+
+```yaml
+-      - "${OPENCODEX_PORT:-10100}:10100"
++      - "${OPENCODEX_BIND_ADDRESS:-127.0.0.1}:${OPENCODEX_PORT:-10100}:10100"
+```
+
+   `"${PORT}:10100"` publishes on `0.0.0.0` of the Docker host. Loopback is the correct default for a local Docker
+   Desktop deployment; document the opt-in to `0.0.0.0` or a LAN/Tailscale address for remote-hub use.
+
+3. **Docs token path [Medium].** `docs-site/src/content/docs/guides/remote-hub.md:175` reads the token from
+   `/run/secrets/ocx_api_token` while the bootstrap step uses the canonical `ocx-state` volume path. Fix the
+   English source and the six mirrored locales in the PR's file list (`fr,ja,ko,ru,tr,zh-cn,zh-tw`).
+
+**Conflict recipe:** none textually — `git merge-tree` reports only `added in remote`. Rebase onto current `dev`
+and re-run CI; the conflict risk is zero and the CI risk is total (intake-only checks so far).
+
+**Regression tests.**
+
+- Existing: `tests/container-bootstrap.test.ts` (+32) covers `docker/bootstrap-token.ts` — chunked input, exact
+  4096-byte maximum, rejection of empty/multiline/oversized input. RED on dev only in the new-file sense.
+  **Layout gate:** `resolveTarget(layout, "container-bootstrap.test.ts")` returns **`null`** (probed). This file
+  **will fail `tests/test-layout.test.ts`** unless its basename is added to the `"explicit"` map in
+  `scripts/test-layout/layout.json` in the same commit. Suggested mapping:
+  `"container-bootstrap.test.ts": "service"`, matching the existing `tests/service/service-probe-docker.test.ts`
+  neighbor; place the file at `tests/service/container-bootstrap.test.ts`.
+- **Missing, must be added:** nothing asserts container runtime identity. Add a runtime-stage assertion that
+  `readOpenCodexCompatibilityVersion()` returns a valid SHA-256 value, so a future Dockerfile edit that drops the
+  generator fails the build rather than silently changing routing.
+
+**Focused verifier:** `bun test tests/service/container-bootstrap.test.ts`, `bun test tests/test-layout.test.ts`,
+`bun run typecheck`, plus an exact-head container build and full cross-platform CI.
+
+**Accept criteria (C-ACTIVATION-GROUNDING-01).** Three conditional paths, each with a stated scenario:
+
+- *Manifest present* (fixed build): `readOpenCodexCompatibilityVersion()` non-null -> `subject.ts` resolves the
+  full subject -> container routes identically to an npm install.
+- *Manifest absent* (today's build): returns `null` -> bare `subjectIds` -> unknown-evidence policy. The new
+  build-stage assertion must make this state unreachable in a shipped image.
+- *Bind override*: unset `OPENCODEX_BIND_ADDRESS` -> `127.0.0.1`; explicitly set to `0.0.0.0` -> published on all
+  interfaces, which the remote-hub guide must describe as a deliberate opt-in.
+
+**Docs-site sync:** `guides/remote-hub.md` English + 6 locales (token path, and the new bind-address opt-in).
+
+**Security boundary:** **yes.** Deployment surface and token handling -> `AGENTS.md`/`MAINTAINERS.md` explicit
+security review required before merge. Flag in the PR body; do not self-approve.
+
+**PR skeleton.**
+
+```
+title: feat(docker): Compose deployment with runtime-identical image and loopback default
+
+## Summary
+Carries #3421 with two fixes. The image excluded src/generated/compatibility-version.json and
+never ran the package generator, so readOpenCodexCompatibilityVersion() returned null and
+live-route subject resolution fell back to bare subjectIds -- a routing difference from every
+other install, not merely absent metadata. Compose also published the data port on all host
+interfaces; the default is now loopback with a documented opt-in.
+
+## Verification
+- bun test tests/service/container-bootstrap.test.ts
+- bun test tests/test-layout.test.ts
+- Exact-head container build + cross-platform CI
+
+## Checklist
+- [x] Security review requested (deployment + token handling)
+- [x] Docs updated (remote-hub token path, bind opt-in)
+- [x] New test basename registered in scripts/test-layout/layout.json
+
+Closes #3421.
+
+Co-authored-by: Skyline-23 <flight@skyline23.com>
+```
+
+---
+
+### E4 — #3531 carry: `agy` alias without displacing the #2960 label
+
+**This item changed materially since the lane doc (D3). Read this section, not the lane's fix list.**
+
+**Disposition:** LAND_WITH_FIX, carried — but the headline blocker is already resolved by the author.
+
+**What I verified, by execution rather than reading.** The lane reports the PR breaking
+`codex-catalog.test.ts:2286` ("the issue reproduction uses the effective model alias for the picker label", added
+by `0892b99d7` for #2960). I reproduced both heads against `origin/dev` exports:
+
+| Head | `src/providers/derive.ts` content | `bun test ... -t "effective model alias"` |
+|---|---|---|
+| `f486b5d60` (lane's head) | seed **+ `enrichProviderFromRegistry` backfill** of `prov.alias` | **1 fail** — `Expected "google-antigravity/gemini-3.7", Received "agy/gemini-3.7"` |
+| `e5137f6f2` (current head) | seed **only** | **2 pass / 0 fail** |
+
+Full current-head diff applied to a `79e03643d` export:
+`bun test tests/codex-integration/codex-catalog.test.ts tests/providers/provider-model-aliases.test.ts`
+-> **279 pass / 0 fail**.
+
+**The mechanism, which the lane doc did not isolate.** The `sync.ts` early return is *not* what broke #2960. I
+applied that hunk alone to a clean dev export: **268 pass / 0 fail**. The breakage came from the extra line the
+author has since removed:
+
+```ts
+  // f486b5d60 only, inside enrichProviderFromRegistry:
+  if (prov.alias === undefined && seed.alias !== undefined) prov.alias = seed.alias;
+```
+
+That backfill made the registry alias visible to the **#2960 display path**, which composes the label as
+`${provider.alias || name}/${alias}` (`src/codex/catalog/provider-fetch.ts:2444`). With `prov.alias === "agy"` the
+effective-alias label became `agy/gemini-3.7` instead of `google-antigravity/gemini-3.7`. So the label
+contradiction the brief asks me to resolve **is exactly the "route through model-alias display" question**, and
+the current head resolves it by *not* letting the registry alias reach that path.
+
+**Remaining blockers (both still live at `e5137f6f2`).**
+
+1. **[Medium] The two display paths now disagree by construction.** `routedDisplayName` returns `agy/<model>`
+   (`sync.ts:277-279`), while the #2960 alias path still emits `google-antigravity/<alias>` because
+   `provider.alias` is unset there. A user with `modelAliases` configured sees the long prefix; a user without
+   sees `agy/`. That is defensible (configured aliases win) but it is **undocumented and untested**. Add the
+   regression the lane asked for: Antigravity **with** a `modelAliases` entry, pinning
+   `google-antigravity/gemini-3.7`, adjacent to the existing #2960 test at `:2286` so the coupling is visible to
+   the next editor.
+2. **[Medium] The doc-comment contract is now false.** `src/codex/catalog/sync.ts:265-271` states "All other
+   providers keep the raw slug exactly as before." The change adds a second provider-specific rule without
+   updating that sentence. Current text to replace:
+
+```ts
+ * The model-id portion also carries a redundant `<vendor>-` prefix (`deepseek-deepseek-v4-flash`)
+ * that is dropped for display. All other providers keep the raw slug exactly as before.
+```
+
+   Target:
+
+```ts
+ * The model-id portion also carries a redundant `<vendor>-` prefix (`deepseek-deepseek-v4-flash`)
+ * that is dropped for display. Google Antigravity is relabeled to the compact `agy/` prefix for the
+ * same reason: `google-antigravity/` alone consumes most of the picker row. This is the raw-slug
+ * path only -- a configured `modelAliases` entry is labeled by the effective-alias path in
+ * catalog/provider-fetch.ts (#2960) and keeps the canonical provider name. All other providers
+ * keep the raw slug exactly as before.
+```
+
+3. **[Low] The early return still bypasses later display rules.** Harmless today (the only later rule is the
+   Command Code branch, which cannot match `google-antigravity`), so this is a readability preference, not a
+   correctness blocker. Optional: convert to `if (provider === "google-antigravity") model = ...` composition.
+   **Do not** treat this as required — the lane's High rating was driven by the #2960 failure, which is gone.
+
+**Field/enum chain — `ProviderRegistryEntry.alias`.** See section 4; this is the only new config field in wp5 and
+its chain is deliberately truncated.
+
+**Conflict recipe:** none. Merge-base is `0f27bbeb3`; a rebase onto `79e03643d` is clean (no wp5-adjacent file
+moved). Verified by applying the head diff to a `79e03643d` export with `git apply` — clean, tests green.
+
+**Regression tests.** Existing on the head: `tests/providers/provider-model-aliases.test.ts` (+105) — `agy/`
+resolution, case-insensitivity (`AGY/`), canonical name preserved, user-defined alias overriding the built-in, and
+**ambiguity across insertion order in both directions** (the strongest assertion in the change). RED on dev: no
+`alias: "agy"` in the registry. Plus `codex-catalog.test.ts` (+15) for the compact label.
+**To add:** the `modelAliases`-present case from blocker 1.
+
+**Focused verifier:**
+`bun test tests/codex-integration/codex-catalog.test.ts tests/providers/provider-model-aliases.test.ts`
+— 279 pass / 0 fail on the current head; must stay green with the added case.
+
+**Accept criteria (C-ACTIVATION-GROUNDING-01).** Four conditional paths, each with a scenario:
+
+- *Registry alias active, no user alias*: `agy/gemini-3.8-flash` routes to `google-antigravity`; picker shows
+  `agy/gemini-3.8-flash`.
+- *User alias configured*: `alias: "antigrav"` -> **both** `antigrav/` and `agy/` route (additive fallback).
+- *Ambiguous alias*: a second provider explicitly configured with `alias: "agy"` wins over the registry fallback,
+  **independent of object insertion order** — both orders asserted.
+- *`modelAliases` configured* (the #2960 path): label stays `google-antigravity/gemini-3.7`. This is the case that
+  broke on the previous head and the one the new test must pin.
+
+**Docs-site sync:** if any locale documents provider namespaces for Antigravity, add `agy`. Check
+`rg -n "google-antigravity" docs-site/` before opening; do not assume.
+
+**PR skeleton.**
+
+```
+title: feat(catalog,providers): compact `agy` alias for google-antigravity
+
+## Summary
+Adds a built-in `agy` namespace for google-antigravity: routing accepts `agy/<model>`
+case-insensitively, and the Codex picker relabels raw routed slugs. Configured provider
+aliases still win, and the registry fallback applies only when unambiguous.
+
+The label question is settled explicitly: a provider with a configured `modelAliases` entry
+keeps the canonical `google-antigravity/<alias>` label from #2960, because the registry alias
+is deliberately NOT backfilled onto the runtime provider row. A regression test pins that.
+
+## Verification
+- bun test tests/codex-integration/codex-catalog.test.ts tests/providers/provider-model-aliases.test.ts (279 pass / 0 fail)
+- bun run typecheck
+
+## Checklist
+- [x] Focused tests pass
+- [x] #2960 regression test unchanged and still green
+
+Closes #3531. Supersedes the alias half of #3528.
+
+Co-authored-by: benedictusrey888 <hartanto.benedictus.reynaldo.w0@s.mail.nagoya-u.ac.jp>
+```
+
+---
+
+### E5 — #3464 IMPLEMENT: launchd survives a mise package swap
+
+**Disposition:** IMPLEMENT. No open PR. macOS counterpart to the resolved Linux/mise issue #2898.
+
+**Defect, re-verified on `79e03643d`.** `cliEntry()` (`src/service.ts:66-73`) resolves both the Bun runtime and the
+CLI entry from `import.meta.dir` — i.e. **inside the installed package tree**. `buildPlist()` (`:489-490`) calls it
+and bakes the pair into the plist via `buildServiceShellCommand(bun, cli)` (`:556-559`).
+
+The repair already exists **for systemd only**. `stableLauncherEntry()` (`:95-117`) finds an absolute `ocx` on
+`PATH` lexically, and its doc-comment (`:77-94`) describes this exact failure: "Under a version manager that tree
+is a versioned directory ... An upgrade installs 2.36.0 and deletes 2.35.0". `buildServiceLauncherShellCommand()`
+(`:567-570`) already builds the launcher-shaped command. `installSystemd()` (`:3361`) uses both. Verified by
+`rg -n "stableLauncherEntry" src/`: exactly two hits, the definition and the systemd caller.
+**`buildPlist` and `installLaunchd` never call it.** That asymmetry is the whole bug.
+
+**File change map (`src/service.ts`).**
+
+1. `buildPlist()` at `:489` — accept an injected launcher exactly as `buildUnit()` does (`:3268-3271`):
+
+```ts
+-export function buildPlist(proxyEnv: { name: string; value: string }[] = resolvedProxyEnv()): string {
+-  const { bun, bunRuntimeSource, cli } = cliEntry();
++export function buildPlist(
++  proxyEnv: { name: string; value: string }[] = resolvedProxyEnv(),
++  deps: { launcher?: string | null } = {},
++): string {
++  const { bun, bunRuntimeSource, cli } = cliEntry();
++  const launcher = deps.launcher ?? null;
+```
+
+   and at `:511`:
+
+```ts
+-  const command = buildServiceShellCommand(bun, cli);
++  const command = launcher
++    ? buildServiceLauncherShellCommand(launcher)
++    : buildServiceShellCommand(bun, cli);
+```
+
+   When `launcher` is set, omit the two Bun-runtime env keys, mirroring `buildUnit`'s `...(launcher ? [] : [...])`
+   at `:3285-3288` — a baked `OCX_BUN_RUNTIME_PATH` pointing into the deleted versioned tree is the same stale-path
+   bug in a different key.
+
+2. `installLaunchd()` at `:2244` — resolve **once** and pass the same value to both the plist and install state,
+   exactly as `installSystemd()` does (`:3358-3366`), so the staleness check cannot validate a path the job does
+   not run:
+
+```ts
+-  writeServiceDefinitionFile(p, buildPlist(), "utf8");
++  const launcher = stableLauncherEntry();
++  writeServiceDefinitionFile(p, buildPlist(resolvedProxyEnv(), { launcher }), "utf8");
+```
+
+   and the matching `writeServiceInstallState("scheduler", launcher)` (the parameter already exists at `:238` and
+   is recorded as `launcherPath` at `:246`).
+
+3. **Skew becomes actionable, not auto-repairing.** Per the lane's explicit recommendation and the non-goals in
+   section 1: on detected skew, surface an actionable error naming `opencodex service restart` — the reporter
+   confirmed that single command fully repaired the state. **Do not auto-restart**: restarting a service
+   mid-request is a larger behavioral change than this issue authorizes.
+
+**Conflict recipe:** none — new work on a file untouched by `0f27bbeb3..79e03643d` (verified by path-filtered
+`git log`, empty output). Semantic care only: `src/service.ts` is also implicated by #3320 (DEFER), so nothing
+competes for it in this work-phase.
+
+**Regression tests.** Extend `tests/service/service.test.ts` — it already imports `stableLauncherEntry`,
+`buildPlist`, and `buildUnit` (`:10`), and already has a shim-resolution case at `:1211`. **Prefer this over a new
+file**: a new basename such as `service-launchd-stable-launcher.test.ts` does resolve (`-> service`, probed) but
+adds layout surface for no benefit.
+
+- `"the launchd plist runs the stable launcher when one is on PATH"` — RED on dev: `buildPlist` takes no launcher
+  argument, so the test cannot compile against `dev`; after the change it asserts the plist `ProgramArguments`
+  string contains the launcher and **not** the versioned `import.meta.dir` CLI path.
+- `"a launchd install with no stable launcher keeps the Bun + CLI pair"` — the inactive branch.
+- Mirror the systemd single-resolution assertion at `:387-391`
+  (`expect(installLaunchd.match(/stableLauncherEntry\(\)/g)).toHaveLength(1)`) so the plist and the install state
+  can never disagree.
+
+**Focused verifier:** `bun test tests/service/service.test.ts` — 193 pass / 0 fail on dev; plus `bun run typecheck`
+and `bun run privacy:scan` (the new error message must name a command, never a token or account id).
+
+**Accept criteria (C-ACTIVATION-GROUNDING-01).**
+
+- *Launcher found*: `PATH` contains an absolute executable `ocx` -> plist execs the launcher; Bun-runtime env keys
+  omitted; install state records `launcherPath`.
+- *Launcher absent*: no `ocx` on `PATH` -> unchanged Bun + CLI pair, both env keys present. The existing 193 tests
+  cover this and must stay green.
+- *Relative `PATH` entry*: rejected — `stableLauncherEntry` accepts only absolute paths (`:112`), because a bare
+  `ocx` re-resolved on every restart turns a service definition into a PATH-hijacking surface. Assert this
+  explicitly; it is a security property, not a detail.
+- *Skew detected*: actionable error naming `opencodex service restart`; **no** automatic restart.
+
+**Docs-site sync:** if a macOS service guide documents the baked plist command, note the launcher indirection.
+Run `rg -n "LaunchAgents|com.opencodex.proxy" docs-site/` before opening.
+
+**Security boundary:** partial. Not auth/OAuth/CORS/workflows, but `stableLauncherEntry`'s absolute-path rule is a
+PATH-hijacking guard. Call it out in the PR body so a reviewer checks it deliberately rather than as a diff detail.
+
+**PR skeleton.**
+
+```
+title: fix(service): bake the stable ocx launcher into the launchd plist
+
+## Summary
+cliEntry() resolves Bun and the CLI from import.meta.dir, so the launchd plist names paths
+inside the versioned package tree. Under mise/asdf an upgrade replaces that tree; the old
+proxy keeps serving from the retained old package (#3464), which is how a stale 2.10.1
+proxy kept answering for a 2.42.0 CLI. systemd already avoids this via stableLauncherEntry();
+launchd never called it. Resolve once in installLaunchd and pass the same value to both the
+plist and the install state, so the staleness check cannot validate a path the job does not run.
+
+## Verification
+- bun test tests/service/service.test.ts
+- bun run typecheck
+- bun run privacy:scan
+
+## Checklist
+- [x] Focused tests pass
+- [x] No auto-restart of a running service
+- [x] Launcher must be an absolute path (PATH-hijacking guard asserted)
+
+Closes #3464.
+```
+
+---
+
+### E6 — #3425 IMPLEMENT: a fresh 100% burst window must exclude the account
+
+**Disposition:** IMPLEMENT. No open PR owns this path — #3502 is Anthropic OAuth, #3529 is API-key failover;
+neither touches the Codex ChatGPT account pool.
+
+**Defect, re-verified on `79e03643d`. Two reinforcing mechanisms.**
+
+*Mechanism 1.* `isTerminalShortWindow()` (`src/codex/routing.ts:408-422`) returns `false` unless `shortResetAt` is
+finite, positive, and still in the future (`:415-421`). A snapshot with `shortPercent: 100` and a missing
+`shortResetAt` therefore scores `CODEX_UNKNOWN_USAGE_SCORE` (`= 101`, `src/codex/quota.ts:112`) at `:387`, and
+admission predicates treat `>= 101` as selectable (`src/codex/auth-context.ts:70`).
+
+*Mechanism 2.* `502` is in `TRANSIENT_SERVER_STATUSES` (`src/codex/quota-rejection.ts:101`) and returns
+`transient-server-error` at `:283` — **before** the 429/402 quota branch at `:284`. A quota exhaustion wrapped in a
+bare 502 produces no quota signal at all, matching the reporter's `sendCount: 1` and empty `recoveryKinds`.
+
+Together: the snapshot says 100% but cannot exclude, the 502s say nothing, and the pool wedges — 118 consecutive
+502s over 23 minutes while account B sat at 3%.
+
+**The constraint that makes this hard, and must not be broken.** `tests/codex-integration/codex-routing.test.ts:143`
+("a full burst window scores terminal while it is still in force (#3029)") pins the **opposite** direction at
+`:159`:
+
+```ts
+    // No resetAt at all cannot be aged, so it stays unknown: a wrongly-selected account
+    // fails one request, a wrongly-excluded one is invisible until someone reads the pool.
+    expect(computeCodexUsageScore({ shortPercent: 100 }, undefined, now)).toBe(CODEX_UNKNOWN_USAGE_SCORE);
+```
+
+This is a deliberate trade documented at `routing.ts:395-407`, and #3425 is what it looks like when it goes wrong.
+
+**File change map — resolve the contradiction with freshness, not by inverting the rule.**
+
+The missing input is *age*, and it already exists: `StoredAccountQuota.updatedAt` (`src/codex/quota.ts:36`, set to
+`Date.now()` at `:281` and `:456`), with disk hydration already rejecting rows older than
+`QUOTA_DISK_MAX_AGE_MS = 6h` (`:42`, `:491`). The reason `:159` says "cannot be aged" is that
+`computeCodexUsageScore`'s parameter type (`routing.ts:363-368`) simply does not carry `updatedAt`.
+
+1. Widen the accepted shape at `routing.ts:363-368` with an **optional** `updatedAt?: number`.
+2. Extend `isTerminalShortWindow` (`:408-422`) with a second admission route:
+
+```ts
+  const resetAt = quota.shortResetAt;
+  if (typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt <= 0) {
+    // #3425: a reading with no reset timestamp cannot be aged BY ITS RESET -- but it can be
+    // aged by its observation time. A 100% window observed seconds ago is a measured refusal,
+    // and leaving it selectable wedges the pool on it (118 consecutive 502s over 23 minutes).
+    // Freshness, not reset presence, is what keeps #3029 safe in both directions: a stale
+    // reading still falls back to unknown and a recovered account is never stranded.
+    const observedAt = quota.updatedAt;
+    if (typeof observedAt !== "number" || !Number.isFinite(observedAt)) return false;
+    return now - observedAt <= TERMINAL_SHORT_WINDOW_FRESHNESS_MS;
+  }
+```
+
+   with `TERMINAL_SHORT_WINDOW_FRESHNESS_MS` a new exported constant, deliberately **much** tighter than the 6h
+   disk horizon. Recommend `5 * 60_000`: shorter than any plausible 5h burst window, long enough that a snapshot
+   taken at admission is still fresh at selection.
+
+   **This keeps `:159` green unchanged**, because that call passes no `updatedAt` — a bare `{ shortPercent: 100 }`
+   literal still returns unknown. That is the property that makes the contradiction resolvable without rewriting a
+   #3029 assertion.
+
+3. **Affinity release [second half].** Clear or re-evaluate sticky affinity after a bounded run of consecutive
+   failures on one account, so a 502 storm cannot pin the pool even when no quota signal is produced. Keep
+   post-200 `streamAborted` terminal as today.
+
+**Explicitly not doing:** reclassifying 502 out of `TRANSIENT_SERVER_STATUSES`. A 502 genuinely is transient in the
+general case; demoting every one would strand accounts on ordinary gateway blips. The bounded-consecutive-failure
+release in (3) addresses the storm without that collateral.
+
+**Conflict recipe:** none — `src/codex/routing.ts` and `src/codex/quota.ts` are untouched in
+`0f27bbeb3..79e03643d` (verified, empty path-filtered log).
+
+**Regression tests.** Extend `tests/codex-integration/codex-routing.test.ts` — it already owns the #3029 block
+(`:143-173`) and the live-selection cases (`:176-232`) with `setAccountQuotaFromParsed` helpers.
+
+- `"a fresh full burst window with no reset timestamp still excludes the account (#3425)"` — RED on dev: today
+  `{ shortPercent: 100, updatedAt: now }` scores `101`; after the change it scores `100`.
+- `"a stale full burst window with no reset timestamp stays unknown (#3029)"` — the opposite-direction guard:
+  `updatedAt: now - 6 * 60_000` -> `CODEX_UNKNOWN_USAGE_SCORE`. **This test is what proves the fix did not invert
+  #3029**, and it is non-negotiable.
+- `"a 502 storm does not pin the pool to an exhausted account (#3425)"` — account A `shortPercent: 100` with a
+  fresh `updatedAt` and no `shortResetAt`, account B healthy, threshold 80, multiple admissions -> new admissions
+  select B.
+- `"a bare 502 does not override a fresh snapshot"` — asserts the 502 classification is unchanged and the
+  exclusion comes from the snapshot, not from reclassifying the status.
+
+**Focused verifier:** `bun test tests/codex-integration/codex-routing.test.ts` — 168 pass / 0 fail on dev; must
+stay green with ~4 added cases, **including the untouched `:143` #3029 block**. Also
+`bun test tests/codex-integration/codex-quota-rejection.test.ts` (proves 502 classification is unchanged) and
+`bun run test:changed` (`src/codex/routing.ts` has many importers).
+
+**Accept criteria (C-ACTIVATION-GROUNDING-01).** Four conditional paths:
+
+- *Future reset present*: unchanged — terminal (`:149` still green).
+- *Past reset present*: unchanged — unknown (`:155` still green).
+- *No reset, fresh observation* **(new)**: terminal -> account excluded, `applyQuotaAutoSwitch` fires.
+- *No reset, stale or absent observation*: unknown -> account stays selectable (`:159` still green).
+
+**Docs-site sync:** if account-pool selection is documented, note that a fresh 100% burst reading excludes an
+account even without a reset timestamp. Run `rg -n "shortResetAt|burst window" docs-site/` before opening.
+
+**Security boundary:** **yes, adjacent.** Account-pool and quota logic. `MAINTAINERS.md` security review requested;
+the over-eager-exclusion direction (#3029) is a real regression risk and the stale-reading test is the evidence
+that it is handled. `privacy:scan` must stay green — no account identifiers in any new log line.
+
+**PR skeleton.**
+
+```
+title: fix(codex): exclude a freshly-observed 100% burst window without a reset timestamp
+
+## Summary
+An exhausted Codex account kept serving 118 consecutive 502s over 23 minutes while a healthy
+account sat at 3% (#3425). Two mechanisms reinforce: isTerminalShortWindow requires a FUTURE
+shortResetAt (src/codex/routing.ts:415-421), so a 100% snapshot with no timestamp scores
+unknown and stays selectable; and 502 is transient (quota-rejection.ts:101), so the failures
+produce no quota signal to correct it.
+
+Gate on snapshot FRESHNESS instead of reset presence. StoredAccountQuota.updatedAt already
+exists; a 100% window observed seconds ago is a measured refusal, while a stale one still
+falls back to unknown. That preserves #3029 in both directions, and the existing assertion
+that a bare {shortPercent: 100} stays unknown is untouched and still green.
+
+502 stays classified transient: demoting every gateway blip would strand accounts. The storm
+is addressed by releasing sticky affinity after a bounded run of consecutive failures.
+
+## Verification
+- bun test tests/codex-integration/codex-routing.test.ts
+- bun test tests/codex-integration/codex-quota-rejection.test.ts
+- bun run test:changed / typecheck / privacy:scan
+
+## Checklist
+- [x] Security review requested (account-pool selection)
+- [x] Both directions tested: fresh excludes, stale does not
+- [x] #3029 assertions unchanged
+
+Closes #3425.
+```
+
+---
+
+## 4. Field/enum chains for new config fields
+
+Exactly one new field is introduced across wp5. E0/E1/E2 add none (test and docs only); E3 adds environment
+variables, not config fields; E5 adds no persisted field (`launcherPath` already exists at `service.ts:246`);
+E6 adds a module constant, not a config field.
+
+### `ProviderRegistryEntry.alias` (E4) — deliberately truncated chain
+
+| Stage | Location | Behavior |
+|---|---|---|
+| **Declaration** | `src/providers/registry.ts:130` — `alias?: string;` | New optional field on the registry entry interface. |
+| **Creation** | `src/providers/registry.ts:1902` — `{ id: "google-antigravity", alias: "agy", ... }` | The only populated instance. |
+| **Serialization (seed)** | `src/providers/derive.ts:221` — `...(entry.alias ? { alias: entry.alias } : {})` | Reaches `providerConfigSeed`, so `ocx provider add` (`src/cli/provider.ts:174`) writes `alias = "agy"` into the user's config as an editable value. |
+| **Deserialization** | `OcxProviderConfig.alias`, `src/types/provider.ts:174` | Pre-existing field. `src/config.ts:2178-2183` already validates and can `delete provider.alias` on collision — no new validation needed. |
+| **Consumer (routing)** | `src/router.ts:679-708` | Two passes: configured aliases first, then the registry fallback, each rejecting ambiguity with a thrown error. |
+| **Consumer (display)** | `src/codex/catalog/sync.ts:277-279` | Raw-slug picker label only. |
+| **NOT a consumer — the load-bearing gap** | `src/providers/derive.ts` `enrichProviderFromRegistry` (`:451-570`) | The registry alias is **not** backfilled onto the runtime provider row. |
+
+**Why the chain stops there, and why it must.** `src/codex/catalog/provider-fetch.ts:2444` composes the #2960
+effective-alias label as `${provider.alias || name}/${alias}`. Adding a one-line backfill in
+`enrichProviderFromRegistry` makes `provider.alias === "agy"` visible there and rewrites the #2960 label from
+`google-antigravity/gemini-3.7` to `agy/gemini-3.7` — reproduced as a hard test failure on head `f486b5d60`.
+
+**Implementer instruction:** do **not** "complete" this chain by adding the enrich backfill. The truncation is the
+fix. If a future change needs the alias on the runtime row, it must simultaneously decide what the #2960 label
+should be and update that test with an explicit rationale. Record this in the PR body so the next editor does not
+read the gap as an oversight.
+
+---
+
+## 5. Risk and rollback per layer
+
+| Layer | Risk | Likelihood | Rollback |
+|---|---|---|---|
+| E0 | Removal assertion is over-strict if `seed()` semantics differ from the route | Low | Revert one test file; no runtime impact. |
+| E1 | None beyond a stricter test | Very low | Revert one test file. |
+| E2 | A locale mistranslates the wire distinction | Low | Revert docs; no runtime impact. |
+| E3 | Build-stage generator changes image build time or fails in CI; the loopback default breaks an existing remote-hub user | Medium | Revert the PR. **Announce the bind change in release notes** — it is a behavior change for anyone relying on the all-interfaces default. |
+| E4 | Compact label surprises users expecting the full provider name; alias ambiguity throws where it previously fell through | Low–Medium | Revert; `alias` is additive and unset elsewhere, so the blast radius is one provider. |
+| E5 | A launchd plist naming a launcher later removed from `PATH` | Low | Revert; `launcher === null` restores today's exact behavior. Mitigation: absolute-path validation at install time. |
+| E6 | **Over-eager exclusion strands a recovered account (#3029 inverted)** | Medium — the real risk of this work-phase | Revert. Mitigations: the 5-minute freshness bound, the mandatory stale-reading test, and no change to 502 classification. |
+
+**Security-boundary items requiring the `MAINTAINERS.md` review exception:**
+
+- **E3 (#3421)** — deployment surface and token handling: `compose.yaml` publish address, `docker/bootstrap-token.ts`,
+  documented token paths. Explicit security review before merge.
+- **E6 (#3425)** — account-pool selection and quota logic, auth-adjacent. Explicit security review; both regression
+  directions must be demonstrated in the PR body.
+- **E5 (#3464)** — partial: the absolute-path requirement in `stableLauncherEntry` is a PATH-hijacking guard. Not a
+  full security review, but call it out so the reviewer checks it deliberately.
+
+None of E0–E2, E4 touches auth, OAuth, CORS, or workflows.
+
+---
+
+## 6. Out-of-scope / deferred items of this family
+
+| Item | Disposition | Evidence-backed reason (carried from the lane docs, re-verified where cheap) |
+|---|---|---|
+| #3528 | **SUPERSEDED (alias half)** | Head moved `735e3f5c5` -> `f9f5f836d` and the alias half is **gone**: `git show tmp-pr-3528-new:src/codex/catalog/sync.ts \| rg agy` returns nothing and the registry `alias: "agy"` is absent. The residual `ocx effort` CLI half (+575) is unrelated scope on a stale pre-#3518 layout (179 files, mostly test moves it would revert). Close the alias half in favor of E4; ask for `ocx effort` as its own PR against current `dev`. Same author, so no `Co-authored-by` needed. **Do not cite byte-identity — that evidence is stale.** |
+| #3508 | **DEFER** | `gui/src/pages/logs-filter.ts` is imported by exactly one file, its own test; `Logs.tsx` still filters inline at `:516`. Green, approved, `CLEAN` — and still 175 lines of unreachable source plus a second divergent definition of "how a log row is filtered". Flips to LAND_AS_IS the moment the `Logs.tsx` call-site migration is open. |
+| #3383 | **DEFER** | 121 commits behind; `CONFLICTING` across 15 files including `Models.tsx`, nine locales, and `src/server/index.ts` (a composition root under the no-`await` invariant, so hand resolution only); no cross-platform CI ever run on the head; and an unvalidated management request body at `agent-settings-routes.ts:674`. |
+| #2716 | **DEFER** | 118 commits behind; `changed in both` on 12 files (`Models.tsx` + nine locales + the providers reference); zero exact-head CI for a +1325-line GUI change with a 433-line test file; and 391 lines of out-of-scope `docs/superpowers/` planning artifacts that `AGENTS.md` places in `devlog/`. |
+| #3329 | **DEFER from wp5** (was LAND_WITH_FIX) | Real feature with the lane's strongest test evidence, but 138 commits behind with a **semantic** conflict in `src/server/responses/core.ts` — one of the three files `AGENTS.md` forbids from reaching `src/lab/` — plus a verified High correctness bug (reset metadata dropped for body-confirmed quota inside 5xx at `:1645-1647`) and a Korean doc contradicting the runtime. It is the only wp5 item whose fix list requires re-reasoning a protected core path; carrying it alongside six other landings would put the riskiest change behind the weakest review attention. Its commit authorship is also unresolved (`" " <wj@nas-backup>` + `claude <noreply@anthropic.com>`), which must be settled with the author before any carry. Recommend its own work-phase. |
+
+---
+
+## 7. Execution order summary
+
+1. **Re-verify drift** (section 0) — `git fetch origin dev`, re-read every PR head. Three dev moves and two head
+   moves have already occurred.
+2. **E0** -> merge. Coherence for the reorg-deletion family.
+3. **E1, E2, E4** -> open in parallel; independent files, mergeable in any order.
+4. **E5, E6** -> open with security-review requests; E6 must show both regression directions.
+5. **E3** -> open with security review; needs a container build in CI.
+6. **Closures**: #3528 (alias half, citing E4 and the current head state), then #3508 / #3383 / #2716 / #3329
+   deferral comments with the section 6 reasons.
+7. **Ledger**: append every landing to `060_closeout.md` with merge SHA and ancestry exit code.
+
+---
+
+## E7 — #3329 per-combo `cooldownMs` / `waitForCooldownMs` (LAND_WITH_FIX, appended by 008 round 2)
+
+Supersedes the DEFER mentions of #3329 elsewhere in this doc. Single disposition: **LAND_WITH_FIX**.
+
+**Why it is its own layer.** Shares no source file with E0-E6; shares `src/types/config.ts` with
+the DEFERRED #3383 only. Lands last in wp5 because it is the only wp5 item that touches
+`src/server/responses/core.ts` (lab-boundary-protected) and needs a full cross-platform matrix.
+
+**Mergeability.** `git merge-tree --write-tree origin/dev refs/tmp/pr-3329` → CLEAN at
+`79e03643d` (008 table). The "semantic core.ts conflict" premise from lane 004 is a GitHub-probe
+artifact; the carry is `git merge origin/dev` onto the PR head, not a hand re-resolution.
+Post-merge, run `bun test tests/lab/core-lab-boundary.test.ts` (exists; the lane's
+`tests/core-lab-boundary.test.ts` path was wrong) to prove `core.ts` still does not reach `src/lab/`.
+
+**Branch.** `codex/260905-combo-cooldown-knobs` from `refs/tmp/pr-3329` merged with `origin/dev`;
+trailer `Co-authored-by: Veritas-7 <234569343+Veritas-7@users.noreply.github.com>`.
+
+**File change map.**
+
+| Path | Change |
+|------|--------|
+| `src/combos/{types,resolve,failover,index}.ts`, `src/types/config.ts`, management route | carried from PR (feature) |
+| `src/server/responses/core.ts` (PR hunk near dev `:1645-1647`) | **fix 1**: keep `resetAt` when the *effective* classification is quota (402/429 OR body-confirmed quota inside a 5xx as normalized by `shouldRetryCodexPoolAccountQuota`), not when the raw status is 402/429; keep the `cyberFailure` exclusion |
+| `tests/codex-integration/combos.test.ts` (+302), `tests/routing/combo-management-api.test.ts` (+130), `tests/server/server-combo-failover-e2e.test.ts` (+98), `tests/providers/cyber-policy-error-fidelity.test.ts` (+15) | PR tests relocated by the merge (rename-aware) |
+| new test in `tests/server/server-combo-failover-e2e.test.ts` | **fix 2**: "body-confirmed quota inside HTTP 503 with no alternate account retains x-codex-*-reset-at on the combo target" — RED on PR head (target re-eligible immediately), GREEN after fix 1 |
+| `docs-site/src/content/docs/ko/guides/combos.md:130` | **fix 3**: bound the immediate-503 claim to `waitForCooldownMs: 0` or earliest-cooldown > budget |
+| `docs-site/.../{en,ja,ko,ru,zh-cn}/guides/combos.md` | **fix 4**: state that `Retry-After` and Codex reset signals take precedence over configured `cooldownMs` |
+| `tests/routing/combo-management-api.test.ts` | **fix 5**: assert `explicitDefault` persistence around combo update (CodeRabbit) |
+
+**Field chain (PLAN-FIELD-CHAIN-01)** for `cooldownMs`, `waitForCooldownMs`:
+creation `src/types/config.ts` (optional numbers on combo config) → serialization: config persist
+via management route (`src/server/management/...` combo update) → deserialization: config load +
+`src/combos/resolve.ts` defaults → consumer: `src/combos/failover.ts` cooldown/wait budget.
+Reviewer checks names match across the four files.
+
+**Activation scenarios (C-ACTIVATION-GROUNDING-01).**
+
+- Cooldown path: combo with `cooldownMs: 60000`; first target fails 500 → e2e test asserts second
+  target selected and first target's cooldown expiry ≈ now+60s.
+- Wait budget path: all targets cooling, `waitForCooldownMs: 200`, earliest expiry in 100ms →
+  request waits and succeeds; with expiry in 5s → 503 immediately.
+- Fix 1 path: 503 whose body is the Codex quota-exhausted shape, single-account pool → reset
+  metadata retained (the new test).
+
+**Verifiers (run at P of wp5; all exist and read the targets):**
+`bun test tests/codex-integration/combos.test.ts`, `bun test tests/routing/combo-management-api.test.ts`
+(sandbox: EADDRINUSE → hosted-CI-only), `bun test tests/server/server-combo-failover-e2e.test.ts`
+(same), `bun test tests/lab/core-lab-boundary.test.ts`, `bun run typecheck`, exact-head full matrix.
+
+**Risk/rollback.** Feature is opt-in (fields absent → prior behavior); rollback is a revert of the
+squash. Fix 1 narrows an over-eager cooldown reset; regression test guards it.
+
+**PR skeleton.** Title `feat(combos): per-combo cooldownMs and waitForCooldownMs (carry of #3329)`;
+body: Summary, Verification (the five verifiers + CI run), Checklist, stack table
+(E7 independent, base `dev`), `Co-authored-by` trailer, "Supersedes #3329".
+

--- a/devlog/_plan/260905_open_work_closeout/060_ledger.md
+++ b/devlog/_plan/260905_open_work_closeout/060_ledger.md
@@ -1,0 +1,26 @@
+# 060 — Merge ledger and closeout (append-only)
+
+Rows are appended by each work-phase's D. Landing SHA proof: `git fetch origin dev &&
+git merge-base --is-ancestor <sha> FETCH_HEAD` → exit 0.
+
+| WP | Item | Disposition | Carry branch / PR | Head SHA | CI run id | Landing SHA | Ancestry proof (cmd + exit) | Original closed (comment URL) |
+|----|------|-------------|-------------------|----------|-----------|-------------|-----------------------------|-------------------------------|
+
+## Closure comments (issue/PR → landing SHA)
+
+(none yet)
+
+## Verifier policy
+
+No repository-wide local suite was run in any phase; focused files, `bun run typecheck`,
+`bun run test:changed`, and exact-head hosted CI only. Pushes use `--no-verify` because the
+pre-push hook would run the forbidden suite.
+
+## wp6 stop condition (authoritative)
+
+Every LAND/REIMPLEMENT/IMPLEMENT row has a landing SHA with ancestry exit 0 and an
+original-closure link (or an explicit keep-open rider: #3522, #3462); every DEFER/SUPERSEDED
+has a closure or comment link; `bun run privacy:scan` exit 0 on the closeout commit; then the
+unit moves to `devlog/_fin/`. The ledger header above is the single schema (010 §7 was aligned
+to it in audit round 2).
+


### PR DESCRIPTION
## Summary

Docs-only wp0 of the 260905 open-work closeout campaign: opens `devlog/_plan/260905_open_work_closeout/` with the live PR/issue manifest (000), five read-only research lanes (001-005), consolidated per-item dispositions with drift corrections (006), a two-round adversarial plan audit and its synthesis (007-008), diff-level decade docs for the five implementation stacks (010-050), and the merge-ledger skeleton (060).

No `src/`, `tests/`, or `gui/` change. The implementation stacks follow as separate PRs.

## Verification

- `bun run privacy:scan` — passed (the only gate that reads `devlog/`).
- `bun test tests/repo-hygiene.test.ts` — 13 pass / 0 fail.
- Every filename in the unit carries a numeric prefix; no gitlink added.

## Checklist

- [x] Targets `dev`
- [x] Docs-only; no runtime behavior change
- [x] Privacy scan green



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning and audit documentation for triaging, verifying, and closing open pull requests and bug issues.
  * Documented recommended dispositions, merge order, conflict-resolution plans, regression verification, risks, dependencies, and rollback procedures.
  * Added an append-only closeout ledger format with landing evidence and completion criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->