### PR TITLE
refactor(adapters-cursor): isolate desktop executor type contract (split S04 L0/5)

### DIFF
--- a/src/adapters/cursor/desktop-executor-contract.ts
+++ b/src/adapters/cursor/desktop-executor-contract.ts
@@ -1,0 +1,15 @@
+/**
+ * Opt-in external executor for computer-use / record-screen. opencodex is a headless proxy and
+ * cannot drive a screen itself; set these commands only when running on a host that can. Each
+ * command receives the request as JSON on stdin and must print a JSON result on stdout.
+ */
+export interface DesktopExecutorConfig {
+  /** Command (run via the platform shell) handling computer-use. Receives `{toolCallId, actions}` on stdin. */
+  computerUseCommand?: string;
+  /** Command handling record-screen. Receives `{mode, toolCallId, saveAsFilename?}` on stdin. */
+  recordScreenCommand?: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  /** Max time to wait for the external process. Default 30s. */
+  timeoutMs?: number;
+}

--- a/src/adapters/cursor/native-exec-desktop.ts
+++ b/src/adapters/cursor/native-exec-desktop.ts
@@ -17,24 +17,11 @@ import {
 } from "./gen/agent_pb";
 import { errorText } from "./native-exec-common";
 import type { CursorNativeToolDeps } from "./native-exec-tools";
+import type { DesktopExecutorConfig } from "./desktop-executor-contract";
 
 const DEFAULT_DESKTOP_TIMEOUT_MS = 30_000;
 
-/**
- * Opt-in external executor for computer-use / record-screen. opencodex is a headless proxy and
- * cannot drive a screen itself; set these commands only when running on a host that can. Each
- * command receives the request as JSON on stdin and must print a JSON result on stdout.
- */
-export interface DesktopExecutorConfig {
-  /** Command (run via the platform shell) handling computer-use. Receives `{toolCallId, actions}` on stdin. */
-  computerUseCommand?: string;
-  /** Command handling record-screen. Receives `{mode, toolCallId, saveAsFilename?}` on stdin. */
-  recordScreenCommand?: string;
-  cwd?: string;
-  env?: Record<string, string>;
-  /** Max time to wait for the external process. Default 30s. */
-  timeoutMs?: number;
-}
+export type { DesktopExecutorConfig } from "./desktop-executor-contract";
 
 /**
  * Build `computerUse` / `recordScreen` deps from external executor commands. Returns `{}` when no

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -698,7 +698,7 @@ export interface OcxProviderConfig {
    * headless and cannot control a screen itself; provide commands here only when running on a host
    * that can. With no executor, these tools honestly report "not supported".
    */
