### PR TITLE
feat(oauth): add google-antigravity to OAuth 401 replay and force-refresh providers

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -547,7 +547,7 @@ export async function getValidAccessTokenSnapshot(provider: string): Promise<OAu
 }
 
 /** Providers whose upstream-401 replay path may force a snapshot refresh. */
-const FORCE_REFRESH_PROVIDERS = new Set(["xai", "github-copilot", "kiro"]);
+const FORCE_REFRESH_PROVIDERS = new Set(["xai", "github-copilot", "kiro", "google-antigravity"]);
 
 export async function forceRefreshOAuthAccessSnapshot(
   rejected: OAuthAccessSnapshot,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -4373,6 +4373,11 @@ async function handleResponsesInner(
         releaseCodexAuthContextProbeLease(authCtx);
         return formatErrorResponse(401, "authentication_error", publicOAuthAuthenticationErrorMessage(err));
       }
+      if (route.provider.googleMode === "cloud-code-assist" && !refreshed.projectId) {
+        upstream.abort();
+        releaseCodexAuthContextProbeLease(authCtx);
+        return formatErrorResponse(401, "authentication_error", publicOAuthAuthenticationErrorMessage(new Error("Cloud Code Assist project is required")));
+      }
       sentOAuthSnapshot = refreshed;
       replayOAuthCredentialSnapshot = {
         accountId: refreshed.accountId,
@@ -6127,6 +6132,10 @@ async function handleResponsesInner(
         } catch (err) {
           cleanupUpstreamAbort();
           return formatErrorResponse(401, "authentication_error", publicOAuthAuthenticationErrorMessage(err));
+        }
+        if (route.provider.googleMode === "cloud-code-assist" && !refreshed.projectId) {
+          cleanupUpstreamAbort();
+          return formatErrorResponse(401, "authentication_error", publicOAuthAuthenticationErrorMessage(new Error("Cloud Code Assist project is required")));
         }
         sentOAuthSnapshot = refreshed;
         replayOAuthCredentialSnapshot = {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -3327,8 +3327,12 @@ async function handleResponsesInner(
 
   // OAuth providers: swap in a fresh access token (auto-refreshed) as the Bearer key, so the
   // existing openai-chat / anthropic adapters authenticate with no change.
-  const isOAuth401ReplayProvider = (route.providerName === "xai" || route.providerName === "github-copilot" || route.providerName === "kiro")
-    && route.provider.authMode === "oauth";
+  const isOAuth401ReplayProvider = (
+    route.providerName === "xai"
+    || route.providerName === "github-copilot"
+    || route.providerName === "kiro"
+    || route.providerName === "google-antigravity"
+  ) && route.provider.authMode === "oauth";
   let sentOAuthSnapshot: OAuthAccessSnapshot | undefined;
   let replayOAuthCredentialSnapshot: Pick<OAuthAccessSnapshot, "accountId" | "generation"> | undefined;
   let anthropicPoolAccountId: string | null = null;
@@ -4379,7 +4383,11 @@ async function handleResponsesInner(
       }
       const refreshedProvider = resolveProviderTransport(
         route.providerName,
-        { ...route.provider, apiKey: refreshed.accessToken },
+        {
+          ...route.provider,
+          apiKey: refreshed.accessToken,
+          ...(refreshed.projectId ? { project: refreshed.projectId } : {}),
+        },
         parsed.options.promptCacheKey,
         route.providerName === "github-copilot"
           ? resolveCopilotApiBaseUrl(refreshed.apiBaseUrl)
@@ -6130,7 +6138,11 @@ async function handleResponsesInner(
         }
         const refreshedProvider = resolveProviderTransport(
           route.providerName,
-          { ...route.provider, apiKey: refreshed.accessToken },
+          {
+            ...route.provider,
+            apiKey: refreshed.accessToken,
+            ...(refreshed.projectId ? { project: refreshed.projectId } : {}),
+          },
           parsed.options.promptCacheKey,
           route.providerName === "github-copilot"
             ? resolveCopilotApiBaseUrl(refreshed.apiBaseUrl)

--- a/tests/server/server-google-antigravity-oauth-401-replay.test.ts
+++ b/tests/server/server-google-antigravity-oauth-401-replay.test.ts
@@ -39,13 +39,13 @@ afterEach(() => {
   if (testDir) removeTreeWithRetry(testDir);
 });
 
-async function seedOAuth(expires = Date.now() + 3_600_000): Promise<void> {
+async function seedOAuth(expires = Date.now() + 3_600_000, projectId?: string | null): Promise<void> {
   await saveCredential("google-antigravity", {
     access: "rejected-access",
     refresh: "initial-refresh",
     expires,
     accountId: "antigravity-test-account",
-    projectId: "initial-project-id",
+    ...(projectId !== undefined ? (projectId ? { projectId } : {}) : { projectId: "initial-project-id" }),
     source: "oauth",
   });
 }
@@ -58,6 +58,24 @@ function antigravityConfig(): OcxConfig {
     providers: {
       "google-antigravity": {
         adapter: "google",
+        baseUrl: DAILY_API_BASE,
+        authMode: "oauth",
+        googleMode: "cloud-code-assist",
+        project: "initial-project-id",
+        models: ["gemini-3.8-flash"],
+      },
+    },
+  } as OcxConfig;
+}
+
+function antigravityPassthroughConfig(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "google-antigravity",
+    providers: {
+      "google-antigravity": {
+        adapter: "openai-responses",
         baseUrl: DAILY_API_BASE,
         authMode: "oauth",
         googleMode: "cloud-code-assist",
@@ -91,14 +109,14 @@ function sseSuccessBody(text: string): string {
   return `data: ${JSON.stringify(jsonSuccessBody(text))}\n\n`;
 }
 
-async function postResponses(server: ReturnType<typeof startServer>): Promise<Response> {
+async function postResponses(server: ReturnType<typeof startServer>, stream = false): Promise<Response> {
   return originalFetch(new URL("/v1/responses", server.url), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
       model: "google-antigravity/gemini-3.8-flash",
       input: "hello",
-      stream: false,
+      stream,
     }),
   });
 }
@@ -119,7 +137,7 @@ function installOAuthFetch(
   apiStatuses: number[],
   options: {
     tokenErrorDescription?: string;
-    refreshedProjectId?: string;
+    refreshedProjectId?: string | null;
   } = {},
 ): { chatAuth: string[]; chatProjects: string[]; counts: { refresh: number } } {
   const chatAuth: string[] = [];
@@ -149,9 +167,48 @@ function installOAuthFetch(
 
     // Google Cloud Code Assist project discovery
     if (url.includes(":loadCodeAssist")) {
+      if (options.refreshedProjectId === null) {
+        return new Response(JSON.stringify({}), { status: 404, headers: { "content-type": "application/json" } });
+      }
       return new Response(JSON.stringify({
         cloudaicompanionProject: options.refreshedProjectId ?? "refreshed-project-id",
       }), { headers: { "content-type": "application/json" } });
+    }
+
+    if (url.includes(":onboardUser")) {
+      if (options.refreshedProjectId === null) {
+        return new Response(JSON.stringify({}), { status: 404, headers: { "content-type": "application/json" } });
+      }
+    }
+
+    // Responses passthrough endpoint
+    if (url.endsWith("/responses") && url.includes("daily-cloudcode-pa.googleapis.com")) {
+      const auth = new Headers(init?.headers).get("authorization") ?? "";
+      chatAuth.push(auth);
+      const status = apiStatuses.shift() ?? 200;
+      if (status === 401) {
+        return new Response(JSON.stringify({
+          error: {
+            code: 401,
+            message: "Request had invalid authentication credentials.",
+            status: "UNAUTHENTICATED",
+          },
+        }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({
+        id: "resp-passthrough",
+        output: [{
+          id: "msg-passthrough",
+          type: "message",
+          content: [{ type: "output_text", text: "ok after passthrough" }],
+        }],
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
 
     // Google Antigravity Generate Content endpoint
@@ -381,6 +438,87 @@ describe("Google Antigravity OAuth upstream 401 replay", () => {
       expect(refreshCalls).toBe(1);
       expect(attemptsByBearer.get("Bearer rejected-access")).toBe(2);
       expect(attemptsByBearer.get("Bearer fresh-access")).toBe(2);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("negative project-less refresh rejects replay in native Responses passthrough", async () => {
+    await seedOAuth(undefined, null);
+    saveConfig(antigravityPassthroughConfig());
+    const observed = installOAuthFetch([401], { refreshedProjectId: null });
+    const server = startServer(0);
+    try {
+      const response = await postResponses(server);
+      const json = await response.json() as { error?: { code?: string; message?: string; type?: string } };
+      expect(response.status).toBe(401);
+      expect(json.error?.type).toBe("authentication_error");
+      expect(json.error?.message).toBe(PUBLIC_OAUTH_AUTHENTICATION_ERROR);
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("negative project-less refresh rejects replay in generic adapter", async () => {
+    await seedOAuth(undefined, null);
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([401], { refreshedProjectId: null });
+    const server = startServer(0);
+    try {
+      const response = await postResponses(server);
+      const json = await response.json() as { error?: { code?: string; message?: string; type?: string } };
+      expect(response.status).toBe(401);
+      expect(json.error?.type).toBe("authentication_error");
+      expect(json.error?.message).toBe(PUBLIC_OAUTH_AUTHENTICATION_ERROR);
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("negative project-less refresh rejects replay in chat completions", async () => {
+    await seedOAuth(undefined, null);
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([401], { refreshedProjectId: null });
+    const server = startServer(0);
+    try {
+      const response = await postChat(server);
+      const json = await response.json() as { error?: { message?: string; type?: string } };
+      expect(response.status).toBe(401);
+      expect(json.error?.type).toBe("authentication_error");
+      expect(json.error?.message).toBe(PUBLIC_OAUTH_AUTHENTICATION_ERROR);
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("401 then 200 on /v1/responses with stream: true performs one refresh and one replay with refreshed token and project", async () => {
+    await seedOAuth();
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([401, 200], { refreshedProjectId: "stream-project-999" });
+    const server = startServer(0);
+    try {
+      const response = await postResponses(server, true);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let streamText = "";
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        streamText += decoder.decode(chunk.value, { stream: true });
+      }
+      expect(streamText).toContain("ok after google refresh");
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access", "Bearer fresh-access"]);
+      expect(observed.chatProjects).toEqual(["initial-project-id", "stream-project-999"]);
     } finally {
       await server.stop(true);
     }

--- a/tests/server/server-google-antigravity-oauth-401-replay.test.ts
+++ b/tests/server/server-google-antigravity-oauth-401-replay.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveConfig } from "../../src/config";
+import { forceRefreshOAuthAccessSnapshot, getValidAccessTokenSnapshot } from "../../src/oauth";
+import { saveCredential } from "../../src/oauth/store";
+import { startServer } from "../../src/server";
+import type { OcxConfig } from "../../src/types";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "../helpers/isolated-codex-home";
+import { removeTreeWithRetry } from "../helpers/remove-tree";
+
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const DAILY_API_BASE = "https://daily-cloudcode-pa.googleapis.com";
+const PUBLIC_OAUTH_AUTHENTICATION_ERROR = "OAuth authentication failed. Check the OpenCodex account status and retry.";
+const WINDOWS_PATH_CANARY = "C:\\Users\\Alice\\.opencodex\\auth.json.ocx-tmp";
+const UNC_PATH_CANARY = "\\\\server\\share\\opencodex\\auth.json.ocx-tmp";
+const POSIX_PATH_CANARY = "/home/alice/.opencodex/auth.json.ocx-tmp";
+
+let testDir = "";
+let previousHome: string | undefined;
+let isolatedCodexHome: IsolatedCodexHome | null = null;
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  previousHome = process.env.OPENCODEX_HOME;
+  isolatedCodexHome = installIsolatedCodexHome("ocx-google-401-codex-");
+  testDir = mkdtempSync(join(tmpdir(), "ocx-google-401-"));
+  process.env.OPENCODEX_HOME = testDir;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  isolatedCodexHome?.restore();
+  isolatedCodexHome = null;
+  if (testDir) removeTreeWithRetry(testDir);
+});
+
+async function seedOAuth(expires = Date.now() + 3_600_000): Promise<void> {
+  await saveCredential("google-antigravity", {
+    access: "rejected-access",
+    refresh: "initial-refresh",
+    expires,
+    accountId: "antigravity-test-account",
+    projectId: "initial-project-id",
+    source: "oauth",
+  });
+}
+
+function antigravityConfig(): OcxConfig {
+  return {
+    port: 0,
+    hostname: "127.0.0.1",
+    defaultProvider: "google-antigravity",
+    providers: {
+      "google-antigravity": {
+        adapter: "google",
+        baseUrl: DAILY_API_BASE,
+        authMode: "oauth",
+        googleMode: "cloud-code-assist",
+        project: "initial-project-id",
+        models: ["gemini-3.8-flash"],
+      },
+    },
+  } as OcxConfig;
+}
+
+function jsonSuccessBody(text: string): Record<string, unknown> {
+  return {
+    response: {
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{ text }],
+        },
+        finishReason: "STOP",
+      }],
+      usageMetadata: {
+        promptTokenCount: 5,
+        candidatesTokenCount: 3,
+        totalTokenCount: 8,
+      },
+    },
+  };
+}
+
+function sseSuccessBody(text: string): string {
+  return `data: ${JSON.stringify(jsonSuccessBody(text))}\n\n`;
+}
+
+async function postResponses(server: ReturnType<typeof startServer>): Promise<Response> {
+  return originalFetch(new URL("/v1/responses", server.url), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "google-antigravity/gemini-3.8-flash",
+      input: "hello",
+      stream: false,
+    }),
+  });
+}
+
+async function postChat(server: ReturnType<typeof startServer>): Promise<Response> {
+  return originalFetch(new URL("/v1/chat/completions", server.url), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "google-antigravity/gemini-3.8-flash",
+      messages: [{ role: "user", content: "hello" }],
+      stream: false,
+    }),
+  });
+}
+
+function installOAuthFetch(
+  apiStatuses: number[],
+  options: {
+    tokenErrorDescription?: string;
+    refreshedProjectId?: string;
+  } = {},
+): { chatAuth: string[]; chatProjects: string[]; counts: { refresh: number } } {
+  const chatAuth: string[] = [];
+  const chatProjects: string[] = [];
+  const counts = { refresh: 0 };
+  globalThis.fetch = (async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    // Google OAuth refresh token endpoint
+    if (url === GOOGLE_TOKEN_ENDPOINT) {
+      counts.refresh += 1;
+      if (options.tokenErrorDescription !== undefined) {
+        return new Response(JSON.stringify({
+          error: "invalid_grant",
+          error_description: options.tokenErrorDescription,
+        }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({
+        access_token: "fresh-access",
+        refresh_token: "fresh-refresh",
+        expires_in: 3600,
+      }), { headers: { "content-type": "application/json" } });
+    }
+
+    // Google Cloud Code Assist project discovery
+    if (url.includes(":loadCodeAssist")) {
+      return new Response(JSON.stringify({
+        cloudaicompanionProject: options.refreshedProjectId ?? "refreshed-project-id",
+      }), { headers: { "content-type": "application/json" } });
+    }
+
+    // Google Antigravity Generate Content endpoint
+    if (url.includes("/v1internal:streamGenerateContent") || url.includes("/v1internal:generateContent")) {
+      const auth = new Headers(init?.headers).get("authorization") ?? "";
+      chatAuth.push(auth);
+      if (typeof init?.body === "string") {
+        try {
+          const parsedBody = JSON.parse(init.body) as { project?: string };
+          if (parsedBody.project) chatProjects.push(parsedBody.project);
+        } catch { /* ignore */ }
+      }
+      const status = apiStatuses.shift() ?? 200;
+      if (status === 401) {
+        return new Response(JSON.stringify({
+          error: {
+            code: 401,
+            message: "Request had invalid authentication credentials.",
+            status: "UNAUTHENTICATED",
+          },
+        }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("alt=sse")) {
+        return new Response(sseSuccessBody("ok after google refresh"), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response(JSON.stringify(jsonSuccessBody("ok after google refresh")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  return { chatAuth, chatProjects, counts };
+}
+
+describe("Google Antigravity OAuth upstream 401 replay", () => {
+  test("forceRefreshOAuthAccessSnapshot supports google-antigravity", async () => {
+    await seedOAuth();
+    installOAuthFetch([], { refreshedProjectId: "rediscovered-project-xyz" });
+
+    const snapshot = await getValidAccessTokenSnapshot("google-antigravity");
+    expect(snapshot.provider).toBe("google-antigravity");
+    expect(snapshot.accessToken).toBe("rejected-access");
+
+    const refreshed = await forceRefreshOAuthAccessSnapshot(snapshot);
+    expect(refreshed.provider).toBe("google-antigravity");
+    expect(refreshed.accessToken).toBe("fresh-access");
+    expect(refreshed.projectId).toBe("rediscovered-project-xyz");
+  });
+
+  test("initial OAuth refresh projects raw provider failures before responding", async () => {
+    await seedOAuth(0);
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([], {
+      tokenErrorDescription: `EACCES writing ${WINDOWS_PATH_CANARY}, ${UNC_PATH_CANARY}, or ${POSIX_PATH_CANARY}`,
+    });
+    const server = startServer(0);
+    try {
+      const response = await postResponses(server);
+      const json = await response.json() as { error?: { code?: string; message?: string; type?: string } };
+      const message = json.error?.message ?? "";
+      expect(response.status).toBe(401);
+      expect(json.error?.type).toBe("authentication_error");
+      expect(message).toBe(PUBLIC_OAUTH_AUTHENTICATION_ERROR);
+      expect(message).not.toContain(WINDOWS_PATH_CANARY);
+      expect(message).not.toContain(UNC_PATH_CANARY);
+      expect(message).not.toContain(POSIX_PATH_CANARY);
+      expect(message).not.toContain("auth.json");
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual([]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("OAuth 401 replay projects raw refresh failures before responding", async () => {
+    await seedOAuth();
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([401], {
+      tokenErrorDescription: `EACCES writing ${WINDOWS_PATH_CANARY}, ${UNC_PATH_CANARY}, or ${POSIX_PATH_CANARY}`,
+    });
+    const server = startServer(0);
+    try {
+      const response = await postResponses(server);
+      const json = await response.json() as { error?: { code?: string; message?: string; type?: string } };
+      const message = json.error?.message ?? "";
+      expect(response.status).toBe(401);
+      expect(json.error?.type).toBe("authentication_error");
+      expect(message).toBe(PUBLIC_OAUTH_AUTHENTICATION_ERROR);
+      expect(message).not.toContain(WINDOWS_PATH_CANARY);
+      expect(message).not.toContain(UNC_PATH_CANARY);
+      expect(message).not.toContain(POSIX_PATH_CANARY);
+      expect(message).not.toContain("auth.json");
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("401 then 200 on /v1/responses performs one refresh and one replay with refreshed token and project", async () => {
+    await seedOAuth();
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([401, 200], { refreshedProjectId: "new-project-456" });
+    const server = startServer(0);
+    try {
+      const response = await postResponses(server);
+      expect(response.status).toBe(200);
+      const json = await response.json() as { output?: { type: string; content?: { text?: string }[] }[] };
+      expect(json.output?.find(item => item.type === "message")?.content?.[0]?.text).toBe("ok after google refresh");
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access", "Bearer fresh-access"]);
+      expect(observed.chatProjects).toEqual(["initial-project-id", "new-project-456"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("401 then 200 on /v1/chat/completions performs one refresh and one replay seamlessly", async () => {
+    await seedOAuth();
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([401, 200], { refreshedProjectId: "chat-project-789" });
+    const server = startServer(0);
+    try {
+      const response = await postChat(server);
+      expect(response.status).toBe(200);
+      const json = await response.json() as { choices?: { message?: { content?: string } }[] };
+      expect(json.choices?.[0]?.message?.content).toBe("ok after google refresh");
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access", "Bearer fresh-access"]);
+      expect(observed.chatProjects).toEqual(["initial-project-id", "chat-project-789"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("401 then 401 replays once and propagates the second error cleanly", async () => {
+    await seedOAuth();
+    saveConfig(antigravityConfig());
+    const observed = installOAuthFetch([401, 401]);
+    const server = startServer(0);
+    try {
+      const response = await postResponses(server);
+      expect(response.status).toBe(401);
+      expect(observed.counts.refresh).toBe(1);
+      expect(observed.chatAuth).toEqual(["Bearer rejected-access", "Bearer fresh-access"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("concurrent 401 responses join one IdP refresh", async () => {
+    await seedOAuth();
+    saveConfig(antigravityConfig());
+    let refreshCalls = 0;
+    let signalRefreshStarted!: () => void;
+    const refreshStarted = new Promise<void>(resolve => { signalRefreshStarted = resolve; });
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>(resolve => { releaseRefresh = resolve; });
+    let releaseRejectedRequests!: () => void;
+    const rejectedRequestsReady = new Promise<void>(resolve => { releaseRejectedRequests = resolve; });
+    const attemptsByBearer = new Map<string, number>();
+
+    globalThis.fetch = (async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === GOOGLE_TOKEN_ENDPOINT) {
+        refreshCalls += 1;
+        signalRefreshStarted();
+        await refreshGate;
+        return new Response(JSON.stringify({
+          access_token: "fresh-access",
+          refresh_token: "fresh-refresh",
+          expires_in: 3600,
+        }), { headers: { "content-type": "application/json" } });
+      }
+      if (url.includes(":loadCodeAssist")) {
+        return new Response(JSON.stringify({
+          cloudaicompanionProject: "concurrent-project-id",
+        }), { headers: { "content-type": "application/json" } });
+      }
+      if (url.includes("/v1internal:streamGenerateContent") || url.includes("/v1internal:generateContent")) {
+        const bearer = new Headers(init?.headers).get("authorization") ?? "";
+        attemptsByBearer.set(bearer, (attemptsByBearer.get(bearer) ?? 0) + 1);
+        if (bearer === "Bearer rejected-access") {
+          if (attemptsByBearer.get(bearer) === 2) releaseRejectedRequests();
+          await rejectedRequestsReady;
+          return new Response(JSON.stringify({
+            error: {
+              code: 401,
+              message: "Request had invalid authentication credentials.",
+              status: "UNAUTHENTICATED",
+            },
+          }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.includes("alt=sse")) {
+          return new Response(sseSuccessBody("concurrent ok"), {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        return new Response(JSON.stringify(jsonSuccessBody("concurrent ok")), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    const server = startServer(0);
+    try {
+      const first = postResponses(server);
+      const second = postResponses(server);
+      await refreshStarted;
+      releaseRefresh();
+      const [a, b] = await Promise.all([first, second]);
+      expect([a.status, b.status]).toEqual([200, 200]);
+      expect(refreshCalls).toBe(1);
+      expect(attemptsByBearer.get("Bearer rejected-access")).toBe(2);
+      expect(attemptsByBearer.get("Bearer fresh-access")).toBe(2);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3575

Add `google-antigravity` to the set of OAuth providers supported by automatic upstream 401 recovery and force-refresh replay (`isOAuth401ReplayProvider` and `FORCE_REFRESH_PROVIDERS`), with fail-closed Cloud Code Assist project invariant enforcement.

### Root Cause
When Google Antigravity OAuth session tokens expire, desynchronize, or are invalidated upstream by Google, upstream API requests fail with 401 Unauthorized. Other OAuth providers (`xai`, `github-copilot`, `kiro`) automatically intercept upstream 401s, force-refresh the snapshot via `forceRefreshOAuthAccessSnapshot`, and transparently replay the request. For `google-antigravity`, the absence from `isOAuth401ReplayProvider` and `FORCE_REFRESH_PROVIDERS` caused requests to terminate immediately, returning raw 401 errors to client applications until manual credential re-resolution occurred.

### Key Changes
1. **`src/oauth/index.ts`**: Add `"google-antigravity"` to `FORCE_REFRESH_PROVIDERS` so `forceRefreshOAuthAccessSnapshot` allows forced refresh for Antigravity tokens.
2. **`src/server/responses/core.ts`**:
   - Add `route.providerName === "google-antigravity"` to `isOAuth401ReplayProvider` for both streaming and non-streaming responses.
   - Enforce fail-closed guard in both passthrough and generic adapter 401 replay paths: when `googleMode === "cloud-code-assist"` and `!refreshed.projectId`, reject the identity replacement and abort replay with an authentication error, preventing project-less tokens from reusing stale/mismatched project metadata.
   - Synchronize refreshed `projectId` in `refreshedProvider` during 401 replay so any re-discovered project is paired with the fresh token.
3. **`tests/server/server-google-antigravity-oauth-401-replay.test.ts`**:
   - End-to-end and unit test coverage for 401 refresh and replay on `/v1/responses` (both streaming `stream: true` consuming SSE and non-streaming) and `/v1/chat/completions`.
   - Negative tests verifying that project-less refresh rejects replay across native Responses passthrough, generic adapter, and chat completions.
   - Error projection sanitization on initial refresh and replay failure.
   - Single-replay enforcement preventing infinite loops on persistent 401.
   - Concurrent 401 request deduplication joining a single in-flight IdP refresh.

## Verification

Ran targeted unit and integration test suites:
```bash
bun test tests/server/server-google-antigravity-oauth-401-replay.test.ts
bun test tests/server/server-xai-oauth-401-replay.test.ts
bun test tests/server/server-kiro-oauth-401-replay.test.ts
bun test tests/adapters/google/google-antigravity-oauth.test.ts
bun scripts/test-layout/verify.ts --domain server --skip-tests
```
All 11 tests in the Antigravity replay suite passed cleanly.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Google Antigravity OAuth recovery when access tokens expire or are rejected.
  - Automatically refreshes credentials and retries affected requests, including streaming responses.
  - Preserves the associated project during recovery to prevent invalid replay attempts.
  - Handles concurrent authentication failures with a single refresh operation.
  - Provides clearer authentication errors without exposing local file paths or credential details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->