### PR TITLE
fix(usage): standardize OpenAI estimates on API pricing

### DIFF
--- a/devlog/_fin/260905_api_estimate_baseline/010_patch.md
+++ b/devlog/_fin/260905_api_estimate_baseline/010_patch.md
@@ -5,7 +5,13 @@ The three new policy scenarios were observed red before the table change, then g
 Typecheck/privacy/diff checks pass; docs build emits 425 pages. Direct production-estimator
 invocation returned identical native/API costs (3.25 Standard / 6.50 Fast) for the documented
 cache-heavy 300k fixture, with long-context classification and API cache-write pricing.
-Full-suite, CI and landing evidence are recorded in the associated pull request.
+Consult the associated pull request for full-suite, current-head CI and landing status;
+this implementation record does not certify that those stages have completed.
+
+Review amendment: preserve `verified-derived` and an API-reference source on native Astra/Sol
+rows, while API-key rows remain verified. Numeric API prices, Fast multipliers and long-context
+bands remain identical. Regression assertions distinguish native estimate provenance from API
+price verification, including normalized main/pool labels. No subscription billing rule returns.
 
 C2 policy correction requested by the maintainer: all built-in display estimates use API pricing, not subscription credit conversion or subscription-only exceptions. No account settings, model metadata, provider destinations, releases or live services change.
 

