### PR TITLE
fix(codex): preserve disk state when account deletion is uncertain

### DIFF
--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
 import {
-  atomicWriteFile,
   deleteConfigTopLevelKey,
   getConfigPath,
   saveConfigPreservingClaudeCode,
@@ -107,13 +106,10 @@ function restoreRuntimeConfig(target: OcxConfig, snapshot: OcxConfig): void {
   Object.assign(target, snapshot);
 }
 
-function restorePersistedConfig(configPath: string, previousBytes: string): void {
-  try {
-    if (readFileSync(configPath, "utf8") === previousBytes) return;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+function assertPersistedConfigUnchanged(configPath: string, previousBytes: string): void {
+  if (readFileSync(configPath, "utf8") !== previousBytes) {
+    throw new CodexAccountDeleteRollbackError();
   }
-  atomicWriteFile(configPath, previousBytes);
 }
 
 /**
@@ -162,7 +158,7 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
       } catch (error) {
         restoreRuntimeConfig(runtimeConfig, previousConfig);
         try {
-          restorePersistedConfig(configPath, previousPersistedConfig);
+          assertPersistedConfigUnchanged(configPath, previousPersistedConfig);
         } catch {
           throw new CodexAccountDeleteRollbackError();
         }

--- a/src/codex/account-lifecycle.ts
+++ b/src/codex/account-lifecycle.ts
@@ -106,8 +106,8 @@ function restoreRuntimeConfig(target: OcxConfig, snapshot: OcxConfig): void {
   Object.assign(target, snapshot);
 }
 
-function assertPersistedConfigUnchanged(configPath: string, previousBytes: string): void {
-  if (readFileSync(configPath, "utf8") !== previousBytes) {
+function assertPersistedConfigUnchanged(configPath: string, previousBytes: Buffer): void {
+  if (!readFileSync(configPath).equals(previousBytes)) {
     throw new CodexAccountDeleteRollbackError();
   }
 }
@@ -129,7 +129,7 @@ export function deleteCodexAccount(runtimeConfig: OcxConfig, accountId: string):
     const previousConfig = structuredClone(runtimeConfig);
     const configPath = getConfigPath();
     const hasPersistedConfig = existsSync(configPath);
-    const previousPersistedConfig = hasPersistedConfig ? readFileSync(configPath, "utf8") : undefined;
+    const previousPersistedConfig = hasPersistedConfig ? readFileSync(configPath) : undefined;
     const hadStoredAccount = (runtimeConfig.codexAccounts ?? [])
       .some(account => !account.isMain && account.id === accountId);
     const hadVisiblePickerBinding = hadStoredAccount

--- a/tests/codex-integration/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-integration/codex-account-delete-atomicity.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync} from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import * as accountStoreModule from "../../src/codex/account-store";
 import {
@@ -8,6 +14,7 @@ import {
 } from "../../src/codex/account-store";
 import {
   CodexAccountDeleteCleanupError,
+  CodexAccountDeleteRollbackError,
   deleteCodexAccount,
 } from "../../src/codex/account-lifecycle";
 import {
@@ -85,7 +92,26 @@ describe("Codex account delete persistence ordering", () => {
     }
   });
 
-  test("a failure after durable config replacement restores the prior config", () => {
+  test("a failure before durable config replacement rethrows while disk remains unchanged", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const beforeBytes = readFileSync(getConfigPath(), "utf8");
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(() => { throw new Error("forced pre-write failure"); });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow("forced pre-write failure");
+      expect(config).toEqual(before);
+      expect(readFileSync(getConfigPath(), "utf8")).toBe(beforeBytes);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  test("a failure after durable config replacement leaves changed disk untouched", () => {
     const config = seededConfig();
     const before = structuredClone(config);
     const beforeBytes = readFileSync(getConfigPath(), "utf8");
@@ -97,11 +123,61 @@ describe("Codex account delete persistence ordering", () => {
       });
 
     try {
-      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow("forced post-write failure");
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
 
       expect(config).toEqual(before);
-      expect(readFileSync(getConfigPath(), "utf8")).toBe(beforeBytes);
-      expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(true);
+      expect(readFileSync(getConfigPath(), "utf8")).not.toBe(beforeBytes);
+      expect(loadConfig().codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  test("a concurrent external edit remains byte-identical after uncertain failure", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const realSave = configModule.saveConfigPreservingClaudeCode;
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(candidate => {
+        realSave(candidate);
+        const external = loadConfig();
+        external.port = 12345;
+        writeFileSync(getConfigPath(), JSON.stringify(external, null, 2) + "\n");
+        throw new Error("forced concurrent failure");
+      });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
+      const persisted = loadConfig();
+      expect(persisted.port).toBe(12345);
+      expect(persisted.codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
+      expect(config).toEqual(before);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  test("a missing config after uncertain failure is not recreated", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const realSave = configModule.saveConfigPreservingClaudeCode;
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(candidate => {
+        realSave(candidate);
+        unlinkSync(getConfigPath());
+        throw new Error("forced missing-file failure");
+      });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
+      expect(existsSync(getConfigPath())).toBe(false);
+      expect(config).toEqual(before);
       expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
       expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
       expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();

--- a/tests/codex-integration/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-integration/codex-account-delete-atomicity.test.ts
@@ -163,6 +163,36 @@ describe("Codex account delete persistence ordering", () => {
     }
   });
 
+  test("distinct bytes with the same decoded text are treated as changed", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const validBytes = Buffer.from('{"value":"\uFFFD"}\n', "utf8");
+    const malformedBytes = Buffer.concat([
+      Buffer.from('{"value":"', "utf8"),
+      Buffer.from([0x80]),
+      Buffer.from('"}\n', "utf8"),
+    ]);
+    expect(validBytes.equals(malformedBytes)).toBe(false);
+    expect(validBytes.toString("utf8")).toBe(malformedBytes.toString("utf8"));
+    writeFileSync(getConfigPath(), validBytes);
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(() => {
+        writeFileSync(getConfigPath(), malformedBytes);
+        throw new Error("forced byte-alias failure");
+      });
+
+    try {
+      expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
+      expect(readFileSync(getConfigPath()).equals(malformedBytes)).toBe(true);
+      expect(config).toEqual(before);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
   test("a missing config after uncertain failure is not recreated", () => {
     const config = seededConfig();
     const before = structuredClone(config);

--- a/tests/codex-integration/codex-account-delete-atomicity.test.ts
+++ b/tests/codex-integration/codex-account-delete-atomicity.test.ts
@@ -7,7 +7,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import * as fsModule from "node:fs";
 import * as accountStoreModule from "../../src/codex/account-store";
+import * as websocketRegistryModule from "../../src/codex/websocket-registry";
+import * as quotaAutoRefreshStateModule from "../../src/codex/quota-auto-refresh-state";
 import {
   getCodexAccountCredential,
   saveCodexAccountCredential,
@@ -139,18 +142,22 @@ describe("Codex account delete persistence ordering", () => {
   test("a concurrent external edit remains byte-identical after uncertain failure", () => {
     const config = seededConfig();
     const before = structuredClone(config);
+    let replacementBytes: Buffer | undefined;
     const realSave = configModule.saveConfigPreservingClaudeCode;
     const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
       .mockImplementation(candidate => {
         realSave(candidate);
         const external = loadConfig();
         external.port = 12345;
-        writeFileSync(getConfigPath(), JSON.stringify(external, null, 2) + "\n");
+        replacementBytes = Buffer.from(JSON.stringify(external, null, 2) + "\n", "utf8");
+        writeFileSync(getConfigPath(), replacementBytes);
         throw new Error("forced concurrent failure");
       });
 
     try {
       expect(() => deleteCodexAccount(config, ACCOUNT_ID)).toThrow(CodexAccountDeleteRollbackError);
+      expect(replacementBytes).toBeDefined();
+      expect(readFileSync(getConfigPath())).toEqual(replacementBytes);
       const persisted = loadConfig();
       expect(persisted.port).toBe(12345);
       expect(persisted.codexAccounts?.some(account => account.id === ACCOUNT_ID)).toBe(false);
@@ -213,6 +220,88 @@ describe("Codex account delete persistence ordering", () => {
       expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
     } finally {
       saveSpy.mockRestore();
+    }
+  });
+
+  test("an unreadable config after uncertain failure preserves state and sanitizes errors", () => {
+    const config = seededConfig();
+    const before = structuredClone(config);
+    const configPath = getConfigPath();
+    const beforeBytes = readFileSync(configPath);
+    const readSpy = spyOn(fsModule, "readFileSync");
+    const removeSpy = spyOn(accountStoreModule, "removeCodexAccountCredential");
+    const invalidateSpy = spyOn(websocketRegistryModule, "invalidateCodexWebSocketsForAccount");
+    const forgetSpy = spyOn(quotaAutoRefreshStateModule, "forgetCodexQuotaAutoRefreshAccount");
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode")
+      .mockImplementation(() => {
+        readSpy.mockImplementationOnce(() => {
+          throw new Error("EACCES /private/config.json Bearer read-secret-token");
+        });
+        throw new Error("write failed /private/config.json Bearer write-secret-token");
+      });
+
+    try {
+      let thrown: unknown;
+      try {
+        deleteCodexAccount(config, ACCOUNT_ID);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(readSpy).toHaveBeenLastCalledWith(configPath);
+      expect(thrown).toBeInstanceOf(CodexAccountDeleteRollbackError);
+      expect((thrown as Error).message).toBe(
+        "Account deletion failed and the previous config could not be restored. Restart before retrying.",
+      );
+      expect(String(thrown)).not.toContain("/private/config.json");
+      expect(String(thrown)).not.toContain("secret-token");
+      expect((thrown as Error).cause).toBeUndefined();
+      expect(config).toEqual(before);
+      expect(readFileSync(configPath)).toEqual(beforeBytes);
+      expect(getCodexAccountCredential(ACCOUNT_ID)).not.toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(true);
+      expect(getAccountQuota(ACCOUNT_ID)).not.toBeNull();
+      expect(removeSpy).not.toHaveBeenCalled();
+      expect(invalidateSpy).not.toHaveBeenCalled();
+      expect(forgetSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+      saveSpy.mockRestore();
+      removeSpy.mockRestore();
+      invalidateSpy.mockRestore();
+      forgetSpy.mockRestore();
+    }
+  });
+
+  test("a transient config skips persistence but still removes credentials and runtime state", () => {
+    const config = seededConfig();
+    const configPath = getConfigPath();
+    unlinkSync(configPath);
+    const saveSpy = spyOn(configModule, "saveConfigPreservingClaudeCode");
+    const removeSpy = spyOn(accountStoreModule, "removeCodexAccountCredential");
+    const invalidateSpy = spyOn(websocketRegistryModule, "invalidateCodexWebSocketsForAccount");
+    const forgetSpy = spyOn(quotaAutoRefreshStateModule, "forgetCodexQuotaAutoRefreshAccount");
+
+    try {
+      expect(deleteCodexAccount(config, ACCOUNT_ID)).toBe(true);
+      expect(saveSpy).not.toHaveBeenCalled();
+      expect(existsSync(configPath)).toBe(false);
+      expect(config.codexAccounts).toEqual([]);
+      expect(config.codexAccountNamespaces).toEqual({ stable: ACCOUNT_ID });
+      expect(config.pausedCodexAccountIds).toBeUndefined();
+      expect(config.codexAccountPriorities).toBeUndefined();
+      expect(config.activeCodexAccountPinned).toBeUndefined();
+      expect(config.activeCodexAccountId).toBeUndefined();
+      expect(getCodexAccountCredential(ACCOUNT_ID)).toBeNull();
+      expect(isAccountNeedsReauth(ACCOUNT_ID)).toBe(false);
+      expect(getAccountQuota(ACCOUNT_ID)).toBeNull();
+      expect(removeSpy).toHaveBeenCalledWith(ACCOUNT_ID);
+      expect(invalidateSpy).toHaveBeenCalledWith(ACCOUNT_ID);
+      expect(forgetSpy).toHaveBeenCalledWith(ACCOUNT_ID);
+    } finally {
+      saveSpy.mockRestore();
+      removeSpy.mockRestore();
+      invalidateSpy.mockRestore();
+      forgetSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

If saving an account deletion fails after another writer changed the config file, restoring an old snapshot would overwrite that writer's bytes. Keep the previous runtime state, preserve the actual disk bytes, and stop before credential/runtime cleanup when persistence cannot be verified. Missing or unreadable files also remain untouched.

Carries #3536, retaining SB Yoon's two commits and their source provenance. Existing successful-deletion and post-commit cleanup semantics remain intact; the separate management route's second-save contract is outside this layer.

Stack layer 2/5. Depends on #3682 (`codex/c-lane-3638-d778`); review only this account-persistence delta. Child #3688 carries OAuth configuration on this branch. Merge bottom-up into `dev`.

## Verification

- Local tests, typechecks and builds are forbidden by the maintainer and were not run.
- `macmini-cf`, Bun 1.4.0, exact head `21f3eb212181f65aed4265c7f46f2b5846316e92`: six account/config/auth test files — 314 pass, 0 fail. Source SHA256 verified before execution.
- Independent security review at that head: PASS; no blocking findings.
- Regression coverage includes changed bytes, missing/unreadable config, different invalid-UTF8 bytes, unchanged-byte save failure, and successful cleanup ordering.
- Independent security review and hosted current-head CI must pass before merge; draft pending final verification.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: SB Yoon <44089734+yansigit@users.noreply.github.com>
