### PR TITLE
fix(combos): revalidate waits and decode quota evidence strictly

### DIFF
--- a/src/combos/resolve.ts
+++ b/src/combos/resolve.ts
@@ -361,6 +361,8 @@ export async function pickComboTargetWithWait(
     throw error;
   }
   if (options.abortSignal?.aborted) return null;
+  // Management updates can delete or rename the combo while this request sleeps.
+  if (!getCombo(config, comboId)) return null;
   return pickComboTarget(config, comboId, {
     exclude: excluded,
     now: now + delay,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1602,7 +1602,11 @@ export async function consumeComboFailure(
   // display-safe body carries a recognized quota message.
   let quotaConfirmedByBody = false;
   try {
-    const body = await readBoundedResponseBody(response, { signal });
+    const body = await readBoundedResponseBody(response, {
+      signal,
+      // Match shouldRetryCodexPoolAccountQuota before treating a 5xx body as quota evidence.
+      fatalUtf8: response.status >= 500 && response.status < 600,
+    });
     usage = usageFromComboFailureText(body.text);
     if (
       response.status >= 500 && response.status < 600

--- a/tests/codex-integration/codex-quota-rejection.test.ts
+++ b/tests/codex-integration/codex-quota-rejection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { classifyCodexPreStreamRejection } from "../../src/codex/quota-rejection";
 import { BOUNDED_BODY_MAX_BYTES } from "../../src/lib/bounded-body";
-import { shouldRetryCodexPoolAccountQuota } from "../../src/server/responses/core";
+import { consumeComboFailure, shouldRetryCodexPoolAccountQuota } from "../../src/server/responses/core";
 
 function jsonRejection(status: number, error: Record<string, unknown>): Response {
   return Response.json({ error }, { status });
@@ -125,6 +125,34 @@ describe("Codex pre-stream quota rejection classification", () => {
     [502, "x".repeat(BOUNDED_BODY_MAX_BYTES + 1)],
   ])("keeps unrelated or oversized HTTP %i failures transient", async (status, body) => {
     await expect(shouldRetryCodexPoolAccountQuota(new Response(body, { status }))).resolves.toBe(false);
+  });
+
+  test.each([
+    ["malformed UTF-8", [0xff], false],
+    ["valid UTF-8 replacement character", [0xef, 0xbf, 0xbd], true],
+  ] as const)("combo and account quota evidence agree for %s", async (_label, marker, quotaExpected) => {
+    const encoder = new TextEncoder();
+    const bytes = new Uint8Array([
+      ...encoder.encode('{"error":{"message":"The usage limit has been reached '),
+      ...marker,
+      ...encoder.encode('"}}'),
+    ]);
+    const resetAt = "2026-09-05T12:00:00Z";
+    const response = new Response(bytes, {
+      status: 503,
+      headers: { "content-type": "application/json", "x-codex-primary-reset-at": resetAt },
+    });
+    await expect(shouldRetryCodexPoolAccountQuota(response)).resolves.toBe(quotaExpected);
+    const failure = await consumeComboFailure(response);
+    expect(failure.response.status).toBe(503);
+    if (quotaExpected) {
+      expect(failure.resetAt).toEqual([resetAt]);
+      expect(failure.classificationText).toContain("The usage limit has been reached");
+    } else {
+      expect(failure.resetAt).toBeUndefined();
+      expect(failure.classificationText).toBe("Provider error 503");
+    }
+    expect(response.bodyUsed).toBe(true);
   });
 
   test("fails closed for malformed UTF-8 and an already-aborted read", async () => {

--- a/tests/codex-integration/combos.test.ts
+++ b/tests/codex-integration/combos.test.ts
@@ -640,6 +640,30 @@ describe("combo target cooldowns", () => {
     }
   });
 
+  test.each(["deleted", "renamed"] as const)("returns null when the combo is %s during cooldown wait", async change => {
+    const config = baseConfig({ combos: { free: VALID_COMBO } });
+    const now = 1_000_000;
+    coolComboTarget("free", target, { now, cooldownMs: 3_000 });
+    const sleeps: number[] = [];
+    const pick = await pickComboTargetWithWait(config, "free", {
+      now,
+      waitForCooldownMs: 5_000,
+      sleep: async ms => {
+        sleeps.push(ms);
+        config.combos = change === "renamed" ? { renamed: config.combos!.free! } : {};
+      },
+    });
+    expect(sleeps).toEqual([3_000]);
+    expect(pick).toBeNull();
+    if (change === "renamed") expect(getCombo(config, "renamed")).toBeDefined();
+  });
+
+  test("still rejects a combo that is missing before cooldown selection", async () => {
+    await expect(pickComboTargetWithWait(baseConfig(), "missing", {
+      waitForCooldownMs: 5_000,
+    })).rejects.toBeInstanceOf(UnknownComboError);
+  });
+
   test("returns null when real sleepWithAbort rejects after an abort", async () => {
     const config = baseConfig({
       combos: {


### PR DESCRIPTION
## Summary

Follow-up to #3606: a combo deleted or renamed during a configured cooldown wait now returns through the existing unavailable path instead of throwing UnknownComboError. Malformed UTF-8 cannot be treated as body-confirmed 5xx quota evidence; decoding matches the existing Codex quota-retry boundary.

## Verification

- Typecheck, privacy/static checks and test-file syntax checks passed.
- Five regression cases authored for deletion/rename and malformed quota evidence.
- No tests run locally. Final dev Linux CI is the batch gate.

## Checklist

- [x] Two concrete defects in the just-landed cooldown feature.
- [x] No new configuration or documentation contract.
- [x] Quota evidence remains fail-closed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Combo targeting now handles combos deleted or renamed during cooldown waits without selecting an invalid target.
  * Missing combo requests now return an appropriate error before cooldown selection begins.
  * Malformed upstream error responses are classified safely, preventing false quota or retry detection while still consuming the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->