### PR TITLE
refactor(combos): isolate combo identifier helpers (split S11 L1/5)

### DIFF
--- a/src/combos/identifiers.ts
+++ b/src/combos/identifiers.ts
@@ -87,4 +87,3 @@ export function resolveComboId(
 export function isValidComboId(id: string): boolean {
   return COMBO_ID_PATTERN.test(id);
 }
-

--- a/src/combos/identifiers.ts
+++ b/src/combos/identifiers.ts
@@ -1,0 +1,90 @@
+import { SUPPORTED_NATIVE_OPENAI_SLUGS } from "../codex/catalog/native-models";
+import type { OcxComboConfig, OcxComboTarget, OcxConfig } from "../types";
+
+export const COMBO_NAMESPACE = "combo";
+
+export function preservesPhysicalComboProvider(
+  config: Pick<OcxConfig, "providers" | "combos">,
+): boolean {
+  return Object.hasOwn(config.providers, COMBO_NAMESPACE)
+    && Object.keys(config.combos ?? {}).length === 0;
+}
+
+const COMBO_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+/** True only for an explicitly opted-in bare native-family alias. */
+export function isNativeAliasCombo(
+  combo: { alias?: string | null; nativeAlias?: boolean },
+): boolean {
+  const alias = typeof combo.alias === "string" ? combo.alias.trim() : "";
+  return combo.nativeAlias === true
+    && SUPPORTED_NATIVE_OPENAI_SLUGS.has(alias);
+}
+
+export function targetKey(target: Pick<OcxComboTarget, "provider" | "model">): string {
+  return `${target.provider}/${target.model}`;
+}
+
+export function parseComboModelId(modelId: string): string | null {
+  const slash = modelId.indexOf("/");
+  if (slash <= 0 || modelId.slice(0, slash) !== COMBO_NAMESPACE) return null;
+  const id = modelId.slice(slash + 1);
+  return id.length > 0 ? id : null;
+}
+
+export function comboModelId(id: string): string {
+  return `${COMBO_NAMESPACE}/${id}`;
+}
+
+/** Public model id clients request: the alias when set, else the default `combo/<id>`. */
+export function comboPublicModelId(id: string, combo: { alias?: string | null }): string {
+  const alias = typeof combo.alias === "string" ? combo.alias.trim() : "";
+  return alias || comboModelId(id);
+}
+
+/**
+ * Persisted selector that hides a combo from discovery. Native aliases keep the canonical
+ * `combo/<id>` selector because their bare public id remains the native OpenAI disable key.
+ */
+export function comboDisabledModelId(
+  id: string,
+  combo: { alias?: string | null; nativeAlias?: boolean },
+): string {
+  return isNativeAliasCombo(combo) ? comboModelId(id) : comboPublicModelId(id, combo);
+}
+
+/** Every persisted selector that can refer to this combo in `disabledModels`. */
+export function comboDisabledModelSelectors(
+  id: string,
+  combo: { alias?: string | null; nativeAlias?: boolean },
+): string[] {
+  const canonical = comboModelId(id);
+  const preferred = comboDisabledModelId(id, combo);
+  return preferred === canonical ? [canonical] : [canonical, preferred];
+}
+
+/**
+ * Resolve a client-requested model id to a combo config key. The canonical `combo/<id>`
+ * form wins first (back-compat); otherwise an exact alias match across configured combos.
+ */
+export function resolveComboId(
+  config: { combos?: Record<string, OcxComboConfig> },
+  modelId: string,
+): string | null {
+  const direct = parseComboModelId(modelId);
+  if (direct) return direct;
+  const combos = config.combos;
+  if (!combos) return null;
+  for (const [id, raw] of Object.entries(combos)) {
+    if (!raw || typeof raw !== "object") continue;
+    const alias = typeof raw.alias === "string" ? raw.alias.trim() : "";
+    if (alias && alias === modelId) return id;
+  }
+  return null;
+}
+
+
+export function isValidComboId(id: string): boolean {
+  return COMBO_ID_PATTERN.test(id);
+}
+

--- a/src/combos/types.ts
+++ b/src/combos/types.ts
@@ -1,25 +1,10 @@
 import { isCodexReasoningEffort } from "../reasoning-effort";
 import { SUPPORTED_NATIVE_OPENAI_SLUGS } from "../codex/catalog/native-models";
-import type {
-  OcxComboConfig,
-  OcxComboDefaultEffort,
-  OcxComboReasoningEffortMode,
-  OcxComboStrategy,
-  OcxComboTarget,
-  OcxConfig,
-  OcxProviderConfig,
-} from "../types";
+import type { OcxComboConfig, OcxComboDefaultEffort, OcxComboReasoningEffortMode, OcxComboStrategy, OcxComboTarget, OcxProviderConfig } from "../types";
+import { COMBO_NAMESPACE, isValidComboId, targetKey } from "./identifiers";
 
-export const COMBO_NAMESPACE = "combo";
+export { COMBO_NAMESPACE, preservesPhysicalComboProvider, isNativeAliasCombo, targetKey, parseComboModelId, comboModelId, comboPublicModelId, comboDisabledModelId, comboDisabledModelSelectors, resolveComboId, isValidComboId } from "./identifiers";
 
-export function preservesPhysicalComboProvider(
-  config: Pick<OcxConfig, "providers" | "combos">,
-): boolean {
-  return Object.hasOwn(config.providers, COMBO_NAMESPACE)
-    && Object.keys(config.combos ?? {}).length === 0;
-}
-
-const COMBO_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 /**
  * Public alias shape: one optional "/" segment, each segment id-shaped. Bare aliases
  * (no "/") are the masquerade case — the combo answers to a mandated model id with no
@@ -49,77 +34,6 @@ export interface NormalizedComboConfig {
   /** Display-only label for the catalog row, or null when unset. */
   displayName: string | null;
   targets: Array<Required<OcxComboTarget>>;
-}
-
-/** True only for an explicitly opted-in bare native-family alias. */
-export function isNativeAliasCombo(
-  combo: { alias?: string | null; nativeAlias?: boolean },
-): boolean {
-  const alias = typeof combo.alias === "string" ? combo.alias.trim() : "";
-  return combo.nativeAlias === true
-    && SUPPORTED_NATIVE_OPENAI_SLUGS.has(alias);
-}
-
-export function targetKey(target: Pick<OcxComboTarget, "provider" | "model">): string {
-  return `${target.provider}/${target.model}`;
-}
-
-export function parseComboModelId(modelId: string): string | null {
-  const slash = modelId.indexOf("/");
-  if (slash <= 0 || modelId.slice(0, slash) !== COMBO_NAMESPACE) return null;
-  const id = modelId.slice(slash + 1);
-  return id.length > 0 ? id : null;
-}
-
-export function comboModelId(id: string): string {
-  return `${COMBO_NAMESPACE}/${id}`;
-}
-
-/** Public model id clients request: the alias when set, else the default `combo/<id>`. */
-export function comboPublicModelId(id: string, combo: { alias?: string | null }): string {
-  const alias = typeof combo.alias === "string" ? combo.alias.trim() : "";
-  return alias || comboModelId(id);
-}
-
-/**
- * Persisted selector that hides a combo from discovery. Native aliases keep the canonical
- * `combo/<id>` selector because their bare public id remains the native OpenAI disable key.
- */
-export function comboDisabledModelId(
-  id: string,
-  combo: { alias?: string | null; nativeAlias?: boolean },
-): string {
-  return isNativeAliasCombo(combo) ? comboModelId(id) : comboPublicModelId(id, combo);
-}
-
-/** Every persisted selector that can refer to this combo in `disabledModels`. */
-export function comboDisabledModelSelectors(
-  id: string,
-  combo: { alias?: string | null; nativeAlias?: boolean },
-): string[] {
-  const canonical = comboModelId(id);
-  const preferred = comboDisabledModelId(id, combo);
-  return preferred === canonical ? [canonical] : [canonical, preferred];
-}
-
-/**
- * Resolve a client-requested model id to a combo config key. The canonical `combo/<id>`
- * form wins first (back-compat); otherwise an exact alias match across configured combos.
- */
-export function resolveComboId(
-  config: { combos?: Record<string, OcxComboConfig> },
-  modelId: string,
-): string | null {
-  const direct = parseComboModelId(modelId);
-  if (direct) return direct;
-  const combos = config.combos;
-  if (!combos) return null;
-  for (const [id, raw] of Object.entries(combos)) {
-    if (!raw || typeof raw !== "object") continue;
-    const alias = typeof raw.alias === "string" ? raw.alias.trim() : "";
-    if (alias && alias === modelId) return id;
-  }
-  return null;
 }
 
 /**
@@ -391,10 +305,6 @@ export function comboDefaultEffort(
   return typeof value === "string" && isCodexReasoningEffort(value)
     ? value as OcxComboDefaultEffort
     : null;
-}
-
-export function isValidComboId(id: string): boolean {
-  return COMBO_ID_PATTERN.test(id);
 }
 
 export function listComboIds(config: { combos?: Record<string, OcxComboConfig> }): string[] {

--- a/tests/codex-integration/combos.test.ts
+++ b/tests/codex-integration/combos.test.ts
@@ -62,6 +62,9 @@ import {
 } from "../../src/providers/quota-routing-cache";
 import { catalogConvergenceFactory } from "../helpers/catalog-convergence";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
+import * as publicCombos from "../../src/combos";
+import * as comboIdentifiers from "../../src/combos/identifiers";
+import { repoPath } from "../helpers/repo-root";
 
 const VALID_COMBO = { targets: [{ provider: "a", model: "m1" }] };
 
@@ -1200,4 +1203,26 @@ describe("combo generation reconciliation", () => {
     noteComboSuccess("free", originalCombo, removedPick.target, 0);
     expect(pickComboTarget(original, "free")?.target.provider).toBe("b");
   });
+});
+
+test("combo identifiers leaf preserves public export identity without facade imports", () => {
+  const names = [
+    "COMBO_NAMESPACE",
+    "preservesPhysicalComboProvider",
+    "isNativeAliasCombo",
+    "targetKey",
+    "parseComboModelId",
+    "comboModelId",
+    "comboPublicModelId",
+    "comboDisabledModelId",
+    "comboDisabledModelSelectors",
+    "resolveComboId",
+    "isValidComboId",
+  ] as const;
+  for (const name of names) {
+    expect(publicCombos[name]).toBe(comboIdentifiers[name]);
+  }
+  const source = readFileSync(repoPath("src", "combos", "identifiers.ts"), "utf8");
+  expect(source.split(/\r?\n/).some(line => /from\s+["']\.\/(types|index)["']/.test(line)))
+    .toBe(false);
 });


### PR DESCRIPTION
## Summary

- Pure move: the combo identifier helpers of `src/combos/types.ts` (`COMBO_NAMESPACE`, id pattern/validation, `targetKey`, `parseComboModelId`/`comboModelId`/`comboPublicModelId`/`comboDisabledModelId`/`comboDisabledModelSelectors`, `resolveComboId`, native-alias predicate — lines 13–22, 54–124, 396–399) move verbatim to `src/combos/identifiers.ts` (89 lines). `types.ts` keeps validation/normalization and re-exports all 11 moved values, so all 22 previously exported names stay importable from `combos/types` and the `combos/index.ts` facade is untouched (19 direct importers unchanged).
- Why: 423-line file over the 400-line module limit; identifiers are a dependency-free leaf that validation consumes, so the split removes an implicit forward reference inside the file. Zero behavior change.
- Plan and evidence: `devlog/_plan/260905_now_split_train/320_combos_types.md`; rules `003_parent_decisions.md` (PURE-MOVE-SIZE-01, TYPE-CYCLE-01).

**Stack** (S11 codex-misc — independent layers, each based on `dev`; no cascade between them):

| # | PR | Branch | Base | Review focus |
|---|----|--------|------|--------------|
| 5 | TBD | codex/split-oauth-github-copilot | dev | github-copilot |
| 4 | TBD | codex/split-routing-trace | dev | routing/trace |
| 3 | TBD | codex/split-codex-cli-install-provenance | dev | cli-install-provenance |
| 2 | TBD | codex/split-codex-subagent-defaults | dev | subagent-defaults |
| 1 | this PR | codex/split-combos-types ← you are here | dev | identifiers leaf |

Base: dev. Review this PR's diff only (3 files, +118/−94; non-move diff: 2 leaf imports, 5 facade wiring lines, 25 test lines). Move-aware view: `git diff --color-moved=dimmed-zebra dev...HEAD`.

## Verification

- `bun run typecheck` → exit 0
- Focused (combos, codex-catalog, combo-management-api, provider-id-rewrite) → 372 pass / 0 fail
- `tests/lab/core-lab-boundary.test.ts` → 17 pass / 0 fail
- Cycle gate including inline `import("…")` type edges: 18 files walked, no path returns to `types.ts`/`index.ts`/the leaf; the three pre-existing type cycles under `src/types` are unchanged.
- Red-drives, then restored: wrapping `comboModelId` at the facade fails the new identity assertion; breaking `comboDisabledModelSelectors` in the leaf fails `combos.test.ts:193`.
- `bun run privacy:scan` → passed; `git diff --check dev...HEAD` clean.
- New test: identity of all 11 moved values via facade vs leaf; leaf has no back-edge.
- Full suite on the remote CI host (`lidge`) at this exact SHA: recorded in the devlog doc.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (devlog unit records the layer; no user-facing change).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (combo id validation moved byte-for-byte).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent combo model identifiers and aliases for selecting configured combo models.
  - Added support for resolving combo models by canonical ID or exact configured alias.
  - Improved handling of disabled combo model selectors, including native OpenAI aliases.
  - Added validation and parsing for combo model IDs, with malformed identifiers handled safely.
- **Bug Fixes**
  - Preserved physical combo provider behavior when no configured combos are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->