### PR TITLE
fix(models): enforce pending selection write guards

### DIFF
--- a/docs-site/src/content/docs/fr/reference/management-api.md
+++ b/docs-site/src/content/docs/fr/reference/management-api.md
@@ -175,7 +175,10 @@ d’abord et soumettez le résumé renvoyé. Préférez la quarantaine lorsqu’
 | `PUT /api/model-visibility` | Modifier atomiquement la visibilité au niveau du fournisseur ou du modèle | 400 fournisseur, portée, cible ou corps non valide |
 | `GET, POST /api/custom-models` | Répertoriez les modèles personnalisés ou ajoutez-en un | 400 champs invalides ; 404 fournisseur manquant ; 409 dupliquer le modèle |
 | `PUT, DELETE /api/custom-models/{id}` | Modifier ou supprimer un modèle personnalisé | 400 invalide id/fields ; 404 introuvable ; 409 modèle en double |
-| `GET, PUT /api/selected-models` | Lire les listes autorisées et la disponibilité des fournisseurs, ou remplacer une liste autorisée | 400 fournisseur ou corps manquant ; 404 fournisseur inconnu |
+| `GET, PUT /api/selected-models` | Lire les listes autorisées et la disponibilité des fournisseurs, ou remplacer une liste autorisée | 400 fournisseur ou corps manquant ; 404 fournisseur inconnu; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | Lire les préréglages ou choisir le mode preset/all/custom | 400 mode invalide ou préréglage indisponible; 404 fournisseur inconnu; PUT 409 `initial_model_selection_pending` |
+
+Tant qu’une liste initiale fiable n’est pas disponible, les requêtes PUT valides vers `/api/selected-models` et `/api/model-presets` renvoient HTTP 409 avec le code `initial_model_selection_pending`. Actualisez la découverte des modèles (par exemple, `GET /api/models`), puis réessayez après sa réussite.
 
 ### Comptes OAuth, clés de fournisseur et clés du plan de données
 

--- a/docs-site/src/content/docs/ja/reference/management-api.md
+++ b/docs-site/src/content/docs/ja/reference/management-api.md
@@ -147,7 +147,10 @@ Authorization: Bearer <admin-token>
 | `PUT /api/model-visibility` |プロバイダーレベルまたはモデルレベルの可視性をアトミックに変更 | 400 プロバイダー、スコープ、ターゲット、または本文が無効です。
 | `GET, POST /api/custom-models` |カスタム モデルをリストするか追加する | 400 個の無効なフィールド。 404 プロバイダーがありません。 409 複製モデル |
 | `PUT, DELETE /api/custom-models/{id}` | 1 つのカスタム モデルを編集または削除する | 400 個の無効な ID/フィールド。 404 が見つかりません。 409 複製モデル |
-| `GET, PUT /api/selected-models` |プロバイダーのホワイトリストと可用性を読み取るか、1 つのホワイトリストを置き換えます。 400 のプロバイダー/本体が欠落しています。 404 不明なプロバイダ |
+| `GET, PUT /api/selected-models` | プロバイダーの許可リストと可用性を読む、または許可リストを置き換える | 400 プロバイダー/本文の不足; 404 不明なプロバイダー; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | プリセット情報を読む、または preset/all/custom モードを選ぶ | 400 不正なモードまたは未提供のプリセット; 404 不明なプロバイダー; PUT 409 `initial_model_selection_pending` |
+
+信頼できる初回モデル一覧が確定するまで、有効な `PUT /api/selected-models` と `PUT /api/model-presets` も HTTP 409 とコード `initial_model_selection_pending` を返します。`GET /api/models` などでモデル一覧を更新し、取得に成功してから再試行してください。
 
 ### OAuth アカウント、プロバイダー キー、およびデータプレーン キー
 

