### PR TITLE
fix(oauth): preserve provider configuration during login

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1258,6 +1258,7 @@ function applyOAuthPresetCatalog(
   // with live discovery do not expose an enumerable account catalog here, so their saved
   // default remains operator-owned.
   if (
+    provider.liveModels !== true &&
     provider.defaultModel
     && preset.defaultModel
     && preset.models

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1407,24 +1407,18 @@ function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["a
   return pool.length > 0 ? pool : undefined;
 }
 
-/**
- * Add/refresh an OAuth provider's config entry on a config object (does not persist).
- *
- * Providers whose registry entry sets `allowKeyAuthOverride` (xai, github-copilot) can be
- * billed through a stored API key instead of the OAuth login (router.ts honors
- * `authMode: "key"` for them). A blind preset overwrite here deletes `apiKey`/`apiKeyPool`
- * on every OAuth login, silently destroying the stored key and forcing a re-paste — and it
- * flips billing back to the subscription without the user asking. Carry the key fields over
- * and keep key billing while usable key material remains and the user was not explicitly on
- * oauth. If the final key was removed and only the old key mode remains, let the OAuth
- * preset restore `authMode: "oauth"` so the newly saved OAuth credential can be used.
- *
- * After preservation, `apiKey` always has exactly one matching pool entry (inserting via the
- * same content-derived id as the API-key manager when the active key was missing from the
- * pool). Key mode reflects stored user intent (explicit `"key"` or omitted mode with safe
- * key material) — never whether the login CLI process can resolve an env reference. Env-backed
- * availability is decided at proxy routing time in `router.ts`.
- */
+const OAUTH_LOGIN_OWNED_PROVIDER_FIELDS = [
+  "adapter",
+  "baseUrl",
+  "authMode",
+  "headers",
+  "apiKeyTransport",
+  "responsesPath",
+  "googleMode",
+  "keyOptional",
+] as const satisfies readonly (keyof OcxProviderConfig)[];
+
+/** Add/refresh only an OAuth provider's login-owned config fields (does not persist). */
 export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (provider === "chatgpt") return;
   const def = OAUTH_PROVIDERS[provider];
@@ -1433,32 +1427,21 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   const namespaceCollision = codexAccountNamespaceProviderCollisionError(config.codexAccountNamespaces, provider);
   if (namespaceCollision) throw new Error(namespaceCollision);
   const existing = config.providers[provider];
-  const next: OcxProviderConfig = { ...def.providerConfig };
-  // `liveModels` is a user-facing provider toggle. Preserve either explicit setting across login;
-  // Antigravity's CCA discovery now uses its real RPC, so legacy `true` remains a valid choice.
-  if (typeof existing?.liveModels === "boolean" && !isLegacyCommandCodeStaticCatalog(existing)) {
-    next.liveModels = existing.liveModels;
+  const next: OcxProviderConfig = structuredClone(existing ?? def.providerConfig);
+  for (const field of OAUTH_LOGIN_OWNED_PROVIDER_FIELDS) {
+    const value = def.providerConfig[field];
+    if (value === undefined) delete next[field];
+    else next[field] = structuredClone(value) as never;
   }
-  // The Command Code protocol-version pin is an operator compatibility control. A re-login,
-  // add-account, or reauth rebuilds the row from the preset, which has no version; carry the
-  // existing pin so authentication changes do not silently revert the documented control.
-  if (existing?.commandCodeVersion !== undefined) {
-    next.commandCodeVersion = existing.commandCodeVersion;
+  // The original Command Code seed was an implementation-owned static catalog, not an
+  // operator opt-out. Promote that exact legacy shape when OAuth login refreshes the row.
+  if (provider === "command-code" && existing && isLegacyCommandCodeStaticCatalog(existing)) {
+    next.liveModels = def.providerConfig.liveModels;
   }
-  // User-configured price overlays are operator data, not preset state; a
-  // re-login, add-account, or reauth must not silently drop them from the
-  // Logs/Usage estimates.
-  if (existing?.modelCosts !== undefined) {
-    next.modelCosts = existing.modelCosts;
-  }
-  // The per-provider account-failover opt-out is operator intent about SPENDING, and the login
-  // path is exactly where losing it does damage: adding a second account both rebuilds this row
-  // from the preset and creates the 2-account quorum that turns presence-driven rotation on
-  // (#2568d). Dropping the opt-out here would enable the thing the operator switched off, at the
-  // moment they were doing something unrelated.
-  if (existing?.oauthAccountFailover !== undefined) {
-    next.oauthAccountFailover = existing.oauthAccountFailover;
-  }
+  // OAuth-only providers must never retain credentials for a different auth mechanism.
+  delete next.apiKey;
+  delete next.apiKeyPool;
+  delete (next as unknown as Record<string, unknown>).azureCredential;
   if (existing && getProviderRegistryEntry(provider)?.allowKeyAuthOverride === true) {
     // Shared sanitizeApiKeyValue trim / no-CRLF checks from api-key pool writes.
     let storedApiKey = sanitizeApiKeyValue(existing.apiKey);

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1238,6 +1238,36 @@ function isLegacyAntigravityStaticCatalog(provider: OcxProviderConfig): boolean 
     ]);
 }
 
+/** Refresh registry-owned catalog fields while preserving valid operator selections. */
+function applyOAuthPresetCatalog(
+  provider: OcxProviderConfig,
+  preset: OcxProviderConfig,
+): void {
+  for (const field of OAUTH_RECONCILE_FIELDS) {
+    if (JSON.stringify(provider[field]) === JSON.stringify(preset[field])) continue;
+    if (preset[field] !== undefined) {
+      provider[field] = cloneProviderField(preset[field]) as never;
+    } else {
+      delete provider[field];
+    }
+  }
+  if (provider.liveModels === undefined && preset.liveModels !== undefined) {
+    provider.liveModels = preset.liveModels;
+  }
+  // Heal only a selection that the refreshed static catalog no longer contains. Providers
+  // with live discovery do not expose an enumerable account catalog here, so their saved
+  // default remains operator-owned.
+  if (
+    provider.defaultModel
+    && preset.defaultModel
+    && preset.models
+    && preset.models.length > 0
+    && !(provider.models ?? []).includes(provider.defaultModel)
+  ) {
+    provider.defaultModel = preset.defaultModel;
+  }
+}
+
 /** Promote only the versioned canonical static seed; unmarked `liveModels: false` remains user intent. */
 function migrateLegacyAntigravityStaticCatalog(config: OcxConfig): boolean {
   if (config.googleAntigravityStaticCatalogVersion !== 1) return false;
@@ -1276,24 +1306,7 @@ function projectOAuthProviderReconciliation(config: OcxConfig): OAuthReconcilePr
     }
     if (def && prov.authMode === "oauth") {
       const preset = def.providerConfig;
-      for (const field of OAUTH_RECONCILE_FIELDS) {
-        if (JSON.stringify(prov[field]) === JSON.stringify(preset[field])) continue;
-        if (preset[field] !== undefined) {
-          prov[field] = cloneProviderField(preset[field]) as never;
-        } else {
-          delete prov[field];
-        }
-      }
-      if (prov.liveModels === undefined && preset.liveModels !== undefined) {
-        prov.liveModels = preset.liveModels;
-      }
-      // Heal a defaultModel that no longer exists in the refreshed list (e.g. a deprecated snapshot).
-      // Skip providers without a static preset `models` list: for live-discovery providers
-      // (e.g. command-code OAuth) the account-scoped catalog is not enumerable here, so any
-      // persisted defaultModel is a user selection and must not be overwritten by the seed.
-      if (prov.defaultModel && preset.defaultModel && preset.models && preset.models.length > 0 && !(prov.models ?? []).includes(prov.defaultModel)) {
-        prov.defaultModel = preset.defaultModel;
-      }
+      applyOAuthPresetCatalog(prov, preset);
     }
     if (JSON.stringify(prov) !== beforeProvider) {
       changed = true;
@@ -1433,6 +1446,9 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
     if (value === undefined) delete next[field];
     else next[field] = structuredClone(value) as never;
   }
+  // Login used to rebuild the whole row from the preset, so catalog data refreshed
+  // immediately. Keep that timing without overwriting unrelated operator-owned fields.
+  applyOAuthPresetCatalog(next, def.providerConfig);
   // The original Command Code seed was an implementation-owned static catalog, not an
   // operator opt-out. Promote that exact legacy shape when OAuth login refreshes the row.
   if (provider === "command-code" && existing && isLegacyCommandCodeStaticCatalog(existing)) {

--- a/tests/oauth/oauth-provider-reconcile.test.ts
+++ b/tests/oauth/oauth-provider-reconcile.test.ts
@@ -229,7 +229,7 @@ describe("OAuth provider reconciliation", () => {
     // holds; only the rows the projection actually changed may be replaced.
     expect(config.providers.untouched).toBe(liveUntouched);
   });
-  test("refreshes a saved Antigravity 3.5 preset without touching credentials or user fields", async () => {
+  test("refreshes a saved Antigravity live catalog without touching credentials or user fields", async () => {
     const home = mkdtempSync(join(tmpdir(), "ocx-gemini-36-reconcile-"));
     homes.push(home);
     process.env.OPENCODEX_HOME = home;
@@ -261,7 +261,7 @@ describe("OAuth provider reconciliation", () => {
 
     expect(reconcileOAuthProviders(config)).toBe(true);
     const provider = config.providers["google-antigravity"];
-    expect(provider.defaultModel).toBe("gemini-3.8-flash");
+    expect(provider.defaultModel).toBe("gemini-3.5-flash-low");
     expect(provider.models).toEqual([
       "gemini-3.8-flash",
       "gemini-3.7-flash",
@@ -288,7 +288,7 @@ describe("OAuth provider reconciliation", () => {
     });
 
     const persisted = loadConfig();
-    expect(persisted.providers["google-antigravity"]?.defaultModel).toBe("gemini-3.8-flash");
+    expect(persisted.providers["google-antigravity"]?.defaultModel).toBe("gemini-3.5-flash-low");
     expect(persisted.providers["google-antigravity"]?.liveModels).toBe(true);
     expect(reconcileOAuthProviders(config)).toBe(false);
   });
@@ -365,6 +365,28 @@ describe("OAuth provider reconciliation", () => {
     // Capability records still refresh from the registry — preservation is about the
     // user's CHOICE, not about freezing the row.
     expect(provider.modelReasoningEfforts?.["gemini-3.8-flash"]).toEqual(["low", "medium", "high"]);
+  });
+
+  test("does not validate a live-models default against the static preset", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "google-antigravity",
+      providers: {
+        "google-antigravity": {
+          ...structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
+          authMode: "oauth",
+          liveModels: true,
+          models: ["account-specific-model"],
+          defaultModel: "account-specific-model",
+        },
+      },
+    } satisfies OcxConfig;
+
+    expect(reconcileOAuthProviders(config, false)).toBe(true);
+    expect(config.providers["google-antigravity"].defaultModel).toBe("account-specific-model");
+
+    upsertOAuthProvider(config, "google-antigravity");
+    expect(config.providers["google-antigravity"].defaultModel).toBe("account-specific-model");
   });
 
   test("preserves an explicit Antigravity static opt-out without the legacy migration marker", () => {

--- a/tests/oauth/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth/oauth-upsert-preserves-api-key.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { upsertOAuthProvider } from "../../src/oauth";
+import { OAUTH_PROVIDERS, upsertOAuthProvider } from "../../src/oauth";
 import {
   apiKeyPoolEntryId,
   listProviderApiKeys,
@@ -345,6 +345,35 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(provider.apiKey).toBeUndefined();
     expect(provider.apiKeyPool).toBeUndefined();
     expect(provider.note).toBe("stale-note");
+  });
+
+  test("refreshes registry-owned catalog fields immediately without losing operator fields", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "anthropic",
+      providers: {
+        anthropic: {
+          adapter: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          authMode: "oauth",
+          models: ["retired-model"],
+          defaultModel: "retired-model",
+          contextWindow: 1,
+          disabled: true,
+          note: "operator-note",
+        },
+      },
+    } as unknown as OcxConfig;
+
+    upsertOAuthProvider(config, "anthropic");
+
+    const provider = config.providers.anthropic!;
+    const preset = OAUTH_PROVIDERS.anthropic!.providerConfig;
+    expect(provider.models).toEqual(preset.models);
+    expect(provider.contextWindow).toBe(preset.contextWindow);
+    expect(provider.defaultModel).toBe(preset.defaultModel);
+    expect(provider.disabled).toBe(true);
+    expect(provider.note).toBe("operator-note");
   });
 
   test.each(["login", "add-account", "reauthentication"])(

--- a/tests/oauth/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth/oauth-upsert-preserves-api-key.test.ts
@@ -344,7 +344,67 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(provider.authMode).toBe("oauth");
     expect(provider.apiKey).toBeUndefined();
     expect(provider.apiKeyPool).toBeUndefined();
-    expect(provider.note).toBeUndefined();
+    expect(provider.note).toBe("stale-note");
+  });
+
+  test.each(["login", "add-account", "reauthentication"])(
+    "preserves operator policy and unknown fields during %s-shaped upsert",
+    operation => {
+      const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+      const existing = config.providers.xai! as OcxConfig["providers"][string] & Record<string, unknown>;
+      existing.disabled = true;
+      existing.requestPacing = { enabled: true, minIntervalMs: 250 };
+      existing.retryOn429 = { attempts: 4, intervalMs: 900 };
+      existing.refreshPolicy = "lazy-only";
+      existing.selectedModels = ["grok-4"];
+      existing.note = `operator-${operation}`;
+      existing.modelCosts = { "grok-4": { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } };
+      existing.oauthAccountFailover = { enabled: false };
+      existing.forwardCompatibleFlag = { enabled: true };
+
+      upsertOAuthProvider(config, "xai");
+
+      const provider = config.providers.xai! as typeof existing;
+      expect(provider.disabled).toBe(true);
+      expect(provider.requestPacing).toEqual({ enabled: true, minIntervalMs: 250 });
+      expect(provider.retryOn429).toEqual({ attempts: 4, intervalMs: 900 });
+      expect(provider.refreshPolicy).toBe("lazy-only");
+      expect(provider.selectedModels).toEqual(["grok-4"]);
+      expect(provider.note).toBe(`operator-${operation}`);
+      expect(provider.modelCosts).toEqual({ "grok-4": { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } });
+      expect(provider.oauthAccountFailover).toEqual({ enabled: false });
+      expect(provider.forwardCompatibleFlag).toEqual({ enabled: true });
+      expect(provider.apiKey).toBe("stored-key-sentinel");
+    },
+  );
+
+  test("removes incompatible API-key and Azure credentials while preserving unknown fields", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "anthropic",
+      providers: {
+        anthropic: {
+          adapter: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          authMode: "key",
+          apiKey: "stale-key",
+          apiKeyPool: [{ id: "stale", key: "stale-key" }],
+          azureCredential: { token: "stale" },
+          disabled: true,
+          forwardCompatibleFlag: "retain-me",
+        },
+      },
+    } as unknown as OcxConfig;
+
+    upsertOAuthProvider(config, "anthropic");
+
+    const provider = config.providers.anthropic! as OcxConfig["providers"][string] & Record<string, unknown>;
+    expect(provider.apiKey).toBeUndefined();
+    expect(provider.apiKeyPool).toBeUndefined();
+    expect(provider.azureCredential).toBeUndefined();
+    expect(provider.disabled).toBe(true);
+    expect(provider.forwardCompatibleFlag).toBe("retain-me");
+    expect(provider.authMode).toBe("oauth");
   });
 
   test("a fresh login on an unconfigured provider gets the untouched preset", () => {
@@ -354,5 +414,28 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(provider.authMode).toBe("oauth");
     expect(provider.apiKey).toBeUndefined();
     expect(provider.apiKeyPool).toBeUndefined();
+  });
+
+  test("promotes the legacy Command Code static catalog during OAuth upsert", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "command-code",
+      providers: {
+        "command-code": {
+          adapter: "command-code",
+          baseUrl: "https://api.commandcode.ai",
+          authMode: "oauth",
+          liveModels: false,
+          defaultModel: "deepseek-v4-flash",
+          models: ["deepseek-v4-flash", "kimi-k3", "glm-5.2"],
+          note: "operator-note",
+        },
+      },
+    } as unknown as OcxConfig;
+
+    upsertOAuthProvider(config, "command-code");
+
+    expect(config.providers["command-code"]!.liveModels).toBe(true);
+    expect(config.providers["command-code"]!.note).toBe("operator-note");
   });
 });


### PR DESCRIPTION
## Summary

- Preserve operator-managed provider configuration when OAuth login, account addition, or reauthentication refreshes provider credentials.
- Replace only OAuth-owned fields while retaining valid API-key pools, billing intent, policy fields, model costs, and unknown forward-compatible fields.
- Remove credentials that are incompatible with the selected provider and retain the legacy Command Code static-catalog migration to live model discovery.

## Verification

- `bun test tests/oauth/oauth-upsert-preserves-api-key.test.ts` — 24 passed, 0 failed on the current PR head.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `git diff --check upstream/dev...HEAD` — passed.
- `bun run test` — passed on exact-tip head `171451d33` (exit 0; 305.44s).
- Independent correctness/security review completed; the live-model CodeRabbit finding was fixed with startup and upsert regressions, and its thread is resolved.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No user-facing command or configuration contract changed.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth provider updates now preserve existing configuration and operator-defined settings during sign-in.
  - Provider catalogs and supported models are refreshed automatically when OAuth settings are updated.
  - Account-specific model preferences are preserved during provider reconciliation.
  - Invalid or incompatible credential fields are removed to prevent configuration conflicts.
  - Legacy Command Code provider settings are upgraded automatically.
  - Existing provider notes and custom fields are retained during OAuth updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