-  desktopExecutor?: import("../adapters/cursor/native-exec-desktop").DesktopExecutorConfig;
+  desktopExecutor?: import("../adapters/cursor/desktop-executor-contract").DesktopExecutorConfig;
   /**
    * Cursor adapter only: unsafe opt-in escape hatch for Cursor server-driven built-in local
    * read/write/delete/ls/grep/shell/fetch execution. Prefer `nativeLocalExec: "on"` for new

--- a/tests/providers/cursor/cursor-desktop-exec.test.ts
+++ b/tests/providers/cursor/cursor-desktop-exec.test.ts
@@ -7,8 +7,14 @@ import {
   RecordScreenArgsSchema,
 } from "../../../src/adapters/cursor/gen/agent_pb";
 import { handleCursorNativeExec } from "../../../src/adapters/cursor/native-exec";
-import { desktopDepsFromConfig } from "../../../src/adapters/cursor/native-exec-desktop";
+import {
+  desktopDepsFromConfig,
+  type DesktopExecutorConfig as DesktopExecutorConfigViaImplementation,
+} from "../../../src/adapters/cursor/native-exec-desktop";
+import type { DesktopExecutorConfig } from "../../../src/adapters/cursor/desktop-executor-contract";
 import { shellInvocation } from "../../../src/lib/win-exec";
+import { readFileSync } from "node:fs";
+import { repoPath } from "../../helpers/repo-root";
 
 function execMessage(message: Parameters<typeof create<typeof ExecServerMessageSchema>>[1]["message"]) {
   return create(ExecServerMessageSchema, { id: 3, execId: "exec-test", message });
@@ -27,6 +33,22 @@ function echoJson(json: string, platform: NodeJS.Platform = process.platform): s
 }
 
 describe("Cursor desktop executor hooks", () => {
+  test("DesktopExecutorConfig is one contract reachable from both paths, and provider types no longer import the implementation", () => {
+    // Type-level parity: the historical export and the contract leaf must be the same shape.
+    const viaContract: DesktopExecutorConfig = { computerUseCommand: "x", timeoutMs: 1 };
+    const viaImplementation: DesktopExecutorConfigViaImplementation = viaContract;
+    expect(desktopDepsFromConfig(viaImplementation)).toHaveProperty("computerUse");
+
+    // Graph guard: the contract is dependency-free and src/types/provider.ts points at it,
+    // not at native-exec-desktop.ts (that edge closed a type cycle through tool-definitions).
+    const contract = readFileSync(repoPath("src", "adapters", "cursor", "desktop-executor-contract.ts"), "utf8");
+    expect(contract).not.toMatch(/^\s*import\s/m);
+    expect(contract).toMatch(/^export interface DesktopExecutorConfig \{/m);
+    const provider = readFileSync(repoPath("src", "types", "provider.ts"), "utf8");
+    expect(provider).toContain('import("../adapters/cursor/desktop-executor-contract").DesktopExecutorConfig');
+    expect(provider).not.toContain("native-exec-desktop");
+  });
+
   test("desktopDepsFromConfig returns empty deps when nothing configured", () => {
     expect(desktopDepsFromConfig(undefined)).toEqual({});
     expect(desktopDepsFromConfig({})).toEqual({});


### PR DESCRIPTION
## Summary

- Pure move: `DesktopExecutorConfig` (15 lines, `src/adapters/cursor/native-exec-desktop.ts:23–37`) moves verbatim to a dependency-free `src/adapters/cursor/desktop-executor-contract.ts`; `native-exec-desktop.ts` keeps the historical export via `export type { DesktopExecutorConfig } from "./desktop-executor-contract"` plus a local `import type`; `src/types/provider.ts:701` retargets its inline `import()` type to the contract.
- Why: breaks the type-only edge `src/types/provider.ts → native-exec-desktop.ts → native-exec-tools.ts → tool-definitions.ts → src/types.ts` so the upcoming cursor adapter split layers cannot join that cycle. Zero runtime change (every added/changed binding is erased).
- Plan and evidence: `devlog/_plan/260905_now_split_train/105_cursor_desktop_executor_contract.md`; parent decisions in `003_parent_decisions.md` (TYPE-CYCLE-01, PURE-MOVE-SIZE-01).

**Stack** (merge bottom-up; S04 adapters-cursor):

| # | PR | Branch | Base | Review focus |
|---|----|--------|------|--------------|
| 5 | TBD | codex/split-adapters-cursor-protobuf-events | codex/split-adapters-cursor-tool-definitions | protobuf-events |
| 4 | TBD | codex/split-adapters-cursor-request-builder | codex/split-adapters-cursor-images | request-builder |
| 3 | TBD | codex/split-adapters-cursor-images | codex/split-cursor-desktop-executor-contract | images |
| 2 | TBD | codex/split-adapters-cursor-catalog | codex/split-cursor-desktop-executor-contract | catalog |
| 1 | TBD | codex/split-adapters-cursor-tool-definitions | codex/split-cursor-desktop-executor-contract | tool-definitions |
| 0 | this PR | codex/split-cursor-desktop-executor-contract ← you are here | dev | desktop executor type contract |

Base: dev. Review this PR's diff only (3 files, +18/−16; non-move diff 4 lines). Move-aware view: `git diff --color-moved=dimmed-zebra dev...HEAD`.

## Verification

- `bun run typecheck` → exit 0
- `bun test tests/providers/cursor/cursor-desktop-exec.test.ts` → 14 pass / 0 fail
- `bun run privacy:scan` → passed
- `wc -l`: contract 15, native-exec-desktop 194 (was 207), provider.ts 723 (unchanged count)
- Export parity (origin/dev vs HEAD): `{DesktopExecutorConfig, desktopDepsFromConfig}` both sides; independent read-only review (gpt-6-astra) confirmed byte-identical move and zero new runtime imports.
- Full suite on the remote CI host (`lidge`) at this exact SHA: recorded in the devlog doc once it completes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (devlog unit records the layer; no user-facing behavior change).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (type-only move; no runtime path touched).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Clarified the configuration contract for optional external desktop executors.
  - Configuration can specify commands for computer-use and screen recording, along with an optional working directory, environment variables, and timeout.
  - The configuration contract is now available through a dedicated public interface for consistent use across supported integrations.
  - Existing desktop executor behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->