### PR TITLE
refactor(adapters): isolate xAI schema analysis (split S05 L1/3)

### DIFF
--- a/src/adapters/xai-schema-analysis.ts
+++ b/src/adapters/xai-schema-analysis.ts
@@ -1,0 +1,86 @@
+export function isSchemaObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function decodeJsonPointerToken(token: string): string {
+  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+/** Resolve a local `#/`-rooted JSON Pointer against `root`; undefined when it does not resolve. */
+export function lookupLocalJsonPointer(root: unknown, ref: string): unknown {
+  if (ref === "#" || ref === "#/") return root;
+  if (!ref.startsWith("#/")) return undefined;
+  let current: unknown = root;
+  for (const token of ref.slice(2).split("/").map(decodeJsonPointerToken)) {
+    if (!isSchemaObject(current) || !Object.hasOwn(current, token)) return undefined;
+    current = current[token];
+  }
+  return current;
+}
+
+/** Values a schema pins through `const`/`enum`, or undefined when it pins none. */
+function xaiLiteralValues(schema: unknown): unknown[] | undefined {
+  if (!isSchemaObject(schema)) return undefined;
+  if (Object.hasOwn(schema, "const")) return [schema.const];
+  if (Array.isArray(schema.enum)) return schema.enum;
+  return undefined;
+}
+
+/** JSON type name for a literal, so it can be compared against a `type` keyword. */
+function xaiJsonTypeOf(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "string") return "string";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
+  return "object";
+}
+
+/** Types a schema declares, or undefined when it constrains none. */
+function xaiDeclaredTypes(schema: unknown): Set<string> | undefined {
+  if (!isSchemaObject(schema)) return undefined;
+  const type = schema.type;
+  if (typeof type === "string") return new Set([type]);
+  if (Array.isArray(type) && type.every(item => typeof item === "string")) return new Set(type as string[]);
+  return undefined;
+}
+
+/** `integer` is a subset of `number`, so those two names overlap rather than exclude. */
+function xaiTypesOverlap(left: string, right: string): boolean {
+  if (left === right) return true;
+  return (left === "integer" && right === "number") || (left === "number" && right === "integer");
+}
+
+/**
+ * Conservative mutual-exclusion test: true only when no instance can satisfy both schemas.
+ * Proof comes from disjoint literal sets or disjoint declared types; anything it cannot prove
+ * is reported as overlapping so the caller refuses the merge instead of widening the schema.
+ */
+function xaiSchemasAreProvablyDisjoint(left: unknown, right: unknown): boolean {
+  const leftValues = xaiLiteralValues(left);
+  const rightValues = xaiLiteralValues(right);
+  if (leftValues && rightValues) {
+    const seen = new Set(rightValues.map(value => JSON.stringify(value)));
+    return leftValues.every(value => !seen.has(JSON.stringify(value)));
+  }
+  const leftTypes = xaiDeclaredTypes(left);
+  const rightTypes = xaiDeclaredTypes(right);
+  const literalsExcludedByTypes = (values: unknown[], types: Set<string>): boolean =>
+    values.every(value => ![...types].some(type => xaiTypesOverlap(xaiJsonTypeOf(value), type)));
+  if (leftValues && rightTypes) return literalsExcludedByTypes(leftValues, rightTypes);
+  if (rightValues && leftTypes) return literalsExcludedByTypes(rightValues, leftTypes);
+  if (leftTypes && rightTypes) {
+    return ![...leftTypes].some(leftType => [...rightTypes].some(rightType => xaiTypesOverlap(leftType, rightType)));
+  }
+  return false;
+}
+
+/** Every pair provably disjoint, so a union over them accepts each instance exactly once. */
+export function xaiSchemasArePairwiseDisjoint(schemas: unknown[]): boolean {
+  for (let i = 0; i < schemas.length; i += 1) {
+    for (let j = i + 1; j < schemas.length; j += 1) {
+      if (!xaiSchemasAreProvablyDisjoint(schemas[i], schemas[j])) return false;
+    }
+  }
+  return true;
+}

--- a/src/adapters/xai-tool-schema.ts
+++ b/src/adapters/xai-tool-schema.ts
@@ -1,8 +1,6 @@
 import type { OcxProviderConfig } from "../types";
