### PR TITLE
fix(google): steer Google models away from unrendered LaTeX math formatting (carry of #3480)

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -52,6 +52,7 @@ const GOOGLE_BREVITY_INSTRUCTION = [
   "- Do detailed reasoning internally, not as visible intermediate output.",
   "- Prefer taking the next tool action over explaining; keep calling tools until the task is complete.",
   "- This applies only to intermediate progress text. Your final answer after the work is done is exempt: write it in full and at whatever length the task requires.",
+  "- Formatting: The client environment renders standard Markdown and does not support LaTeX math delimiters ($...$, $$...$$, \\(...\\), \\[...\\]). Do not use LaTeX math delimiters or LaTeX markup (such as \\text{}, \\times, \\le, \\ge, etc.) for variables, formulas, dimensions, or units. Use clean plain text, Markdown, and Unicode symbols (e.g. 180°, 2560 × 1920 px, ≤, ≥, Δ, ±) instead.",
 ].join("\n");
 
 const ANTIGRAVITY_REJECTED_CLAUDE_SDK_PARAGRAPH =

--- a/tests/adapters/google/google-adapter.test.ts
+++ b/tests/adapters/google/google-adapter.test.ts
@@ -174,6 +174,16 @@ describe("google adapter — tool-call ids on the wire", () => {
     expect(instruction.parts[0].text).toContain("Valid tool names for this turn are exactly `exec_command`.");
   });
 
+  test("systemInstruction includes formatting guidance against unrendered LaTeX math", async () => {
+    const body = await geminiBody(parsedWith(
+      [{ role: "user", content: "inspect results" }],
+      [],
+    ));
+    const instruction = body.systemInstruction as { parts: Array<{ text: string }> };
+    expect(instruction.parts[0].text).toContain(String.raw`does not support LaTeX math delimiters ($...$, $$...$$, \(...\), \[...\])`);
+    expect(instruction.parts[0].text).toContain(String.raw`\text{}, \times, \le, \ge`);
+  });
+
   test("functionCall and functionResponse carry the matching tool-call id", async () => {
     const contents = await geminiContents(parsedWith([
       { role: "assistant", content: [{ type: "toolCall", id: "call_abc", name: "bash", arguments: { cmd: "ls" } }] },


### PR DESCRIPTION
## Summary

Google models emit `$...$` / `\\[...\\]` LaTeX in ordinary chat answers, which Codex renders as raw source. This carry appends a LaTeX-avoidance guidance line to the Google `systemInstruction` in `src/adapters/google.ts`, with the escape bug from the earlier review fixed on the author's rebased head `74ef8faae` (the CHANGES_REQUESTED review targets the superseded head `4f5b05468`).

Supersedes #3480 (maintainer carry: original is a contributor draft whose readiness checklist would reset on any push; carry = PR head merged with `origin/dev`).

**Stack** (wp1 merge train, independent layers — each targets `dev`):
| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 1 | this | carry of #3480 | this PR's diff only |

Unit: `devlog/_plan/260905_open_work_closeout/` (010, 011).

## Verification

- `bun run typecheck` — exit 0 on the carry head.
- `bun test tests/adapters/google/google-adapter.test.ts` — 33 pass / 0 fail.
- Exact-head CI on this branch is the merge gate.

## Checklist

- [x] Targets `dev`
- [x] Focused regression test present and green
- [x] Original author credited via `Co-authored-by` trailer

Co-authored-by: benedictusrey <74437942+benedictusrey@users.noreply.github.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Google-generated responses now receive guidance to avoid LaTeX math delimiters and use plain text, Markdown, and Unicode symbols for formulas, variables, dimensions, and units.
  - Supported formatting commands are clarified for more consistent mathematical output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->