### PR TITLE
refactor(providers): isolate OpenAI destination classification (split S02 L1/4)

### DIFF
--- a/src/providers/openai-tiers-destination.ts
+++ b/src/providers/openai-tiers-destination.ts
@@ -1,0 +1,102 @@
+import type { OcxProviderConfig } from "../types";
+import { openaiResponsesUrl } from "../adapters/openai-responses-url";
+
+export const OPENAI_CODEX_PROVIDER_ID = "openai";
+export const LEGACY_OPENAI_MULTI_PROVIDER_ID = "openai-multi";
+export const OPENAI_API_PROVIDER_ID = "openai-apikey";
+export const LEGACY_CHATGPT_PROVIDER_ID = "chatgpt";
+
+export const CODEX_FORWARD_BASE_URL = "https://chatgpt.com/backend-api/codex";
+
+function normalizedBaseUrl(value: string): string | undefined {
+  try {
+    const url = new URL(value.trim());
+    if (url.username || url.password || url.search || url.hash) return undefined;
+    const path = url.pathname.replace(/\/+$/, "");
+    return `${url.origin}${path}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isCanonicalOpenAiForwardProvider(provider: OcxProviderConfig): boolean {
+  return provider.adapter === "openai-responses"
+    && provider.authMode === "forward"
+    && normalizedBaseUrl(provider.baseUrl) === CODEX_FORWARD_BASE_URL;
+}
+
+const OPENAI_API_ORIGIN = "https://api.openai.com";
+const OPENAI_API_BASE_URL = `${OPENAI_API_ORIGIN}/v1`;
+const OPENAI_API_RESPONSES_URL = `${OPENAI_API_BASE_URL}/responses`;
+
+/**
+ * The Responses endpoint the adapter would actually POST key-auth traffic to, normalized.
+ *
+ * Mirrors the adapter's own construction (`src/adapters/openai-responses.ts`): a configured
+ * `responsesPath` is appended to the base verbatim, and only the default branch runs the
+ * `/v1/responses` suffix normalization. Classifying on the base URL alone would call
+ * `baseUrl: "https://api.openai.com"` with `responsesPath: "/other"` official even though that
+ * request never reaches the official Responses endpoint.
+ */
+function resolvedResponsesEndpoint(provider: OcxProviderConfig): string | undefined {
+  try {
+    const raw = provider.responsesPath === undefined
+      ? openaiResponsesUrl(provider.baseUrl)
+      : `${provider.baseUrl.replace(/\/$/, "")}${provider.responsesPath}`;
+    return normalizedBaseUrl(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function isOfficialOpenAiResponsesDestination(provider: OcxProviderConfig): boolean {
+  // Exact normalized URL keeps lookalike/suffix hosts out of this set: `api.openai.com.evil.test`
+  // resolves to its own origin, never to the official one.
+  return resolvedResponsesEndpoint(provider) === OPENAI_API_RESPONSES_URL;
+}
+
+/**
+ * Whether this provider can serve `POST /responses/compact`. The canonical ChatGPT
+ * backend can, and so can the official OpenAI API — but an arbitrary gateway that
+ * merely speaks the Responses wire cannot, and calling it there fails compaction
+ * with an unhelpful error instead of falling back to a routed summary (#422).
+ */
+export function supportsNativeResponsesCompactEndpoint(
+  providerName: string,
+  provider: OcxProviderConfig,
+): boolean {
+  if (isCanonicalOpenAiForwardProvider(provider)) return true;
+  return providerName === OPENAI_API_PROVIDER_ID
+    && provider.adapter === "openai-responses"
+    && normalizedBaseUrl(provider.baseUrl) === OPENAI_API_BASE_URL;
+}
+
+/**
+ * Whether this destination is an OpenAI-operated Responses backend — the canonical ChatGPT Codex
+ * surface or the official OpenAI API.
+ *
+ * Deliberately not keyed on `authMode === "forward"`: a noncanonical forward provider does not
+ * receive the caller's credentials (see the forward-header gate in the Responses adapter), so
+ * forward auth says nothing about which backend is on the other end.
+ */
+export function isOpenAiOperatedResponsesDestination(provider: OcxProviderConfig): boolean {
+  if (isCanonicalOpenAiForwardProvider(provider)) return true;
+  return provider.adapter === "openai-responses"
+    && isOfficialOpenAiResponsesDestination(provider);
+}
+
+/**
+ * Whether this destination can decode a native (non-`ocx1:`) compaction blob.
+ *
+ * Only the backend that minted a blob can decode it. `authMode: "forward"` alone is not a signal:
+ * the adapter forwards caller credentials only to the canonical ChatGPT Codex surface, while a
+ * noncanonical forward provider receives no caller credentials and may point at any backend.
+ *
+ * Relay only to an OpenAI-operated destination or a destination whose operator explicitly opts in.
+ * Keyed by destination rather than provider id: a blob's issuer is the URL that produced it, not the
+ * local config key a replay travels under.
+ */
+export function destinationDecodesNativeCompactionBlob(provider: OcxProviderConfig): boolean {
+  return isOpenAiOperatedResponsesDestination(provider)
+    || provider.decodesNativeCompactionBlobs === true;
+}

--- a/src/providers/openai-tiers.ts
+++ b/src/providers/openai-tiers.ts
@@ -2,13 +2,9 @@ import type { CodexAccountMode, OcxConfig, OcxProviderConfig, ProviderCostOverla
 import { OPENAI_PROVIDER_TIER_VERSION } from "../types";
 import { openaiResponsesUrl } from "../adapters/openai-responses-url";
 import { MAX_COST4_RATE } from "../usage/expected-prices";
+import { OPENAI_CODEX_PROVIDER_ID, LEGACY_OPENAI_MULTI_PROVIDER_ID, LEGACY_CHATGPT_PROVIDER_ID, CODEX_FORWARD_BASE_URL, isCanonicalOpenAiForwardProvider } from "./openai-tiers-destination";
+export { OPENAI_CODEX_PROVIDER_ID, LEGACY_OPENAI_MULTI_PROVIDER_ID, OPENAI_API_PROVIDER_ID, LEGACY_CHATGPT_PROVIDER_ID, CODEX_FORWARD_BASE_URL, isCanonicalOpenAiForwardProvider, supportsNativeResponsesCompactEndpoint, isOpenAiOperatedResponsesDestination, destinationDecodesNativeCompactionBlob } from "./openai-tiers-destination";
 
-export const OPENAI_CODEX_PROVIDER_ID = "openai";
-export const LEGACY_OPENAI_MULTI_PROVIDER_ID = "openai-multi";
-export const OPENAI_API_PROVIDER_ID = "openai-apikey";
-export const LEGACY_CHATGPT_PROVIDER_ID = "chatgpt";
-
-export const CODEX_FORWARD_BASE_URL = "https://chatgpt.com/backend-api/codex";
 const LEGACY_OPENAI_MULTI_PREFIX = `${LEGACY_OPENAI_MULTI_PROVIDER_ID}/`;
 
 function canonicalCodexForwardProvider(mode: CodexAccountMode): OcxProviderConfig {
@@ -18,99 +14,6 @@ function canonicalCodexForwardProvider(mode: CodexAccountMode): OcxProviderConfi
     authMode: "forward",
     codexAccountMode: mode,
   };
-}
-
-function normalizedBaseUrl(value: string): string | undefined {
-  try {
-    const url = new URL(value.trim());
-    if (url.username || url.password || url.search || url.hash) return undefined;
-    const path = url.pathname.replace(/\/+$/, "");
-    return `${url.origin}${path}`;
-  } catch {
-    return undefined;
-  }
-}
-
-export function isCanonicalOpenAiForwardProvider(provider: OcxProviderConfig): boolean {
-  return provider.adapter === "openai-responses"
-    && provider.authMode === "forward"
-    && normalizedBaseUrl(provider.baseUrl) === CODEX_FORWARD_BASE_URL;
-}
-
-const OPENAI_API_ORIGIN = "https://api.openai.com";
-const OPENAI_API_BASE_URL = `${OPENAI_API_ORIGIN}/v1`;
-const OPENAI_API_RESPONSES_URL = `${OPENAI_API_BASE_URL}/responses`;
-
-/**
- * The Responses endpoint the adapter would actually POST key-auth traffic to, normalized.
- *
- * Mirrors the adapter's own construction (`src/adapters/openai-responses.ts`): a configured
- * `responsesPath` is appended to the base verbatim, and only the default branch runs the
- * `/v1/responses` suffix normalization. Classifying on the base URL alone would call
- * `baseUrl: "https://api.openai.com"` with `responsesPath: "/other"` official even though that
- * request never reaches the official Responses endpoint.
- */
-function resolvedResponsesEndpoint(provider: OcxProviderConfig): string | undefined {
-  try {
-    const raw = provider.responsesPath === undefined
-      ? openaiResponsesUrl(provider.baseUrl)
-      : `${provider.baseUrl.replace(/\/$/, "")}${provider.responsesPath}`;
-    return normalizedBaseUrl(raw);
-  } catch {
-    return undefined;
-  }
-}
-
-function isOfficialOpenAiResponsesDestination(provider: OcxProviderConfig): boolean {
-  // Exact normalized URL keeps lookalike/suffix hosts out of this set: `api.openai.com.evil.test`
-  // resolves to its own origin, never to the official one.
-  return resolvedResponsesEndpoint(provider) === OPENAI_API_RESPONSES_URL;
-}
-
-/**
- * Whether this provider can serve `POST /responses/compact`. The canonical ChatGPT
- * backend can, and so can the official OpenAI API — but an arbitrary gateway that
- * merely speaks the Responses wire cannot, and calling it there fails compaction
- * with an unhelpful error instead of falling back to a routed summary (#422).
- */
-export function supportsNativeResponsesCompactEndpoint(
-  providerName: string,
-  provider: OcxProviderConfig,
-): boolean {
-  if (isCanonicalOpenAiForwardProvider(provider)) return true;
-  return providerName === OPENAI_API_PROVIDER_ID
-    && provider.adapter === "openai-responses"
-    && normalizedBaseUrl(provider.baseUrl) === OPENAI_API_BASE_URL;
-}
-
-/**
- * Whether this destination is an OpenAI-operated Responses backend — the canonical ChatGPT Codex
- * surface or the official OpenAI API.
- *
- * Deliberately not keyed on `authMode === "forward"`: a noncanonical forward provider does not
- * receive the caller's credentials (see the forward-header gate in the Responses adapter), so
- * forward auth says nothing about which backend is on the other end.
- */
-export function isOpenAiOperatedResponsesDestination(provider: OcxProviderConfig): boolean {
-  if (isCanonicalOpenAiForwardProvider(provider)) return true;
-  return provider.adapter === "openai-responses"
-    && isOfficialOpenAiResponsesDestination(provider);
-}
-
-/**
- * Whether this destination can decode a native (non-`ocx1:`) compaction blob.
- *
- * Only the backend that minted a blob can decode it. `authMode: "forward"` alone is not a signal:
- * the adapter forwards caller credentials only to the canonical ChatGPT Codex surface, while a
- * noncanonical forward provider receives no caller credentials and may point at any backend.
- *
- * Relay only to an OpenAI-operated destination or a destination whose operator explicitly opts in.
- * Keyed by destination rather than provider id: a blob's issuer is the URL that produced it, not the
- * local config key a replay travels under.
- */
-export function destinationDecodesNativeCompactionBlob(provider: OcxProviderConfig): boolean {
-  return isOpenAiOperatedResponsesDestination(provider)
-    || provider.decodesNativeCompactionBlobs === true;
 }
 
 export interface OpenAiTierMigrationProjection {

--- a/tests/adapters/openai/openai-provider-option.test.ts
+++ b/tests/adapters/openai/openai-provider-option.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { repoPath } from "../../helpers/repo-root";
+import {
+  isCanonicalOpenAiForwardProvider as destinationIsCanonicalOpenAiForwardProvider,
+  OPENAI_CODEX_PROVIDER_ID as DESTINATION_OPENAI_CODEX_PROVIDER_ID,
+} from "../../../src/providers/openai-tiers-destination";
 import { getDefaultConfig } from "../../../src/config";
 import { deriveInitProviders, deriveProviderPresets, listRegistryEntries, providerConfigSeed } from "../../../src/providers/derive";
 import { getProviderRegistryEntry, providerCodexAccountMode } from "../../../src/providers/registry";
@@ -99,4 +105,11 @@ describe("OpenAI single-provider option foundation", () => {
     expect(providerConfigSeed(registry)).toMatchObject({ codexAccountMode: "pool" });
     expect(getDefaultConfig().providers.openai).toMatchObject({ codexAccountMode: "pool" });
   });
+});
+
+test("destination leaf preserves facade bindings without importing the facade", () => {
+  expect(destinationIsCanonicalOpenAiForwardProvider).toBe(isCanonicalOpenAiForwardProvider);
+  expect(DESTINATION_OPENAI_CODEX_PROVIDER_ID).toBe(OPENAI_CODEX_PROVIDER_ID);
+  const source = readFileSync(repoPath("src/providers/openai-tiers-destination.ts"), "utf8");
+  expect(source).not.toMatch(/(?:from\s*|import\s*(?:\(\s*)?)["']\.\/openai-tiers(?:\.ts)?["']/);
 });


### PR DESCRIPTION
## Summary

- Pure move: OpenAI destination identity and classification (provider-id constants, `CODEX_FORWARD_BASE_URL`, `isCanonicalOpenAiForwardProvider`, `supportsNativeResponsesCompactEndpoint`, `isOpenAiOperatedResponsesDestination`, `destinationDecodesNativeCompactionBlob` and their private helpers — `src/providers/openai-tiers.ts:6–11, 23–114`) moves verbatim to `src/providers/openai-tiers-destination.ts` (102 lines). `openai-tiers.ts` keeps the tier-migration projection (319 lines) and re-exports all nine moved names, so every existing import path keeps working.
- Why: 416-line file over the 400-line module limit; destination classification and legacy-tier migration are separate concerns. Zero behavior change.
- Plan and evidence: `devlog/_plan/260905_now_split_train/040_providers_openai_tiers.md`; rules `003_parent_decisions.md` (PURE-MOVE-SIZE-01).

**Stack** (S02 providers; merge bottom-up):

| # | PR | Branch | Base | Review focus |
|---|----|--------|------|--------------|
| 4 | TBD | codex/split-providers-registry-c | codex/split-providers-registry-b | registry entries (c) |
| 3 | TBD | codex/split-providers-registry-b | codex/split-providers-registry-a | registry contracts + entries (b) |
| 2 | TBD | codex/split-providers-registry-a | dev | registry model tables (a) |
| 1 | this PR | codex/split-providers-openai-tiers ← you are here | dev | destination predicates |

Base: dev. Review this PR's diff only (3 files, +117/−99; non-move diff: 2 leaf imports, 1 local import, 1 re-export line, 13 test lines). Move-aware view: `git diff --color-moved=dimmed-zebra dev...HEAD`.

## Verification

- `bun run typecheck` → exit 0
- Focused: openai-provider-option{,-migration,-startup}, codex-convergence-account-selectors, responses-compaction{,-routing}, responses-inbound-store-default → 179 pass / 0 fail
- `tests/lab/core-lab-boundary.test.ts` → 17 pass / 0 fail
- Red-drives, then restored: accepting key auth in `isCanonicalOpenAiForwardProvider` fails `openai-provider-option.test.ts:37`; inverting `supportsNativeResponsesCompactEndpoint` fails `responses-compaction-routing.test.ts:154/167`.
- `bun run privacy:scan` → passed
- New test: leaf bindings are identical (`toBe`) to the facade re-exports; the leaf does not import the facade.
- Full suite on the remote CI host (`lidge`) at this exact SHA: recorded in the devlog doc.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (devlog unit records the layer; no user-facing change).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (auth-mode predicate moved byte-for-byte; guard driven red once).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated OpenAI destination classification and endpoint compatibility logic into a dedicated provider module.
  - Preserved existing public exports while improving internal organization.

- **Tests**
  - Added coverage confirming that destination classification and provider identifiers remain consistent across supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->