### PR TITLE
feat(quota): show subscription credits in capacity bars

### DIFF
--- a/gui/src/components/QuotaBars.tsx
+++ b/gui/src/components/QuotaBars.tsx
@@ -26,6 +26,7 @@ function rawCustomWindowRank(rawLabel: string): number {
   if (rawLabel === "5h") return 0;
   if (rawLabel === "First-party models") return 2;
   if (rawLabel === "API usage") return 3;
+  if (rawLabel === "Total subscription credits") return 4.5;
   return 5;
 }
 
@@ -96,6 +97,22 @@ export function buildQuotaRows(quota: AccountQuota | null, plan: string | null |
       },
     });
   }
+  if (displayQuota.creditsUsd && typeof displayQuota.creditsUsd.percent === "number") {
+    const hasCreditCustom = displayQuota.customWindows?.some(w => /credits?/i.test(w.label));
+    if (!hasCreditCustom) {
+      const localized = localizeCustomQuotaLabel("Total subscription credits", t);
+      ranked.push({
+        rank: rawCustomWindowRank("Total subscription credits"),
+        row: {
+          customLabel: "Total subscription credits",
+          label: localized,
+          limitLabel: localized,
+          percent: displayQuota.creditsUsd.percent,
+          resetAt: displayQuota.creditsUsd.expiresAt,
+        },
+      });
+    }
+  }
   return ranked.sort((a, b) => a.rank - b.rank).map(entry => entry.row);
 }
 
@@ -106,6 +123,9 @@ export function maxQuotaUtilisation(quota: AccountQuota | null): number {
     .filter((n): n is number => typeof n === "number");
   for (const w of quota.customWindows ?? []) {
     if (typeof w.percent === "number") vals.push(w.percent);
+  }
+  if (typeof quota.creditsUsd?.percent === "number") {
+    vals.push(quota.creditsUsd.percent);
   }
   return vals.length ? Math.max(...vals) : -1;
 }

--- a/gui/src/components/QuotaBars.tsx
+++ b/gui/src/components/QuotaBars.tsx
@@ -30,6 +30,15 @@ function rawCustomWindowRank(rawLabel: string): number {
   return 5;
 }
 
