### PR TITLE
fix(oauth): repair proactive-failover policy boundaries (carry of #3502, 1/2)

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -426,7 +426,7 @@ second account.
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `oauthAccountFailover.enabled?` | `boolean` | presence-driven | Global override for the **pre-dispatch account preference** only. `false` stops a healthy request being steered toward the account with more known headroom. It does **not** disable 429 rotation. |
-| `providers.<name>.oauthAccountFailover.enabled?` | `boolean` | inherits | Per-provider override for the same preference; beats the global setting. Only `false` is meaningful — `true` adds nothing over account presence. |
+| `providers.<name>.oauthAccountFailover.enabled?` | `boolean` | inherits | Per-provider override for the same preference; beats the global setting in either direction. `false` declines the preference for this provider even when the global setting is `true`, and `true` opts this provider in even when the global setting is `false`. Reactive 429 rotation is unaffected either way. |
 | `providers.<name>.oauthAccountFailover.strategy?` | `"quota" \| "round-robin" \| "fill-first"` | — | Declared pool strategy for a generic OAuth provider (#695). Persisted through `ocx account strategy <provider> <name>` or `PUT /api/oauth/accounts/pool`; the generic selector does not act on it yet, so omitted and set behave the same today. |
 | `providers.<name>.oauthAccountFailover.autoSwitchThreshold?` | `number` | — | Declared 0–100 usage percent for a proactive switch on a generic OAuth provider (#695). Set with `ocx account auto-switch <provider> threshold <n>`; inert until the selector consumes it. |
 

--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -203,6 +203,7 @@
     "anthropic-pool-toggle-copy.test.ts": "adapters/anthropic",
     "anthropic-quorum-cache.test.ts": "routing",
     "anthropic-reasoning.test.ts": "adapters/anthropic",
+    "anthropic-sidecar-account-failover.test.ts": "adapters/anthropic",
     "anthropic-stream-hardening.test.ts": "adapters/anthropic",
     "anthropic-tail-guard.test.ts": "adapters/anthropic",
     "anthropic-thinking-signature.test.ts": "adapters/anthropic",

--- a/src/oauth/anthropic-routing.ts
+++ b/src/oauth/anthropic-routing.ts
@@ -672,7 +672,13 @@ export function rotateAnthropicAccountOn429(
   // from a count read taken before the failure.
   quorumCache = null;
 
-  const next = pickAlternateAnthropicAccount(config, failedAccountId, now);
+  // The pool's strategy is a PROACTIVE policy. When the pool is disabled, reactive
+  // presence-only recovery must not silently reactivate round-robin/fill-first merely
+  // because those dormant values remain in config. The quota picker is the neutral
+  // recovery policy already used by the default strategy.
+  const next = isAnthropicAccountPoolEnabled(config)
+    ? pickAlternateAnthropicAccount(config, failedAccountId, now)
+    : pickLowestUsage(config, failedAccountId, now);
   if (!next) {
     console.warn("[anthropic-pool] all eligible Anthropic OAuth accounts are in cooldown; returning 429");
     return null;

--- a/src/oauth/generic-account-failover.ts
+++ b/src/oauth/generic-account-failover.ts
@@ -178,15 +178,20 @@ export function isGenericOAuthFailoverEnabled(
  * Whether the pre-dispatch account PREFERENCE may run for this provider.
  *
  * Unlike reactive rotation, this moves a request that upstream has not refused, so it stays
- * refusable: an explicit `false` — per provider first, then global — turns it off. `true` adds
- * nothing over presence, so only `false` is honoured; that keeps the predicate identical to the
- * old behaviour for every operator who never wrote the key, and a malformed value falls through
- * rather than taking a provider out of service.
+ * refusable: an explicit provider value wins over the global default, and a global `false`
+ * turns it off only when the provider has no override. A malformed value falls through rather
+ * than taking a provider out of service.
  */
 function isProactivePreferenceEnabled(config: OcxConfig, providerName: string, now: number): boolean {
   const provider = config.providers?.[providerName];
   if (!provider || !isGenericFailoverProvider(providerName, provider)) return false;
-  if (provider.oauthAccountFailover?.enabled === false) return false;
+  const perProvider = provider.oauthAccountFailover?.enabled;
+  // Preserve the published narrow-over-broad precedence. A provider-specific true may
+  // opt this provider into proactive preference even when the global default is false;
+  // a provider-specific false refuses it even when the global setting is true.
+  if (typeof perProvider === "boolean") {
+    return perProvider && hasFailoverAccountQuorum(providerName, now);
+  }
   if (config.oauthAccountFailover?.enabled === false) return false;
   return hasFailoverAccountQuorum(providerName, now);
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -791,7 +791,7 @@ export interface OcxConfig {
    * What `enabled: false` still refuses is the PRE-DISPATCH preference: steering a request
    * upstream has not refused toward the account with more known headroom. That moves a healthy
    * request, so it stays a real choice. `providers.<name>.oauthAccountFailover` overrides this
-   * per provider, and only `false` is meaningful — `true` adds nothing over presence.
+   * per provider in either direction; reactive 429 rotation remains presence-driven.
    */
   oauthAccountFailover?: {
     enabled?: boolean;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -430,7 +430,7 @@ export interface OcxProviderConfig {
    * activate it, and a 429 with an idle second account is a defect rather than a preference.
    * What an explicit `false` still refuses is the pre-dispatch preference that steers a HEALTHY
    * request toward the account with more known headroom. It beats the global
-   * `oauthAccountFailover`; only `false` is meaningful, since `true` adds nothing over presence.
+   * `oauthAccountFailover` in either direction; reactive 429 rotation remains presence-driven.
    */
   oauthAccountFailover?: {
     enabled?: boolean;

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -1412,8 +1412,17 @@ surface is listed here so a maintainer can find the owner without grepping:
 | Image/video generation loop | `src/images/loop.ts`, `src/images/plan.ts`, `src/images/fulfill.ts`, `src/images/xai-client.ts`, `src/images/xai-video-client.ts`, `src/images/artifacts.ts` | A provider-returned image URL is downloaded into a local artifact once, then served locally; warnings stay URL-free because provider CDN URLs may embed credentials. |
 | GitHub Copilot | `src/providers/xai-transport.ts` (`resolveProviderTransport`), `src/providers/github-copilot-transport.ts` | `resolveProviderTransport` selects the Copilot transport when the routed provider name is `github-copilot`; the Copilot module then resolves its headers and base URL, and the registry seeds the provider row and model fallback. |
 | API-key pools | `src/providers/key-failover.ts` | A 429 rotates the active key and records a cooldown; `provider.apiKey` keeps mirroring the active entry so routing stays single-key. |
+| OAuth account failover | `src/oauth/generic-account-failover.ts`, `src/oauth/anthropic-routing.ts` | Reactive pre-output 429 recovery is presence-driven with 2+ eligible accounts. Pool and `oauthAccountFailover` flags govern proactive routing, not the reactive retry: a disabled Anthropic pool recovers through quota ordering rather than its dormant strategy, and a per-provider `enabled` beats the global default in either direction. |
 | Alibaba regions | `src/providers/alibaba-region-backup.ts`, `src/providers/alibaba-region-migration.ts`, `src/providers/alibaba-region-startup.ts` | Region migration backs up before rewriting and is idempotent across restarts. |
 | Discovery and quota | `src/providers/model-discovery.ts`, `src/providers/quota.ts` | Discovery rejects a response over 4 MiB or past 2,000 raw rows before caching it. |
+
+[Decision Log]
+- 목적과 의도: Keep reactive OAuth 429 recovery available without silently enabling proactive account-routing policy the operator switched off.
+- 기존 구현 및 제약 조건: #3495 made reactive recovery presence-driven, but a disabled Anthropic pool still consulted its dormant strategy on the reactive path, and a per-provider `oauthAccountFailover.enabled: true` could no longer beat a global `false`.
+- 검토한 주요 대안: Restore the old all-or-nothing enable flag; leave the merged behavior and document the gaps; or keep the reactive/proactive split and repair the exact policy boundaries.
+- 선택한 방식: Keep presence-driven reactive recovery, apply proactive precedence only before dispatch, and use quota ordering for disabled-pool Anthropic recovery.
+- 다른 대안 대신 이 방식을 선택한 이유: This preserves the merged product decision without letting disabled proactive settings influence a retry, and it restores the published narrow-over-broad precedence in both directions.
+- 장점, 단점 및 영향: 429 recovery stays automatic for operators with multiple eligible accounts; operators who require no automatic account switch must keep one eligible account, which the GUI and public docs state explicitly.
 
 ## Sidecars
 

--- a/tests/adapters/anthropic/anthropic-sidecar-account-failover.test.ts
+++ b/tests/adapters/anthropic/anthropic-sidecar-account-failover.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The web-search sidecar is a rotation site of its own, and it reaches Anthropic through the
+ * shared 429 hook rather than the main response loop. A pool that is switched off must still
+ * recover there: `anthropicAccountPool.enabled: false` declines PROACTIVE routing, not the
+ * reactive retry that runs only after upstream has already refused the request.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProviderAdapter } from "../../../src/adapters/base";
+import { clearAnthropicAccountPoolState } from "../../../src/oauth/anthropic-routing";
+import { clearGenericFailoverHealth } from "../../../src/oauth/generic-account-failover";
+import { getAccountSet, saveCredential, setActiveAccount } from "../../../src/oauth/store";
+import type { OcxConfig, OcxParsedRequest, OcxProviderConfig } from "../../../src/types";
+import { removeTreeWithRetry } from "../../helpers/remove-tree";
+
+const previousHome = process.env.OPENCODEX_HOME;
+let testHome = "";
+let handleResponses: typeof import("../../../src/server/responses")["handleResponses"];
+let observedKeys: string[] = [];
+let sidecarMode = false;
+
+function fixtureAdapter(provider: OcxProviderConfig): ProviderAdapter {
+  return {
+    name: "anthropic",
+    buildRequest() {
+      return {
+        url: provider.baseUrl,
+        method: "POST",
+        headers: { authorization: `Bearer ${provider.apiKey ?? ""}` },
+        body: "{}",
+      };
+    },
+    async *parseStream() {
+      yield { type: "done" as const };
+    },
+  };
+}
+
+beforeAll(async () => {
+  const actualResolver = await import("../../../src/server/adapter-resolve");
+  const actualResolveAdapter = actualResolver.resolveAdapter;
+  mock.module("../../../src/server/adapter-resolve", () => ({
+    ...actualResolver,
+    resolveAdapter(provider: OcxProviderConfig, cacheRetention?: "none" | "short" | "long") {
+      if (provider.adapter === "test-anthropic-sidecar") return fixtureAdapter(provider);
+      return actualResolveAdapter(provider, cacheRetention);
+    },
+  }));
+
+  mock.module("../../../src/web-search", () => ({
+    buildWebSearchTool: () => ({
+      name: "web_search",
+      parameters: { type: "object", properties: {} },
+    }),
+    planWebSearch: () => sidecarMode
+      ? {
+          backend: "anthropic",
+          hostedTool: { type: "web_search" },
+          settings: { model: "claude-haiku-4-5", reasoning: "low", timeoutMs: 1_000 },
+          maxSearches: 1,
+        }
+      : undefined,
+    shouldResolveOpenAiWebSearchSidecar: () => false,
+    runWithWebSearch: async (args: {
+      parsed: OcxParsedRequest;
+      adapter: ProviderAdapter;
+      on429?: (retryAfter: string | null) => Promise<ProviderAdapter | null>;
+    }) => {
+      const first = await args.adapter.buildRequest(args.parsed);
+      observedKeys.push(new Headers(first.headers).get("authorization") ?? "");
+      const rotated = await args.on429?.("30");
+      if (!rotated) throw new Error("Anthropic sidecar did not rotate after 429");
+      const second = await rotated.buildRequest(args.parsed);
+      observedKeys.push(new Headers(second.headers).get("authorization") ?? "");
+      return new Response("sidecar-ok", { status: 200 });
+    },
+  }));
+
+  ({ handleResponses } = await import("../../../src/server/responses"));
+});
+
+beforeEach(() => {
+  testHome = mkdtempSync(join(tmpdir(), "ocx-oauth-429-boundaries-"));
+  process.env.OPENCODEX_HOME = testHome;
+  observedKeys = [];
+  sidecarMode = false;
+  clearAnthropicAccountPoolState();
+  clearGenericFailoverHealth();
+});
+
+afterEach(() => {
+  clearAnthropicAccountPoolState();
+  clearGenericFailoverHealth();
+  removeTreeWithRetry(testHome);
+});
+
+afterAll(() => {
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  mock.restore();
+});
+
+test("Anthropic web-search sidecar rotates on 429 when proactive pooling is disabled", async () => {
+  sidecarMode = true;
+  for (let index = 0; index < 2; index += 1) {
+    await saveCredential("anthropic", {
+      access: `anthropic-access-${index}`,
+      refresh: `anthropic-refresh-${index}`,
+      expires: Date.now() + 3_600_000,
+      accountId: `anthropic-account-${index}`,
+    } as never, { addAccount: true });
+  }
+  const ids = getAccountSet("anthropic")!.accounts.map(account => account.id);
+  await setActiveAccount("anthropic", ids[0]!);
+
+  const config = {
+    port: 0,
+    defaultProvider: "anthropic",
+    anthropicAccountPool: { enabled: false, strategy: "round-robin" },
+    providers: {
+      anthropic: {
+        adapter: "test-anthropic-sidecar",
+        baseUrl: "https://anthropic-sidecar.test/v1",
+        authMode: "oauth",
+        models: ["model"],
+      },
+    },
+  } as unknown as OcxConfig;
+
+  const response = await handleResponses(new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "anthropic/model",
+      input: "search",
+      stream: true,
+      tools: [{ type: "web_search" }],
+    }),
+  }), config, { model: "", provider: "" });
+
+  expect(response.status).toBe(200);
+  expect(await response.text()).toBe("sidecar-ok");
+  expect(observedKeys).toEqual([
+    "Bearer anthropic-access-0",
+    "Bearer anthropic-access-1",
+  ]);
+});

--- a/tests/fixtures/test-layout-expected.json
+++ b/tests/fixtures/test-layout-expected.json
@@ -40,6 +40,7 @@
   "anthropic-pool-toggle-copy.test.ts": "adapters/anthropic",
   "anthropic-quorum-cache.test.ts": "routing",
   "anthropic-reasoning.test.ts": "adapters/anthropic",
+  "anthropic-sidecar-account-failover.test.ts": "adapters/anthropic",
   "anthropic-stream-hardening.test.ts": "adapters/anthropic",
   "anthropic-tail-guard.test.ts": "adapters/anthropic",
   "anthropic-thinking-signature.test.ts": "adapters/anthropic",

--- a/tests/oauth/adapter-event-oauth-failover.test.ts
+++ b/tests/oauth/adapter-event-oauth-failover.test.ts
@@ -137,9 +137,12 @@ describe("#2568 adapter-event OAuth failover", () => {
       [{ type: "text", text: "ok" }],
     ];
 
-    const body = await (await handleResponses(request(true), config(false), { model: "", provider: "" })).text();
+    const response = await handleResponses(request(true), config(false), { model: "", provider: "" });
+    const body = await response.text();
 
+    expect(response.status).toBe(200);
     expect(attemptKeys).toEqual(["cursor-access-1", "cursor-access-0"]);
+    expect(body).toContain("ok");
     expect(body).not.toContain("rate_limit_exceeded");
   });
 

--- a/tests/oauth/generic-oauth-failover.test.ts
+++ b/tests/oauth/generic-oauth-failover.test.ts
@@ -12,7 +12,7 @@ import {
   preferredInitialAccount,
   rotateGenericOAuthAccountOn429,
 } from "../../src/oauth/generic-account-failover";
-import { getAccountSet, markAccountNeedsReauth, saveCredential } from "../../src/oauth/store";
+import { getAccountSet, markAccountNeedsReauth, saveCredential, setActiveAccount } from "../../src/oauth/store";
 import { clearAccountQuotaCache, setCachedProviderAccountQuotaForTests } from "../../src/providers/quota";
 import { resolveCopilotApiBaseUrl } from "../../src/oauth/github-copilot";
 import { resolveProviderTransport } from "../../src/providers/xai-transport";
@@ -135,6 +135,20 @@ describe("#2568 generic OAuth account failover", () => {
     setCachedProviderAccountQuotaForTests("xai", ids[1]!, { fiveHourPercent: 1 });
     expect(preferredInitialAccount(config(false), "xai")).toBeNull();
     expect(preferredInitialAccount(config(true, false), "xai")).toBeNull();
+  });
+
+  test("a provider-level true overrides a global proactive opt-out", async () => {
+    // The documented precedence is narrow-over-broad in BOTH directions. A per-provider false
+    // refuses the preference under a global true (pinned above); the mirror case is an operator
+    // who declines steering globally and opts one provider back in. Honouring only `false`
+    // silently drops that opt-in.
+    const ids = await seed(2);
+    await setActiveAccount("xai", ids[0]!);
+    clearGenericFailoverHealth("xai");
+    setCachedProviderAccountQuotaForTests("xai", ids[0]!, { fiveHourPercent: 99 });
+    setCachedProviderAccountQuotaForTests("xai", ids[1]!, { fiveHourPercent: 1 });
+
+    expect(preferredInitialAccount(config(false, true), "xai")).toBe(ids[1]);
   });
 
   test("a second account flagged for reauth is not a quorum", async () => {

--- a/tests/routing/always-on-429-failover.test.ts
+++ b/tests/routing/always-on-429-failover.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../../src/oauth/anthropic-routing";
 import { clearPoolRotationState } from "../../src/codex/pool-rotation";
 import { getAccountSet, saveCredential, setActiveAccount } from "../../src/oauth/store";
-import { clearAccountQuotaCache } from "../../src/providers/quota";
+import { clearAccountQuotaCache, setCachedProviderAccountQuotaForTests } from "../../src/providers/quota";
 import type { OcxConfig } from "../../src/types";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 
@@ -97,6 +97,24 @@ describe("Anthropic reactive 429 failover without the pool flag", () => {
     // rate-limited request on an account the operator deliberately logged in is not.
     const ids = await seedAccounts(2);
     expect(rotateAnthropicAccountOn429(poolDisabled(), ids[0]!, null)).toBe(ids[1]);
+  });
+
+  test("a disabled pool does not apply its dormant proactive strategy to reactive recovery", async () => {
+    // The pool flag buys PROACTIVE routing: affinity, quota ranking, and the declared strategy.
+    // Leaving `strategy: "round-robin"` in a config whose pool is off is not an opt-in to
+    // round-robin -- it is dormant configuration. Reactive recovery must therefore fall back to
+    // the neutral quota picker rather than reactivating the strategy the operator switched off.
+    const ids = await seedAccounts(3);
+    setCachedProviderAccountQuotaForTests("anthropic", ids[1]!, { fiveHourPercent: 90 });
+    setCachedProviderAccountQuotaForTests("anthropic", ids[2]!, { fiveHourPercent: 10 });
+    const disabledRoundRobin = {
+      ...poolAbsent(),
+      anthropicAccountPool: { enabled: false, strategy: "round-robin" },
+    } as OcxConfig;
+
+    // Round-robin would hand back ids[1] (the next account in order); quota ordering picks the
+    // account with the most headroom instead.
+    expect(rotateAnthropicAccountOn429(disabledRoundRobin, ids[0]!, null)).toBe(ids[2]);
   });
 
   test("a single account is still a strict no-op", async () => {


### PR DESCRIPTION
## Summary

Two OAuth failover policy defects from #3502, split from its Kiro half so the `src/oauth/` security surface is reviewed on its own. `src/oauth/anthropic-routing.ts`: a *disabled* pool no longer applies its dormant proactive strategy to reactive recovery (it recovers via `pickLowestUsage`). `src/oauth/generic-account-failover.ts`: a per-provider `enabled: true` now beats a global `false` in both directions, with the `typeof` guard preserved. Doc comments in `src/types/{config,provider}.ts`, the English `providers.md` row that claimed only `false` was meaningful, and the `structure/04` owner row are corrected.

Carries #3502 (author @Ingwannu) onto current `dev`; contributor hunks reapplied. Supersedes #3502 together with the 2/2 layer.

Security boundary: touches `src/oauth/` (restricted surface). Owner-authored carry so `unsponsored_surface` does not fire; no credential, token, or flow change — policy selection only. MAINTAINERS.md security review applies.

**Stack** (merge bottom-up; each layer targets the branch below):
| # | Layer | Branch | Base |
|---|-------|--------|------|
| 1 | B1 | codex/260905-oauth-failover-policy-boundaries | dev |
| 2 | B2 | codex/260905-kiro-continuation-auth-context | B1 |
| 3 | B3 | codex/260905-claude-native-fallback | B2 |
| 4 | B4 | codex/260905-startup-reconcile-persistence | B3 |
| 5 | B6 | codex/260905-combo-failure-classification | B4 |

Depends on the layers below it. Review this PR's diff only. Unit: `devlog/_plan/260905_open_work_closeout/` (020, 021, 022).

## Verification

- `bun run typecheck` — exit 0 on this layer and on the stack top (`d0f80e85f`).
- `bun test tests/adapters/anthropic/anthropic-sidecar-account-failover.test.ts tests/oauth/adapter-event-oauth-failover.test.ts tests/oauth/generic-oauth-failover.test.ts tests/routing/always-on-429-failover.test.ts` — RED on dev 41 pass / 2 fail (`a provider-level true overrides a global proactive opt-out`, `a disabled pool does not apply its dormant proactive strategy`), GREEN 43 pass / 0 fail. Layout guard 17/0.
- Stack top: 214 pass / 0 fail across all layers' focused files + layout guard + `tests/lab/core-lab-boundary.test.ts`.
- Exact-head hosted CI is the merge gate (no repository-wide local suite by maintainer instruction).

## Checklist

- [x] Targets `dev` (stack layer)
- [x] Focused regression test RED before / GREEN after
- [x] Original author credited via `Co-authored-by` trailer in the branch commit

Co-authored-by: Ingwannu <186453546+Ingwannu@users.noreply.github.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Per-provider OAuth account failover settings now explicitly override the global setting in either direction.
  - Reactive Anthropic account rotation after a 429 response now respects whether proactive account pooling is enabled.
  - When pooling is disabled, recovery selects the account with the most available quota instead of applying dormant proactive rotation strategies.

- **Documentation**
  - Updated configuration and architecture documentation to clarify proactive versus reactive OAuth account failover behavior and provider-specific overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->