--- a/docs-site/src/content/docs/ko/reference/management-api.md
+++ b/docs-site/src/content/docs/ko/reference/management-api.md
@@ -150,7 +150,10 @@ Authorization: Bearer <admin-token>
 | `PUT /api/model-visibility` | provider 또는 model 수준의 visibility를 원자적으로 변경합니다 | 400 잘못된 provider, scope, target, 또는 본문 |
 | `GET, POST /api/custom-models` | custom model을 나열하거나 하나를 추가합니다 | 400 잘못된 필드; 404 provider 없음; 409 중복 model |
 | `PUT, DELETE /api/custom-models/{id}` | custom model 하나를 수정하거나 삭제합니다 | 400 잘못된 id/필드; 404 찾을 수 없음; 409 중복 model |
-| `GET, PUT /api/selected-models` | provider allowlist와 가용성을 읽거나 allowlist 하나를 교체합니다 | 400 provider/body 누락; 404 알 수 없는 provider |
+| `GET, PUT /api/selected-models` | provider allowlist와 가용성을 읽거나 allowlist 하나를 교체합니다 | 400 provider/body 누락; 404 알 수 없는 provider; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | 프리셋 정보를 읽거나 preset/all/custom 모드를 선택합니다 | 400 잘못된 mode 또는 지원하지 않는 프리셋; 404 알 수 없는 provider; PUT 409 `initial_model_selection_pending` |
+
+신뢰할 수 있는 초기 모델 목록을 확보하기 전에는 유효한 `PUT /api/selected-models`와 `PUT /api/model-presets` 요청도 HTTP 409와 `initial_model_selection_pending` 코드를 반환합니다. `GET /api/models` 등으로 모델 목록을 정상적으로 갱신한 뒤 재시도하세요.
 
 ### OAuth 계정, provider key, 데이터 평면 키
 

