### PR TITLE
chore(release): open dev at 2.44.0 before releasing 2.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Prepare the owner-requested 2.43.0 release by moving dev from 2.43.0 to 2.44.0 before either channel publishes. The release candidate stays pinned to af50c6d3451078a7d298b044c08fd2684c9e8eeb.

This bootstraps the first release of the new pre-move workflow: default main still contains its old workflow_call definition, so the existing bump-dev-version.ts command prepares the same one-file change locally.

The owner requested the merge and release. If required, the repository-owner pull-request bypass will be used after verification; no self-approval is claimed.

## Verification

- Release candidate push-event Cross-platform CI: https://github.com/lidge-jun/opencodex/actions/runs/33974061890 (success).
- Exact PR-head CI and Service lifecycle must pass before merge.
- Verify the diff changes only package.json version from 2.43.0 to 2.44.0.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (version-line preparation only).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults (no credential/workflow changes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version from 2.43.0 to 2.44.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->