### PR TITLE
test(oauth): isolate key-login live reload from public DNS

### DIFF
--- a/devlog/_plan/260906_key_login_ci_timeout/000_plan.md
+++ b/devlog/_plan/260906_key_login_ci_timeout/000_plan.md
@@ -1,0 +1,31 @@
+# 000 — Diagnose the key-login live-update CI timeout
+
+One focused PABCD repair cycle. Baseline dev `922bfa653a013647881316f3d95f0631a87acb10` differs from failed CI head `73190c20443876fe1dbf4e9dde5d25644e48e71a` only by the previous lane's outcome record.
+
+## Evidence and outcome
+
+Public CI run 33999342751, job 101395411095, failed `tests/oauth/key-login-live-update.test.ts:61` after 15,046ms against a 15,000ms test budget. The shard finished 9,470 pass, 7 skip, 1 fail. The log records server startup but no failing assertion or awaited-operation trace. Other execution jobs passed; Windows six-shard tests were intentionally skipped by the push workflow.
+
+Keep the same disk/live modelCosts and rotated-key assertions. Locate the wait before changing code. A passing retry alone does not explain the failure.
+
+## Investigation and conditional change map
+
+- Read `tests/oauth/key-login-live-update.test.ts` and instrument its asynchronous boundaries only in remote scratch: key-login commit, management read and server stop.
+- Trace `src/oauth/login-cli.ts` notify, `src/server/local-provider-reload-client.ts` request, `src/server/management/provider-routes.ts` reload validation/convergence, and the server's shutdown hooks. Preserve every admission predicate.
+- The fixture currently installs the real Umans hostname both before start and through the replacement preset. Check whether DNS/network dependence causes the observed wait. If established, modify only the test fixture: use a synthetic controlled destination via the existing baseUrl override, preserve real local attestation/reload/convergence, assert the reload outcome, and clean owned resources. No timeout extension, skip or mock of the operation under test.
+- If the wait is a production lifecycle defect instead, amend this plan with the observed boundary and smallest production correction before B. Do not introduce speculative cancellation or security changes.
+- Put the final evidence and failure disposition in `010_outcome.md`; unpublished security findings, if any, remain in ignored scratch.
+
+## Execution and acceptance
+
+Class C2 for a hermetic fixture correction; promote to C4 with independent security review if executed auth/admission logic must change. Main owns refs/PR/FSM; one remote worker owns serialized macOS reproduction under the shared test-user lock, and an independent reviewer owns static analysis. Inherit the parent model. No local suite, typecheck, build or hooks. Remote pinned Bun 1.4.0 and synthetic fixtures only; do not access personal accounts/services. No requested token/cost budget; six-hour checkpoint, not an automatic success condition.
+
+Required evidence: original failure and causal trace, focused remote original/fixed comparison, original assertions intact, relevant adjacent tests and typecheck, independent review, current-head hosted CI, admin merge and actual dev ancestry. Follow final dev CI for this repair. Existing user push/admin authorization applies; every push uses --no-verify. No release, deployment, global relink, integration-branch direct push or changes to another lane's jobs.
+
+DONE requires those actual outcomes. NOOP needs proof current dev already resolves the failure. Unknown cause, an expired wait, and a red CI are not completion. Append a separate cycle only if a distinct necessary repair appears.
+
+## A evidence amendment: controlled failure path
+
+Remote pinned-Bun macOS reproduction: original fixture passes in 95.42ms with controlled outbound HTTP. Delaying only the real Umans DNS answer gives reload transport-unavailable at ~10.28s, successful local config GET at ~10.29s, then `server.stop(true)` begins and remains unsettled until the original 15s test timeout (15,008.86ms). The trace identifies `providerDestinationResolvedError` as the DNS caller. This reproduces the CI timeout shape; the uninstrumented historical CI log still does not prove which external delay occurred there.
+
+Selected change is test-only: an owned literal-loopback upstream in beforeEach with a deterministic catalog response, `umansKeyConfig(baseUrl, port)` using explicit private-network opt-in, the existing key-provider constructor's URL override plus private-network opt-in on the replacement row, and awaited upstream teardown after the proxy. Preserve all four original assertions and the 15s ceiling; additionally assert reload outcome is `reloaded` and config GET is HTTP200. No production auth, destination validation, transport or shutdown change. Focused remote gate covers this test, key-login overlay merge, OAuth live update, local reload client and direct transport, plus root typecheck. A controlled delayed-DNS run must remain green with zero DNS calls from the fixed fixture.

