### PR TITLE
fix(ci): reconcile quota routes and integration fixtures

### DIFF
--- a/skills/ocx/references/01_management_surface.md
+++ b/skills/ocx/references/01_management_surface.md
@@ -72,6 +72,21 @@ JSON mode: `envelope`.
 
 - Reads local config; drives no management API route.
 
+### `ocx provider resets`
+
+Recently detected quota resets and whether reset notifications are enabled.
+
+| Method | Route |
+|---|---|
+| GET | `/api/quota-resets` |
+
+| Flag | Value | Meaning |
+|---|---|---|
+| `--json` | boolean | Emit reset events as JSON. |
+| `--limit` | number | Limit returned events; defaults to 20, capped at 100. |
+
+JSON mode: `payload`.
+
 ### `ocx account list`
 
 Codex OAuth accounts with pool priority and pause state.
@@ -587,6 +602,6 @@ JSON mode: `payload`.
 
 ## Counts
 
-- declared capabilities: 32
+- declared capabilities: 33
 - of those, state-changing: 13
 - head-resolved invocations: 2

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -154,6 +154,17 @@ export const CAPABILITIES: readonly Capability[] = [
     details: ["Reads local config; drives no management API route."],
   },
   {
+    command: ["provider", "resets"],
+    summary: "Recently detected quota resets and whether reset notifications are enabled.",
+    routes: [{ method: "GET", path: "/api/quota-resets" }],
+    flags: [
+      { name: "--json", value: "boolean", summary: "Emit reset events as JSON." },
+      { name: "--limit", value: "number", summary: "Limit returned events; defaults to 20, capped at 100." },
+    ],
+    mutates: false,
+    json: "payload",
+  },
+  {
     command: ["provider", "keychain"],
     summary: "Move a provider's API key into the OS keychain, restore it, or report where it lives.",
     routes: [

--- a/src/server/management-api.ts
+++ b/src/server/management-api.ts
@@ -138,7 +138,7 @@ async function handleLabRoutesOnDemand(ctx: ManagementContext): Promise<Response
  * its config resolution on all of them.
  */
 async function handleQuotaResetRoutesOnDemand(ctx: ManagementContext): Promise<Response | null> {
-  if (ctx.url.pathname !== "/api/quota-resets") return null;
+  if (!pathInManagementNamespace(ctx.url.pathname, "/api/quota-resets")) return null;
   const { handleQuotaResetRoutes } = await import("./management/quota-reset-routes");
   return handleQuotaResetRoutes(ctx);
 }

--- a/src/server/management/route-registry.ts
+++ b/src/server/management/route-registry.ts
@@ -276,6 +276,8 @@ export const MANAGEMENT_ROUTES: readonly ManagementRoute[] = [
   { method: "POST", path: "/api/providers/test", module: "server/management/provider-routes", mutates: true },
   { method: "PUT", path: "/api/providers", module: "server/management/provider-routes", mutates: true, exempt: { reason: "deferred-verb", why: "Issue #3280 scopes this atomic batch endpoint to the GUI JSON editor; a matching CLI verb is outside wp5 and remains owed.", owner: "wp5-followup", ownerDoc: "devlog/_plan/260903_bug_drawdown_bcda/050_phase5.md" } },
   { method: "PUT", path: "/api/provider-context-caps", module: "server/management/provider-routes", mutates: true },
+  // server/management/quota-reset-routes
+  { method: "GET", path: "/api/quota-resets", module: "server/management/quota-reset-routes", mutates: false, mechanism: "negated-guard" },
   // server/management/request-history-routes
   { method: "GET", path: "/api/request-history", module: "server/management/request-history-routes", mutates: false },
   // server/management/routing-analytics-routes

--- a/tests/gui/rate-limit-reset-credits.test.ts
+++ b/tests/gui/rate-limit-reset-credits.test.ts
@@ -503,6 +503,7 @@ describe("rate-limit reset credits", () => {
       expect(getAccountQuota("burst-A")).toEqual({
         shortPercent: 97,
         shortResetAt: 1787401330,
+        shortObservedAt: expect.any(Number),
         shortWindowSeconds: 18000,
         weeklyPercent: 12,
         weeklyResetAt: 1788000000,

--- a/tests/usage/quota-reset-notify.test.ts
+++ b/tests/usage/quota-reset-notify.test.ts
@@ -481,6 +481,8 @@ describe("activation is the single switch", () => {
     // The end-to-end proof: config -> activation -> the production quota writer -> HTTP body.
     // Every earlier test exercises one link; this is the only one that shows the chain holds.
     const bodies: string[] = [];
+    const webhookUrl = "https://quota-webhook.example.test/hook";
+    const originalFetch = globalThis.fetch;
     const server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
@@ -499,7 +501,7 @@ describe("activation is the single switch", () => {
       },
       quotaResetNotify: {
         enabled: true,
-        webhookUrl: `http://127.0.0.1:${server.port}/hook`,
+        webhookUrl,
         allowPrivateNetwork: true,
         // Passive-only: this asserts the live request path fires without any timer involved.
         pollSeconds: 0,
@@ -509,6 +511,13 @@ describe("activation is the single switch", () => {
     const previousHome = process.env["OPENCODEX_HOME"];
     process.env["OPENCODEX_HOME"] = home;
     try {
+      // Config must satisfy the production HTTPS rule. Only the transport for this exact
+      // synthetic URL is redirected to the local receiver; activation and payload delivery
+      // remain real, without adding TLS fixtures or weakening production validation.
+      globalThis.fetch = ((input, init) => originalFetch(
+        String(input) === webhookUrl ? `http://127.0.0.1:${server.port}/hook` : input,
+        init,
+      )) as typeof fetch;
       resetQuotaResetNotifyCacheForTests();
       resetQuotaResetStoreForTests();
       resetQuotaResetActivationForTests();
@@ -539,6 +548,7 @@ describe("activation is the single switch", () => {
       expect(payload["percentAfter"]).toBe(2);
       expect(bodies[0]).not.toContain("operator@example.com");
     } finally {
+      globalThis.fetch = originalFetch;
       setQuotaResetSink(null);
       resetQuotaResetActivationForTests();
       resetQuotaResetNotifyCacheForTests();


### PR DESCRIPTION
## Summary

Fixes concrete failures in the final dev run 33943525788 at 55395a9dc:

- Linux 2/4: declare the existing quota-reset GET route and its existing CLI command; use the same lazy namespace delegation pattern as other optional handlers.
- Linux 1/4: retain shortObservedAt in the pre-existing exact quota-record assertion.
- Linux 3/4: the activation fixture now uses a valid HTTPS webhook configuration; only its synthetic test transport is mapped to the real loopback receiver. Production validation remains unchanged.

## Verification

- Typecheck and diff checks passed; generated capability surface refreshed from its source table.
- RED evidence is the actual GitHub Linux jobs 101246770906, 101246770920 and 101246770972.
- No local tests or suites run. The next dev HEAD CI provides execution verification.
- The unrelated update-restart failure is being handled separately; this PR does not claim to fix it.

## Checklist

- [x] Only observed quota integration failures changed.
- [x] Route/capability/generated surface stay synchronized.
- [x] No authentication relaxation or test skip.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the read-only `ocx provider resets` command to view recently detected quota resets and notification status.
  - Supports JSON output and configurable result limits, with up to 100 reset events returned.

- **Bug Fixes**
  - Improved quota-reset route handling for requests under the quota-reset path.
  - Corrected tracking of short-window observations for five-hour primary quotas.

- **Documentation**
  - Added management-surface documentation for the provider reset capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->