### PR TITLE
test(oauth): exercise the account-removal path the quorum test is named for

### DIFF
--- a/tests/routing/anthropic-quorum-cache.test.ts
+++ b/tests/routing/anthropic-quorum-cache.test.ts
@@ -25,7 +25,7 @@ import {
   resetAnthropicRoutingForManualSelection,
   rotateAnthropicAccountOn429,
 } from "../../src/oauth/anthropic-routing";
-import { getAccountSet, markAccountNeedsReauth, saveCredential } from "../../src/oauth/store";
+import { getAccountSet, markAccountNeedsReauth, removeAccount, saveCredential } from "../../src/oauth/store";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 
 const originalHome = process.env.OPENCODEX_HOME;
@@ -158,15 +158,17 @@ describe("Anthropic failover quorum cache", () => {
   });
 
   test("removing an account invalidates immediately, not after the TTL", async () => {
-    // The management DELETE route calls clearAnthropicSessionAffinityForAccount for Anthropic.
-    // Without invalidation there, deleting the second account would leave quorum true for up to
-    // 2s -- long enough for a request to record an id whose credential is already gone.
+    // Mirror the real DELETE route (src/server/management/oauth-account-routes.ts): the
+    // credential is removed FIRST, and only then is routing state cleared. Clearing affinity
+    // alone leaves the roster at 2, so the predicate could never observe the transition this
+    // test is named for -- it could only assert that the store was re-read.
     const start = Date.now();
     const ids = await seed(2);
     expect(hasAnthropicFailoverQuorum(start)).toBe(true);
+    expect(await removeAccount("anthropic", ids[1]!)).toBe(true);
     clearAnthropicSessionAffinityForAccount(ids[1]!);
     markStoreUnread();
-    hasAnthropicFailoverQuorum(start + 1);
+    expect(hasAnthropicFailoverQuorum(start + 1)).toBe(false);
     expect(storeWasRead()).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #3530. The restored contract test `removing an account invalidates immediately, not after the TTL` never removed an account: it cleared session affinity, marked the store unread, and asserted only that the store was re-read. With two accounts still in the roster the predicate could not observe the transition the test is named for, so deleting the `removeAccount` call from the DELETE route would have left it green. The test now mirrors the route order (`removeAccount` first, then `clearAnthropicSessionAffinityForAccount`) and asserts quorum is actually `false` afterward.

Unit: `devlog/_plan/260905_open_work_closeout/` (050 E0, 051).

## Verification

- `bun test tests/routing/anthropic-quorum-cache.test.ts` — 7 pass / 0 fail. RED probe: with the new `removeAccount` line commented out the new `toBe(false)` assertion fails (6 pass / 1 fail), proving the assertion observes the roster reduction; the sibling "manual account selection invalidates immediately" test still passes with two accounts intact.
- `bun run typecheck` — exit 0.
- Test-only change; hosted CI on the final dev tip is the batch gate per maintainer instruction.

## Checklist

- [x] Targets `dev`
- [x] Test proven RED without the behavior it guards
- [x] No runtime change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated routing tests to verify that removing an account immediately invalidates the associated quorum cache.
  - Test behavior now matches the account deletion flow more closely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->