--- a/tests/oauth/key-login-live-update.test.ts
+++ b/tests/oauth/key-login-live-update.test.ts
@@ -7,6 +7,7 @@ import { commitKeyLoginProvider, providerConfigFromKeyLoginProvider } from "../.
 import { KEY_LOGIN_PROVIDERS } from "../../src/oauth/key-providers";
 import { startServer } from "../../src/server";
 import { createLocalAttestationSecret } from "../../src/lib/local-management-attestation";
+import type { LocalProviderReloadResult } from "../../src/server/local-provider-reload-client";
 import type { OcxConfig } from "../../src/types";
 import { refreshUserCostOverlays } from "../../src/usage/user-cost-overlays";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "../helpers/isolated-codex-home";
@@ -22,8 +23,9 @@ import { removeTreeWithRetry } from "../helpers/remove-tree";
 let testDir = "";
 let previousHome: string | undefined;
 let isolatedCodexHome: IsolatedCodexHome | null = null;
+let upstream: ReturnType<typeof Bun.serve>;
 
-function umansKeyConfig(port = 0): OcxConfig {
+function umansKeyConfig(baseUrl: string, port = 0): OcxConfig {
   return {
     port,
     hostname: "127.0.0.1",
@@ -31,7 +33,8 @@ function umansKeyConfig(port = 0): OcxConfig {
     providers: {
       umans: {
         adapter: "anthropic",
-        baseUrl: "https://api.code.umans.ai",
+        baseUrl,
+        allowPrivateNetwork: true,
         apiKey: "sk-old",
       },
     },
@@ -43,10 +46,18 @@ beforeEach(() => {
   isolatedCodexHome = installIsolatedCodexHome("ocx-key-login-live-");
   testDir = mkdtempSync(join(tmpdir(), "ocx-key-login-live-"));
   process.env.OPENCODEX_HOME = testDir;
-  saveConfig(umansKeyConfig());
+  // Reload validates the provider destination before adopting disk state. Use an
+  // owned literal address so this persistence regression cannot wait on public DNS.
+  upstream = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => Response.json({ data: [{ id: "umans-coder", type: "model" }] }),
+  });
+  saveConfig(umansKeyConfig(upstream.url.toString()));
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await upstream.stop(true);
   // The overlay registry is module-level; reset it so rows added through the
   // live provider update path cannot leak into later tests in a shared run.
   refreshUserCostOverlays({ providers: {} } as unknown as OcxConfig);
@@ -83,8 +94,13 @@ describe("CLI key-login live-update overlay preservation", () => {
       saveConfig(edited);
 
       const config = loadConfig();
-      const replacement = providerConfigFromKeyLoginProvider(KEY_LOGIN_PROVIDERS.umans, "sk-rotated");
-      const merged = await commitKeyLoginProvider(config, "umans", replacement);
+      const replacement = {
+        ...providerConfigFromKeyLoginProvider(KEY_LOGIN_PROVIDERS.umans, "sk-rotated", upstream.url.toString()),
+        allowPrivateNetwork: true,
+      };
+      let reload: LocalProviderReloadResult | null = null;
+      const merged = await commitKeyLoginProvider(config, "umans", replacement, result => { reload = result; });
+      expect(reload).toEqual({ kind: "reloaded" });
       expect(merged.modelCosts).toEqual(edited.providers.umans!.modelCosts);
 
       // Reload treats disk as authoritative and never re-saves it.
@@ -95,7 +111,9 @@ describe("CLI key-login live-update overlay preservation", () => {
       // The running proxy must also carry the overlay in its live config:
       // A silent early return or failed reload would leave the in-memory DTO stale
       // even though disk is correct.
-      const live = (await fetch(new URL("/api/config", server.url)).then(r => r.json())) as {
+      const response = await fetch(new URL("/api/config", server.url));
+      expect(response.status).toBe(200);
+      const live = (await response.json()) as {
         providers: Record<string, { modelCosts?: Record<string, unknown> }>;
       };
       expect(live.providers.umans?.modelCosts).toEqual(edited.providers.umans!.modelCosts);

--- a/tests/oauth/key-login-live-update.test.ts
+++ b/tests/oauth/key-login-live-update.test.ts
@@ -23,7 +23,7 @@ import { removeTreeWithRetry } from "../helpers/remove-tree";
 let testDir = "";
 let previousHome: string | undefined;
 let isolatedCodexHome: IsolatedCodexHome | null = null;
-let upstream: ReturnType<typeof Bun.serve>;
+let upstream: ReturnType<typeof Bun.serve> | undefined;
 
 function umansKeyConfig(baseUrl: string, port = 0): OcxConfig {
   return {
@@ -57,15 +57,19 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  await upstream.stop(true);
-  // The overlay registry is module-level; reset it so rows added through the
-  // live provider update path cannot leak into later tests in a shared run.
-  refreshUserCostOverlays({ providers: {} } as unknown as OcxConfig);
-  if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
-  else process.env.OPENCODEX_HOME = previousHome;
-  isolatedCodexHome?.restore();
-  isolatedCodexHome = null;
-  if (testDir) removeTreeWithRetry(testDir);
+  try {
+    await upstream?.stop(true);
+  } finally {
+    upstream = undefined;
+    // The overlay registry is module-level; reset it so rows added through the
+    // live provider update path cannot leak into later tests in a shared run.
+    refreshUserCostOverlays({ providers: {} } as unknown as OcxConfig);
+    if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousHome;
+    isolatedCodexHome?.restore();
+    isolatedCodexHome = null;
+    if (testDir) removeTreeWithRetry(testDir);
+  }
 });
 
 describe("CLI key-login live-update overlay preservation", () => {
@@ -95,7 +99,7 @@ describe("CLI key-login live-update overlay preservation", () => {
 
       const config = loadConfig();
       const replacement = {
-        ...providerConfigFromKeyLoginProvider(KEY_LOGIN_PROVIDERS.umans, "sk-rotated", upstream.url.toString()),
+        ...providerConfigFromKeyLoginProvider(KEY_LOGIN_PROVIDERS.umans, "sk-rotated", config.providers.umans!.baseUrl),
         allowPrivateNetwork: true,
       };
       let reload: LocalProviderReloadResult | null = null;

--- a/tests/oauth/key-login-live-update.test.ts
+++ b/tests/oauth/key-login-live-update.test.ts
@@ -102,9 +102,9 @@ describe("CLI key-login live-update overlay preservation", () => {
         ...providerConfigFromKeyLoginProvider(KEY_LOGIN_PROVIDERS.umans, "sk-rotated", config.providers.umans!.baseUrl),
         allowPrivateNetwork: true,
       };
-      let reload: LocalProviderReloadResult | null = null;
-      const merged = await commitKeyLoginProvider(config, "umans", replacement, result => { reload = result; });
-      expect(reload).toEqual({ kind: "reloaded" });
+      const reloads: Array<LocalProviderReloadResult | null> = [];
+      const merged = await commitKeyLoginProvider(config, "umans", replacement, result => { reloads.push(result); });
+      expect(reloads).toEqual([{ kind: "reloaded" }]);
       expect(merged.modelCosts).toEqual(edited.providers.umans!.modelCosts);
 
       // Reload treats disk as authoritative and never re-saves it.


### PR DESCRIPTION
## Summary

The key-login live-update regression used the real Umans hostname while calling the real provider reload endpoint. That endpoint validates destination DNS before adopting disk state, so the persistence test depended on public DNS availability. On macOS, a controlled delayed DNS response reproduces the observed 15-second timeout: the reload client gives up after 10 seconds and server teardown waits for the outstanding handler.

Use an owned loopback upstream for both the original and replacement provider rows, with the existing explicit private-network opt-in. Keep actual attestation, reload, catalog convergence, and all four disk/live assertions. Also assert the reload outcome and management HTTP status. The 15-second limit and production code are unchanged.

The historical CI log identifies only the outer timeout; the controlled reproduction proves this failure path, not the exact cause of that historical runner's delay.

## Verification

- Failed dev CI: https://github.com/lidge-jun/opencodex/actions/runs/33999342751/job/101395411095 (9,470 pass, 7 skip, one 15-second timeout).
- Remote macOS, pinned Bun 1.4.0: original test passed in 95.42ms; controlled delayed DNS reproduced the timeout in 15,008.86ms, with the awaited boundaries recorded.
- Independent plan and final code reviews passed. Exact final test bytes at fcd235dbd passed the controlled DNS-delay case in54.08ms with6 assertions, zero DNS calls, real reload success and0.68ms proxy shutdown.
- Remote final checks:36 pass across5 files (84 assertions), dedicated test-file strict typecheck exit0, privacy exit0. Prior root src typecheck is reused only with unchanged src/tsconfig/package/lock identity; the separate test typecheck covers the assertion type that root excludes. The earlier TS2769 finding was fixed without casts and its failed evidence is retained.
- Final-head [hosted CI34000761304](https://github.com/lidge-jun/opencodex/actions/runs/34000761304) completed successfully, including Linux4/macOS2 and the aggregate gate. The previously failing macOS test passed in106.65ms; its shard finished9,471 pass /0fail. The remote checkout was restored clean and all owned test processes stopped.
- No local suites, typechecks or builds were run. No retry, skip or timeout increase was added.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