--- a/devlog/_fin/260905_api_estimate_baseline/010_patch.md
+++ b/devlog/_fin/260905_api_estimate_baseline/010_patch.md
@@ -1,0 +1,23 @@
+# API-only estimate baseline
+
+Implementation record: focused checks 119 pass/0 fail; original baseline 118 pass/0 fail.
+The three new policy scenarios were observed red before the table change, then green after it.
+Typecheck/privacy/diff checks pass; docs build emits 425 pages. Direct production-estimator
+invocation returned identical native/API costs (3.25 Standard / 6.50 Fast) for the documented
+cache-heavy 300k fixture, with long-context classification and API cache-write pricing.
+Full-suite, CI and landing evidence are recorded in the associated pull request.
+
+C2 policy correction requested by the maintainer: all built-in display estimates use API pricing, not subscription credit conversion or subscription-only exceptions. No account settings, model metadata, provider destinations, releases or live services change.
+
+Search/owners: `CODEX_FAST_CREDIT_MODELS`, `CODEX_PRICING`, `confirmedPriorityRelation`, `API-equivalent` in `src/usage/expected-prices.ts`, its request/attempt consumers in `cost.ts`, adjacent usage/FastWire tests, provider reference and catalog SoT. Delete the subscription overlay branch and reuse existing API declarations; no new abstraction or config switch.
+
+File map:
+
+- `src/usage/expected-prices.ts`: same verified Astra/Sol API tuples for both OpenAI identities; remove native 2.5x override; both identities use the existing API Fast map. Apply Astra >272k tier and Fast+long stacking to both identities, including both Daybreak Blue selectors. Preserve API-only virtual identities, other vendors and user override precedence.
+- `tests/usage/usage-cost.test.ts`: identical native/API outcomes, raw-input boundary including cache, request/attempt/combo parity, API Fast+long composition and response-default precedence. Retain reseller and user-price negatives.
+- `tests/routing/fastwire-observability.test.ts`: update only native Sol synthetic-price expectations from the subscription multiplier to API 2x; preserve attempt provenance assertions.
+- `docs-site/src/content/docs/reference/configuration/providers.md`, `structure/03_catalog-and-subagents.md`: document one API-reference estimate policy; remove subscription-rate discussion from current behavior docs. Prior archived records remain history.
+
+Verification: named usage/FastWire files, typecheck, privacy scan, docs frozen install/build, independent focused review, full suite on isolated macmini-cf checkout, current-head CI before authorized no-verify push/admin merge to dev. Verify merge SHA ancestry. No repository-wide suite on the workstation.
+
+Source: https://developers.openai.com/api/docs/models/gpt-6-astra and https://developers.openai.com/api/docs/pricing (opened 2026-09-05 KST). Astra API 10/1/12.5/50 (input/read/write/output), long 20/2/25/75; Fast 2x applicable rates. This is a display-price policy, not a claim about a user's bill.

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -93,12 +93,11 @@ The [API price table](https://developers.openai.com/api/docs/pricing) reprices t
 above 272k, counting cached tokens toward the threshold. Fast and long-context rates combine;
 this also applies to the published GPT-5.6 API rows and their Pro virtual selections.
 
-[Codex/ChatGPT pricing](https://learn.chatgpt.com/docs/pricing) is separate: Astra and GPT-5.6
-Fast consume **2.5x** Standard credits, versus **2x** for the API. The inspected native rate card
-does not publish a separate 272k band; that does **not** mean tokens after 272k are free.
-OpenCodex does not import the API's long-context surcharge into native Astra. Its native dollar
-display is an **API-equivalent estimate**, including an estimated cache-write rate, not a credit
-conversion or invoice. Credit purchase prices depend on the plan or agreement.
+All built-in dollar estimates use **API-reference prices**, including Codex-login routes.
+Astra and GPT-5.6 therefore use the same API base/cache rates, **2x Fast** multiplier, and
+published long-context bands on `openai` and `openai-apikey`. The two Daybreak Blue selectors
+follow the Sol API reference. These are comparison estimates, not invoices or credit-balance
+predictions. Explicit provider/model price overrides still take precedence.
 
 ## Provider entries (`OcxProviderConfig`)
 

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -116,7 +116,7 @@ const QWEN38_MAX_PRICING = "https://qwen.ai/blog?id=qwen3.8 (Qwen release announ
 export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
   { provider: "openai-apikey", modelId: "gpt-6-astra", cost4: GPT6_ASTRA, source: ASTRA_API_PRICING, verifiedAt: "2026-09-05", status: "verified" },
   // Display estimates use API prices for both login and API-key routes, including cache writes.
-  { provider: "openai", modelId: "gpt-6-astra", cost4: GPT6_ASTRA, source: ASTRA_API_PRICING, verifiedAt: "2026-09-05", status: "verified" },
+  { provider: "openai", modelId: "gpt-6-astra", cost4: GPT6_ASTRA, source: `API-reference comparison estimate: ${ASTRA_API_PRICING}`, verifiedAt: "2026-09-05", status: "verified-derived" },
   // claude-fable-5-1 now HAS a generated jawcode row, so the two Anthropic surfaces resolve
   // from it and these overlays are the fallback rather than the primary source. They stay:
   // the overlay lookup is keyed by the configured provider id, so an account-pool log label
@@ -246,8 +246,8 @@ export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
 export const VERIFIED_PRICE_OVERRIDES: readonly ExpectedPriceOverlay[] = [
   ...["openai", "openai-apikey"].map((provider): ExpectedPriceOverlay => ({
     provider, modelId: "gpt-5.6-sol", cost4: GPT56_SOL,
-    source: OPENAI_GPT56_PRICING,
-    verifiedAt: "2026-09-05", status: "verified",
+    source: provider === "openai" ? `API-reference comparison estimate: ${OPENAI_GPT56_PRICING}` : OPENAI_GPT56_PRICING,
+    verifiedAt: "2026-09-05", status: provider === "openai" ? "verified-derived" : "verified",
   })),
   {
     provider: "xai",

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -44,8 +44,6 @@ const GEMINI_31_PRO: Cost4 = { input: 2, output: 12, cacheRead: 0.2, cacheWrite:
 const GPT56_SOL: Cost4 = { input: 4, output: 20, cacheRead: 0.4, cacheWrite: 5 };
 const GPT6_ASTRA: Cost4 = { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 };
 const ASTRA_API_PRICING = "https://developers.openai.com/api/docs/models/gpt-6-astra";
-const CODEX_PRICING = "https://learn.chatgpt.com/docs/pricing";
-const CODEX_SPEED = "https://learn.chatgpt.com/docs/agent-configuration/speed";
 /**
  * Daybreak aliases. `daybreak-*-latest` never appears in the pricing table itself — only its
  * current snapshot does — so these tuples are the snapshot's published rates and carry
@@ -117,9 +115,8 @@ const QWEN38_MAX_PRICING = "https://qwen.ai/blog?id=qwen3.8 (Qwen release announ
 
 export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
   { provider: "openai-apikey", modelId: "gpt-6-astra", cost4: GPT6_ASTRA, source: ASTRA_API_PRICING, verifiedAt: "2026-09-05", status: "verified" },
-  // Native dollars are API-equivalent estimates, not conversion of plan-dependent credits.
-  // The native rate card publishes neither a 272k surcharge nor a cache-write price.
-  { provider: "openai", modelId: "gpt-6-astra", cost4: GPT6_ASTRA, source: `API-equivalent estimate (including cache writes): ${ASTRA_API_PRICING}; native credits: ${CODEX_PRICING}`, verifiedAt: "2026-09-05", status: "verified-derived" },
+  // Display estimates use API prices for both login and API-key routes, including cache writes.
+  { provider: "openai", modelId: "gpt-6-astra", cost4: GPT6_ASTRA, source: ASTRA_API_PRICING, verifiedAt: "2026-09-05", status: "verified" },
   // claude-fable-5-1 now HAS a generated jawcode row, so the two Anthropic surfaces resolve
   // from it and these overlays are the fallback rather than the primary source. They stay:
   // the overlay lookup is keyed by the configured provider id, so an account-pool log label
@@ -249,8 +246,8 @@ export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
 export const VERIFIED_PRICE_OVERRIDES: readonly ExpectedPriceOverlay[] = [
   ...["openai", "openai-apikey"].map((provider): ExpectedPriceOverlay => ({
     provider, modelId: "gpt-5.6-sol", cost4: GPT56_SOL,
-    source: provider === "openai" ? `API-equivalent estimate: ${OPENAI_GPT56_PRICING}; native credits: ${CODEX_PRICING}` : OPENAI_GPT56_PRICING,
-    verifiedAt: "2026-09-05", status: provider === "openai" ? "verified-derived" : "verified",
+    source: OPENAI_GPT56_PRICING,
+    verifiedAt: "2026-09-05", status: "verified",
   })),
   {
     provider: "xai",
@@ -323,7 +320,6 @@ export interface PriorityPricingRule {
 }
 
 const XAI_PRIORITY_PRICING = "https://docs.x.ai/developers/advanced-api-usage/priority-processing";
-const CODEX_FAST_CREDIT_MODELS = new Set(["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-daybreak-blue-latest"]);
 
 /**
  * Exact provider/model priority premiums. Routed resellers never inherit a vendor rule merely
@@ -340,12 +336,9 @@ export const PRIORITY_PRICING_RULES: readonly PriorityPricingRule[] = [
       .map(([modelId, multiplier]): PriorityPricingRule => ({
         provider,
         modelId,
-        multiplier: provider === "openai" && CODEX_FAST_CREDIT_MODELS.has(modelId)
-          ? 2.5 : multiplier,
-        source: provider === "openai" && CODEX_FAST_CREDIT_MODELS.has(modelId) ? CODEX_SPEED
-          : modelId === "gpt-6-astra" ? ASTRA_API_PRICING : "https://openai.com/api-fast-mode/",
-        verifiedAt: modelId === "gpt-6-astra" || (provider === "openai" && CODEX_FAST_CREDIT_MODELS.has(modelId))
-          ? "2026-09-05" : "2026-08-05",
+        multiplier,
+        source: modelId === "gpt-6-astra" ? ASTRA_API_PRICING : "https://openai.com/api-fast-mode/",
+        verifiedAt: modelId === "gpt-6-astra" ? "2026-09-05" : "2026-08-05",
       })),
   ),
   ...["gpt-5.6-sol-pro", "gpt-5.6-terra-pro", "gpt-5.6-luna-pro"].map((modelId): PriorityPricingRule => ({
@@ -413,7 +406,8 @@ const OPENAI_LONG_CONTEXT: Cost4 = { input: 2, output: 1.5, cacheRead: 2, cacheW
 const UNIFORM_DOUBLE: Cost4 = { input: 2, output: 2, cacheRead: 2, cacheWrite: 2 };
 
 const OPENAI_PRICING_DOC = "https://developers.openai.com/api/docs/pricing";
-const OPENAI_GPT56_CONTEXT_MODELS = [
+const OPENAI_CONTEXT_MODELS = [
+  "gpt-6-astra",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
@@ -425,22 +419,17 @@ const OPENAI_GPT56_CONTEXT_MODELS = [
 ];
 
 export const CONTEXT_TIERS: readonly ContextTier[] = [
-  // API only: the Codex credit rate card does not establish this threshold for native Astra.
-  {
-    provider: "openai-apikey", modelId: "gpt-6-astra", thresholdInputTokens: 272_000,
-    inclusive: false, multiplier: OPENAI_LONG_CONTEXT, confirmedPriorityRelation: "stack",
-    source: ASTRA_API_PRICING, verifiedAt: "2026-09-05",
-  },
+  // API-reference estimates do not apply subscription-only exemptions or multipliers.
   ...["openai", "openai-apikey"].flatMap(provider =>
-    OPENAI_GPT56_CONTEXT_MODELS.map((modelId): ContextTier => ({
+    OPENAI_CONTEXT_MODELS.map((modelId): ContextTier => ({
       provider,
       modelId,
       thresholdInputTokens: 272_000,
       inclusive: false,
       multiplier: OPENAI_LONG_CONTEXT,
-      confirmedPriorityRelation: provider === "openai-apikey" ? "stack" : "exclusive",
+      confirmedPriorityRelation: "stack",
       source: OPENAI_PRICING_DOC,
-      verifiedAt: provider === "openai-apikey" ? "2026-09-05" : "2026-08-03",
+      verifiedAt: "2026-09-05",
     })),
   ),
   {
@@ -450,9 +439,9 @@ export const CONTEXT_TIERS: readonly ContextTier[] = [
     thresholdInputTokens: 272_000,
     inclusive: false,
     multiplier: OPENAI_LONG_CONTEXT,
-    confirmedPriorityRelation: "exclusive",
+    confirmedPriorityRelation: "stack",
     source: OPENAI_PRICING_DOC,
-    verifiedAt: "2026-08-11",
+    verifiedAt: "2026-09-05",
   },
   {
     // The bare selector is the separately billed API-key alias. Daybreak Red has no tier row:
@@ -462,9 +451,9 @@ export const CONTEXT_TIERS: readonly ContextTier[] = [
     thresholdInputTokens: 272_000,
     inclusive: false,
     multiplier: OPENAI_LONG_CONTEXT,
-    confirmedPriorityRelation: "exclusive",
+    confirmedPriorityRelation: "stack",
     source: OPENAI_PRICING_DOC,
-    verifiedAt: "2026-08-11",
+    verifiedAt: "2026-09-05",
   },
   {
     provider: "xai",

--- a/structure/03_catalog-and-subagents.md
+++ b/structure/03_catalog-and-subagents.md
@@ -119,9 +119,12 @@ preserving custom descriptions and other stored row fields.
 The API registry separately owns Astra's 1,050,000 context / 922,000 input / 128,000 output and
 five API effort levels. Trusted discovery snapshots carry the output ceiling as well as input
 and context, so reconstruction cannot drop it. User output limits may only lower that ceiling.
-Pricing remains provider-scoped: native Astra dollars are explicitly derived estimates, native
-Fast uses 2.5x, API Fast uses 2x and stacks with its published >272k band. No API long-context
-band is inferred for native Astra. See the public provider reference for the dated source table.
+Pricing remains provider-scoped and API-referenced for every built-in dollar estimate, including
+Codex-login routes. Both OpenAI identities use the same Astra/Sol API base and cache prices,
+API Fast multipliers and published long-context bands; Fast stacks with long context for Astra,
+GPT-5.6 and the Daybreak Blue selectors. No subscription-specific exception or credit multiplier
+enters the estimate. Explicit user price overrides remain authoritative. See the public provider
+reference for the dated source table.
 
 Native bare OpenAI entries form one `openai` group. The provider's Pool(default)/Direct option
 changes account selection without changing those ids; `openai-apikey/<model>` creates the separate

--- a/tests/routing/fastwire-observability.test.ts
+++ b/tests/routing/fastwire-observability.test.ts
@@ -558,8 +558,8 @@ describe("FastWire per-attempt cost", () => {
         tierOutcome: outcome,
       },
     ], overlays, { requestedServiceTier: "priority" })!;
-    expect(estimate.priorityMultiplier).toBe(2.5);
-    expect(estimate.cost.total).toBeCloseTo(4.0, 9);
+    expect(estimate.priorityMultiplier).toBe(2);
+    expect(estimate.cost.total).toBeCloseTo(3.2, 9);
   });
 
   test("combo prices each attempt from its own outcome before the top-level tier", () => {
@@ -600,10 +600,10 @@ describe("FastWire per-attempt cost", () => {
       overlays,
       { requestedServiceTier: "priority" },
     )!;
-    expect(estimate.attempts?.[0]?.cost.total).toBeCloseTo(4.0, 9);
+    expect(estimate.attempts?.[0]?.cost.total).toBeCloseTo(3.2, 9);
     expect(estimate.attempts?.[1]?.cost.total).toBeCloseTo(1.6, 9);
-    expect(estimate.cost.total).toBeCloseTo(5.6, 9);
-    expect(estimate.cost.total).not.toBeCloseTo(8.0, 9);
+    expect(estimate.cost.total).toBeCloseTo(4.8, 9);
+    expect(estimate.cost.total).not.toBeCloseTo(6.4, 9);
   });
 
   test("old attempts without outcomes retain the top-level fallback", () => {
@@ -611,8 +611,8 @@ describe("FastWire per-attempt cost", () => {
       { ordinal: 1, provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage },
       { ordinal: 2, provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage },
     ], overlays, { requestedServiceTier: "priority" })!;
-    expect(estimate.cost.total).toBeCloseTo(8.0, 9);
-    expect(estimate.attempts?.every(attempt => attempt.priorityMultiplier === 2.5)).toBe(true);
+    expect(estimate.cost.total).toBeCloseTo(6.4, 9);
+    expect(estimate.attempts?.every(attempt => attempt.priorityMultiplier === 2)).toBe(true);
   });
 
   test("confirmed OpenRouter priority is a standard-price lower bound, while downgrade and OpenAI stay unchanged", () => {
@@ -684,8 +684,8 @@ describe("FastWire per-attempt cost", () => {
       usage,
       tierOutcome: confirmedPriority,
     }], overlays)!;
-    expect(openAi.cost.total).toBeCloseTo(4.0, 9);
-    expect(openAi.priorityMultiplier).toBe(2.5);
+    expect(openAi.cost.total).toBeCloseTo(3.2, 9);
+    expect(openAi.priorityMultiplier).toBe(2);
     expect(openAi.priorityLowerBound).toBeUndefined();
   });
 

--- a/tests/usage/usage-cost.test.ts
+++ b/tests/usage/usage-cost.test.ts
@@ -485,20 +485,39 @@ describe("estimateRequestCost", () => {
   });
 });
 
-describe("Astra provider-specific pricing", () => {
+describe("OpenAI API-reference pricing", () => {
   const model = "gpt-6-astra";
   const usage = { inputTokens: 300_000, outputTokens: 10_000, cachedInputTokens: 200_000, cacheCreationInputTokens: 20_000 };
 
-  test("native is a flat API-equivalent estimate with native Fast 2.5x", () => {
-    for (const provider of ["openai", "openai-main"]) {
+  test("native and API Astra use the same long-context and Fast API rates", () => {
+    for (const provider of ["openai", "openai-main", "openai-pabcdef", "openai-apikey"]) {
       const base = estimateRequestCost({ provider, model, usage, usageStatus: "reported" })!;
       expect(base).not.toBeNull();
-      expect(base.cost.total).toBeCloseTo(1.75, 9);
-      expect(base.estimated).toBe(true);
-      expect(base.contextTier).toBeUndefined();
+      expect(base.cost.total).toBeCloseTo(3.25, 9);
+      expect(base.price?.status).toBe("verified");
+      expect(base.contextTier).toBe("long");
       const fast = estimateRequestCost({ provider, model, usage, usageStatus: "reported", serviceTier: { responseServiceTier: "fast" } })!;
-      expect(fast.cost.total).toBeCloseTo(4.375, 9);
-      expect(fast.priorityMultiplier).toBe(2.5);
+      expect(fast.cost.total).toBeCloseTo(6.5, 9);
+      expect(fast.priorityMultiplier).toBe(2);
+      const attempt = { ordinal: 1, provider, model, usage, usageStatus: "reported" as const };
+      expect(estimateAttemptCost(attempt, undefined, "priority")?.cost.total).toBeCloseTo(6.5, 9);
+      expect(estimateComboCost([attempt, { ...attempt, ordinal: 2 }], undefined, "priority")?.cost.total).toBeCloseTo(13, 9);
+    }
+  });
+
+  test("OpenAI route identity never changes the API-reference cost", () => {
+    for (const [native, api] of [[model, model], ["gpt-5.6-sol", "gpt-5.6-sol"], ["gpt-5.6-terra", "gpt-5.6-terra"], ["gpt-5.6-luna", "gpt-5.6-luna"], ["gpt-daybreak-blue-latest", "daybreak-blue-latest"]]) {
+      for (const inputTokens of [272_000, 272_001, 800_000]) {
+        for (const serviceTier of [undefined, { responseServiceTier: "priority" }, { responseServiceTier: "default", requestedServiceTier: "priority" }]) {
+          const input = { usage: { ...usage, inputTokens }, usageStatus: "reported" as const, serviceTier };
+          const nativeCost = estimateRequestCost({ ...input, provider: "openai", model: native! });
+          const apiCost = estimateRequestCost({ ...input, provider: "openai-apikey", model: api! });
+          expect(nativeCost).not.toBeNull();
+          expect(nativeCost?.cost).toEqual(apiCost?.cost);
+          expect(nativeCost?.contextTier).toBe(apiCost?.contextTier);
+          expect(nativeCost?.priorityMultiplier).toBe(apiCost?.priorityMultiplier);
+        }
+      }
     }
   });
 
@@ -563,39 +582,39 @@ describe("priority (Fast) service tier multiplier", () => {
   // multiplier, and a 1M-token prompt would silently also trip the context tier (#908).
   const usage = { inputTokens: 200_000, outputTokens: 20_000 };
 
-  test("P1. priority tier applies 2.5x multiplier for gpt-5.6-sol", () => {
+  test("P1. priority tier applies 2x multiplier for gpt-5.6-sol", () => {
     const base = estimateRequestCost({ provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage }, overlays);
     const fast = estimateRequestCost({ provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage, serviceTier: "priority" }, overlays);
     expect(base).not.toBeNull();
     expect(fast).not.toBeNull();
     // base: 5*0.2 + 30*0.02 = 1.6
     expect(base!.cost.total).toBeCloseTo(1.6, 9);
-    // fast: 2.5x => 4.0
-    expect(fast!.cost.total).toBeCloseTo(4.0, 9);
-    expect(fast!.priorityMultiplier).toBe(2.5);
+    // fast: 2x => 3.2
+    expect(fast!.cost.total).toBeCloseTo(3.2, 9);
+    expect(fast!.priorityMultiplier).toBe(2);
     expect(base!.priorityMultiplier).toBeUndefined();
   });
 
-  test("P1b. Fast mode applies the current 2.5x price for gpt-5.6-luna (#907)", () => {
+  test("P1b. Fast mode applies the current 2x price for gpt-5.6-luna (#907)", () => {
     const base = estimateRequestCost({ provider: "openai", model: "gpt-5.6-luna", usageStatus: "reported", usage });
     const fast = estimateRequestCost({ provider: "openai", model: "gpt-5.6-luna", usageStatus: "reported", usage, serviceTier: "priority" });
     expect(base).not.toBeNull();
     expect(fast).not.toBeNull();
-    // Post-cut standard: 200K×$0.20/M + 20K×$1.20/M = $0.064. Fast (2.5x): $0.16.
+    // Post-cut standard: 200K×$0.20/M + 20K×$1.20/M = $0.064. Fast (2x): $0.128.
     expect(base!.cost.total).toBeCloseTo(0.064, 9);
-    expect(fast!.cost.total).toBeCloseTo(0.16, 9);
-    expect(fast!.priorityMultiplier).toBe(2.5);
+    expect(fast!.cost.total).toBeCloseTo(0.128, 9);
+    expect(fast!.priorityMultiplier).toBe(2);
   });
 
-  test("P1c. Fast mode applies the current 2.5x price for gpt-5.6-terra (#907)", () => {
+  test("P1c. Fast mode applies the current 2x price for gpt-5.6-terra (#907)", () => {
     const base = estimateRequestCost({ provider: "openai", model: "gpt-5.6-terra", usageStatus: "reported", usage });
     const fast = estimateRequestCost({ provider: "openai", model: "gpt-5.6-terra", usageStatus: "reported", usage, serviceTier: "priority" });
     expect(base).not.toBeNull();
     expect(fast).not.toBeNull();
-    // Post-cut standard: 200K×$2/M + 20K×$12/M = $0.64. Fast (2.5x): $1.6.
+    // Post-cut standard: 200K×$2/M + 20K×$12/M = $0.64. Fast (2x): $1.28.
     expect(base!.cost.total).toBeCloseTo(0.64, 9);
-    expect(fast!.cost.total).toBeCloseTo(1.6, 9);
-    expect(fast!.priorityMultiplier).toBe(2.5);
+    expect(fast!.cost.total).toBeCloseTo(1.28, 9);
+    expect(fast!.priorityMultiplier).toBe(2);
   });
 
   test("P2. priority tier applies 2.5x multiplier for gpt-5.5", () => {
@@ -637,8 +656,8 @@ describe("priority (Fast) service tier multiplier", () => {
       { ordinal: 1, provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage },
     ], overlays, "priority");
     expect(combo).not.toBeNull();
-    expect(combo!.cost.total).toBeCloseTo(4.0, 9);
-    expect(combo!.priorityMultiplier).toBe(2.5);
+    expect(combo!.cost.total).toBeCloseTo(3.2, 9);
+    expect(combo!.priorityMultiplier).toBe(2);
   });
 
   test("P7. effectiveServiceTier priority: response > requested > configured", () => {
@@ -675,14 +694,14 @@ describe("priority (Fast) service tier multiplier", () => {
   });
 
   test("P9b. Daybreak priority rules stay inside their routable provider namespace", () => {
-    expect(findPriorityPricingRule("openai", "gpt-daybreak-blue-latest")?.multiplier).toBe(2.5);
+    expect(findPriorityPricingRule("openai", "gpt-daybreak-blue-latest")?.multiplier).toBe(2);
     expect(findPriorityPricingRule("openai-apikey", "daybreak-blue-latest")?.multiplier).toBe(2);
     expect(findPriorityPricingRule("openai-apikey", "gpt-daybreak-blue-latest")).toBeUndefined();
     expect(findPriorityPricingRule("openai", "daybreak-blue-latest")).toBeUndefined();
     const alias = estimateRequestCost({ provider: "openai", model: "gpt-daybreak-blue-latest", usageStatus: "reported", usage, serviceTier: "priority" });
     const sol = estimateRequestCost({ provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage, serviceTier: "priority" });
     expect(alias?.cost.total).toBeCloseTo(sol!.cost.total, 9);
-    expect(sol?.estimated).toBe(true);
+    expect(sol?.estimated).toBe(false);
     const api = estimateRequestCost({ provider: "openai-apikey", model: "gpt-5.6-sol", usageStatus: "reported", usage, serviceTier: "priority" });
     expect(api?.cost.total).toBeCloseTo(2.4, 9);
     expect(api?.estimated).toBe(false);
@@ -692,8 +711,8 @@ describe("priority (Fast) service tier multiplier", () => {
     const base = estimateAttemptCost({ ordinal: 1, provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage }, overlays);
     const fast = estimateAttemptCost({ ordinal: 1, provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage }, overlays, "priority");
     expect(base!.cost.total).toBeCloseTo(1.6, 9);
-    expect(fast!.cost.total).toBeCloseTo(4.0, 9);
-    expect(fast!.priorityMultiplier).toBe(2.5);
+    expect(fast!.cost.total).toBeCloseTo(3.2, 9);
+    expect(fast!.priorityMultiplier).toBe(2);
   });
 });
 
@@ -975,23 +994,18 @@ describe("long-context pricing tiers (#908)", () => {
     expect(est!.cost.total).toBeCloseTo(5_000_000 / 1e6 * 1.75 + 10_000 / 1e6 * 14, 9);
   });
 
-  test("L8. Fast and long context are mutually exclusive, by PROVENANCE", () => {
+  test("L8. Fast stacks with the API long-context reference; explicit downgrade wins", () => {
     const usage = { inputTokens: 300_000, outputTokens: 20_000 };
-    // Response-confirmed Fast: OpenAI does not serve long context in Fast mode,
-    // so the request really was Fast and the context tier must not apply.
+    // The fixed synthetic base yields long input 3.0 + output 0.9, then API Fast doubles it.
     const confirmed = sol(usage, { responseServiceTier: "priority" });
-    expect(confirmed!.contextTier).toBeUndefined();
-    expect(confirmed!.priorityMultiplier).toBe(2.5);
-    expect(confirmed!.cost.total).toBeCloseTo(5.25, 9);
+    expect(confirmed!.contextTier).toBe("long");
+    expect(confirmed!.priorityMultiplier).toBe(2);
+    expect(confirmed!.cost.total).toBeCloseTo(7.8, 9);
 
-    // Requested/configured only, with no response confirmation: a >272k request
-    // cannot have been served as Fast, so it was downgraded and bills long.
-    // Suppressing the tier here would under-bill exactly the downgraded request.
     for (const tier of [{ requestedServiceTier: "priority" }, { configuredServiceTier: "priority" }]) {
-      const downgraded = sol(usage, tier);
-      expect(downgraded!.contextTier).toBe("long");
-      expect(downgraded!.cost.total).toBeCloseTo(3.9, 9);
+      expect(sol(usage, tier)!.cost.total).toBeCloseTo(7.8, 9);
     }
+    expect(sol(usage, { responseServiceTier: "default", requestedServiceTier: "priority" })!.cost.total).toBeCloseTo(3.9, 9);
   });
 
   test("L9. combo carries the tier when any attempt is long", () => {

--- a/tests/usage/usage-cost.test.ts
+++ b/tests/usage/usage-cost.test.ts
@@ -494,11 +494,13 @@ describe("OpenAI API-reference pricing", () => {
       const base = estimateRequestCost({ provider, model, usage, usageStatus: "reported" })!;
       expect(base).not.toBeNull();
       expect(base.cost.total).toBeCloseTo(3.25, 9);
-      expect(base.price?.status).toBe("verified");
+      expect(base.price?.status).toBe(provider === "openai-apikey" ? "verified" : "verified-derived");
+      expect(base.estimated).toBe(provider !== "openai-apikey");
       expect(base.contextTier).toBe("long");
       const fast = estimateRequestCost({ provider, model, usage, usageStatus: "reported", serviceTier: { responseServiceTier: "fast" } })!;
       expect(fast.cost.total).toBeCloseTo(6.5, 9);
       expect(fast.priorityMultiplier).toBe(2);
+      expect(fast.estimated).toBe(provider !== "openai-apikey");
       const attempt = { ordinal: 1, provider, model, usage, usageStatus: "reported" as const };
       expect(estimateAttemptCost(attempt, undefined, "priority")?.cost.total).toBeCloseTo(6.5, 9);
       expect(estimateComboCost([attempt, { ...attempt, ordinal: 2 }], undefined, "priority")?.cost.total).toBeCloseTo(13, 9);
@@ -701,7 +703,7 @@ describe("priority (Fast) service tier multiplier", () => {
     const alias = estimateRequestCost({ provider: "openai", model: "gpt-daybreak-blue-latest", usageStatus: "reported", usage, serviceTier: "priority" });
     const sol = estimateRequestCost({ provider: "openai", model: "gpt-5.6-sol", usageStatus: "reported", usage, serviceTier: "priority" });
     expect(alias?.cost.total).toBeCloseTo(sol!.cost.total, 9);
-    expect(sol?.estimated).toBe(false);
+    expect(sol?.estimated).toBe(true);
     const api = estimateRequestCost({ provider: "openai-apikey", model: "gpt-5.6-sol", usageStatus: "reported", usage, serviceTier: "priority" });
     expect(api?.cost.total).toBeCloseTo(2.4, 9);
     expect(api?.estimated).toBe(false);


### PR DESCRIPTION
## Summary

- Use one API-reference cost policy for Codex-login and API-key OpenAI routes. Remove subscription credit multipliers and exemptions from display estimates.
- Keep API base/cache prices and model-specific Fast factors; apply the published Astra/GPT-5.6/Daybreak Blue long-context bands and Fast composition consistently. User price overrides and other provider policies are preserved.
- Update current documentation and regression tests. Model configuration, credentials, runtime services, and releases are unchanged.

## Verification

- Focused usage/FastWire tests: 119 pass, 0 fail; new policy cases observed red then green.
- `bun run typecheck`, `bun run privacy:scan`, `git diff --check`: passed.
- Documentation frozen install/build: passed, 425 pages.
- Direct estimator smoke: native/API both 3.25 Standard / 6.50 Fast for the cache-heavy 300k fixture.
- Full `bun run test` passed (exit 0) on macmini-cf at `18fa433c041d59148a83c11af6be10abe742015e`, Bun 1.4.0 / Node 22.22.0: 17,999 pass, 14 skip, 0 fail. No workstation-wide suite was run. Current-head CI must pass before merge.
- Maintainer review addressed: native comparison estimates retain `verified-derived` and `estimated: true`; API-key rates remain verified. Numeric API rates and policy are identical. The implementation record no longer implies unfinished verification or landing is complete.
- Maintainer explicitly requested API-only estimates, `git push --no-verify`, and merge. As authorized in this task, admin bypass will be used only after CI passes; no self-approval is claimed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No security boundary, dependencies or workflow permissions changed.
