### PR TITLE
fix(codex): preserve short-window observation provenance for routing

### DIFF
--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -22,6 +22,8 @@ export type StoredAccountQuota = {
    */
   shortPercent?: number;
   shortResetAt?: number;
+  /** Local observation time of shortPercent; unrelated quota/credit updates never refresh it. */
+  shortObservedAt?: number;
   shortWindowSeconds?: number;
   customWindows?: Array<{ label: string; percent: number; resetAt?: number }>;
   resetCredits?: number;
@@ -288,6 +290,7 @@ export function setAccountQuotaFromParsed(
     if (existing?.monthlyResetAt !== undefined) next.monthlyResetAt = existing.monthlyResetAt;
     if (existing?.monthlyIsPrimaryWindow === true) next.monthlyIsPrimaryWindow = true;
     if (existing?.shortPercent !== undefined) next.shortPercent = existing.shortPercent;
+    if (existing?.shortObservedAt !== undefined) next.shortObservedAt = existing.shortObservedAt;
     if (existing?.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
     if (existing?.shortWindowSeconds !== undefined) next.shortWindowSeconds = existing.shortWindowSeconds;
     if (existing?.customWindows !== undefined) next.customWindows = existing.customWindows;
@@ -323,13 +326,17 @@ export function setAccountQuotaFromParsed(
   }
 
   if (snapshotHasShort(quota)) {
-    if (quota.shortPercent !== undefined) next.shortPercent = quota.shortPercent;
+    if (quota.shortPercent !== undefined) {
+      next.shortPercent = quota.shortPercent;
+      if (Number.isFinite(quota.shortPercent)) next.shortObservedAt = next.updatedAt;
+    }
     if (quota.shortResetAt !== undefined) next.shortResetAt = quota.shortResetAt;
     if (quota.shortWindowSeconds !== undefined) next.shortWindowSeconds = quota.shortWindowSeconds;
   } else {
     // Header and reset-credit updates are partial snapshots. Preserve the last full WHAM
     // burst tuple when those updates do not carry enough window metadata to replace it.
     if (existing?.shortPercent !== undefined) next.shortPercent = existing.shortPercent;
+    if (existing?.shortObservedAt !== undefined) next.shortObservedAt = existing.shortObservedAt;
     if (existing?.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
     if (existing?.shortWindowSeconds !== undefined) next.shortWindowSeconds = existing.shortWindowSeconds;
   }
@@ -511,6 +518,7 @@ export function updateAccountQuota(
     ...(existing?.weeklyResetAt !== undefined ? { weeklyResetAt: existing.weeklyResetAt } : {}),
     ...(existing?.monthlyResetAt !== undefined ? { monthlyResetAt: existing.monthlyResetAt } : {}),
     ...(existing?.shortPercent !== undefined ? { shortPercent: existing.shortPercent } : {}),
+    ...(existing?.shortObservedAt !== undefined ? { shortObservedAt: existing.shortObservedAt } : {}),
     ...(existing?.shortResetAt !== undefined ? { shortResetAt: existing.shortResetAt } : {}),
     ...(existing?.shortWindowSeconds !== undefined ? { shortWindowSeconds: existing.shortWindowSeconds } : {}),
     ...(existing?.customWindows !== undefined ? { customWindows: existing.customWindows } : {}),

--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -114,6 +114,14 @@ const CODEX_MAX_RESET_DERIVED_COOLDOWN_MS = 15 * 60_000;
 /** Minimum gap between probe leases for one cooled-down account. */
 export const CODEX_QUOTA_PROBE_INTERVAL_MS = 5 * 60_000;
 export const CODEX_FAILURE_WINDOW_MS = 5 * 60_000;
+/**
+ * How recently a 100% burst reading must have been OBSERVED to exclude an account when it
+ * carries no reset timestamp (#3425). Deliberately far tighter than the 6h disk-hydration
+ * horizon in `quota.ts`: shorter than any plausible five-hour burst window, so a persisted
+ * reading can never strand a recovered account, and long enough that a snapshot taken at
+ * admission is still fresh when selection reads it.
+ */
+export const TERMINAL_SHORT_WINDOW_FRESHNESS_MS = 5 * 60_000;
 /** How long a transient failure keeps the account out of pool selection. */
 export const CODEX_TRANSIENT_SOFT_AVOID_MS = 30_000;
 const CODEX_TRANSIENT_SOFT_AVOID_ESCALATION_MS = [
@@ -365,6 +373,7 @@ export function computeCodexUsageScore(quota: {
   monthlyPercent?: number;
   shortPercent?: number;
   shortResetAt?: number;
+  updatedAt?: number;
 } | null, plan?: unknown, now: number = Date.now()): number {
   if (!quota) return CODEX_UNKNOWN_USAGE_SCORE;
   const finite = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
@@ -404,15 +413,28 @@ export function computeCodexUsageScore(quota: {
  * direction here is the one that keeps an account selectable: a wrongly-selected account
  * fails one request, while a wrongly-excluded one is invisible until someone reads the pool
  * by hand.
+ *
+ * That last paragraph held only while observation time was unavailable here (#3425). A
+ * reading with no reset timestamp cannot be aged BY ITS RESET, but it can be aged by WHEN IT
+ * WAS OBSERVED, and `StoredAccountQuota.updatedAt` already carries that. A 100% window
+ * observed seconds ago is a measured refusal, not an unaged guess: leaving it selectable is
+ * what wedged a pool on 118 consecutive 502s over 23 minutes while another account sat at 3%,
+ * because 502 is transient and produced no quota signal to correct the choice. Freshness keeps
+ * both directions of #3029 safe - a stale reading still falls back to unknown, so a recovered
+ * account is never stranded.
  */
 function isTerminalShortWindow(
-  quota: { shortPercent?: number; shortResetAt?: number },
+  quota: { shortPercent?: number; shortResetAt?: number; updatedAt?: number },
   now: number,
 ): boolean {
   if (typeof quota.shortPercent !== "number" || !Number.isFinite(quota.shortPercent)) return false;
   if (quota.shortPercent < CODEX_EXHAUSTED_USAGE_PERCENT) return false;
   const resetAt = quota.shortResetAt;
-  if (typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt <= 0) return false;
+  if (typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt <= 0) {
+    const observedAt = quota.updatedAt;
+    if (typeof observedAt !== "number" || !Number.isFinite(observedAt)) return false;
+    return now - observedAt <= TERMINAL_SHORT_WINDOW_FRESHNESS_MS;
+  }
   // Both units reach storage: `normalizeResetAt` does not scale, and the GUI disambiguates
   // by magnitude at read time. A comparison written against one assumption is off by 1000x
   // against the other, and in the seconds-read-as-milliseconds direction every terminal

--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -373,7 +373,7 @@ export function computeCodexUsageScore(quota: {
   monthlyPercent?: number;
   shortPercent?: number;
   shortResetAt?: number;
-  updatedAt?: number;
+  shortObservedAt?: number;
 } | null, plan?: unknown, now: number = Date.now()): number {
   if (!quota) return CODEX_UNKNOWN_USAGE_SCORE;
   const finite = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
@@ -414,26 +414,22 @@ export function computeCodexUsageScore(quota: {
  * fails one request, while a wrongly-excluded one is invisible until someone reads the pool
  * by hand.
  *
- * That last paragraph held only while observation time was unavailable here (#3425). A
- * reading with no reset timestamp cannot be aged BY ITS RESET, but it can be aged by WHEN IT
- * WAS OBSERVED, and `StoredAccountQuota.updatedAt` already carries that. A 100% window
- * observed seconds ago is a measured refusal, not an unaged guess: leaving it selectable is
- * what wedged a pool on 118 consecutive 502s over 23 minutes while another account sat at 3%,
- * because 502 is transient and produced no quota signal to correct the choice. Freshness keeps
- * both directions of #3029 safe - a stale reading still falls back to unknown, so a recovered
- * account is never stranded.
+ * A missing reset can instead be aged by shortObservedAt (#3425). General updatedAt is not
+ * sufficient: credit-only updates preserve the old short tuple but advance that timestamp.
+ * Old disk snapshots without short-window provenance remain unknown.
  */
 function isTerminalShortWindow(
-  quota: { shortPercent?: number; shortResetAt?: number; updatedAt?: number },
+  quota: { shortPercent?: number; shortResetAt?: number; shortObservedAt?: number },
   now: number,
 ): boolean {
   if (typeof quota.shortPercent !== "number" || !Number.isFinite(quota.shortPercent)) return false;
   if (quota.shortPercent < CODEX_EXHAUSTED_USAGE_PERCENT) return false;
   const resetAt = quota.shortResetAt;
   if (typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt <= 0) {
-    const observedAt = quota.updatedAt;
+    const observedAt = quota.shortObservedAt;
     if (typeof observedAt !== "number" || !Number.isFinite(observedAt)) return false;
-    return now - observedAt <= TERMINAL_SHORT_WINDOW_FRESHNESS_MS;
+    const age = now - observedAt;
+    return age >= 0 && age <= TERMINAL_SHORT_WINDOW_FRESHNESS_MS;
   }
   // Both units reach storage: `normalizeResetAt` does not scale, and the GUI disambiguates
   // by magnitude at read time. A comparison written against one assumption is off by 1000x

--- a/tests/codex-integration/codex-routing.test.ts
+++ b/tests/codex-integration/codex-routing.test.ts
@@ -162,6 +162,35 @@ describe("codex routing", () => {
       .toBe(CODEX_UNKNOWN_USAGE_SCORE);
   });
 
+  test("a fresh full burst window with no reset timestamp still excludes the account (#3425)", () => {
+    // #3425: an exhausted account served 118 consecutive 502s over 23 minutes while a healthy
+    // account sat at 3%. The upstream reading said 100% but carried no shortResetAt, and 502 is
+    // classified transient, so nothing ever corrected the selection. A reading that cannot be
+    // aged by its RESET can still be aged by its OBSERVATION time, and a 100% window observed
+    // seconds ago is a measured refusal rather than an optimistic guess.
+    const now = 1_700_000_000_000;
+    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now }, undefined, now)).toBe(100);
+    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now - 60_000 }, undefined, now)).toBe(100);
+    // Still narrow in the other axis: a non-terminal fresh reading is unaffected.
+    expect(computeCodexUsageScore({ shortPercent: 99, updatedAt: now }, undefined, now))
+      .toBe(CODEX_UNKNOWN_USAGE_SCORE);
+  });
+
+  test("a stale full burst window with no reset timestamp stays unknown (#3029)", () => {
+    // The opposite-direction guard, and the reason the fix is freshness rather than an
+    // inversion of #3029. Disk hydration accepts a persisted reading for six hours, so an
+    // observation old enough to have outlived a five-hour window must fall back to unknown -
+    // otherwise a recovered account is excluded until someone reads the pool by hand.
+    const now = 1_700_000_000_000;
+    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now - 6 * 60_000 }, undefined, now))
+      .toBe(CODEX_UNKNOWN_USAGE_SCORE);
+    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now - 5 * 60 * 60_000 }, undefined, now))
+      .toBe(CODEX_UNKNOWN_USAGE_SCORE);
+    // A future-dated observation is not evidence of freshness either.
+    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: Number.NaN }, undefined, now))
+      .toBe(CODEX_UNKNOWN_USAGE_SCORE);
+  });
+
   test("a terminal burst window is read in either unit (#3029)", () => {
     // normalizeResetAt does not scale, and the GUI disambiguates by magnitude at read time,
     // so both seconds and milliseconds reach storage. A comparison written against one
@@ -210,6 +239,38 @@ describe("codex routing", () => {
     updateAccountQuota("b", 20);
     const recovered = makeConfig({ activeCodexAccountId: "a" });
     expect(resolveCodexAccountForThread("thread-terminal-recovered", recovered, now)).toBe("a");
+  });
+
+  test("a 502 storm does not pin the pool to an exhausted account (#3425)", () => {
+    // The reported wedge: A reads 100% with no reset timestamp, every request comes back 502,
+    // and 502 is transient so it produces no quota signal to correct the selection. The
+    // exclusion therefore has to come from the snapshot itself. B carries known headroom, so
+    // an unknown-scoring A would be kept and this assertion fails on the unfixed scorer.
+    const now = Date.now();
+    setAccountQuotaFromParsed("a", { shortPercent: 100 });
+    updateAccountQuota("b", 3);
+    const config = makeConfig({ activeCodexAccountId: "a" });
+    expect(resolveCodexAccountForThread("thread-storm-new", config, now)).toBe("b");
+
+    // A thread already bound to A must move too - this is the half the reporter saw as 118
+    // consecutive failures on one credential. Bind while A is cool so the rebind below is a
+    // real transition rather than a first selection that happened to pick B.
+    clearAccountQuota("a");
+    clearAccountQuota("b");
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+    const bound = makeConfig({ activeCodexAccountId: "a" });
+    expect(resolveCodexAccountForThread("thread-storm-bound", bound, now)).toBe("a");
+    clearAccountQuota("a");
+    setAccountQuotaFromParsed("a", { shortPercent: 100 });
+    expect(resolveCodexAccountForThread("thread-storm-bound", bound, now)).toBe("b");
+  });
+
+  test("a bare 502 is still classified transient (#3425)", () => {
+    // The exclusion above comes from the snapshot, not from demoting 502 out of the transient
+    // set. A gateway blip genuinely is transient in the general case, and reclassifying every
+    // one would strand accounts on ordinary upstream noise.
+    expect(classifyCodexUpstreamOutcome(502)).toBe("transient");
   });
 
   test("the priority tier reads the request clock, not wall time (#3029)", () => {

--- a/tests/codex-integration/codex-routing.test.ts
+++ b/tests/codex-integration/codex-routing.test.ts
@@ -169,10 +169,10 @@ describe("codex routing", () => {
     // aged by its RESET can still be aged by its OBSERVATION time, and a 100% window observed
     // seconds ago is a measured refusal rather than an optimistic guess.
     const now = 1_700_000_000_000;
-    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now }, undefined, now)).toBe(100);
-    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now - 60_000 }, undefined, now)).toBe(100);
+    expect(computeCodexUsageScore({ shortPercent: 100, shortObservedAt: now }, undefined, now)).toBe(100);
+    expect(computeCodexUsageScore({ shortPercent: 100, shortObservedAt: now - 60_000 }, undefined, now)).toBe(100);
     // Still narrow in the other axis: a non-terminal fresh reading is unaffected.
-    expect(computeCodexUsageScore({ shortPercent: 99, updatedAt: now }, undefined, now))
+    expect(computeCodexUsageScore({ shortPercent: 99, shortObservedAt: now }, undefined, now))
       .toBe(CODEX_UNKNOWN_USAGE_SCORE);
   });
 