--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -19,7 +19,7 @@ ocx models disable '<model-id>'
 ocx models provider openrouter on
 ```
 
-After GUI registration or OAuth login, the confirmation dialog opens the Models page. CLI registration and login print model-management commands; JSON includes structured next steps. `--no-wait` reports pending login, not completion. Start the proxy with `ocx start` before using live model commands.
+After GUI registration or OAuth login, the confirmation dialog lets you open the Models page. CLI registration and login print model-management commands; JSON includes structured next steps. `--no-wait` reports pending login, not completion. Start the proxy with `ocx start` before using live model commands.
 
 ## Provider-related top-level fields
 

--- a/docs-site/src/content/docs/reference/management-api.md
+++ b/docs-site/src/content/docs/reference/management-api.md
@@ -194,7 +194,10 @@ first and submit the returned digest. Prefer quarantine when recovery may be nee
 | `PUT /api/model-visibility` | Atomically change provider- or model-level visibility | 400 invalid provider, scope, target, or body |
 | `GET, POST /api/custom-models` | List custom models or add one | 400 invalid fields; 404 provider missing; 409 duplicate model |
 | `PUT, DELETE /api/custom-models/{id}` | Edit or delete one custom model | 400 invalid id/fields; 404 not found; 409 duplicate model |
-| `GET, PUT /api/selected-models` | Read provider allowlists and availability, or replace one allowlist | 400 missing provider/body; 404 unknown provider |
+| `GET, PUT /api/selected-models` | Read provider allowlists and availability, or replace one allowlist | 400 missing provider/body; 404 unknown provider; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | Read preset summaries or choose preset/all/custom mode | 400 invalid mode or unsupported preset; 404 unknown provider; PUT 409 `initial_model_selection_pending` |
+
+Valid PUT requests to `/api/selected-models` and `/api/model-presets` return HTTP 409 with code `initial_model_selection_pending` until a reliable initial model list is available. Refresh model discovery (for example, `GET /api/models`) and retry after it succeeds.
 
 ### OAuth accounts, provider keys, and data-plane keys
 

--- a/docs-site/src/content/docs/ru/reference/management-api.md
+++ b/docs-site/src/content/docs/ru/reference/management-api.md
@@ -169,7 +169,10 @@ Endpoint'ы storage cleanup могут перемещать или навсег�
 | `PUT /api/model-visibility` | Атомарно изменить видимость на уровне провайдера или модели | 400 invalid provider, scope, target or body |
 | `GET, POST /api/custom-models` | Показать список custom-моделей или добавить одну | 400 invalid fields; 404 provider missing; 409 duplicate model |
 | `PUT, DELETE /api/custom-models/{id}` | Изменить или удалить одну custom-модель | 400 invalid id/fields; 404 not found; 409 duplicate model |
-| `GET, PUT /api/selected-models` | Прочитать allowlist'ы и availability провайдеров либо заменить один allowlist | 400 missing provider/body; 404 unknown provider |
+| `GET, PUT /api/selected-models` | Прочитать allowlist'ы и availability провайдеров либо заменить один allowlist | 400 missing provider/body; 404 unknown provider; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | Прочитать пресеты или выбрать режим preset/all/custom | 400 неверный режим или неподдерживаемый пресет; 404 неизвестный провайдер; PUT 409 `initial_model_selection_pending` |
+
+Пока достоверный исходный список моделей не получен, корректные PUT-запросы к `/api/selected-models` и `/api/model-presets` возвращают HTTP 409 с кодом `initial_model_selection_pending`. Обновите список моделей, например через `GET /api/models`, и повторите запрос после успешного получения списка.
 
 ### OAuth-аккаунты, ключи провайдеров и ключи data plane
 

--- a/docs-site/src/content/docs/tr/reference/management-api.md
+++ b/docs-site/src/content/docs/tr/reference/management-api.md
@@ -187,7 +187,10 @@ gönderin. Kurtarma gerekebileceğinde karantinayı tercih edin.
 | `PUT /api/model-visibility` | Sağlayıcı veya model düzeyindeki görünürlüğü atomik olarak değiştirin | 400 geçersiz sağlayıcı, kapsam, hedef veya gövde |
 | `GET, POST /api/custom-models` | Özel modelleri listeleyin veya bir tane ekleyin | 400 geçersiz alanlar; 404 sağlayıcı eksik; 409 yinelenen model |
 | `PUT, DELETE /api/custom-models/{id}` | Bir özel modeli düzenleyin veya silin | 400 geçersiz kimlik/alanlar; 404 bulunamadı; 409 yinelenen model |
-| `GET, PUT /api/selected-models` | Sağlayıcı izin listelerini ve kullanılabilirliğini okuyun veya bir izin listesini değiştirin | 400 eksik sağlayıcı/gövde; 404 bilinmeyen sağlayıcı |
+| `GET, PUT /api/selected-models` | Sağlayıcı izin listelerini ve kullanılabilirliğini okuyun veya bir izin listesini değiştirin | 400 eksik sağlayıcı/gövde; 404 bilinmeyen sağlayıcı; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | Ön ayarları okuyun veya preset/all/custom modunu seçin | 400 geçersiz mod veya desteklenmeyen ön ayar; 404 bilinmeyen sağlayıcı; PUT 409 `initial_model_selection_pending` |
+
+Güvenilir ilk model listesi hazır olana kadar `/api/selected-models` ve `/api/model-presets` için geçerli PUT istekleri de HTTP 409 ve `initial_model_selection_pending` kodunu döndürür. Model keşfini örneğin `GET /api/models` ile yenileyin ve başarılı olduktan sonra yeniden deneyin.
 
 ### OAuth hesapları, sağlayıcı anahtarları ve veri düzlemi anahtarları
 

--- a/docs-site/src/content/docs/zh-cn/reference/management-api.md
+++ b/docs-site/src/content/docs/zh-cn/reference/management-api.md
@@ -147,7 +147,10 @@ Authorization: Bearer <admin-token>
 | `PUT /api/model-visibility` | 原子性地更改 provider 级或 model 级可见性 | 400 provider、scope、target 或请求体无效 |
 | `GET, POST /api/custom-models` | 列出自定义模型或添加一个 | 400 字段无效；404 provider 缺失；409 模型重复 |
 | `PUT, DELETE /api/custom-models/{id}` | 编辑或删除一个自定义模型 | 400 id/字段无效；404 未找到；409 模型重复 |
-| `GET, PUT /api/selected-models` | 读取 provider 允许列表和可用性，或替换一个允许列表 | 400 缺少 provider/请求体；404 未知 provider |
+| `GET, PUT /api/selected-models` | 读取 provider 允许列表和可用性，或替换一个允许列表 | 400 缺少 provider/请求体；404 未知 provider; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | 读取预设信息或选择 preset/all/custom 模式 | 400 模式无效或不支持该预设；404 未知提供者; PUT 409 `initial_model_selection_pending` |
+
+可靠的初始模型列表尚未确认时，有效的 `PUT /api/selected-models` 和 `PUT /api/model-presets` 请求也会返回 HTTP 409 和代码 `initial_model_selection_pending`。请使用 `GET /api/models` 等方式刷新模型列表，成功后再重试。
 
 ### OAuth 账户、provider 密钥和数据平面密钥
 

--- a/docs-site/src/content/docs/zh-tw/reference/management-api.md
+++ b/docs-site/src/content/docs/zh-tw/reference/management-api.md
@@ -147,7 +147,10 @@ Session 簽發在需要 data-plane 認證時停用，這包含遠端綁定。遠
 | `PUT /api/model-visibility` | 原子地變更供應商或模型層級可見性 | 400 無效供應商、scope、目標或 body |
 | `GET, POST /api/custom-models` | 列出自訂模型或新增一個 | 400 無效欄位；404 供應商缺失；409 重複模型 |
 | `PUT, DELETE /api/custom-models/{id}` | 編輯或刪除一個自訂模型 | 400 無效 id/欄位；404 未找到；409 重複模型 |
-| `GET, PUT /api/selected-models` | 讀取供應商允許清單與可用性，或取代一個允許清單 | 400 缺失供應商/body；404 未知供應商 |
+| `GET, PUT /api/selected-models` | 讀取供應商允許清單與可用性，或取代一個允許清單 | 400 缺失供應商/body；404 未知供應商; PUT 409 `initial_model_selection_pending` |
+| `GET, PUT /api/model-presets` | 讀取預設資訊或選擇 preset/all/custom 模式 | 400 模式無效或不支援該預設；404 未知供應商; PUT 409 `initial_model_selection_pending` |
+
+尚未確認可靠的初始模型清單時，有效的 `PUT /api/selected-models` 和 `PUT /api/model-presets` 請求也會回傳 HTTP 409 和代碼 `initial_model_selection_pending`。請使用 `GET /api/models` 等方式更新模型清單，成功後再重試。
 
 ### OAuth 帳號、供應商金鑰與 data-plane 金鑰
 

--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -826,6 +826,7 @@
     "native-profile-store.test.ts": "codex-integration",
     "new-model-policy.test.ts": "providers",
     "initial-model-selection.test.ts": "providers",
+    "initial-selection-write-fence.test.ts": "providers",
     "model-selection-guidance.test.ts": "cli",
     "nous-oauth-live.test.ts": "providers",
     "nous-oauth.test.ts": "providers",

--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -841,6 +841,9 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
       return jsonResponse({ error: "mode must be preset, all, or custom" }, 400);
     }
     const target = config.providers[provider];
+    if (initialModelSelectionPending(target)) {
+      return jsonResponse({ error: "Initial model discovery is pending. Refresh the model list and retry.", code: "initial_model_selection_pending" }, 409);
+    }
     if (mode === "all") {
       // Same effect as today's empty-list PUT: no allowlist, no marker to reconcile.
       delete target.selectedModels;
@@ -903,6 +906,9 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
     const provider = typeof body.provider === "string" ? body.provider : "";
     if (!provider || !hasOwnProvider(config.providers, provider)) {
       return jsonResponse({ error: "unknown provider" }, provider ? 404 : 400);
+    }
+    if (initialModelSelectionPending(config.providers[provider])) {
+      return jsonResponse({ error: "Initial model discovery is pending. Refresh the model list and retry.", code: "initial_model_selection_pending" }, 409);
     }
     const models = Array.isArray(body.models)
       ? [...new Set(body.models.filter((m): m is string => typeof m === "string"))]

--- a/src/server/management/model-routes.ts
+++ b/src/server/management/model-routes.ts
@@ -840,6 +840,9 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
     if (mode !== "preset" && mode !== "all" && mode !== "custom") {
       return jsonResponse({ error: "mode must be preset, all, or custom" }, 400);
     }
+    if (mode === "preset" && !hasModelPreset(provider)) {
+      return jsonResponse({ error: `no model preset is shipped for provider '${provider}'` }, 400);
+    }
     const target = config.providers[provider];
     if (initialModelSelectionPending(target)) {
       return jsonResponse({ error: "Initial model discovery is pending. Refresh the model list and retry.", code: "initial_model_selection_pending" }, 409);
@@ -857,9 +860,6 @@ export async function handleModelRoutes(ctx: ManagementContext): Promise<Respons
       target.modelPreset = { ...(target.modelPreset ?? {}), mode: "custom" };
       persistConfig(config);
       return jsonResponse({ ok: true, provider, mode, selected: [...(target.selectedModels ?? [])] });
-    }
-    if (!hasModelPreset(provider)) {
-      return jsonResponse({ error: `no model preset is shipped for provider '${provider}'` }, 400);
     }
     const models = await fetchAllModels(config);
     const catalogIds = models.filter(m => m.provider === provider).map(m => m.id);

--- a/tests/fixtures/test-layout-expected.json
+++ b/tests/fixtures/test-layout-expected.json
@@ -663,6 +663,7 @@
   "native-profile-store.test.ts": "codex-integration",
   "new-model-policy.test.ts": "providers",
   "initial-model-selection.test.ts": "providers",
+  "initial-selection-write-fence.test.ts": "providers",
   "model-selection-guidance.test.ts": "cli",
   "nous-oauth-live.test.ts": "providers",
   "nous-oauth.test.ts": "providers",

--- a/tests/providers/initial-model-selection.test.ts
+++ b/tests/providers/initial-model-selection.test.ts
@@ -12,7 +12,6 @@ import { providerConfigSeed } from "../../src/providers/derive";
 import { getProviderRegistryEntry } from "../../src/providers/registry";
 import { safeConfigDTO, providerEditorConfigDTO } from "../../src/server/auth-cors";
 import { handleManagementAPI } from "../../src/server/management-api";
-import { buildClaudeDesktopState } from "../../src/server/management/shared";
 import { upsertOAuthProvider } from "../../src/oauth";
 import { commitKeyLoginProvider } from "../../src/oauth/login-cli";
 import type { OcxConfig, OcxProviderConfig } from "../../src/types";
@@ -321,7 +320,9 @@ describe("initial provider model switches", () => {
     const listed = (await response.json()).filter((row: { provider: string }) => row.provider === "vendor");
     expect(listed).toHaveLength(20);
     expect(listed.every((row: { disabled: boolean; initialSelectionPending: boolean }) => row.disabled && row.initialSelectionPending)).toBe(true);
-    expect((await buildClaudeDesktopState(config)).models.some(model => model.route.startsWith("vendor/"))).toBe(false);
+    const desktop = await api(config, "/api/claude-desktop");
+    expect(desktop.status).toBe(200);
+    expect((await desktop.json()).models.some((model: { route: string }) => model.route.startsWith("vendor/"))).toBe(false);
     for (const path of ["/api/injection-model", "/api/subagent-model-fallback"]) {
       const candidates = await (await api(config, path)).json();
       expect(JSON.stringify(candidates.available)).not.toContain("vendor/");

--- a/tests/providers/initial-model-selection.test.ts
+++ b/tests/providers/initial-model-selection.test.ts
@@ -12,6 +12,7 @@ import { providerConfigSeed } from "../../src/providers/derive";
 import { getProviderRegistryEntry } from "../../src/providers/registry";
 import { safeConfigDTO, providerEditorConfigDTO } from "../../src/server/auth-cors";
 import { handleManagementAPI } from "../../src/server/management-api";
+import { buildClaudeDesktopState } from "../../src/server/management/shared";
 import { upsertOAuthProvider } from "../../src/oauth";
 import { commitKeyLoginProvider } from "../../src/oauth/login-cli";
 import type { OcxConfig, OcxProviderConfig } from "../../src/types";
@@ -320,6 +321,7 @@ describe("initial provider model switches", () => {
     const listed = (await response.json()).filter((row: { provider: string }) => row.provider === "vendor");
     expect(listed).toHaveLength(20);
     expect(listed.every((row: { disabled: boolean; initialSelectionPending: boolean }) => row.disabled && row.initialSelectionPending)).toBe(true);
+    expect((await buildClaudeDesktopState(config)).models.some(model => model.route.startsWith("vendor/"))).toBe(false);
     for (const path of ["/api/injection-model", "/api/subagent-model-fallback"]) {
       const candidates = await (await api(config, path)).json();
       expect(JSON.stringify(candidates.available)).not.toContain("vendor/");

--- a/tests/providers/initial-selection-write-fence.test.ts
+++ b/tests/providers/initial-selection-write-fence.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getConfigPath, saveConfig } from "../../src/config";
+import { flushConfigDirHardeningForTests } from "../../src/config/paths";
+import { clearModelCache } from "../../src/codex/model-cache";
+import { initializeProviderModelSelection, reconcileInitialModelSelections } from "../../src/providers/initial-model-selection";
+import { handleManagementAPI } from "../../src/server/management-api";
+import type { OcxConfig, OcxProviderConfig } from "../../src/types";
+import { catalogConvergenceFactory } from "../helpers/catalog-convergence";
+import { installIsolatedCodexHome, type IsolatedCodexHome } from "../helpers/isolated-codex-home";
+import { ManagementRequest } from "../helpers/management-auth";
+import { removeTreeWithRetry } from "../helpers/remove-tree";
+
+const ids = ["anthropic/claude-opus-5", "openai/gpt-5.6-sol"];
+const operations = [
+  { path: "/api/model-presets", input: { mode: "all" }, selected: undefined, mode: undefined },
+  { path: "/api/model-presets", input: { mode: "custom" }, selected: [ids[0]], mode: "custom" },
+  { path: "/api/model-presets", input: { mode: "preset" }, selected: ids, mode: "preset" },
+  { path: "/api/selected-models", input: { models: [ids[1]] }, selected: [ids[1]], mode: "custom" },
+  { path: "/api/selected-models", input: { models: [] }, selected: undefined, mode: "custom" },
+] as const;
+let home: string;
+let previousHome: string | undefined;
+let codex: IsolatedCodexHome;
+beforeEach(() => {
+  previousHome = process.env.OPENCODEX_HOME;
+  home = mkdtempSync(join(tmpdir(), "ocx-selection-writes-"));
+  process.env.OPENCODEX_HOME = home;
+  codex = installIsolatedCodexHome("ocx-selection-writes-codex-");
+});
+afterEach(async () => {
+  clearModelCache();
+  await flushConfigDirHardeningForTests();
+  codex.restore();
+  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = previousHome;
+  removeTreeWithRetry(home);
+});
+
+function fixture(state: "pending" | "ready" | "legacy"): OcxConfig {
+  const provider: OcxProviderConfig = {
+    adapter: "openai-chat", baseUrl: "https://models.example.test/v1", authMode: "key",
+    apiKey: "fixture-key", liveModels: false, models: [...ids],
+    selectedModels: [ids[0]], modelPreset: { mode: "preset", appliedVersion: 1 },
+  };
+  const config: OcxConfig = { port: 0, defaultProvider: "openrouter", providers: { openrouter: provider }, clientIntegrations: { codex: false } };
+  if (state !== "legacy") initializeProviderModelSelection("openrouter", provider);
+  if (state === "ready") reconcileInitialModelSelections(config, ids.map(id => ({ provider: "openrouter", id })), ["openrouter"]);
+  saveConfig(config);
+  return config;
+}
+
+async function put(config: OcxConfig, operation: typeof operations[number]): Promise<Response> {
+  const url = new URL(`http://localhost${operation.path}`);
+  const request = new ManagementRequest(url, {
+    method: "PUT", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider: "openrouter", ...operation.input }),
+  });
+  const response = await handleManagementAPI(request, url, config, { createManagementConvergeCodex: catalogConvergenceFactory() });
+  if (!response) throw new Error("missing management route");
+  return response;
+}
+
+test.each([...operations])("pending selection write is rejected without mutation: %j", async operation => {
+  const config = fixture("pending");
+  const before = structuredClone(config);
+  const disk = readFileSync(getConfigPath(), "utf8");
+  const response = await put(config, operation);
+  expect(response.status).toBe(409);
+  expect(await response.json()).toMatchObject({ code: "initial_model_selection_pending" });
+  expect(config).toEqual(before);
+  expect(readFileSync(getConfigPath(), "utf8")).toBe(disk);
+  expect(config.providers.openrouter.disabled).not.toBe(true);
+});
+
+for (const state of ["ready", "legacy"] as const) {
+  test.each([...operations])(`${state} selection write retains normal behavior: %j`, async operation => {
+    const config = fixture(state);
+    const response = await put(config, operation);
+    expect(response.status).toBe(200);
+    expect(config.providers.openrouter.selectedModels).toEqual(operation.selected === undefined ? undefined : [...operation.selected]);
+    expect(config.providers.openrouter.modelPreset?.mode).toBe(operation.mode);
+    expect(config.providers.openrouter.disabled).not.toBe(true);
+    expect(config.providers.openrouter.initialModelSelection?.status).toBe(state === "ready" ? "ready" : undefined);
+  });
+}

