### PR TITLE
fix(codex): harden legacy config diagnostics

### DIFF
--- a/src/codex/legacy-config-keys.ts
+++ b/src/codex/legacy-config-keys.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { resolveCodexHomeDir } from "./home";
 import { parseTomlDocument } from "./project-config-warnings";
+import { redactUserPath } from "../lib/redact";
 
 /**
  * Keys that are valid in model catalog data but not at the top level of the
@@ -45,7 +46,7 @@ export function collectLegacyCodexConfigKeyDiagnostics(
       found.push({
         path,
         code: key,
-        detail: `${path}: top-level '${key}' is not a valid Codex config key. `
+        detail: `top-level '${key}' is not a valid Codex config key. `
           + "codex --strict-config rejects the whole file. Remove the key and put durable guidance in AGENTS.md.",
       });
     }
@@ -56,11 +57,12 @@ export function collectLegacyCodexConfigKeyDiagnostics(
 export function formatLegacyCodexConfigKeyDiagnosticsForDoctor(
   result: LegacyCodexConfigKeyDiagnosticsResult,
 ): string[] {
+  const displayPath = redactUserPath(result.path);
   if (result.status === "unavailable") {
-    return [`  --     Codex config at ${result.path} could not be read (${result.reason}); legacy-key check skipped`];
+    return [`  --     Codex config at ${displayPath} could not be read (${result.reason}); legacy-key check skipped`];
   }
   if (result.diagnostics.length === 0) {
     return ["  ok     no unsupported legacy top-level keys in the Codex config"];
   }
-  return result.diagnostics.map(diagnostic => `[WARN] ${diagnostic.detail}`);
+  return result.diagnostics.map(diagnostic => `[WARN] ${redactUserPath(diagnostic.path)}: ${diagnostic.detail}`);
 }

--- a/src/codex/project-config-warnings.ts
+++ b/src/codex/project-config-warnings.ts
@@ -32,6 +32,8 @@ interface TomlDocument {
   sections: Map<string, Record<string, string>>;
 }
 
+type TomlMultilineDelimiter = '"""' | "'''";
+
 let diagnosticsCache: { at: number; warnings: ProjectCodexConfigWarning[] } | null = null;
 
 function hasInjectedOpenaiBaseUrl(content: string): boolean {
@@ -55,13 +57,91 @@ function parseTomlString(raw: string): string {
   return raw.slice(1, -1);
 }
 
+function multilineCloseIndex(
+  line: string,
+  delimiter: TomlMultilineDelimiter,
+  from: number,
+): number {
+  let index = line.indexOf(delimiter, from);
+  while (index >= 0 && delimiter === '"""') {
+    let backslashes = 0;
+    for (let cursor = index - 1; cursor >= 0 && line[cursor] === "\\"; cursor -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) break;
+    index = line.indexOf(delimiter, index + delimiter.length);
+  }
+  return index;
+}
+
+/**
+ * Find a multiline TOML string that starts outside a comment or single-line string.
+ *
+ * This parser intentionally understands only the root/table subset needed by Codex
+ * diagnostics. It still has to skip multiline string bodies lexically: prose in
+ * `developer_instructions` can contain key-shaped examples or `[table]` snippets, and
+ * treating those examples as configuration changes the diagnostic's meaning.
+ */
+function multilineStateAfterLine(
+  line: string,
+  active: TomlMultilineDelimiter | null,
+): { active: TomlMultilineDelimiter | null; consumed: boolean } {
+  if (active) {
+    const close = multilineCloseIndex(line, active, 0);
+    if (close < 0) return { active, consumed: true };
+    const tail = multilineStateAfterLine(line.slice(close + active.length), null);
+    return {
+      active: tail.active,
+      consumed: true,
+    };
+  }
+
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let consumed = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index]!;
+    if (quote === '"') {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === quote) quote = null;
+      continue;
+    }
+    if (quote === "'") {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === "#") return { active: null, consumed };
+
+    const delimiter: TomlMultilineDelimiter | null = line.startsWith('"""', index)
+      ? '"""'
+      : line.startsWith("'''", index)
+        ? "'''"
+        : null;
+    if (delimiter) {
+      consumed = true;
+      const close = multilineCloseIndex(line, delimiter, index + delimiter.length);
+      if (close < 0) return { active: delimiter, consumed: true };
+      index = close + delimiter.length - 1;
+      continue;
+    }
+    if (character === '"' || character === "'") quote = character;
+  }
+  return { active: null, consumed };
+}
+
 /** Lightweight TOML parse for root keys and [section] tables (Codex config shape). */
 export function parseTomlDocument(content: string): TomlDocument {
   const root: Record<string, string> = {};
   const sections = new Map<string, Record<string, string>>();
   let current = root;
+  let multiline: TomlMultilineDelimiter | null = null;
 
   for (const line of content.split("\n")) {
+    const multilineState = multilineStateAfterLine(line, multiline);
+    multiline = multilineState.active;
+    if (multilineState.consumed) continue;
+
     const table = line.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/);
     if (table) {
       const name = table[1]!.trim();

--- a/src/codex/project-config-warnings.ts
+++ b/src/codex/project-config-warnings.ts
@@ -138,9 +138,19 @@ export function parseTomlDocument(content: string): TomlDocument {
   let multiline: TomlMultilineDelimiter | null = null;
 
   for (const line of content.split("\n")) {
+    const wasMultiline = multiline !== null;
     const multilineState = multilineStateAfterLine(line, multiline);
     multiline = multilineState.active;
-    if (multilineState.consumed) continue;
+    if (multilineState.consumed) {
+      // The declaration itself is still configuration even though its multiline VALUE must
+      // not be scanned as keys/tables. A legacy root key using a multiline value therefore
+      // remains visible to strict-config diagnostics; only the body is opaque.
+      if (!wasMultiline) {
+        const declaration = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=\s*(?:"""|''')/);
+        if (declaration) current[declaration[1]!] = "";
+      }
+      continue;
+    }
 
     const table = line.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/);
     if (table) {

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -328,6 +328,21 @@ Root TOML keys must be written before the first `[table]`. Re-injection strips t
 both shapes — opencodex blocks, injected root base-url overrides, stale root context-window
 overrides, and stale catalog paths — before rewriting, so switching between forms leaves no residue.
 
+Read-only doctor and project-routing diagnostics use a lightweight root/table TOML reader rather
+than mutating or normalizing the user's file. That reader must lexically skip both basic and literal
+multiline string bodies: instruction prose can contain key-shaped examples and `[table]` snippets,
+which are data rather than configuration. Diagnostic result objects may retain the real path for
+local correlation, but every formatted doctor line must pass it through the shared user-path
+redaction boundary before display.
+
+[Decision Log]
+- 목적과 의도: Keep strict-config diagnostics useful without interpreting instruction prose as TOML or exposing OS account names in shareable output.
+- 기존 구현 및 제약 조건: The diagnostic reader intentionally covers only Codex root keys and tables; a full TOML dependency is not otherwise required.
+- 검토한 주요 대안: Add a full TOML parser, scan raw lines for one legacy key, or preserve the lightweight parser with multiline lexical state.
+- 선택한 방식: Preserve the bounded reader, skip multiline string bodies before key/table matching, and redact paths only at the formatting boundary.
+- 다른 대안 대신 이 방식을 선택한 이유: All consumers keep one root/table interpretation while internal diagnostics retain actionable local paths.
+- 장점, 단점 및 영향: False positives and username disclosure are removed; unsupported exotic TOML syntax remains outside this diagnostic reader's contract.
+
 Native Codex sub-agent defaults are a separate, explicit opt-in. When
 `syncCodexSubagentDefaults` is true and `injectionModel` is set, injection writes marker-owned
 `agents.default_subagent_model` and, when configured,

--- a/tests/codex-integration/codex-legacy-config-keys.test.ts
+++ b/tests/codex-integration/codex-legacy-config-keys.test.ts
@@ -79,4 +79,88 @@ describe("legacy Codex config keys", () => {
     if (result.status !== "available") return;
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  test("ignores key-shaped and table-shaped text inside a basic multiline string", () => {
+    writeConfig([
+      'developer_instructions = """',
+      "Example only:",
+      'persistent_instructions = "not a config key"',
+      "[model_messages]",
+      'persistent_instructions = "also prose"',
+      '"""',
+      'model = "gpt-5.3"',
+    ].join("\n"));
+    const result = collectLegacyCodexConfigKeyDiagnostics({ codexConfigPath: configPath });
+    expect(result.status).toBe("available");
+    if (result.status !== "available") return;
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  test("ignores key-shaped and table-shaped text inside a literal multiline string", () => {
+    writeConfig([
+      "developer_instructions = '''",
+      "Example only:",
+      "persistent_instructions = 'not a config key'",
+      "[profiles.example]",
+      "persistent_instructions = 'also prose'",
+      "'''",
+      'model = "gpt-5.3"',
+    ].join("\n"));
+    const result = collectLegacyCodexConfigKeyDiagnostics({ codexConfigPath: configPath });
+    expect(result.status).toBe("available");
+    if (result.status !== "available") return;
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  test("does not treat triple-quote text inside ordinary one-line strings as multiline syntax", () => {
+    for (const content of [
+      `persistent_instructions = '"""'`,
+      `persistent_instructions = "'''"`,
+    ]) {
+      writeConfig(content);
+      const result = collectLegacyCodexConfigKeyDiagnostics({ codexConfigPath: configPath });
+      expect(result.status).toBe("available");
+      if (result.status !== "available") continue;
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).toEqual(["persistent_instructions"]);
+    }
+  });
+
+  test("tracks a second multiline value opened on the first value's closing line", () => {
+    writeConfig([
+      "instruction_fragments = [",
+      '  """first block',
+      '  """, """second block',
+      '  persistent_instructions = "still prose"',
+      '  [model_messages]',
+      '  """',
+      "]",
+    ].join("\n"));
+    const result = collectLegacyCodexConfigKeyDiagnostics({ codexConfigPath: configPath });
+    expect(result.status).toBe("available");
+    if (result.status !== "available") return;
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  test("doctor formatting redacts user names in available and unavailable paths", () => {
+    const available = formatLegacyCodexConfigKeyDiagnosticsForDoctor({
+      status: "available",
+      path: "/home/alice/.codex/config.toml",
+      diagnostics: [{
+        path: "/home/alice/.codex/config.toml",
+        code: "persistent_instructions",
+        detail: "top-level 'persistent_instructions' is invalid",
+      }],
+    });
+    expect(available.join("\n")).toContain("/home/[USER]/.codex/config.toml");
+    expect(available.join("\n")).not.toContain("alice");
+
+    const unavailable = formatLegacyCodexConfigKeyDiagnosticsForDoctor({
+      status: "unavailable",
+      path: String.raw`C:\Users\Bob\secret-config\config.toml`,
+      reason: "read_failed",
+    });
+    expect(unavailable.join("\n")).toContain(String.raw`C:\Users\[USER]\[REDACTED]\config.toml`);
+    expect(unavailable.join("\n")).not.toContain("Bob");
+    expect(unavailable.join("\n")).not.toContain("secret-config");
+  });
 });

--- a/tests/codex-integration/codex-legacy-config-keys.test.ts
+++ b/tests/codex-integration/codex-legacy-config-keys.test.ts
@@ -141,6 +141,21 @@ describe("legacy Codex config keys", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  test("still flags a legacy root key whose value uses basic or literal multiline syntax", () => {
+    for (const content of [
+      'persistent_instructions = """Be brief."""',
+      `persistent_instructions = '''Be brief.'''`,
+      ['persistent_instructions = """', "Be brief.", '"""'].join("\n"),
+      ["persistent_instructions = '''", "Be brief.", "'''"].join("\n"),
+    ]) {
+      writeConfig(content);
+      const result = collectLegacyCodexConfigKeyDiagnostics({ codexConfigPath: configPath });
+      expect(result.status).toBe("available");
+      if (result.status !== "available") continue;
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).toEqual(["persistent_instructions"]);
+    }
+  });
+
   test("doctor formatting redacts user names in available and unavailable paths", () => {
     const available = formatLegacyCodexConfigKeyDiagnosticsForDoctor({
       status: "available",


### PR DESCRIPTION
## Summary

Follow-up to #3545 after its two review blockers landed on `dev`.

- make the shared lightweight Codex TOML reader lexically skip basic (`"""`) and literal (`'''`) multiline string bodies before matching root keys or table headers;
- keep the useful trailing-comment table-header fix from #3545;
- keep exact paths in internal diagnostic results, but pass every available/unavailable doctor-formatted path through the shared `redactUserPath` boundary;
- document why the bounded reader and display-boundary redaction are required.

## Failure reproduced on current dev

At base `1362b1a3841b4de20177e5d65865a513dd7936c4`, this valid Codex config:

```toml
developer_instructions = """
Example only:
persistent_instructions = "not a config key"
"""
```

produced one legacy-key warning. A fabricated shareable doctor result for `/home/alice/.codex/config.toml` also printed `alice` verbatim.

The parser previously stayed in root scope while scanning multiline prose, so key-shaped text became configuration and table-shaped text could change parser scope.

## Design

This remains a deliberately small root/table reader rather than adding a new full-TOML dependency. A lexical state machine:

- detects multiline delimiters only outside comments and ordinary one-line strings;
- ignores escaped basic-string closing delimiters;
- handles a second multiline value opened on the first value's closing line;
- skips the entire multiline statement/body;
- leaves ordinary one-line values containing `"""` or `'''` parseable.

Path redaction happens only in the doctor formatter, so local callers retain the real path for correlation while shareable text masks POSIX/Windows user names and sensitive path segments.

## Verification

- `bun test tests/codex-integration/codex-legacy-config-keys.test.ts tests/codex-integration/project-config-warnings.test.ts` — 33 pass / 0 fail.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check` — passed.
- Tests ran with fresh `HOME`, `OPENCODEX_HOME`, and `CODEX_HOME`; all five protected real runtime files retained identical mode, size, and SHA-256.
- Local verification used the installed Bun 1.3.14; exact-head hosted CI on the repository-pinned Bun 1.4.0 is the merge gate.

## Checklist

- [x] Targets `dev`.
- [x] Focused regressions cover both multiline syntaxes, table/key-shaped prose, chained multiline values, ordinary one-line triple-quote text, multiline values on the legacy key itself, and POSIX/Windows path redaction.
- [x] Architecture decision recorded in `structure/02_config-and-codex-home.md`.
- [x] No runtime config, daemon, dependency, workflow, GUI, or release change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration diagnostics so examples and table-like text inside multiline instruction values are no longer incorrectly reported as legacy settings.
  - Diagnostic output now redacts user names and directory details from displayed file paths.

- **Documentation**
  - Added guidance explaining configuration diagnostics, multiline value handling, and path redaction behavior.

- **Tests**
  - Added coverage for multiline configuration values, diagnostic accuracy, and privacy-preserving path display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Review follow-up `84855cfdd`: preserve the declaration key when its value is multiline; CodeRabbit thread resolved after focused revalidation.
