### PR TITLE
fix(ci): restore quota-reset route coverage

### DIFF
--- a/skills/ocx/references/01_management_surface.md
+++ b/skills/ocx/references/01_management_surface.md
@@ -72,6 +72,23 @@ JSON mode: `envelope`.
 
 - Reads local config; drives no management API route.
 
+### `ocx provider resets`
+
+Show recently detected quota resets.
+
+| Method | Route |
+|---|---|
+| GET | `/api/quota-resets` |
+
+| Flag | Value | Meaning |
+|---|---|---|
+| `--limit` | number | Maximum number of reset events to return. |
+| `--json` | boolean | Emit the reset-event payload as JSON. |
+
+JSON mode: `payload`.
+
+- An empty result distinguishes notifications being disabled from no reset having been detected yet.
+
 ### `ocx account list`
 
 Codex OAuth accounts with pool priority and pause state.
@@ -587,6 +604,6 @@ JSON mode: `payload`.
 
 ## Counts
 
-- declared capabilities: 32
+- declared capabilities: 33
 - of those, state-changing: 13
 - head-resolved invocations: 2

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -154,6 +154,18 @@ export const CAPABILITIES: readonly Capability[] = [
     details: ["Reads local config; drives no management API route."],
   },
   {
+    command: ["provider", "resets"],
+    summary: "Show recently detected quota resets.",
+    routes: [{ method: "GET", path: "/api/quota-resets" }],
+    flags: [
+      { name: "--limit", value: "number", summary: "Maximum number of reset events to return." },
+      { name: "--json", value: "boolean", summary: "Emit the reset-event payload as JSON." },
+    ],
+    mutates: false,
+    json: "payload",
+    details: ["An empty result distinguishes notifications being disabled from no reset having been detected yet."],
+  },
+  {
     command: ["provider", "keychain"],
     summary: "Move a provider's API key into the OS keychain, restore it, or report where it lives.",
     routes: [

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -138,7 +138,7 @@ async function handleLabRoutesOnDemand(ctx: ManagementContext): Promise<Response
  * its config resolution on all of them.
  */
 async function handleQuotaResetRoutesOnDemand(ctx: ManagementContext): Promise<Response | null> {
-  if (ctx.url.pathname !== "/api/quota-resets") return null;
+  if (!pathInManagementNamespace(ctx.url.pathname, "/api/quota-resets")) return null;
   const { handleQuotaResetRoutes } = await import("./management/quota-reset-routes");
   return handleQuotaResetRoutes(ctx);
 }

--- a/src/server/management/route-registry.ts
+++ b/src/server/management/route-registry.ts
@@ -81,6 +81,8 @@ export interface ManagementRoute {
 export const MANAGEMENT_ROUTES: readonly ManagementRoute[] = [
   // server/management-api
   { method: "POST", path: "/api/stop", module: "server/management-api", mutates: true },
+  // server/management/quota-reset-routes
+  { method: "GET", path: "/api/quota-resets", module: "server/management/quota-reset-routes", mutates: false },
   // codex/auth-api
   { method: "DELETE", path: "/api/codex-auth/accounts", module: "codex/auth-api", mutates: true },
   { method: "GET", path: "/api/codex-auth/accounts", module: "codex/auth-api", mutates: false },

--- a/tests/gui/rate-limit-reset-credits.test.ts
+++ b/tests/gui/rate-limit-reset-credits.test.ts
@@ -504,6 +504,7 @@ describe("rate-limit reset credits", () => {
         shortPercent: 97,
         shortResetAt: 1787401330,
         shortWindowSeconds: 18000,
+        shortObservedAt: expect.any(Number),
         weeklyPercent: 12,
         weeklyResetAt: 1788000000,
         updatedAt: expect.any(Number),

--- a/tests/usage/quota-reset-notify.test.ts
+++ b/tests/usage/quota-reset-notify.test.ts
@@ -481,14 +481,11 @@ describe("activation is the single switch", () => {
     // The end-to-end proof: config -> activation -> the production quota writer -> HTTP body.
     // Every earlier test exercises one link; this is the only one that shows the chain holds.
     const bodies: string[] = [];
-    const server = Bun.serve({
-      port: 0,
-      hostname: "127.0.0.1",
-      async fetch(req) {
-        bodies.push(await req.text());
-        return new Response("ok");
-      },
-    });
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      bodies.push(String(init?.body ?? ""));
+      return new Response("ok");
+    }) as typeof globalThis.fetch;
 
     const home = mkdtempSync(join(tmpdir(), "ocx-live-"));
     writeFileSync(join(home, "config.json"), JSON.stringify({
@@ -499,7 +496,7 @@ describe("activation is the single switch", () => {
       },
       quotaResetNotify: {
         enabled: true,
-        webhookUrl: `http://127.0.0.1:${server.port}/hook`,
+        webhookUrl: "https://hooks.example.test/quota-reset",
         allowPrivateNetwork: true,
         // Passive-only: this asserts the live request path fires without any timer involved.
         pollSeconds: 0,
@@ -543,7 +540,7 @@ describe("activation is the single switch", () => {
       resetQuotaResetActivationForTests();
       resetQuotaResetNotifyCacheForTests();
       clearAccountQuota();
-      server.stop(true);
+      globalThis.fetch = realFetch;
       if (previousHome === undefined) delete process.env["OPENCODEX_HOME"];
       else process.env["OPENCODEX_HOME"] = previousHome;
     }


### PR DESCRIPTION
## Summary

- Restore declarative management-route coverage for the existing quota-reset endpoint.
- Declare the existing `ocx provider resets` command in the capability registry and regenerate its command-surface reference.
- Repair the quota-reset webhook test seam to use a valid HTTPS URL without opening a local listener, and align the reset-credit expectation with the current observation record.

## Verification

- `bun test tests/server/management-route-registry.test.ts tests/usage/quota-reset-notify.test.ts tests/cli/cli-capabilities.test.ts tests/gui/rate-limit-reset-credits.test.ts` (91 pass, 0 fail)
- `bun run typecheck`
- `bun run privacy:scan`
- `bun run test`
- `git diff --check`

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ocx provider resets` to display recently detected quota resets.
  * Supports result limits and JSON output for scripting and automation.
  * Added a management API endpoint for retrieving quota reset information.
  * Empty results distinguish between disabled notifications and no detected resets.

* **Documentation**
  * Documented the new command, options, output format, and quota reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