--- a/tests/providers/initial-selection-write-fence.test.ts
+++ b/tests/providers/initial-selection-write-fence.test.ts
@@ -39,28 +39,32 @@ afterEach(async () => {
   removeTreeWithRetry(home);
 });
 
-function fixture(state: "pending" | "ready" | "legacy"): OcxConfig {
+function fixture(state: "pending" | "ready" | "legacy", name = "openrouter"): OcxConfig {
   const provider: OcxProviderConfig = {
     adapter: "openai-chat", baseUrl: "https://models.example.test/v1", authMode: "key",
     apiKey: "fixture-key", liveModels: false, models: [...ids],
-    selectedModels: [ids[0]], modelPreset: { mode: "preset", appliedVersion: 1 },
+    selectedModels: [ids[0]], modelPreset: { mode: name === "openrouter" ? "preset" : "custom", appliedVersion: 1 },
   };
-  const config: OcxConfig = { port: 0, defaultProvider: "openrouter", providers: { openrouter: provider }, clientIntegrations: { codex: false } };
-  if (state !== "legacy") initializeProviderModelSelection("openrouter", provider);
-  if (state === "ready") reconcileInitialModelSelections(config, ids.map(id => ({ provider: "openrouter", id })), ["openrouter"]);
+  const config: OcxConfig = { port: 0, defaultProvider: name, providers: { [name]: provider }, clientIntegrations: { codex: false } };
+  if (state !== "legacy") initializeProviderModelSelection(name, provider);
+  if (state === "ready") reconcileInitialModelSelections(config, ids.map(id => ({ provider: name, id })), [name]);
   saveConfig(config);
   return config;
 }
 
-async function put(config: OcxConfig, operation: typeof operations[number]): Promise<Response> {
-  const url = new URL(`http://localhost${operation.path}`);
+async function request(config: OcxConfig, path: string, body: string): Promise<Response> {
+  const url = new URL(`http://localhost${path}`);
   const request = new ManagementRequest(url, {
     method: "PUT", headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ provider: "openrouter", ...operation.input }),
+    body,
   });
   const response = await handleManagementAPI(request, url, config, { createManagementConvergeCodex: catalogConvergenceFactory() });
   if (!response) throw new Error("missing management route");
   return response;
+}
+
+function put(config: OcxConfig, operation: typeof operations[number]): Promise<Response> {
+  return request(config, operation.path, JSON.stringify({ provider: config.defaultProvider, ...operation.input }));
 }
 
 test.each([...operations])("pending selection write is rejected without mutation: %j", async operation => {
@@ -86,3 +90,36 @@ for (const state of ["ready", "legacy"] as const) {
     expect(config.providers.openrouter.initialModelSelection?.status).toBe(state === "ready" ? "ready" : undefined);
   });
 }