-
-function isSchemaObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
+export { lookupLocalJsonPointer } from "./xai-schema-analysis";
+import { isSchemaObject, lookupLocalJsonPointer, xaiSchemasArePairwiseDisjoint } from "./xai-schema-analysis";
 
 export function isXaiSchemaTarget(provider: Pick<OcxProviderConfig, "baseUrl">): boolean {
   try {
@@ -56,22 +54,6 @@ interface XaiSchemaBudget {
 /** One budget per tool: a large catalog must not let one schema spend another's allowance. */
 function createXaiSchemaBudget(): XaiSchemaBudget {
   return { remainingNodes: XAI_MAX_SCHEMA_NODES, remainingVariants: XAI_MAX_ROOT_VARIANTS };
-}
-
-function decodeJsonPointerToken(token: string): string {
-  return token.replace(/~1/g, "/").replace(/~0/g, "~");
-}
-
-/** Resolve a local `#/`-rooted JSON Pointer against `root`; undefined when it does not resolve. */
-export function lookupLocalJsonPointer(root: unknown, ref: string): unknown {
-  if (ref === "#" || ref === "#/") return root;
-  if (!ref.startsWith("#/")) return undefined;
-  let current: unknown = root;
-  for (const token of ref.slice(2).split("/").map(decodeJsonPointerToken)) {
-    if (!isSchemaObject(current) || !Object.hasOwn(current, token)) return undefined;
-    current = current[token];
-  }
-  return current;
 }
 
 /** Resolve local `#/` `$ref`s. Unresolvable, cyclic, or over-budget refs return undefined. */
@@ -166,73 +148,6 @@ function xaiPropertyMergeIsLossless(variants: Record<string, unknown>[]): boolea
 function xaiRequiredSetsMatch(variants: Record<string, unknown>[]): boolean {
   const serialized = variants.map(variant => [...stringRequiredFields(variant.required)].sort().join("\0"));
   return serialized.every(value => value === serialized[0]);
-}
-
-/** Values a schema pins through `const`/`enum`, or undefined when it pins none. */
-function xaiLiteralValues(schema: unknown): unknown[] | undefined {
-  if (!isSchemaObject(schema)) return undefined;
-  if (Object.hasOwn(schema, "const")) return [schema.const];
-  if (Array.isArray(schema.enum)) return schema.enum;
-  return undefined;
-}
-
-/** JSON type name for a literal, so it can be compared against a `type` keyword. */
-function xaiJsonTypeOf(value: unknown): string {
-  if (value === null) return "null";
-  if (Array.isArray(value)) return "array";
-  if (typeof value === "string") return "string";
-  if (typeof value === "boolean") return "boolean";
-  if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
-  return "object";
-}
-
-/** Types a schema declares, or undefined when it constrains none. */
-function xaiDeclaredTypes(schema: unknown): Set<string> | undefined {
-  if (!isSchemaObject(schema)) return undefined;
-  const type = schema.type;
-  if (typeof type === "string") return new Set([type]);
-  if (Array.isArray(type) && type.every(item => typeof item === "string")) return new Set(type as string[]);
-  return undefined;
-}
-
-/** `integer` is a subset of `number`, so those two names overlap rather than exclude. */
-function xaiTypesOverlap(left: string, right: string): boolean {
-  if (left === right) return true;
-  return (left === "integer" && right === "number") || (left === "number" && right === "integer");
-}
-
-/**
- * Conservative mutual-exclusion test: true only when no instance can satisfy both schemas.
- * Proof comes from disjoint literal sets or disjoint declared types; anything it cannot prove
- * is reported as overlapping so the caller refuses the merge instead of widening the schema.
- */
-function xaiSchemasAreProvablyDisjoint(left: unknown, right: unknown): boolean {
-  const leftValues = xaiLiteralValues(left);
-  const rightValues = xaiLiteralValues(right);
-  if (leftValues && rightValues) {
-    const seen = new Set(rightValues.map(value => JSON.stringify(value)));
-    return leftValues.every(value => !seen.has(JSON.stringify(value)));
-  }
-  const leftTypes = xaiDeclaredTypes(left);
-  const rightTypes = xaiDeclaredTypes(right);
-  const literalsExcludedByTypes = (values: unknown[], types: Set<string>): boolean =>
-    values.every(value => ![...types].some(type => xaiTypesOverlap(xaiJsonTypeOf(value), type)));
-  if (leftValues && rightTypes) return literalsExcludedByTypes(leftValues, rightTypes);
-  if (rightValues && leftTypes) return literalsExcludedByTypes(rightValues, leftTypes);
-  if (leftTypes && rightTypes) {
-    return ![...leftTypes].some(leftType => [...rightTypes].some(rightType => xaiTypesOverlap(leftType, rightType)));
-  }
-  return false;
-}
-
-/** Every pair provably disjoint, so a union over them accepts each instance exactly once. */
-function xaiSchemasArePairwiseDisjoint(schemas: unknown[]): boolean {
-  for (let i = 0; i < schemas.length; i += 1) {
-    for (let j = i + 1; j < schemas.length; j += 1) {
-      if (!xaiSchemasAreProvablyDisjoint(schemas[i], schemas[j])) return false;
-    }
-  }
-  return true;
 }
 
 /** Deduplicate schemas by serialized shape, preserving first-seen order. */

--- a/tests/providers/xai/xai-tool-schema.test.ts
+++ b/tests/providers/xai/xai-tool-schema.test.ts
@@ -1,4 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { lookupLocalJsonPointer } from "../../../src/adapters/xai-tool-schema";
+import {
+  lookupLocalJsonPointer as lookupLocalJsonPointerFromAnalysis,
+  xaiSchemasArePairwiseDisjoint,
+} from "../../../src/adapters/xai-schema-analysis";
+import { repoPath } from "../../helpers/repo-root";
 import {
   createOpenAIChatAdapter as createOpenAIChatAdapterProduction,
 } from "../../../src/adapters/openai-chat";
@@ -399,4 +406,11 @@ describe("xAI Grok CLI tool schema normalization", () => {
 
     expect(body.tools).toBeUndefined();
   });
+});
+
+test("schema-analysis leaf preserves pointer identity, disjointness, and import isolation", () => {
+  expect(lookupLocalJsonPointer).toBe(lookupLocalJsonPointerFromAnalysis);
+  expect(xaiSchemasArePairwiseDisjoint([{ type: "string" }, { const: "view" }])).toBe(false);
+  expect(xaiSchemasArePairwiseDisjoint([{ type: "string" }, { type: "number" }])).toBe(true);
+  expect(readFileSync(repoPath("src", "adapters", "xai-schema-analysis.ts"), "utf8")).not.toMatch(/^import\s/m);
 });


### PR DESCRIPTION
## Summary

- Pure move: the schema-analysis helpers of `src/adapters/xai-tool-schema.ts` (object predicate, JSON-pointer lookup, literal/type extraction and the pairwise-disjointness analysis — lines 3–6, 61–76, 171–237) move verbatim to a dependency-free `src/adapters/xai-schema-analysis.ts` (86 lines). `xai-tool-schema.ts` keeps ref resolution, composition, union expansion and `normalizeXaiToolParameters` (351 lines) and re-exports `lookupLocalJsonPointer`, so all four existing exports stay importable from the original path.
- Why: 436-line file over the 400-line module limit; schema analysis is self-contained (zero imports). Zero behavior change.
- Plan and evidence: `devlog/_plan/260905_now_split_train/160_adapters_xai_tool_schema.md`; rules `003_parent_decisions.md` (PURE-MOVE-SIZE-01).

**Stack** (S05 adapters-misc — independent layers, each based on `dev`; no cascade between them):

| # | PR | Branch | Base | Review focus |
|---|----|--------|------|--------------|
| 3 | TBD | codex/split-adapters-ollama-native | dev | ollama-native |
| 2 | TBD | codex/split-adapters-command-code | dev | command-code |
| 1 | this PR | codex/split-adapters-xai-tool-schema ← you are here | dev | schema analysis leaf |

Base: dev. Review this PR's diff only (3 files, +102/−87; non-move diff: 2 boundary lines, 2 export modifiers, 14 test lines). Move-aware view: `git diff --color-moved=dimmed-zebra dev...HEAD`.

## Verification

- `bun run typecheck` → exit 0
- Focused: `tests/providers/xai/xai-tool-schema.test.ts tests/lib/reasoning-replay-scope-source.test.ts` → 14 pass / 0 fail
- `tests/lab/core-lab-boundary.test.ts` → 17 pass / 0 fail (reached from `src/server/responses/core.ts`)
- Red-drives, then restored: forcing pairwise-disjoint to `true` fails the overlapping-`oneOf` case (widens to `anyOf`); a Lab import in the leaf fails the transitive boundary guard with the full chain.
- `bun run privacy:scan` → passed
- Production importers unchanged (core.ts, openai-chat.ts, openai-responses.ts). New test: pointer lookup identity via both paths, disjointness truth table, leaf has no imports.
- Full suite on the remote CI host (`lidge`) at this exact SHA: recorded in the devlog doc.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (devlog unit records the layer; no user-facing change).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (schema budget/depth guards untouched).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema analysis support for resolving local JSON Pointers.
  * Added conservative detection of mutually exclusive schemas based on literal values and declared types.
  * Made the JSON Pointer helper available through the existing tool-schema interface.

* **Tests**
  * Added coverage for pointer resolution, schema disjointness checks, re-export consistency, and import isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->