### PR TITLE
fix(oauth): retain operator settings across provider login

### DIFF
--- a/docs-site/src/content/docs/reference/cli/providers-accounts.md
+++ b/docs-site/src/content/docs/reference/cli/providers-accounts.md
@@ -75,6 +75,11 @@ ocx login xai
 ocx login anthropic
 ```
 
+OAuth reauthentication preserves operator settings such as model selections, pricing overrides,
+and account failover preferences. Login-owned transport/authentication fields and registry-owned
+catalog metadata are refreshed. A live-discovery provider keeps its selected default model; a
+static provider can replace a default that no longer exists in its refreshed catalog.
+
 A proxy that is already running picks up the new credential without a restart: the CLI asks it to
 reload that one provider from disk, and the request carries no credential of its own. If the
 running proxy cannot accept that request — most often because it started from a build that predates

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1449,6 +1449,9 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
     if (value === undefined) delete next[field];
     else next[field] = structuredClone(value) as never;
   }
+  // A login may activate a different account. CCA dispatch must take that account's
+  // project from its credential snapshot, never retain the previous account's project.
+  if (next.googleMode === "cloud-code-assist") delete next.project;
   // Login used to rebuild the whole row from the preset, so catalog data refreshed
   // immediately. Keep that timing without overwriting unrelated operator-owned fields.
   applyOAuthPresetCatalog(next, def.providerConfig);

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1239,6 +1239,37 @@ function isLegacyAntigravityStaticCatalog(provider: OcxProviderConfig): boolean 
     ]);
 }
 
+/** Refresh registry-owned catalog fields while preserving valid operator selections. */
+function applyOAuthPresetCatalog(
+  provider: OcxProviderConfig,
+  preset: OcxProviderConfig,
+): void {
+  for (const field of OAUTH_RECONCILE_FIELDS) {
+    if (JSON.stringify(provider[field]) === JSON.stringify(preset[field])) continue;
+    if (preset[field] !== undefined) {
+      provider[field] = cloneProviderField(preset[field]) as never;
+    } else {
+      delete provider[field];
+    }
+  }
+  if (provider.liveModels === undefined && preset.liveModels !== undefined) {
+    provider.liveModels = preset.liveModels;
+  }
+  // Heal only a selection that the refreshed static catalog no longer contains. Providers
+  // with live discovery do not expose an enumerable account catalog here, so their saved
+  // default remains operator-owned.
+  if (
+    provider.liveModels !== true &&
+    provider.defaultModel
+    && preset.defaultModel
+    && preset.models
+    && preset.models.length > 0
+    && !(provider.models ?? []).includes(provider.defaultModel)
+  ) {
+    provider.defaultModel = preset.defaultModel;
+  }
+}
+
 /** Promote only the versioned canonical static seed; unmarked `liveModels: false` remains user intent. */
 function migrateLegacyAntigravityStaticCatalog(config: OcxConfig): boolean {
   if (config.googleAntigravityStaticCatalogVersion !== 1) return false;
@@ -1277,24 +1308,7 @@ function projectOAuthProviderReconciliation(config: OcxConfig): OAuthReconcilePr
     }
     if (def && prov.authMode === "oauth") {
       const preset = def.providerConfig;
-      for (const field of OAUTH_RECONCILE_FIELDS) {
-        if (JSON.stringify(prov[field]) === JSON.stringify(preset[field])) continue;
-        if (preset[field] !== undefined) {
-          prov[field] = cloneProviderField(preset[field]) as never;
-        } else {
-          delete prov[field];
-        }
-      }
-      if (prov.liveModels === undefined && preset.liveModels !== undefined) {
-        prov.liveModels = preset.liveModels;
-      }
-      // Heal a defaultModel that no longer exists in the refreshed list (e.g. a deprecated snapshot).
-      // Skip providers without a static preset `models` list: for live-discovery providers
-      // (e.g. command-code OAuth) the account-scoped catalog is not enumerable here, so any
-      // persisted defaultModel is a user selection and must not be overwritten by the seed.
-      if (prov.defaultModel && preset.defaultModel && preset.models && preset.models.length > 0 && !(prov.models ?? []).includes(prov.defaultModel)) {
-        prov.defaultModel = preset.defaultModel;
-      }
+      applyOAuthPresetCatalog(prov, preset);
     }
     if (JSON.stringify(prov) !== beforeProvider) {
       changed = true;
@@ -1408,24 +1422,18 @@ function preservableApiKeyPool(value: unknown): NonNullable<OcxProviderConfig["a
   return pool.length > 0 ? pool : undefined;
 }
 
-/**
- * Add/refresh an OAuth provider's config entry on a config object (does not persist).
- *
- * Providers whose registry entry sets `allowKeyAuthOverride` (xai, github-copilot) can be
- * billed through a stored API key instead of the OAuth login (router.ts honors
- * `authMode: "key"` for them). A blind preset overwrite here deletes `apiKey`/`apiKeyPool`
- * on every OAuth login, silently destroying the stored key and forcing a re-paste — and it
- * flips billing back to the subscription without the user asking. Carry the key fields over
- * and keep key billing while usable key material remains and the user was not explicitly on
- * oauth. If the final key was removed and only the old key mode remains, let the OAuth
- * preset restore `authMode: "oauth"` so the newly saved OAuth credential can be used.
- *
- * After preservation, `apiKey` always has exactly one matching pool entry (inserting via the
- * same content-derived id as the API-key manager when the active key was missing from the
- * pool). Key mode reflects stored user intent (explicit `"key"` or omitted mode with safe
- * key material) — never whether the login CLI process can resolve an env reference. Env-backed
- * availability is decided at proxy routing time in `router.ts`.
- */
+const OAUTH_LOGIN_OWNED_PROVIDER_FIELDS = [
+  "adapter",
+  "baseUrl",
+  "authMode",
+  "headers",
+  "apiKeyTransport",
+  "responsesPath",
+  "googleMode",
+  "keyOptional",
+] as const satisfies readonly (keyof OcxProviderConfig)[];
+
+/** Add/refresh only an OAuth provider's login-owned config fields (does not persist). */
 export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   if (provider === "chatgpt") return;
   const def = OAUTH_PROVIDERS[provider];
@@ -1434,40 +1442,28 @@ export function upsertOAuthProvider(config: OcxConfig, provider: string): void {
   const namespaceCollision = codexAccountNamespaceProviderCollisionError(config.codexAccountNamespaces, provider);
   if (namespaceCollision) throw new Error(namespaceCollision);
   const existing = config.providers[provider];
-  const next: OcxProviderConfig = { ...def.providerConfig };
-  // `liveModels` is a user-facing provider toggle. Preserve either explicit setting across login;
-  // Antigravity's CCA discovery now uses its real RPC, so legacy `true` remains a valid choice.
-  if (typeof existing?.liveModels === "boolean" && !isLegacyCommandCodeStaticCatalog(existing)) {
-    next.liveModels = existing.liveModels;
+  // Clone operator state, including xAI wire choices and their migration version.
+  const next: OcxProviderConfig = structuredClone(existing ?? def.providerConfig);
+  for (const field of OAUTH_LOGIN_OWNED_PROVIDER_FIELDS) {
+    const value = def.providerConfig[field];
+    if (value === undefined) delete next[field];
+    else next[field] = structuredClone(value) as never;
   }
-  // The Command Code protocol-version pin is an operator compatibility control. A re-login,
-  // add-account, or reauth rebuilds the row from the preset, which has no version; carry the
-  // existing pin so authentication changes do not silently revert the documented control.
-  if (existing?.commandCodeVersion !== undefined) {
-    next.commandCodeVersion = existing.commandCodeVersion;
+  // Login used to rebuild the whole row from the preset, so catalog data refreshed
+  // immediately. Keep that timing without overwriting unrelated operator-owned fields.
+  applyOAuthPresetCatalog(next, def.providerConfig);
+  // The original Command Code seed was an implementation-owned static catalog, not an
+  // operator opt-out. Promote that exact legacy shape when OAuth login refreshes the row.
+  if (provider === "command-code" && existing && isLegacyCommandCodeStaticCatalog(existing)) {
+    next.liveModels = def.providerConfig.liveModels;
   }
-  // Reauth/add-account refreshes credentials, not the operator's post-upgrade wire choice.
-  if (provider === "xai") {
-    if (existing?.modelAdapters !== undefined) next.modelAdapters = { ...existing.modelAdapters };
-    if (existing?.xaiResponsesDefaultVersion !== undefined) {
-      next.xaiResponsesDefaultVersion = existing.xaiResponsesDefaultVersion;
-    }
-  }
-  // User-configured price overlays are operator data, not preset state; a
-  // re-login, add-account, or reauth must not silently drop them from the
-  // Logs/Usage estimates.
-  if (existing?.modelCosts !== undefined) {
-    next.modelCosts = existing.modelCosts;
-  }
-  // The per-provider account-failover opt-out is operator intent about SPENDING, and the login
-  // path is exactly where losing it does damage: adding a second account both rebuilds this row
-  // from the preset and creates the 2-account quorum that turns presence-driven rotation on
-  // (#2568d). Dropping the opt-out here would enable the thing the operator switched off, at the
-  // moment they were doing something unrelated.
-  if (existing?.oauthAccountFailover !== undefined) {
-    next.oauthAccountFailover = existing.oauthAccountFailover;
-  }
+  // OAuth-only providers must never retain credentials for a different auth mechanism.
+  delete next.apiKey;
+  delete next.apiKeyPool;
+  delete (next as unknown as Record<string, unknown>).azureCredential;
   if (existing && getProviderRegistryEntry(provider)?.allowKeyAuthOverride === true) {
+    // Retain stored key billing intent without resolving env references in the login process.
+    // An explicit OAuth choice stays OAuth even when usable key material is retained.
     // Shared sanitizeApiKeyValue trim / no-CRLF checks from api-key pool writes.
     let storedApiKey = sanitizeApiKeyValue(existing.apiKey);
     const storedApiKeyPool = preservableApiKeyPool(existing.apiKeyPool);

--- a/tests/oauth/oauth-login-cli-live-update.test.ts
+++ b/tests/oauth/oauth-login-cli-live-update.test.ts
@@ -4,7 +4,9 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig, saveConfig, writePid, writeRuntimePort } from "../../src/config";
-import { upsertOAuthProvider } from "../../src/oauth";
+import { OAUTH_PROVIDERS, runLogin, upsertOAuthProvider } from "../../src/oauth";
+import { getAccountSet, saveCredential } from "../../src/oauth/store";
+import { clearGenericFailoverHealth, preferredInitialAccount } from "../../src/oauth/generic-account-failover";
 import {
   commitKeyLoginProvider,
   notifyRunningProxy,
@@ -59,6 +61,89 @@ afterEach(() => {
 });
 
 describe("CLI OAuth live-update credential preservation", () => {
+  test("Antigravity login emits the new active account's bearer and project without proactive preference", async () => {
+    const providerName = "google-antigravity";
+    const cfg: OcxConfig = {
+      port: 0,
+      hostname: "127.0.0.1",
+      defaultProvider: providerName,
+      oauthAccountFailover: { enabled: false },
+      providers: {
+        [providerName]: {
+          ...structuredClone(OAUTH_PROVIDERS[providerName]!.providerConfig),
+          project: "project-a",
+          liveModels: false,
+          oauthAccountFailover: { enabled: false },
+        },
+      },
+    };
+    saveConfig(cfg);
+    await saveCredential(providerName, {
+      access: "access-a", refresh: "refresh-a", expires: Date.now() + 3_600_000,
+      accountId: "account-a", projectId: "project-a",
+    });
+    const accountA = getAccountSet(providerName)!.activeAccountId;
+    const originalLogin = OAUTH_PROVIDERS[providerName]!.login;
+    const originalFetch = globalThis.fetch;
+    const emitted: Array<{ bearer: string | null; project: unknown }> = [];
+    let server: ReturnType<typeof startServer> | undefined;
+    try {
+      OAUTH_PROVIDERS[providerName]!.login = async () => ({
+        access: "access-b", refresh: "refresh-b", expires: Date.now() + 3_600_000,
+        accountId: "account-b", projectId: "project-b",
+      });
+      globalThis.fetch = (async (input, init) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        if (url.hostname === "127.0.0.1" || url.hostname === "localhost") return originalFetch(input, init);
+        if (url.origin !== "https://daily-cloudcode-pa.googleapis.com"
+          || !["/v1internal:generateContent", "/v1internal:streamGenerateContent"].includes(url.pathname)) {
+          throw new Error("Unexpected external request in CCA login regression");
+        }
+        const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+        const body = typeof init?.body === "string" ? init.body : input instanceof Request ? await input.clone().text() : "";
+        emitted.push({ bearer: headers.get("authorization"), project: (JSON.parse(body) as { project?: unknown }).project });
+        const payload = {
+          response: {
+            candidates: [{ content: { role: "model", parts: [{ text: "account-b response" }] }, finishReason: "STOP" }],
+            usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+          },
+        };
+        return url.searchParams.get("alt") === "sse"
+          ? new Response(`data: ${JSON.stringify(payload)}\n\n`, { headers: { "content-type": "text/event-stream" } })
+          : Response.json(payload);
+      }) as typeof globalThis.fetch;
+
+      await runLogin(providerName, {}, { forceLogin: true });
+      const accounts = getAccountSet(providerName)!;
+      expect(accounts.activeAccountId).not.toBe(accountA);
+      expect(accounts.accounts.find(account => account.id === accounts.activeAccountId)?.credential.accountId).toBe("account-b");
+      clearGenericFailoverHealth(providerName);
+      const persisted = loadConfig();
+      expect(persisted.providers[providerName]!.oauthAccountFailover?.enabled).toBe(false);
+      expect(preferredInitialAccount(persisted, providerName)).toBeNull();
+
+      server = startServer(0);
+      const response = await originalFetch(new URL("/v1/responses", server.url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "google-antigravity/gemini-3.8-flash", input: "hello", stream: false }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("account-b response");
+      // One successful initial dispatch: no 401 or reactive rotation can repair a bad pair.
+      expect(emitted).toEqual([{ bearer: "Bearer access-b", project: "project-b" }]);
+      expect(persisted.providers[providerName]!.project).toBeUndefined();
+    } finally {
+      try {
+        await server?.stop(true);
+      } finally {
+        globalThis.fetch = originalFetch;
+        OAUTH_PROVIDERS[providerName]!.login = originalLogin;
+        clearGenericFailoverHealth(providerName);
+      }
+    }
+  }, 15_000);
+
   test("does not post provider credentials when a legacy health listener has no verified pid", async () => {
     const receivedPaths: string[] = [];
     let healthProbeCount = 0;

--- a/tests/oauth/oauth-provider-reconcile.test.ts
+++ b/tests/oauth/oauth-provider-reconcile.test.ts
@@ -229,7 +229,7 @@ describe("OAuth provider reconciliation", () => {
     // holds; only the rows the projection actually changed may be replaced.
     expect(config.providers.untouched).toBe(liveUntouched);
   });
-  test("refreshes a saved Antigravity 3.5 preset without touching credentials or user fields", async () => {
+  test("refreshes a saved Antigravity live catalog without touching credentials or user fields", async () => {
     const home = mkdtempSync(join(tmpdir(), "ocx-gemini-36-reconcile-"));
     homes.push(home);
     process.env.OPENCODEX_HOME = home;
@@ -261,7 +261,7 @@ describe("OAuth provider reconciliation", () => {
 
     expect(reconcileOAuthProviders(config)).toBe(true);
     const provider = config.providers["google-antigravity"];
-    expect(provider.defaultModel).toBe("gemini-3.8-flash");
+    expect(provider.defaultModel).toBe("gemini-3.5-flash-low");
     expect(provider.models).toEqual([
       "gemini-3.8-flash",
       "gemini-3.7-flash",
@@ -288,7 +288,7 @@ describe("OAuth provider reconciliation", () => {
     });
 
     const persisted = loadConfig();
-    expect(persisted.providers["google-antigravity"]?.defaultModel).toBe("gemini-3.8-flash");
+    expect(persisted.providers["google-antigravity"]?.defaultModel).toBe("gemini-3.5-flash-low");
     expect(persisted.providers["google-antigravity"]?.liveModels).toBe(true);
     expect(reconcileOAuthProviders(config)).toBe(false);
   });
@@ -331,10 +331,9 @@ describe("OAuth provider reconciliation", () => {
   });
 
   test("an explicit 3.7 default survives the 3.8 launch while its capabilities refresh", () => {
-    // The 3.5 case above starts from a RETIRED id, so it only exercises the stale-default
-    // healing branch. This one is the opposite claim, and the one that matters for an
-    // additive rollout: a user who deliberately chose 3.7 must still be on 3.7 afterwards.
-    // Google still serves it, so healing it onto 3.8 would be silently overriding a choice.
+    // The earlier live-discovery case preserves an id outside the static seed. This case
+    // preserves a still-listed choice during an additive catalog rollout, while refreshing
+    // its capability records.
     const home = mkdtempSync(join(tmpdir(), "ocx-antigravity-explicit-default-"));
     homes.push(home);
     process.env.OPENCODEX_HOME = home;
@@ -365,6 +364,53 @@ describe("OAuth provider reconciliation", () => {
     // Capability records still refresh from the registry — preservation is about the
     // user's CHOICE, not about freezing the row.
     expect(provider.modelReasoningEfforts?.["gemini-3.8-flash"]).toEqual(["low", "medium", "high"]);
+  });
+
+  test("does not validate a live-models default against the static preset", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "google-antigravity",
+      providers: {
+        "google-antigravity": {
+          ...structuredClone(OAUTH_PROVIDERS["google-antigravity"].providerConfig),
+          authMode: "oauth",
+          liveModels: true,
+          models: ["account-specific-model"],
+          defaultModel: "account-specific-model",
+        },
+      },
+    } satisfies OcxConfig;
+
+    expect(reconcileOAuthProviders(config, false)).toBe(true);
+    expect(config.providers["google-antigravity"].defaultModel).toBe("account-specific-model");
+
+    upsertOAuthProvider(config, "google-antigravity");
+    expect(config.providers["google-antigravity"].defaultModel).toBe("account-specific-model");
+  });
+
+  test.each(["reconcile", "upsert"] as const)("%s heals an obsolete static default without enabling live discovery", operation => {
+    const preset = OAUTH_PROVIDERS["google-antigravity"].providerConfig;
+    const config: OcxConfig = {
+      port: 10100,
+      defaultProvider: "google-antigravity",
+      providers: {
+        "google-antigravity": {
+          ...structuredClone(preset),
+          liveModels: false,
+          defaultModel: "retired-static-model",
+          models: ["retired-static-model"],
+        },
+      },
+    };
+
+    if (operation === "reconcile") expect(reconcileOAuthProviders(config, false)).toBe(true);
+    else upsertOAuthProvider(config, "google-antigravity");
+
+    const provider = config.providers["google-antigravity"]!;
+    expect(provider.liveModels).toBe(false);
+    expect(provider.defaultModel).toBe(preset.defaultModel);
+    expect(provider.models).toEqual(preset.models);
+    expect(reconcileOAuthProviders(config, false)).toBe(false);
   });
 
   test("preserves an explicit Antigravity static opt-out without the legacy migration marker", () => {

--- a/tests/oauth/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth/oauth-upsert-preserves-api-key.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { upsertOAuthProvider } from "../../src/oauth";
+import { OAUTH_PROVIDERS, upsertOAuthProvider } from "../../src/oauth";
 import { migrateXaiResponsesDefault } from "../../src/providers/xai-responses-opt-in";
 import { resolveWireProtocolOverride } from "../../src/server/adapter-resolve";
 import {
@@ -346,7 +346,7 @@ describe("upsertOAuthProvider credential preservation", () => {
     }
   });
 
-  test("still applies the plain preset for oauth-only providers", () => {
+  test("applies OAuth credentials while preserving notes for oauth-only providers", () => {
     const config = {
       port: 10100,
       defaultProvider: "anthropic",
@@ -366,15 +366,182 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(provider.authMode).toBe("oauth");
     expect(provider.apiKey).toBeUndefined();
     expect(provider.apiKeyPool).toBeUndefined();
-    expect(provider.note).toBeUndefined();
+    expect(provider.note).toBe("stale-note");
+  });
+
+  test("replaces stale login transport fields instead of retaining an alternate credential destination", () => {
+    const config = configWithKey("anthropic", "openai-chat", "https://stale.example.invalid");
+    const existing = config.providers.anthropic!;
+    existing.headers = { Authorization: "Bearer stale-header-sentinel" };
+    existing.apiKeyTransport = "x-api-key";
+    existing.responsesPath = "/stale-responses";
+    existing.googleMode = "vertex";
+    existing.keyOptional = true;
+    const before = structuredClone(existing);
+    const preset = OAUTH_PROVIDERS.anthropic!.providerConfig;
+
+    upsertOAuthProvider(config, "anthropic");
+
+    const provider = config.providers.anthropic!;
+    expect(provider.adapter).toBe("anthropic");
+    expect(provider.baseUrl).toBe("https://api.anthropic.com");
+    expect(provider.authMode).toBe("oauth");
+    expect(provider.headers).toEqual(preset.headers);
+    expect(provider.apiKeyTransport).toBe(preset.apiKeyTransport);
+    expect(provider.responsesPath).toBeUndefined();
+    expect(provider.googleMode).toBeUndefined();
+    expect(provider.keyOptional).toBeUndefined();
+    expect(provider.apiKey).toBeUndefined();
+    expect(provider.apiKeyPool).toBeUndefined();
+    expect(existing).toEqual(before);
+  });
+
+  test("isolates nested operator and unchanged catalog data from the previous row and registry", () => {
+    const preset = OAUTH_PROVIDERS.anthropic!.providerConfig;
+    const presetBefore = structuredClone(preset);
+    const existing = {
+      ...structuredClone(preset),
+      modelCosts: { "operator-model": { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } },
+      forwardCompatibleFlag: { labels: ["keep"] },
+    };
+    const before = structuredClone(existing);
+    const config: OcxConfig = { port: 10100, defaultProvider: "anthropic", providers: { anthropic: existing } };
+
+    upsertOAuthProvider(config, "anthropic");
+
+    const provider = config.providers.anthropic! as typeof existing;
+    expect(provider.models).not.toBe(preset.models);
+    expect(provider.models).not.toBe(existing.models);
+    provider.modelCosts["operator-model"]!.input = 99;
+    provider.forwardCompatibleFlag.labels.push("changed");
+    provider.models!.push("test-only-model");
+    expect(existing).toEqual(before);
+    expect(preset).toEqual(presetBefore);
+  });
+
+  test("refreshes registry-owned catalog fields immediately without losing operator fields", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "anthropic",
+      providers: {
+        anthropic: {
+          adapter: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          authMode: "oauth",
+          models: ["retired-model"],
+          defaultModel: "retired-model",
+          contextWindow: 1,
+          disabled: true,
+          note: "operator-note",
+        },
+      },
+    } as unknown as OcxConfig;
+
+    upsertOAuthProvider(config, "anthropic");
+
+    const provider = config.providers.anthropic!;
+    const preset = OAUTH_PROVIDERS.anthropic!.providerConfig;
+    expect(provider.models).toEqual(preset.models);
+    expect(provider.contextWindow).toBe(preset.contextWindow);
+    expect(provider.defaultModel).toBe(preset.defaultModel);
+    expect(provider.disabled).toBe(true);
+    expect(provider.note).toBe("operator-note");
+  });
+
+  test.each(["login", "add-account", "reauthentication"])(
+    "preserves operator policy and unknown fields during %s-shaped upsert",
+    operation => {
+      const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+      const existing = config.providers.xai! as OcxConfig["providers"][string] & Record<string, unknown>;
+      existing.disabled = true;
+      existing.requestPacing = { enabled: true, minIntervalMs: 250 };
+      existing.retryOn429 = { attempts: 4, intervalMs: 900 };
+      existing.refreshPolicy = "lazy-only";
+      existing.selectedModels = ["grok-4"];
+      existing.note = `operator-${operation}`;
+      existing.modelCosts = { "grok-4": { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } };
+      existing.oauthAccountFailover = { enabled: false };
+      existing.forwardCompatibleFlag = { enabled: true };
+
+      upsertOAuthProvider(config, "xai");
+
+      const provider = config.providers.xai! as typeof existing;
+      expect(provider.disabled).toBe(true);
+      expect(provider.requestPacing).toEqual({ enabled: true, minIntervalMs: 250 });
+      expect(provider.retryOn429).toEqual({ attempts: 4, intervalMs: 900 });
+      expect(provider.refreshPolicy).toBe("lazy-only");
+      expect(provider.selectedModels).toEqual(["grok-4"]);
+      expect(provider.note).toBe(`operator-${operation}`);
+      expect(provider.modelCosts).toEqual({ "grok-4": { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } });
+      expect(provider.oauthAccountFailover).toEqual({ enabled: false });
+      expect(provider.forwardCompatibleFlag).toEqual({ enabled: true });
+      expect(provider.apiKey).toBe("stored-key-sentinel");
+    },
+  );
+
+  test("removes incompatible API-key and Azure credentials while preserving unknown fields", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "anthropic",
+      providers: {
+        anthropic: {
+          adapter: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          authMode: "key",
+          apiKey: "stale-key",
+          apiKeyPool: [{ id: "stale", key: "stale-key" }],
+          azureCredential: { token: "stale" },
+          disabled: true,
+          forwardCompatibleFlag: "retain-me",
+        },
+      },
+    } as unknown as OcxConfig;
+
+    upsertOAuthProvider(config, "anthropic");
+
+    const provider = config.providers.anthropic! as OcxConfig["providers"][string] & Record<string, unknown>;
+    expect(provider.apiKey).toBeUndefined();
+    expect(provider.apiKeyPool).toBeUndefined();
+    expect(provider.azureCredential).toBeUndefined();
+    expect(provider.disabled).toBe(true);
+    expect(provider.forwardCompatibleFlag).toBe("retain-me");
+    expect(provider.authMode).toBe("oauth");
   });
 
   test("a fresh login on an unconfigured provider gets the untouched preset", () => {
     const config = { port: 10100, defaultProvider: "openai", providers: {} } as unknown as OcxConfig;
+    const preset = OAUTH_PROVIDERS.xai!.providerConfig;
+    const before = structuredClone(preset);
     upsertOAuthProvider(config, "xai");
     const provider = config.providers.xai!;
     expect(provider.authMode).toBe("oauth");
     expect(provider.apiKey).toBeUndefined();
     expect(provider.apiKeyPool).toBeUndefined();
+    expect(provider.models).not.toBe(preset.models);
+    provider.models!.push("test-only-model");
+    expect(preset).toEqual(before);
+  });
+
+  test("promotes the legacy Command Code static catalog during OAuth upsert", () => {
+    const config = {
+      port: 10100,
+      defaultProvider: "command-code",
+      providers: {
+        "command-code": {
+          adapter: "command-code",
+          baseUrl: "https://api.commandcode.ai",
+          authMode: "oauth",
+          liveModels: false,
+          defaultModel: "deepseek-v4-flash",
+          models: ["deepseek-v4-flash", "kimi-k3", "glm-5.2"],
+          note: "operator-note",
+        },
+      },
+    } as unknown as OcxConfig;
+
+    upsertOAuthProvider(config, "command-code");
+
+    expect(config.providers["command-code"]!.liveModels).toBe(true);
+    expect(config.providers["command-code"]!.note).toBe("operator-note");
   });
 });

--- a/tests/oauth/oauth-upsert-preserves-api-key.test.ts
+++ b/tests/oauth/oauth-upsert-preserves-api-key.test.ts
@@ -396,6 +396,31 @@ describe("upsertOAuthProvider credential preservation", () => {
     expect(existing).toEqual(before);
   });
 
+  test("clears the previous CCA project only after resolving the canonical login mode", () => {
+    const config = configWithKey("google-antigravity", "google", "https://stale.example.invalid");
+    const existing = config.providers["google-antigravity"]!;
+    existing.googleMode = "vertex";
+    existing.project = "previous-account-project";
+
+    upsertOAuthProvider(config, "google-antigravity");
+
+    expect(config.providers["google-antigravity"]!.googleMode).toBe("cloud-code-assist");
+    expect(config.providers["google-antigravity"]!.project).toBeUndefined();
+    expect(existing.project).toBe("previous-account-project");
+  });
+
+  test("preserves an operator project when the canonical login mode is not CCA", () => {
+    const config = configWithKey("xai", "openai-chat", "https://api.x.ai/v1");
+    const existing = config.providers.xai!;
+    existing.googleMode = "cloud-code-assist";
+    existing.project = "operator-project";
+
+    upsertOAuthProvider(config, "xai");
+
+    expect(config.providers.xai!.googleMode).toBeUndefined();
+    expect(config.providers.xai!.project).toBe("operator-project");
+  });
+
   test("isolates nested operator and unchanged catalog data from the previous row and registry", () => {
     const preset = OAUTH_PROVIDERS.anthropic!.providerConfig;
     const presetBefore = structuredClone(preset);


### PR DESCRIPTION
## Summary

OAuth login currently rebuilds a provider row from its preset and loses operator settings outside a small preservation list. Preserve the existing row, refresh only login-owned transport/auth and registry-owned catalog fields, and keep valid live-discovery defaults. OAuth-only providers discard incompatible key credentials; providers supporting key overrides retain sanitized keys and billing intent. Cloud Code Assist login also clears account-owned project metadata so the next request uses the active credential snapshot.

Carries #3631 onto current `dev`, preserving the newer xAI transport overrides and their regressions. Original source commits: `015c04afd152380e4948c506d49acaa9215694d6`, `3f4e7c5a46d1f078559bda9aa53b88a1d96c4e48`, `171451d338ab76b55185e587986450397f20ee02`.

Stack layer 3/5, depends on #3687 (`codex/c-lane-3536-d778`). Review only the OAuth configuration delta. Later Antigravity replay work consumes this layer; merge bottom-up.

## Verification

- No local tests, typechecks or builds, per explicit maintainer instruction.
- `macmini-cf` Bun 1.4.0 at `7ca5890ba27b84f238445f0dfa4f4f8cba7f6be7`: nine focused files, 174 pass / 0 fail; source archive SHA256 verified.
- Independent security re-review: PASS. A real login from account A to B verifies the first outbound request uses B bearer/B project; startup reconciliation and non-CCA project behavior remain covered.
- Preserve operator fields, explicit live-model choices, xAI protocol overrides, catalog reconciliation, credential removal, and key-mode billing intent.
- Independent security review and current-head hosted CI are required before merge; draft while pending.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: SB Yoon <44089734+yansigit@users.noreply.github.com>
