### PR TITLE
fix(server): opt the compact route out of the request idle timeout

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1752,6 +1752,11 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         if (!isAllowedRequestOrigin(req, policy)) {
           return withCors(formatErrorResponse(403, "origin_rejected", "cross-origin data-plane request blocked"), req, policy);
         }
+        // Compaction buffers the whole upstream turn before the first byte reaches the
+        // client, so the server-level `idleTimeout` (255 s) would close this connection
+        // under a long remote compact even though the upstream is still working. Opt out
+        // the same way the other buffered data-plane routes above and below do.
+        disableResponsesRequestTimeout(req, requestServer);
         const start = Date.now();
         const requestId = nextRequestLogId(start);
         const logCtx: RequestLogContext = {

--- a/tests/server/server-auth.test.ts
+++ b/tests/server/server-auth.test.ts
@@ -602,6 +602,19 @@ describe("server local API auth", () => {
     })).toBe(false);
   });
 
+  test("compact route opts out of the request timeout before it buffers the compaction", () => {
+    // `/v1/responses/compact` answers only after the whole upstream turn has been collected,
+    // so unlike the streaming route it never sends a byte that would keep the connection
+    // alive. Without this opt-out the server-level `idleTimeout` closes a long remote
+    // compact mid-flight and the client sees a truncated body, not an error.
+    const source = readFileSync(new URL("../../src/server/index.ts", import.meta.url), "utf8");
+    const compactStart = source.indexOf('url.pathname === "/v1/responses/compact" && req.method === "POST"');
+    expect(compactStart).toBeGreaterThan(-1);
+    const handlerCall = source.indexOf("await handleResponsesCompact(req, config, logCtx", compactStart);
+    expect(handlerCall).toBeGreaterThan(compactStart);
+    expect(source.slice(compactStart, handlerCall)).toContain("disableResponsesRequestTimeout(req, requestServer);");
+  });
+
   test("responses handler keeps the request timeout until the body is fully accepted", async () => {
     let controller!: ReadableStreamDefaultController<Uint8Array>;
     const body = new ReadableStream<Uint8Array>({


### PR DESCRIPTION
<!-- four-track-landing-status:start -->
### Delivered — superseded by merged work

Verified in `dev` at `5759d9ea2f1e7281cdc01eb9628f2e0a123fb59c`: [#3792](https://github.com/lidge-jun/opencodex/pull/3792) (`823ffeb771`).

Original contribution: **fix(server): opt the compact route out of the request idle timeout**, by @mashfromband.

Accepted compact-request lifetime, with complete-body admission and bounded response-body inactivity.

The original PR is closed as superseded; its contribution remains credited in the landed history.

Attribution strengthened by [#3811](https://github.com/lidge-jun/opencodex/pull/3811), merged as `cf9f662190c4c6770697c45c870941509cc98f9c`. See [CREDITS.md](https://github.com/lidge-jun/opencodex/blob/dev/CREDITS.md#2026-09-07-follow-up-four-track-source-to-landing-attribution) for the source-to-landing attribution record.
<!-- four-track-landing-status:end -->

## Summary

- `/v1/responses/compact` collects the whole upstream compaction before it sends the first byte, so nothing keeps the client connection alive while a long remote compact is in flight. The server-level `idleTimeout` (255 s) then closes the socket and the client receives a truncated body (Codex reports `stream disconnected before completion: ... error decoding response body` from `Error running remote compact task`).
- The other buffered data-plane routes (`/v1/images/*`, `/v1/alpha/search`, `/v1/messages`, `/v1/chat/completions`, `/v1/live`) already opt out with `disableResponsesRequestTimeout(req, requestServer)`. This PR makes the compact route do the same, right after admission and the origin gate.
- Adds a source contract test next to the existing timeout-helper tests that pins the call inside the compact branch (fails on `dev` without the fix, passes with it).

Reproduced locally with a fake upstream that stays silent for >255 s on the compact request: before the change the client saw a cut body at ~255 s, after it the compaction completed. The GoDD-AO proxy in front of this gateway has carried the same one-line change as a local patch since 2.43.0; this upstreams it.

## Verification

- `bun test tests/server/server-auth.test.ts -t "compact route opts out"` — 1 pass with the fix; the same test fails on `dev` with the fix stashed.
- `bun test tests/server/server-auth.test.ts` — 107 pass, 0 fail.
- `bun x tsc --noEmit` — clean.
- `bun scripts/privacy-scan.ts` — passed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (none needed: no user-facing option changed)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (the opt-out runs after admission and the origin gate, matching the other routes)

https://claude.ai/code/session_01VcTuv1wGXdywDr8xeQftdP

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for response compaction requests by preventing long-running operations from being interrupted by the server’s idle timeout.

* **Tests**
  * Added coverage to verify that response compaction requests receive the appropriate timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