@@ -182,13 +182,41 @@ describe("codex routing", () => {
     // observation old enough to have outlived a five-hour window must fall back to unknown -
     // otherwise a recovered account is excluded until someone reads the pool by hand.
     const now = 1_700_000_000_000;
-    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now - 6 * 60_000 }, undefined, now))
+    expect(computeCodexUsageScore({ shortPercent: 100, shortObservedAt: now - 6 * 60_000 }, undefined, now))
       .toBe(CODEX_UNKNOWN_USAGE_SCORE);
-    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: now - 5 * 60 * 60_000 }, undefined, now))
+    expect(computeCodexUsageScore({ shortPercent: 100, shortObservedAt: now - 5 * 60 * 60_000 }, undefined, now))
       .toBe(CODEX_UNKNOWN_USAGE_SCORE);
     // A future-dated observation is not evidence of freshness either.
-    expect(computeCodexUsageScore({ shortPercent: 100, updatedAt: Number.NaN }, undefined, now))
+    expect(computeCodexUsageScore({ shortPercent: 100, shortObservedAt: now + 1 }, undefined, now))
       .toBe(CODEX_UNKNOWN_USAGE_SCORE);
+    expect(computeCodexUsageScore({ shortPercent: 100, shortObservedAt: Number.NaN }, undefined, now))
+      .toBe(CODEX_UNKNOWN_USAGE_SCORE);
+  });
+
+  test("partial updates preserve short-window observation age instead of renewing it", () => {
+    const originalNow = Date.now;
+    let now = 1_700_000_000_000;
+    Date.now = () => now;
+    try {
+      setAccountQuotaFromParsed("a", { shortPercent: 100 });
+      const observedAt = now;
+      expect(getAccountQuota("a")?.shortObservedAt).toBe(observedAt);
+      now += 6 * 60_000;
+      setAccountQuotaFromParsed("a", { resetCredits: 3 });
+      expect(getAccountQuota("a")?.updatedAt).toBe(now);
+      expect(getAccountQuota("a")?.shortObservedAt).toBe(observedAt);
+      expect(computeCodexUsageScore(getAccountQuota("a"), undefined, now)).toBe(CODEX_UNKNOWN_USAGE_SCORE);
+      updateAccountQuota("a", 25);
+      expect(getAccountQuota("a")?.shortObservedAt).toBe(observedAt);
+      setAccountQuotaFromParsed("a", { weeklyPercent: 30 });
+      expect(getAccountQuota("a")?.shortObservedAt).toBe(observedAt);
+      setAccountQuotaFromParsed("a", { shortPercent: 80 });
+      expect(getAccountQuota("a")?.shortObservedAt).toBe(now);
+      setAccountQuotaFromParsed("a", { shortResetAt: now + 60_000 });
+      expect(getAccountQuota("a")?.shortObservedAt).toBeUndefined();
+    } finally {
+      Date.now = originalNow;
+    }
   });
 
   test("a terminal burst window is read in either unit (#3029)", () => {
@@ -246,8 +274,8 @@ describe("codex routing", () => {
     // and 502 is transient so it produces no quota signal to correct the selection. The
     // exclusion therefore has to come from the snapshot itself. B carries known headroom, so
     // an unknown-scoring A would be kept and this assertion fails on the unfixed scorer.
-    const now = Date.now();
     setAccountQuotaFromParsed("a", { shortPercent: 100 });
+    const now = Date.now();
     updateAccountQuota("b", 3);
     const config = makeConfig({ activeCodexAccountId: "a" });
     expect(resolveCodexAccountForThread("thread-storm-new", config, now)).toBe("b");
@@ -263,7 +291,7 @@ describe("codex routing", () => {
     expect(resolveCodexAccountForThread("thread-storm-bound", bound, now)).toBe("a");
     clearAccountQuota("a");
     setAccountQuotaFromParsed("a", { shortPercent: 100 });
-    expect(resolveCodexAccountForThread("thread-storm-bound", bound, now)).toBe("b");
+    expect(resolveCodexAccountForThread("thread-storm-bound", bound, Date.now())).toBe("b");
   });
 
   test("a bare 502 is still classified transient (#3425)", () => {


### PR DESCRIPTION
## Summary

Addresses the missing-reset short-window selection case reported in #3425. A recent terminal short-window reading can exclude an account even without a reset timestamp. Plain 502 remains transient.

The initial candidate used the whole snapshot's updatedAt, which credits-only updates also refresh. Independent inspection caught that regression before merge. This revision records shortObservedAt only when shortPercent is actually observed, preserves its age through unrelated updates and disk serialization, and rejects future timestamps. Old snapshots without provenance remain unknown.

Refs #3425. This targets a demonstrated selection mechanism; it does not claim every cause of the reporter's 502s is proven.

## Verification

- Typecheck exit 0 and whitespace check passed.
- Independent Astra static re-review: both initial blockers resolved, no remaining blockers.
- Regression assertions cover stale, missing, future and partial-update provenance plus active/bound account selection.
- No local tests run for this correction; hosted final dev Linux CI is the batch gate.

## Checklist

- [x] Bounded account-selection correction.
- [x] Persistence creation/carry/serialization/consumption chain inspected.
- [x] No token or credential exposure changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of exhausted short-term usage windows when reset times are unavailable.
  - Fresh, valid usage observations now correctly identify unavailable accounts, while stale or invalid data remains unclassified.
  - Partial quota updates preserve usage observation data, and reset timestamps clear outdated observations.
  - Accounts with freshly exhausted usage windows are bypassed for new and bound threads.
  - HTTP 502 responses continue to be treated as temporary failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->