+
+for (const state of ["pending", "ready", "legacy"] as const) {
+  test("unsupported presets keep permanent validation for " + state, async () => {
+    const config = fixture(state, "no-preset-provider");
+    const before = structuredClone(config);
+    const disk = readFileSync(getConfigPath(), "utf8");
+    const response = await put(config, operations[2]);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "no model preset is shipped for provider 'no-preset-provider'" });
+    expect(config).toEqual(before);
+    expect(readFileSync(getConfigPath(), "utf8")).toBe(disk);
+  });
+}
+
+const validationCases = [
+  { path: "/api/model-presets", body: "{", status: 400, error: "invalid JSON body" },
+  { path: "/api/selected-models", body: "{", status: 400, error: "invalid JSON body" },
+  { path: "/api/model-presets", body: "{}", status: 400, error: "unknown provider" },
+  { path: "/api/selected-models", body: "{}", status: 400, error: "unknown provider" },
+  { path: "/api/model-presets", body: '{"provider":"missing","mode":"invalid"}', status: 404, error: "unknown provider" },
+  { path: "/api/selected-models", body: '{"provider":"missing","models":[]}', status: 404, error: "unknown provider" },
+  { path: "/api/model-presets", body: '{"provider":"openrouter","mode":"invalid"}', status: 400, error: "mode must be preset, all, or custom" },
+];
+test.each(validationCases)("permanent validation precedes pending state: %j", async entry => {
+  const config = fixture("pending");
+  const before = structuredClone(config);
+  const disk = readFileSync(getConfigPath(), "utf8");
+  const response = await request(config, entry.path, entry.body);
+  expect(response.status).toBe(entry.status);
+  expect(await response.json()).toEqual({ error: entry.error });
+  expect(config).toEqual(before);
+  expect(readFileSync(getConfigPath(), "utf8")).toBe(disk);
+});