+const SUBSCRIPTION_CREDITS_LABEL = "Total subscription credits";
+
+function canonicalCustomWindowLabel(rawLabel: string): string {
+  const trimmed = rawLabel.trim();
+  return trimmed.toLowerCase() === SUBSCRIPTION_CREDITS_LABEL.toLowerCase()
+    ? SUBSCRIPTION_CREDITS_LABEL
+    : trimmed;
+}
+
 function localizeCustomQuotaLabel(rawLabel: string, t: TFn): string {
   switch (rawLabel) {
     case "First-party models":
@@ -85,11 +94,12 @@ export function buildQuotaRows(quota: AccountQuota | null, plan: string | null |
     });
   }
   for (const w of displayQuota.customWindows ?? []) {
-    const localized = localizeCustomQuotaLabel(w.label, t);
+    const customLabel = canonicalCustomWindowLabel(w.label);
+    const localized = localizeCustomQuotaLabel(customLabel, t);
     ranked.push({
-      rank: rawCustomWindowRank(w.label),
+      rank: rawCustomWindowRank(customLabel),
       row: {
-        customLabel: w.label,
+        customLabel,
         label: localized,
         limitLabel: localized,
         percent: w.percent,
@@ -99,14 +109,14 @@ export function buildQuotaRows(quota: AccountQuota | null, plan: string | null |
   }
   if (displayQuota.creditsUsd && typeof displayQuota.creditsUsd.percent === "number") {
     const hasSubscriptionCreditsCustom = displayQuota.customWindows?.some(
-      w => w.label.trim().toLowerCase() === "total subscription credits",
+      w => canonicalCustomWindowLabel(w.label) === SUBSCRIPTION_CREDITS_LABEL,
     );
     if (!hasSubscriptionCreditsCustom) {
-      const localized = localizeCustomQuotaLabel("Total subscription credits", t);
+      const localized = localizeCustomQuotaLabel(SUBSCRIPTION_CREDITS_LABEL, t);
       ranked.push({
-        rank: rawCustomWindowRank("Total subscription credits"),
+        rank: rawCustomWindowRank(SUBSCRIPTION_CREDITS_LABEL),
         row: {
-          customLabel: "Total subscription credits",
+          customLabel: SUBSCRIPTION_CREDITS_LABEL,
           label: localized,
           limitLabel: localized,
           percent: displayQuota.creditsUsd.percent,
@@ -126,7 +136,10 @@ export function maxQuotaUtilisation(quota: AccountQuota | null): number {
   for (const w of quota.customWindows ?? []) {
     if (typeof w.percent === "number") vals.push(w.percent);
   }
-  if (typeof quota.creditsUsd?.percent === "number") {
+  const hasSubscriptionCreditsCustom = quota.customWindows?.some(
+    w => canonicalCustomWindowLabel(w.label) === SUBSCRIPTION_CREDITS_LABEL,
+  );
+  if (!hasSubscriptionCreditsCustom && typeof quota.creditsUsd?.percent === "number") {
     vals.push(quota.creditsUsd.percent);
   }
   return vals.length ? Math.max(...vals) : -1;

--- a/gui/src/components/QuotaBars.tsx
+++ b/gui/src/components/QuotaBars.tsx
@@ -98,8 +98,10 @@ export function buildQuotaRows(quota: AccountQuota | null, plan: string | null |
     });
   }
   if (displayQuota.creditsUsd && typeof displayQuota.creditsUsd.percent === "number") {
-    const hasCreditCustom = displayQuota.customWindows?.some(w => /credits?/i.test(w.label));
-    if (!hasCreditCustom) {
+    const hasSubscriptionCreditsCustom = displayQuota.customWindows?.some(
+      w => w.label.trim().toLowerCase() === "total subscription credits",
+    );
+    if (!hasSubscriptionCreditsCustom) {
       const localized = localizeCustomQuotaLabel("Total subscription credits", t);
       ranked.push({
         rank: rawCustomWindowRank("Total subscription credits"),

--- a/tests/gui/quota-bars-rows.test.ts
+++ b/tests/gui/quota-bars-rows.test.ts
@@ -92,6 +92,14 @@ describe("buildQuotaRows (WP070)", () => {
     expect(rows.map(r => r.label)).toEqual(["quota.totalSubscriptionCredits"]);
   });
 
+  test("unrelated credit windows do not suppress direct subscription credits", () => {
+    const rows = buildQuotaRows(quota({
+      customWindows: [{ label: "API credits", percent: 20 }],
+      creditsUsd: { used: 50, limit: 100, remaining: 50, percent: 50 },
+    }), null, t);
+    expect(rows.map(r => r.label)).toEqual(["quota.totalSubscriptionCredits", "API credits"]);
+  });
+
   test("null and empty quotas produce no rows; 30-day plans strip to monthly", () => {
     expect(buildQuotaRows(null, null, t)).toEqual([]);
     expect(buildQuotaRows(quota({}), null, t)).toEqual([]);

--- a/tests/gui/quota-bars-rows.test.ts
+++ b/tests/gui/quota-bars-rows.test.ts
@@ -69,6 +69,29 @@ describe("buildQuotaRows (WP070)", () => {
     expect(rows.map(r => r.label)).toEqual(["quota.totalSubscriptionCredits"]);
   });
 
+  test("direct creditsUsd renders Total subscription credits with resetAt", () => {
+    const rows = buildQuotaRows(quota({
+      fiveHourPercent: 0,
+      weeklyPercent: 0,
+      creditsUsd: { used: 89.96, limit: 90, remaining: 0.04, percent: 99.96, expiresAt: 1790430938000 },
+    }), null, t);
+    expect(rows.map(r => r.limitLabel)).toEqual([
+      "quota.fiveHourLimit",
+      "quota.weeklyLimit",
+      "quota.totalSubscriptionCredits",
+    ]);
+    expect(rows[2]?.percent).toBe(99.96);
+    expect(rows[2]?.resetAt).toBe(1790430938000);
+  });
+
+  test("direct creditsUsd does not duplicate an existing credits custom window", () => {
+    const rows = buildQuotaRows(quota({
+      customWindows: [{ label: "Total subscription credits", percent: 50 }],
+      creditsUsd: { used: 50, limit: 100, remaining: 50, percent: 50 },
+    }), null, t);
+    expect(rows.map(r => r.label)).toEqual(["quota.totalSubscriptionCredits"]);
+  });
+
   test("null and empty quotas produce no rows; 30-day plans strip to monthly", () => {
     expect(buildQuotaRows(null, null, t)).toEqual([]);
     expect(buildQuotaRows(quota({}), null, t)).toEqual([]);
@@ -93,6 +116,11 @@ describe("maxQuotaUtilisation", () => {
       fiveHourPercent: 10,
       customWindows: [{ label: "x", percent: 95 }],
     }))).toBe(95);
+    expect(maxQuotaUtilisation(quota({
+      fiveHourPercent: 0,
+      weeklyPercent: 0,
+      creditsUsd: { used: 90, limit: 90, remaining: 0, percent: 100 },
+    }))).toBe(100);
   });
 });
 

--- a/tests/gui/quota-bars-rows.test.ts
+++ b/tests/gui/quota-bars-rows.test.ts
@@ -86,10 +86,11 @@ describe("buildQuotaRows (WP070)", () => {
 
   test("direct creditsUsd does not duplicate an existing credits custom window", () => {
     const rows = buildQuotaRows(quota({
-      customWindows: [{ label: "Total subscription credits", percent: 50 }],
+      customWindows: [{ label: "  TOTAL SUBSCRIPTION CREDITS  ", percent: 50 }],
       creditsUsd: { used: 50, limit: 100, remaining: 50, percent: 50 },
     }), null, t);
     expect(rows.map(r => r.label)).toEqual(["quota.totalSubscriptionCredits"]);
+    expect(rows[0]?.customLabel).toBe("Total subscription credits");
   });
 
   test("unrelated credit windows do not suppress direct subscription credits", () => {
@@ -129,6 +130,13 @@ describe("maxQuotaUtilisation", () => {
       weeklyPercent: 0,
       creditsUsd: { used: 90, limit: 90, remaining: 0, percent: 100 },
     }))).toBe(100);
+  });
+
+  test("subscription-credit urgency follows the visible canonical custom window", () => {
+    expect(maxQuotaUtilisation(quota({
+      customWindows: [{ label: " total subscription credits ", percent: 25 }],
+      creditsUsd: { used: 99, limit: 100, remaining: 1, percent: 99 },
+    }))).toBe(25);
   });
 });
 


### PR DESCRIPTION
<!-- four-track-landing-status:start -->
### Delivered — superseded by merged work

Verified in `dev` at `5759d9ea2f1e7281cdc01eb9628f2e0a123fb59c`: [#3798](https://github.com/lidge-jun/opencodex/pull/3798) (`b72b8ea6c8`).

Original contribution: **feat(quota): show subscription credits in capacity bars**, by @yansigit.

Subscription-credit quota rows, including duplicate-label and displayed-row urgency handling.

The original PR is closed as superseded; its contribution remains credited in the landed history.

Attribution strengthened by [#3811](https://github.com/lidge-jun/opencodex/pull/3811), merged as `cf9f662190c4c6770697c45c870941509cc98f9c`. See [CREDITS.md](https://github.com/lidge-jun/opencodex/blob/dev/CREDITS.md#2026-09-07-follow-up-four-track-source-to-landing-attribution) for the source-to-landing attribution record.
<!-- four-track-landing-status:end -->

## Summary

- Show `creditsUsd` as a distinct localized **Total subscription credits** capacity row.
- Suppress the row only when a canonical equivalent custom window exists, preventing duplicates without hiding credits behind unrelated labels.
- Canonicalize case/whitespace variants once for deduplication, localization, ordering, and row identity.
- Keep provider urgency sorting aligned with the quota rows actually displayed.

![Subscription credits capacity row](https://raw.githubusercontent.com/yansigit/opencodex/codex/pr-assets/.github/pr-assets/subscription-credits-capacity.jpg)

## Verification

- Rebased onto latest upstream dev (`cededd5ad1b8f8c437813c315c0705ace6c950c3`).
- Exact rebased PR head: `fdc238e1c19b45113074e1f61406e9101a50058c`.
- `bun test tests/gui/quota-bars-rows.test.ts` — 17 passed, 0 failed (50 expect calls).
- `bun run lint:gui` — passed (`oxlint .`).
- `bun run build:gui` — passed (`tsc -b && vite build`, `prepare-package.ts`).
- `bun run typecheck` — passed (`bun x tsc --noEmit`).
- `bun run privacy:scan` — passed.
- `git diff --check upstream/dev...HEAD` — clean (no whitespace errors).
- `bun run test` — full test suite passed (exit code 0).
- All CodeRabbit review comments resolved with regression coverage.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No documentation change: this renders an existing quota field with an existing localized label.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Presentation-only; no credentials, network calls, or accounting writes.)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Subscription credits now appear consistently in quota displays, including their expiration-based reset time.
  - Quota entries are ordered with subscription credits after API usage for clearer presentation.
  - Duplicate subscription-credit entries are avoided when an equivalent custom quota window already exists.
  - Usage calculations now include direct subscription-credit data while preventing double counting.
  - Subscription credits can coexist with unrelated custom quota windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
