### PR TITLE
feat(providers): support BigModel's OpenAI Responses endpoint with live discovery

### DIFF
--- a/src/providers/model-discovery.ts
+++ b/src/providers/model-discovery.ts
@@ -113,6 +113,14 @@ export function providerModelDiscoverySpecError(spec: ProviderModelDiscoverySpec
   if (queryEntries.some(([key, value]) => !key.trim() || key.length > 128 || typeof value !== "string" || value.length > 512)) {
     return "discovery query keys/values exceed their bounds";
   }
+  if (spec.idKey !== undefined && spec.envelopeKey === undefined) {
+    return "idKey requires envelopeKey";
+  }
+  for (const [field, key] of [["envelopeKey", spec.envelopeKey], ["idKey", spec.idKey]] as const) {
+    if (key !== undefined && !/^[A-Za-z][A-Za-z0-9_-]{0,31}$/.test(key)) {
+      return `${field} must be an identifier-shaped key of 1-32 characters`;
+    }
+  }
   for (const [field, value, hardLimit] of [
     ["maxResponseBytes", spec.maxResponseBytes, MODEL_DISCOVERY_MAX_RESPONSE_BYTES],
     ["maxModels", spec.maxModels, MODEL_DISCOVERY_MAX_MODELS],
@@ -137,14 +145,17 @@ export function resolveProviderModelDiscovery(
   providerName: string,
   provider: Pick<OcxProviderConfig, "baseUrl" | "adapter"> & Partial<Pick<OcxProviderConfig, "authMode">>,
 ): ResolvedProviderModelDiscovery {
-  // The dashboard permits a canonical preset to be saved under a different name. Recover its
-  // registry-owned discovery policy by transport in that case. The destination helper is limited
-  // to exact fixed-key baseUrl + adapter matches, so custom endpoints, OAuth rows, templates, and
-  // overridable destinations cannot acquire another provider's discovery URL or filter.
+  // The dashboard permits a canonical preset to be saved under a different name, and a saved
+  // row may carry a registry id as its name while pointing at another entry's transport
+  // (e.g. a `zai`-named row on BigModel's Responses endpoint). Discovery policy follows the
+  // transport the row actually points at: the named entry owns the policy only when it
+  // declares one AND owns the row, and otherwise the destination helper decides. It is
+  // limited to exact fixed-key baseUrl + adapter matches, so custom endpoints, OAuth rows,
+  // templates, and overridable destinations cannot acquire another provider's discovery
+  // URL or filter.
   const namedEntry = getProviderRegistryEntry(providerName);
-  const entry = namedEntry
-    ? (providerMatchesRegistryTransport(providerName, provider) ? namedEntry : undefined)
-    : registryEntryForProviderDestination(provider);
+  const entry = (namedEntry?.modelDiscovery && providerMatchesRegistryTransport(providerName, provider) ? namedEntry : undefined)
+    ?? registryEntryForProviderDestination(provider);
   const spec = entry?.modelDiscovery;
   return {
     ...(spec ? { spec } : {}),
@@ -490,19 +501,26 @@ export function extractProviderModelItems(
     if (value.length > limit) return { ok: false, reason: "too_many_models" };
     data = value;
   } else {
-    const envelope = extractModelEnvelopeRows(value, discovery.maxModels, ["data"]);
+    const envelope = extractModelEnvelopeRows(
+      value,
+      discovery.maxModels,
+      discovery.spec?.envelopeKey ? [discovery.spec.envelopeKey] : ["data"],
+    );
     if (!envelope.ok) return envelope;
     data = envelope.rows;
-    siblings = buildSiblingIndex(value, limit);
+    // The sibling index exists to join a SECONDARY `models[]` array onto `data[]` rows
+    // (#1797). A declared `models` envelope IS the row source, not a sibling.
+    siblings = discovery.spec?.envelopeKey ? null : buildSiblingIndex(value, limit);
   }
 
   const items: ProviderModelsApiItem[] = [];
   const seen = new Set<string>();
+  const idKey = discovery.spec?.idKey ?? "id";
   for (const raw of data) {
     if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
       return { ok: false, reason: "invalid_shape" };
     }
-    const id = (raw as { id?: unknown }).id;
+    const id = (raw as Record<PropertyKey, unknown>)[idKey];
     if (!isValidModelDiscoveryModelId(id)) return { ok: false, reason: "invalid_shape" };
     const prefix = discovery.spec?.stripIdPrefix;
     let finalId = id;
@@ -510,7 +528,9 @@ export function extractProviderModelItems(
       finalId = finalId.slice(prefix.length);
       if (!isValidModelDiscoveryModelId(finalId)) continue;
     }
-    const item = finalId === id ? raw as ProviderModelsApiItem : { ...(raw as ProviderModelsApiItem), id: finalId };
+    const item = idKey === "id" && finalId === id
+      ? raw as ProviderModelsApiItem
+      : { ...(raw as ProviderModelsApiItem), id: finalId };
     // Admission is decided on the ORIGINAL `data[]` row, before any sibling
     // enrichment. Merging first let a `models[]` entry supply the very field a
     // provider filter requires — reproduced against the real Chutes policy,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -96,6 +96,15 @@ interface ProviderModelDiscoverySharedSpec {
    * Empty/invalid remainders skip that row only.
    */
   stripIdPrefix?: string;
+  /**
+   * Opt-in nonstandard envelope for providers whose models API is not OpenAI-shaped:
+   * model rows live under this top-level key instead of `data`. Registry-only
+   * declaration — an undeclared provider keeps the default `data` envelope, so a
+   * stray `models` key on an openai-chat response still cannot pose as a catalog (#617).
+   */
+  envelopeKey?: string;
+  /** Row key carrying the model id when `envelopeKey` is declared; defaults to `id`. */
+  idKey?: string;
 }
 
 type ProviderModelDiscoveryLocation =
@@ -2542,6 +2551,37 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // No liveModels: the same reasoning as the pay-as-you-go row — an unverified live claim
     // yields an empty picker at runtime.
     note: "Domestic BigModel Coding Plan endpoint (open.bigmodel.cn)",
+  },
+
+  // BigModel's Coding Plan also serves the OpenAI Responses wire at /api/v1 — the same
+  // subscription product as the Chat Completions row above on a separate endpoint, so it
+  // gets its own row rather than a baseUrl override. Its models API is NOT OpenAI-shaped:
+  // rows arrive as `{models: [{slug, ...}]}` with the id under `slug` plus rich per-model
+  // metadata (context_window, supported_reasoning_levels), so the entry declares the
+  // envelope explicitly. An undeclared provider keeps the default `{data:[{id}]}` shape —
+  // a stray `models` key on an openai-chat response still cannot pose as a catalog (#617).
+  // Evidence (verified live 2026-09-05): POST /api/v1/responses answers the standard
+  // Responses object; GET /api/v1/models lists glm-5.3 / glm-5.3-flash / glm-5-turbo with
+  // context_window 1048576 and reasoning levels low/high/max, matching the 5.3 ladder.
+  {
+    id: "zhipu-bigmodel-responses",
+    label: "Zhipu AI — BigModel Coding Plan (Responses)",
+    baseUrl: "https://open.bigmodel.cn/api/v1",
+    adapter: "openai-responses",
+    authKind: "key",
+    dashboardUrl: "https://bigmodel.cn/console/usercenter/apikeys",
+    defaultModel: "glm-5.3",
+    models: ["glm-5.3", "glm-5.3-flash", "glm-5-turbo"],
+    jawcodeBundle: "zai",
+    modelContextWindows: { "glm-5.3": 1_048_576, "glm-5.3-flash": 1_048_576, "glm-5-turbo": 1_048_576 },
+    modelReasoningEfforts: {
+      "glm-5.3": ZAI_GLM_53_REASONING_EFFORTS,
+      "glm-5.3-flash": ZAI_GLM_53_REASONING_EFFORTS,
+    },
+    modelSupportsReasoningSummaries: { "glm-5.3": true, "glm-5.3-flash": true },
+    preserveReasoningContentModels: ["glm-5.3", "glm-5.3-flash"],
+    modelDiscovery: { path: "models", envelopeKey: "models", idKey: "slug" },
+    note: "Domestic BigModel Coding Plan on the OpenAI Responses wire (open.bigmodel.cn/api/v1)",
   },
   { id: "nanogpt", label: "NanoGPT", baseUrl: "https://nano-gpt.com/api/v1", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://nano-gpt.com/api" },
   { id: "synthetic", label: "Synthetic", baseUrl: "https://api.synthetic.new/openai/v1", adapter: "openai-chat", authKind: "key", dashboardUrl: "https://synthetic.new" },

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2579,13 +2579,19 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // same-named custom row recovers no discovery policy instead of the slug envelope.
     jawcodeBundle: "zai",
     preserveCustomDestination: true,
-    modelContextWindows: { "glm-5.3": 1_048_576, "glm-5.3-flash": 1_048_576, "glm-5-turbo": 1_048_576 },
+    // Live rows (2026-09-05): 5.3 and 5.3-flash expose low/high/max with a max default;
+    // 5-turbo fixes its reasoning at max internally and lists NO selectable levels, so an
+    // explicit [] keeps the undefined entry from falling back to the full routed ladder.
+    modelContextWindows: { "glm-5.3": 1_048_576, "glm-5.3-flash": 1_048_576, "glm-5-turbo": 204_800 },
     modelReasoningEfforts: {
       "glm-5.3": ZAI_GLM_53_REASONING_EFFORTS,
       "glm-5.3-flash": ZAI_GLM_53_REASONING_EFFORTS,
+      "glm-5-turbo": [],
     },
-    modelSupportsReasoningSummaries: { "glm-5.3": true, "glm-5.3-flash": true },
-    preserveReasoningContentModels: ["glm-5.3", "glm-5.3-flash"],
+    modelSupportsReasoningSummaries: { "glm-5.3": true, "glm-5.3-flash": true, "glm-5-turbo": true },
+    // The Responses adapter replays reasoning via this provider-level flag, not the
+    // per-model preserveReasoningContentModels list (a Chat-path field).
+    preserveResponsesReasoningContent: true,
     modelDiscovery: { path: "models", envelopeKey: "models", idKey: "slug" },
     note: "Domestic BigModel Coding Plan on the OpenAI Responses wire (open.bigmodel.cn/api/v1)",
   },

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -2572,7 +2572,13 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     dashboardUrl: "https://bigmodel.cn/console/usercenter/apikeys",
     defaultModel: "glm-5.3",
     models: ["glm-5.3", "glm-5.3-flash", "glm-5-turbo"],
+    liveModels: true,
+    // A user may already own a custom provider named "zhipu-bigmodel-responses" pointing
+    // elsewhere; without this, registry transport canonicalization would retarget it and
+    // send their saved key to BigModel. It also forces the exact-transport match, so a
+    // same-named custom row recovers no discovery policy instead of the slug envelope.
     jawcodeBundle: "zai",
+    preserveCustomDestination: true,
     modelContextWindows: { "glm-5.3": 1_048_576, "glm-5.3-flash": 1_048_576, "glm-5-turbo": 1_048_576 },
     modelReasoningEfforts: {
       "glm-5.3": ZAI_GLM_53_REASONING_EFFORTS,

--- a/tests/providers/provider-model-discovery-contract.test.ts
+++ b/tests/providers/provider-model-discovery-contract.test.ts
@@ -518,6 +518,15 @@ describe("registry-owned provider model discovery", () => {
       authMode: "key",
     });
     expect(custom.spec).toBeUndefined();
+    // The entry opts into preserveCustomDestination, so a same-named row on a custom
+    // destination is an exact-transport mismatch: it recovers no discovery policy at all
+    // instead of resolving the slug envelope against its own custom URL.
+    const sameNamedCustom = resolveProviderModelDiscovery("zhipu-bigmodel-responses", {
+      adapter: "openai-responses",
+      baseUrl: "https://custom.example/api/v1",
+      authMode: "key",
+    });
+    expect(sameNamedCustom.spec).toBeUndefined();
   });
 
   test("rejects control characters and outer whitespace in provider-native model ids", () => {

--- a/tests/providers/provider-model-discovery-contract.test.ts
+++ b/tests/providers/provider-model-discovery-contract.test.ts
@@ -459,6 +459,67 @@ describe("registry-owned provider model discovery", () => {
     });
   });
 
+  test("a declared envelopeKey/idKey spec reads non-OpenAI rows (zhipu-bigmodel-responses)", () => {
+    const discovery = resolveProviderModelDiscovery("zhipu-bigmodel-responses", {
+      adapter: "openai-responses",
+      baseUrl: "https://open.bigmodel.cn/api/v1",
+    });
+    // The real /api/v1/models shape: rows under `models`, ids under `slug`. The extracted
+    // id must be materialized as `id` for the downstream catalog mapping.
+    const live = extractProviderModelItems({
+      models: [
+        { slug: "glm-5.3", context_window: 1048576 },
+        { slug: "glm-5-turbo", context_window: 1048576 },
+      ],
+    }, discovery);
+    expect(live).toEqual({
+      ok: true,
+      rawCount: 2,
+      items: [
+        { slug: "glm-5.3", context_window: 1048576, id: "glm-5.3" },
+        { slug: "glm-5-turbo", context_window: 1048576, id: "glm-5-turbo" },
+      ],
+    });
+
+    // Without the declaration the same body stays invalid: a stray `models` key on an
+    // openai-chat response must never pose as a catalog (#617).
+    const undeclared = resolveProviderModelDiscovery("unknown-provider", {
+      adapter: "openai-chat",
+      baseUrl: "https://example.test/v1",
+    });
+    expect(extractProviderModelItems({ models: [{ slug: "glm-5.3" }] }, undeclared))
+      .toEqual({ ok: false, reason: "invalid_shape" });
+  });
+
+  test("spec validation rejects idKey without envelopeKey and malformed keys", () => {
+    expect(providerModelDiscoverySpecError({ idKey: "slug" }))
+      .toBe("idKey requires envelopeKey");
+    expect(providerModelDiscoverySpecError({ envelopeKey: "not a key" }))
+      .toBe("envelopeKey must be an identifier-shaped key of 1-32 characters");
+    expect(providerModelDiscoverySpecError({ envelopeKey: "models", idKey: "slug" }))
+      .toBeNull();
+  });
+
+  test("a registry-id name on another entry's transport recovers that entry's discovery policy", () => {
+    // A saved row may keep the `zai` id while pointing at BigModel's Responses endpoint.
+    // The name match must not win over the transport: the destination entry's policy applies.
+    const discovery = resolveProviderModelDiscovery("zai", {
+      adapter: "openai-responses",
+      baseUrl: "https://open.bigmodel.cn/api/v1",
+      authMode: "key",
+    });
+    expect(discovery.spec).toEqual({ path: "models", envelopeKey: "models", idKey: "slug" });
+
+    // A custom endpoint still recovers nothing: the destination helper only matches
+    // exact fixed-key registry transports.
+    const custom = resolveProviderModelDiscovery("zai", {
+      adapter: "openai-responses",
+      baseUrl: "https://example.test/api/v1",
+      authMode: "key",
+    });
+    expect(custom.spec).toBeUndefined();
+  });
+
   test("rejects control characters and outer whitespace in provider-native model ids", () => {
     const discovery = resolveProviderModelDiscovery("unknown-provider", {
       adapter: "openai-chat",

--- a/tests/providers/provider-registry-parity.test.ts
+++ b/tests/providers/provider-registry-parity.test.ts
@@ -401,6 +401,15 @@ describe("provider registry parity", () => {
     // place rather than catching it, because it was written from the incomplete
     // state instead of from the family definition.
     expect(zai?.modelDefaultReasoningEfforts).toEqual({ "glm-5.3": "max", "glm-5.3[1m]": "max", "glm-5.3-flash": "max" });
+    // The BigModel Responses row's glm-5-turbo contract comes from the live endpoint
+    // (2026-09-05): NO selectable reasoning levels (an explicit [] — an undefined entry
+    // would fall back to the full routed ladder), a 200K window, summaries on, and the
+    // provider-level Responses replay flag rather than the Chat-path per-model list.
+    const responses = PROVIDER_REGISTRY.find(entry => entry.id === "zhipu-bigmodel-responses");
+    expect(responses?.modelReasoningEfforts?.["glm-5-turbo"]).toEqual([]);
+    expect(responses?.modelContextWindows?.["glm-5-turbo"]).toBe(204_800);
+    expect(responses?.preserveResponsesReasoningContent).toBe(true);
+    expect(responses?.preserveReasoningContentModels).toBeUndefined();
     expect(zai?.modelMaxOutputTokens).toEqual({ "glm-5.3": 131_072, "glm-5.3[1m]": 131_072, "glm-5.3-flash": 131_072 });
     // Every 5.3 row carries the same three-tier ladder. Asserted per member rather
     // than as one object literal so adding a member cannot quietly skip it.

--- a/tests/providers/provider-registry-parity.test.ts
+++ b/tests/providers/provider-registry-parity.test.ts
@@ -33,7 +33,7 @@ function nativeTemplate(): Record<string, unknown> {
 const EXPECTED_KEY_PROVIDER_IDS = [
   "anthropic-apikey", "openai-apikey", "meta-model", "umans", "opencode-go", "neuralwatt", "openrouter", "cline-pass", "cline", "orcarouter", "bizrouter", "groq", "google", "google-vertex", "azure-openai",
   "deepseek", "cerebras", "chutes", "deepinfra", "hyperbolic", "nscale", "vultr", "baseten", "commandcode", "sambanova", "nebius", "digitalocean", "scaleway", "featherless", "novita", "together", "fireworks", "firepass", "moonshot",
-  "huggingface", "nvidia", "venice", "zai", "zhipu-bigmodel", "zhipu-bigmodel-coding", "nanogpt", "synthetic", "siliconflow", "qwen-cloud", "tencent-coding-plan",
+  "huggingface", "nvidia", "venice", "zai", "zhipu-bigmodel", "zhipu-bigmodel-coding", "zhipu-bigmodel-responses", "nanogpt", "synthetic", "siliconflow", "qwen-cloud", "tencent-coding-plan",
   "volcengine", "volcengine-coding-plan", "volcengine-agent-plan", "qianfan", "alibaba", "alibaba-token-plan", "alibaba-token-plan-intl", "parallel", "zenmux", "litellm", "ollama-cloud", "mistral",
   "minimax", "minimax-cn", "kimi-code", "opencode-zen", "vercel-ai-gateway",
   "opencode-free", "xiaomi", "xiaomi-mimo", "kilo", "mimo-free", "mimo", "cloudflare-ai-gateway", "cloudflare-workers-ai", "gitlab-duo",
@@ -948,6 +948,7 @@ describe("provider registry parity", () => {
       "minimax-cn": "minimax",
       "zhipu-bigmodel": "zai",
       "zhipu-bigmodel-coding": "zai",
+      "zhipu-bigmodel-responses": "zai",
     });
     expect(resolveMetadataProvider("gemini")).toBe("google");
     expect(resolveMetadataProvider("minimax-cn")).toBe("minimax");


### PR DESCRIPTION
## Summary

Adds live model discovery for BigModel's OpenAI Responses endpoint:

- Registers `zhipu-bigmodel-responses` — the GLM Coding Plan on the OpenAI Responses wire at `https://open.bigmodel.cn/api/v1` (a separate endpoint from the Chat Completions row, same subscription product, so it gets its own registry row).
- Extends the registry-owned discovery spec with `envelopeKey`/`idKey`: BigModel's models API is not OpenAI-shaped — rows arrive as `{models: [{slug, ...}]}` with the id under `slug` plus per-model metadata (`context_window`, `supported_reasoning_levels`).
- Extraction materializes the declared row key as `id` for the downstream catalog mapping, and a declared `models` envelope is the row source itself rather than a #1797 sibling array.
- Makes discovery policy follow the transport a saved row points at: a row may carry a registry id as its name while pointing at another entry's transport (e.g. a `zai`-named row on BigModel's Responses endpoint). The named entry now owns the policy only when it declares a discovery spec of its own; otherwise the exact-transport destination helper decides.

An undeclared provider keeps the default `{data:[{id}]}` shape, so a stray `models` key on an openai-chat response still cannot pose as a catalog (#617). `idKey` without `envelopeKey` is rejected by spec validation, and custom endpoints, OAuth rows, templates, and overridable destinations still recover no policy at all.

## Evidence: real endpoint behavior (verified live 2026-09-05)

- `POST /api/v1/responses` answers the standard Responses object.
- `GET /api/v1/models` (Bearer key) returns `{models: [{slug, context_window, supported_reasoning_levels, ...}]}` listing `glm-5.3` / `glm-5.3-flash` / `glm-5-turbo`, with `context_window` 1048576 and reasoning levels `low`/`high`/`max` — matching the 5.3 ladder.
- Without this change, a provider configured at that endpoint logs `Provider model discovery ... returned malformed 2xx data [contentType=application/json]` and falls back to the static catalog — including when the row is saved under the `zai` registry id, because the named entry always won the policy lookup.
- With this change, a `zai`-named row on that transport resolves the destination entry's declared envelope and the live catalog appears under the operator's chosen name.

## Verification

- `bun run typecheck` passes.
- `bun test` on the discovery/registry suites: `provider-model-discovery-contract`, `provider-registry-parity`, `provider-static-model-discovery`, `provider-discovery-log-suppression`, `catalog-llamacpp-capabilities` — all pass, including new regressions for the declared-envelope shape, the #617 undeclared guard, spec validation, and the registry-id-name-on-foreign-transport recovery (plus its custom-endpoint negative).
- End-to-end against the live endpoint: `resolveProviderModelDiscoveryUrl` builds `https://open.bigmodel.cn/api/v1/models` and `extractProviderModelItems` parses the real response into catalog items.
- Branch based on current `dev` (0 commits behind).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Zhipu BigModel Coding Plan through the OpenAI Responses API.
  - Added a predefined catalog of three available BigModel models.
  - Improved model discovery for providers using custom response formats and model identifier fields.
  - Added validation to ensure custom model discovery settings are configured consistently.
- **Tests**
  - Added coverage for custom model discovery, provider resolution, and Zhipu provider compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->