### PR DESCRIPTION
## Summary

- Follow up the valid late review findings on #3636: reject preset and selected-model edits while initial discovery is pending, matching the existing visibility-write 409 response.
- Preserve existing authentication and input-validation order, and preserve ready/legacy editing behavior.
- Clarify that the confirmation dialog lets the user open Models. Keep the existing Claude Desktop production filter; add a regression proving that pending candidates are already excluded.

- Preserve permanent JSON/provider/mode/preset-support validation before the pending-state conflict. Add explicit unsupported-provider and validation-precedence regressions.
- Document the PUT 409 code and discovery-retry contract in English and all seven directly translated management API references.

## Verification

- Production TypeScript and isolated typechecking of both regression files passed; `git diff --check` passed.
- Independent static plan and whole-diff reviews passed with no blockers. No local test suites were run.
- Added 25 write cases: 5 pending rejection cases, 10 ready/legacy positive cases, 3 unsupported-provider state cases, and 7 permanent-validation precedence cases, including actual selection/marker outcomes and unchanged pending memory/disk state.
- The Desktop regression uses an actual 20-row pending inventory and calls the shared state builder; no redundant production filtering was added.
- Final candidate bb0547342c9526484b0219d6aaf5bf8927d0a852 needs fresh exact-head hosted CI before the user-authorized admin merge. The previous 3c4ff939 CI is historical only. Documentation build completed successfully (425 pages). Previous CI success is not reused as proof for this patch.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; existing auth and validation precede the new state guards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - Model preset and selected-model updates are temporarily unavailable while initial model discovery is pending.
  - Attempts to change selections during this period receive a conflict response and do not modify configuration.
  - Models from a provider still undergoing initial setup are not exposed through the Claude Desktop model endpoint.

- **Documentation**
  - Documented model-selection and model-preset management endpoints, including pending-state errors and retry guidance.
  - Updated registration guidance clarifies that users can open the Models page after GUI registration or OAuth login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
