### PR TITLE
test(kiro): assert that the bounded completion fallback executes (carry of #3487)

### DIFF
--- a/tests/providers/kiro/kiro-stream.test.ts
+++ b/tests/providers/kiro/kiro-stream.test.ts
@@ -1720,7 +1720,11 @@ describe("kiro adapter — parseStream", () => {
 
     resetKiroCalibration();
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response(streamOf(eventFrame({ content: "Final from fallback." })))) as typeof fetch;
+    let fallbackCalls = 0;
+    globalThis.fetch = (async () => {
+      fallbackCalls++;
+      return new Response(streamOf(eventFrame({ content: "Final from fallback." })));
+    }) as typeof fetch;
     try {
       const falling = createKiroAdapter(provider);
       await falling.buildRequest(sameConversation([bashTool]));
@@ -1730,6 +1734,7 @@ describe("kiro adapter — parseStream", () => {
         eventFrame({ content: "I am checking." }),
         eventFrame({ contextUsagePercentage: 10 }),
       ))));
+      expect(fallbackCalls).toBe(1);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

Carries #3487 to the migrated Kiro test path. The fallback regression now counts its fetch calls, so it fails if the bounded completion fallback stops running even when the calibration estimate stays unchanged.

## Verification

- Seven-line diff inspected at 4b289cd1c; no production change.
- No local tests run in this continuation. Final dev Linux CI is the requested batch gate.

## Checklist

- [x] One focused test correction.
- [x] No documentation or runtime behavior change.
- [x] No secrets or authentication changes.

Co-authored-by: Ingwannu <186453546+Ingwannu@users.noreply.github.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated calibration fallback coverage to verify that exactly one bounded fallback request is made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->