### PR TITLE
fix(gateway): preserve Fable 1M picker selection

### DIFF
--- a/src/claude/model-info.ts
+++ b/src/claude/model-info.ts
@@ -143,14 +143,19 @@ export function buildAnthropicModelInfos(
   // the auto-context widening that let a 372K route carry the marker (and be
   // over-filled) is the #854 defect and does not come back. Guards (audit R1#11):
   // same dedupe set, never double-suffix.
-  const push1mVariant = (base: AnthropicModelInfo, contextWindow: number | undefined, maxInputTokens?: number) => {
+  const push1mVariant = (
+    base: AnthropicModelInfo,
+    contextWindow: number | undefined,
+    maxInputTokens?: number,
+    selectorId?: string,
+  ) => {
     // The [1m] marker makes Claude Code account 1e6 tokens for the row, so it
     // may only name models whose AUTHORITATIVE effective window is >= 1M —
     // never the auto-context widening, which would mark a 372K route and have
     // Claude Code over-fill it (the #854 defect).
     if (contextWindow === undefined || contextWindow < ONE_MILLION) return;
     if (base.id.includes("[1m]")) return;
-    const id = `${base.id}[1m]`;
+    const id = selectorId ?? `${base.id}[1m]`;
     if (seen.has(id)) return;
     seen.add(id);
     // The marker fixes Claude Code's accounting at 1e6, but a model may accept less input
@@ -220,7 +225,15 @@ export function buildAnthropicModelInfos(
     out.push(info);
     // Anthropic passthrough guard (audit 021 #3): never auto-widen canonical claude
     // routes — only a genuine >=1M window earns the variant row there.
-    push1mVariant(info, m.contextWindow, routedMaxInput);
+    // Claude Code groups canonical Fable ids before it compares the [1m] marker. A
+    // reversible native alias keeps the 200K and 1M rows independently selectable;
+    // the Messages ingress restores the canonical Anthropic id before passthrough.
+    const oneMillionSelector = idStyle === "readable"
+      && m.provider === "anthropic"
+      && listedModelId.startsWith("claude-fable-")
+      ? `${claudeCodeNativeAlias(listedModelId)}[1m]`
+      : undefined;
+    push1mVariant(info, m.contextWindow, routedMaxInput, oneMillionSelector);
     // The whole model is passed, not a (provider, id) pair: a combo row lives in its own
     // namespace with no config.providers entry, so the caller classifies it from the
     // aggregated supportsServiceTier the row already carries.

--- a/src/claude/model-info.ts
+++ b/src/claude/model-info.ts
@@ -225,9 +225,9 @@ export function buildAnthropicModelInfos(
     out.push(info);
     // Anthropic passthrough guard (audit 021 #3): never auto-widen canonical claude
     // routes — only a genuine >=1M window earns the variant row there.
-    // Claude Code groups canonical Fable ids before it compares the [1m] marker. A
-    // reversible native alias keeps the 200K and 1M rows independently selectable;
-    // the Messages ingress restores the canonical Anthropic id before passthrough.
+    // Claude Code groups canonical Fable ids before it compares the [1m] marker. This
+    // reversible alias only separates picker families; it is not an OpenAI-native route.
+    // The Messages ingress restores the canonical Anthropic id before passthrough.
     const oneMillionSelector = idStyle === "readable"
       && m.provider === "anthropic"
       && listedModelId.startsWith("claude-fable-")

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -12,6 +12,7 @@ import { enforceAnthropicImageLimits, sniffImageDimensions } from "../adapters/a
 import { normalizeAnthropicImages } from "../adapters/anthropic-image-normalize";
 import { AnthropicRequestError, anthropicToResponsesTranslation, extractOcxEffortDirective, extractOcxRouteDirective, resolveInboundModel, type ClaudeCacheKeySource } from "../claude/inbound";
 import { resolveDesktop3pAlias } from "../claude/desktop-3p";
+import { claudeCodeNativeAlias } from "../claude/alias";
 import { recordDesktopRequest } from "../claude/desktop-health";
 import { stripOneMillionMarker } from "../claude/context-windows";
 import { captureClaudeInbound } from "../claude/inbound-debug";
@@ -76,6 +77,13 @@ function decodeClaudeFastSelector(raw: string, cc?: OcxConfig["claudeCode"]): st
   const bare = raw.slice(0, -"--fast".length);
   const decodedBase = resolveInboundModel(bare, cc);
   return decodedBase === bare ? exact : `${decodedBase}--fast`;
+}
+
+/** Restore the reversible Fable picker alias before Anthropic passthrough checks. */
+function decodeFablePickerAlias(raw: string, cc?: OcxConfig["claudeCode"]): string {
+  const decoded = resolveInboundModel(raw, cc);
+  if (!decoded.startsWith("claude-fable-")) return raw;
+  return claudeCodeNativeAlias(decoded) === raw ? decoded : raw;
 }
 
 function isRec(v: unknown): v is Rec {
@@ -649,6 +657,9 @@ async function handleClaudeMessagesWithBudget(
       }
     }
     if (isRec(anthropicBody) && typeof anthropicBody.model === "string") {
+      anthropicBody.model = decodeFablePickerAlias(anthropicBody.model, config.claudeCode);
+    }
+    if (isRec(anthropicBody) && typeof anthropicBody.model === "string") {
       requestedModel = anthropicBody.model;
       // Decode for Fast only. A Claude alias is `claude-ocx-<provider>--<model>`, so it
       // already uses `--` as its own separator: stripping the marker off the RAW alias would
@@ -1070,6 +1081,8 @@ export async function handleClaudeCountTokens(
     model = stripOneMillionMarker(countRoute);
     raw.model = model;
   }
+  model = decodeFablePickerAlias(model, config.claudeCode);
+  raw.model = model;
   // Fast-only: count_tokens never parsed an effort row, so it must not start. It returns a
   // token estimate and sends no tier, so only the IDENTITY is corrected - without this the
   // synthetic id reaches native passthrough as a model Anthropic has never heard of.

--- a/tests/claude-integration/claude-model-info.test.ts
+++ b/tests/claude-integration/claude-model-info.test.ts
@@ -44,6 +44,22 @@ describe("anthropic-flavor ModelInfo discovery entries (devlog 130 B4b)", () => 
     expect(info!.capabilities.effort.max.supported).toBe(true);
   });
 
+  test("readable Fable rows keep base and 1M selections distinct in Claude Code", () => {
+    const infos = buildAnthropicModelInfos([], [{
+      provider: "anthropic",
+      id: "claude-fable-5-1",
+      contextWindow: 1_000_000,
+      maxInputTokens: 1_000_000,
+    }], undefined, "readable");
+
+    expect(infos.map(info => info.id)).toEqual([
+      "claude-fable-5-1",
+      "claude-ocx-native--claude-fable-5-1[1m]",
+    ]);
+    expect(infos[1]!.display_name).toBe("claude-fable-5-1 (anthropic) · 1M");
+    expect(infos[1]!.max_input_tokens).toBe(1_000_000);
+  });
+
   test("native effective ladder only advertises clamp-identity rungs (audit R4#1)", () => {
     for (const slug of ["gpt-5.5", "gpt-5.4", "gpt-5.6-sol"]) {
       for (const rung of nativeEffectiveLadder(slug)) {

--- a/tests/claude-integration/claude-native-passthrough.test.ts
+++ b/tests/claude-integration/claude-native-passthrough.test.ts
@@ -213,13 +213,21 @@ test("Fable 1M picker alias preserves native passthrough on both Messages endpoi
   const server = startServer(0);
   const pickerModel = "claude-ocx-native--claude-fable-5-1";
   try {
-    const messages = await fetch(new URL("/v1/messages", server.url), {
+    const messagesWithoutMarker = await fetch(new URL("/v1/messages", server.url), {
       method: "POST",
       headers: OAUTH_HEADERS,
       body: JSON.stringify({ ...claudeBody(), model: pickerModel }),
     });
-    expect(messages.status).toBe(200);
-    await messages.text();
+    expect(messagesWithoutMarker.status).toBe(200);
+    await messagesWithoutMarker.text();
+
+    const messagesWithMarker = await fetch(new URL("/v1/messages", server.url), {
+      method: "POST",
+      headers: OAUTH_HEADERS,
+      body: JSON.stringify({ ...claudeBody(), model: `${pickerModel}[1m]` }),
+    });
+    expect(messagesWithMarker.status).toBe(200);
+    await messagesWithMarker.text();
 
     const countTokens = await fetch(new URL("/v1/messages/count_tokens", server.url), {
       method: "POST",
@@ -229,9 +237,10 @@ test("Fable 1M picker alias preserves native passthrough on both Messages endpoi
     expect(countTokens.status).toBe(200);
     expect(await countTokens.json()).toEqual({ input_tokens: 4242 });
 
-    expect(captured).toHaveLength(2);
+    expect(captured).toHaveLength(3);
     expect(captured[0]!.body.model).toBe("claude-fable-5-1");
     expect(captured[1]!.body.model).toBe("claude-fable-5-1");
+    expect(captured[2]!.body.model).toBe("claude-fable-5-1");
   } finally {
     await server.stop(true);
     upstream.stop(true);

--- a/tests/claude-integration/claude-native-passthrough.test.ts
+++ b/tests/claude-integration/claude-native-passthrough.test.ts
@@ -206,6 +206,38 @@ test("count_tokens passes through with native credentials", async () => {
   }
 });
 
+test("Fable 1M picker alias preserves native passthrough on both Messages endpoints", async () => {
+  const captured: Captured[] = [];
+  const upstream = mockAnthropicUpstream(captured);
+  saveConfig(cfg(upstream.url.toString().replace(/\/$/, "")));
+  const server = startServer(0);
+  const pickerModel = "claude-ocx-native--claude-fable-5-1";
+  try {
+    const messages = await fetch(new URL("/v1/messages", server.url), {
+      method: "POST",
+      headers: OAUTH_HEADERS,
+      body: JSON.stringify({ ...claudeBody(), model: pickerModel }),
+    });
+    expect(messages.status).toBe(200);
+    await messages.text();
+
+    const countTokens = await fetch(new URL("/v1/messages/count_tokens", server.url), {
+      method: "POST",
+      headers: OAUTH_HEADERS,
+      body: JSON.stringify({ model: `${pickerModel}[1m]`, messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(countTokens.status).toBe(200);
+    expect(await countTokens.json()).toEqual({ input_tokens: 4242 });
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0]!.body.model).toBe("claude-fable-5-1");
+    expect(captured[1]!.body.model).toBe("claude-fable-5-1");
+  } finally {
+    await server.stop(true);
+    upstream.stop(true);
+  }
+});
+
 test("exposed native passthrough requires dedicated admission and never forwards admission credentials", async () => {
   const admissionSecret = "sk-ant-api03-key";
   const providerBearer = "sk-ant-oat01-provider";


### PR DESCRIPTION
## Summary

- Keep the canonical Fable base row and publish its 1M gateway variant under a reversible native selector so the model picker retains both context choices.
- Normalize that selector back to the canonical Fable model before native `/v1/messages` and `/v1/messages/count_tokens` passthrough.
- Preserve the existing Desktop 3P identifiers and the documented `[1m]` behavior.

The scope is intentionally limited to Fable because the picker family collision was reproduced for Fable. Other canonical Anthropic model selectors remain unchanged.

## Verification

- `bun test tests/claude-integration/claude-model-info.test.ts tests/claude-integration/claude-native-passthrough.test.ts` (28 passed)
- `bun run typecheck`
- `bun run test:changed` (1,543 passed across 95 files)
- `bun run privacy:scan`
- Local picker compatibility harness covered a fresh selection, a saved bare selection, switching back from Opus, persistence, and restart.
- The Fable passthrough test covers `/v1/messages` with and without `[1m]`, plus `/v1/messages/count_tokens` with `[1m]`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added distinct, readable model selections for Claude models with standard and 1M-token context options.
  - 1M-context entries now display clear labels and accurately reflect their expanded input-token capacity.

- **Bug Fixes**
  - Preserved native Claude model routing when using the Fable 1M picker alias.
  - Ensured both message requests and token-count requests continue to work correctly with 1M-context selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->