### PR TITLE
docs: resolve release-plan formatting review notes

### DIFF
--- a/devlog/_plan/260906_release_244_followups/000_plan.md
+++ b/devlog/_plan/260906_release_244_followups/000_plan.md
@@ -1,6 +1,7 @@
 # Release 2.44 follow-up integration
 
 ## Loop contract
+
 - Archetype: spec-satisfaction repair; class C4 for governance, replay and release; C3 for bounded client changes.
 - Trigger: owner authorized the named backlog, bottom-up stacked PR integration, --no-verify pushes, admin merges, maintainer dev policy and release on 2026-09-06.
 - Goal: publish the verified next release after these narrowly scoped fixes.
@@ -12,6 +13,7 @@
 - Resources: existing GitHub account, repository and release OIDC only; no new credentials/purchases. Unlimited requested-model delegation within available concurrency; no owner token/cost cap. Each subprocess <=30 minutes, CI polls <=60 seconds, each phase investigation checkpoint at 60 minutes with evidence-based continuation. No implicit exhausted outcome.
 
 ## Snapshot and sequence
+
 Baseline dev: af344a28eabcee09a5e04c48ab897449792719c2, version 2.44.0. Latest published stable is 2.43.0. Refresh before every layer.
 
 | Work phase | Design | Dependency / independent proof |
@@ -32,4 +34,5 @@ Baseline dev: af344a28eabcee09a5e04c48ab897449792719c2, version 2.44.0. Latest p
 One work-phase is one PABCD cycle. Publish short dependency stacks; use merge commits for parents with live children, squash bounded terminal carries if safe, and recascade after any squash. Independent presentation/governance slices remain their own PRs even though execution is sequential. Every carried contributor receives account-linked Co-authored-by credit. Preserve snapshots of source heads.
 
 ## Evidence boundaries
+
 #3735/#3734 are public current-SHA reports; independently inspect code, author local-pass statements remain reports. Kiro proof is recorded-log shape plus synthetic CI tests, never a live quota-consuming request. #3644 has a network A/B report and landed diagnostic #3693; do not claim a Windows runtime reproduction from mocked tests. Detailed private logs are never committed.

--- a/devlog/_plan/260906_release_244_followups/010_policy.md
+++ b/devlog/_plan/260906_release_244_followups/010_policy.md
@@ -3,6 +3,7 @@
 Depends on roadmap. Class C4; spec-satisfaction. Owner authorizes maintain/admin integration through PRs without a second maintainer approval, including self-authored PRs. Actual inspected roles for both rostered maintainers are admin; current dev rules already permit role 5 PR bypass. The contradiction is primarily normative documentation, plus future Maintain role coverage.
 
 ## Exact change map
+
 - MODIFY MAINTAINERS.md review policy and dated change log: distinguish contributor approvals from explicitly opted-in maintainer integration to dev. Preserve actual independent technical/security review and CI duties; do not call self-integration a second-person approval. Main/preview promotions retain existing rules.
 - MODIFY AGENTS.md branch/review summary: align with maintainer dev exception; PRs still required, force pushes and deletions still blocked.
 - MODIFY scripts/ci/assert-mergeable-review.sh: parse explicit --maintainer-integration in any argv position, retaining optional repository positional argument. Default strict contributor-review path unchanged. Opt-in skips exactly the reviewDecision=APPROVED and qualified non-self approval checks, not review retrieval, objections or race checks. For override, require baseRefName=dev, current authenticated human actor from gh api user, membership in trusted base dev MAINTAINERS roster, and live maintain/admin role. Preserve complete review parsing, maintainer CHANGES_REQUESTED blocking and final head/base/actor authorization recheck. Print only a truthful validation snapshot with head/base/actor; do not emit a privileged merge recipe because head matching cannot atomically bind the PR base. Never accept a CLI-supplied actor, PR-authored roster, bot or unknown role.
@@ -11,14 +12,18 @@ Depends on roadmap. Class C4; spec-satisfaction. Owner authorizes maintain/admin
 - External UPDATE dev ruleset 20763889 only: add RepositoryRole actor_id=2 bypass_mode=pull_request, preserve actor_id=5 and all conditions/rules. Read snapshot immediately before update; compare after. Verify role names through GraphQL repositoryRoleName: maintain=2, admin=5; role4 is write and must never be added. Do not change main 20764415 or preview 20764486. Rollback is the saved before JSON projected to accepted API fields.
 
 ## Activation matrix and verifier
+
 CI test fixture: authorized admin and maintain actors with no second approval on dev pass ONLY opt-in; write/outsider/bot/missing actor/role API error fail; main/preview/stack base fail; pending maintainer objections, API pagination failures, head/base races fail. Default no flag retains all prior strict failures. shell syntax can be read/checked; Bun tests and typecheck run remotely. Live REST readback proves only dev actor list changed; compare main/preview snapshots unchanged.
 
 ## Trust / bypass record
+
 Assets repository integration history; entry script and authenticated GitHub rules API; boundary contributor metadata versus trusted dev roster/live permissions. E7 human policy plus E8 GitHub branch rules; admin can alter rules outside this helper, so helper is an early review check, not universal enforcement. PR bypass does not remove deletion/non-fast-forward rules outside PRs. Security review recorded independently in scratch; final disposition may be published after diff is public.
 
 
 ## Policy-cycle P refresh and delegation
+
 Current dev remains the roadmap baseline; source helper and ruleset snapshots were reread. The preceding D locked the roadmap and made policy the next cycle. Worker owns only scripts/ci/assert-mergeable-review.sh and tests/ci-workflows/assert-mergeable-review.test.ts; main owns MAINTAINERS.md, AGENTS.md, contributing.md, structure/06_docs-and-release.md and GitHub settings. No overlapping writes or local tests. An independent reviewer audits the final script/docs delta before remote CI and dev-only ruleset application.
 
 ## Dispatch repair / policy P amendment
+
 The first helper+tests worker repeatedly read unrelated plan pages and produced no source delta after a scope correction and bounded waits. It was retired without edits. Main now owns scripts/ci/assert-mergeable-review.sh in addition to documentation/settings; a fresh worker owns ONLY tests/ci-workflows/assert-mergeable-review.test.ts. The protocol remains --maintainer-integration in any argv slot, optional repo, actor from gh api user (login/type), baseRefName from PR metadata, maintain/admin role_name from collaborator permission. Final metadata rechecks head/base/author, then actor/role/roster authorization again. Default strict path does not require new fields. No expected evidence or scope was removed. This replan changes dispatch ownership, not the approved policy.

--- a/devlog/_plan/260906_release_244_followups/020_task_input.md
+++ b/devlog/_plan/260906_release_244_followups/020_task_input.md
@@ -3,6 +3,7 @@
 Depends on policy; class C4 for protocol admission. Fix public issue #3735, observed on baseline dev. Preserve the existing unpaired-tool HTTP 400 guard from #3471.
 
 ## Diff-level change map
+
 - MODIFY src/responses/parser.ts at function_call_output classification before tool lookup: route only a complete external task-input envelope to an Ocx user message. Eligibility: type function_call_output, no call_id property (including inherited properties for direct helper calls), nonempty string id/name/namespace, nonempty fully representable text/image output. Do not require specific names, prefixes, namespaces or XML content. Existing standard tool results and custom_tool_call_output keep current path.
 - NEW src/responses/task-input.ts: pure recognition returning supported Ocx user content or undefined, no request mutation/network/storage. Reuse existing content converters only when they preserve every accepted output part and reject invalid mixed arrays rather than silently drop them.
 - MODIFY tests/responses/responses-parser.test.ts, tests/responses/responses-compaction-routing.test.ts and tests/responses/openai-responses-passthrough.test.ts with narrow positive/negative fixtures. No new test file or layout registry entry is needed.
@@ -11,20 +12,24 @@ Depends on policy; class C4 for protocol admission. Fix public issue #3735, obse
 Before: result-shaped external task input enters toolResult branch with undefined call id, then translated-adapter guard returns 400. After: the complete external shape enters user message with intact supported text/images; malformed/orphan tool results still fail. No secret or raw logged transcript is copied to tests.
 
 ## Activation / verifier
+
 Remote parser tests exercise arbitrary tool names/namespaces, blank/empty content remains ineligible, multiple ordered text parts and supported images; retain exact content without orphan marker. Explicit call_id empty/null/number/undefined-own-property remain invalid, as do custom outputs missing identity, partial provenance, unsupported/mixed malformed arrays. Existing genuine call ids remain tool results. Remote endpoint/compaction/passthrough fixtures prove unchanged raw body forwarding and guard failures. ci.yml runtime jobs + typecheck/privacy establish fresh proof. Local saved log provides provenance only; no live Kiro request.
 
 ## Boundary / alternatives
+
 No-op leaves current task creation unusable; configuration cannot distinguish this parser envelope; generic orphan-to-user repair would reverse #3471 and is rejected. Reuse current message types; no persisted schema fields. Classification is compatibility handling, not authentication: no privilege is granted by envelope metadata.
 
 
 ## Source follow-up folded at roadmap lock
+
 Author yrlan-montagnier (Yrlan), GitHub id 71253160: preserve Co-authored-by: Yrlan <71253160+yrlan-montagnier@users.noreply.github.com>. Posted helper may manufacture an encrypted-content-omitted marker that makes encrypted-only input look usable; reject encrypted-only and mixed opaque/unsupported input, never use placeholder text as eligibility. Keep every pre-existing #3471 regression, adding tests rather than replacing them. Add tests/responses/responses-compaction-routing.test.ts and tests/responses/openai-responses-passthrough.test.ts to explicit remote verification. Prefer a dedicated small predicate over relocating passthrough helpers unless byte-for-byte behavior is proved.
 
 ## Task-input cycle P refresh at 25c8d2b4e
+
 The preceding D landed policy #3739 and actual Maintain/Admin settings. Issue #3735 is still open and the author has no open PR; retain the account-linked Yrlan trailer. Source parser at lines 150-160 currently recognizes only message/agent_message as the continuation conversation boundary. Compute the optional external content once near effectiveType and include a recognized envelope in that existing boundary predicate. In the function_call_output branch, clear pendingReasoning, emit a user message and continue; leave the ordinary result branch and core guard unchanged.
 
 Concrete new leaf: src/responses/task-input.ts exports externalTaskInputContent(item: unknown): string | OcxContentPart[] | undefined. It imports only type OcxContentPart and existing isObj/inputContentParts. Require exact function_call_output, no call_id property, nonblank id/name/namespace, and a nonblank string or fully supported array. Array parts are input_text/text/output_text with string text or input_image with nonblank string image_url and optional auto/low/high/original detail. Normalize output_text to input_text before calling the existing input converter; original image detail maps to high by that converter. Require at least one nonblank text or usable image. Reject any unsupported/opaque/malformed member, invalid detail or file-id-only reference as a whole; placeholder text never establishes eligibility. Preserve accepted text bytes, order and image references; no raw-body mutation or helper relocation from passthrough.
 
-Field chain: external JSON shape -> pure leaf validation -> parser user message + existing _continuationConversationMessageIndex -> translated adapter's existing user-content serialization. No new persisted field/schema/config. Passthrough and compact use unchanged raw body. Tests include pending reasoning reset and previous_response_id boundary index=0 for a new envelope without a replay prefix, alongside all old #3471 controls.
+Field chain: external JSON shape -> pure leaf validation -> parser user message + existing `_continuationConversationMessageIndex` -> translated adapter's existing user-content serialization. No new persisted field/schema/config. Passthrough and compact use unchanged raw body. Tests include pending reasoning reset and previous_response_id boundary index=0 for a new envelope without a replay prefix, alongside all old #3471 controls.
 
 Dispatch: main owns new leaf, parser, endpoint/passthrough regressions and English/structure docs; a bounded worker owns only tests/responses/responses-parser.test.ts. Independent A/C reviewer reads named leaf/parser boundaries. No local tests/typecheck/build; remote ci.yml runtime/gates and existing parser/compaction/passthrough suites provide proof. Parser leaves add no core/Lab dependency. No-op/configuration cannot fix this shape; existing input converter is reused behind strict validation.

--- a/devlog/_plan/260906_release_244_followups/030_kiro_results.md
+++ b/devlog/_plan/260906_release_244_followups/030_kiro_results.md
@@ -3,6 +3,7 @@
 Depends on task-input; class C4 for protocol identity. Fix #3734 from recorded Codex code-mode output shape, never by spending live Kiro quota.
 
 ## Diff-level change map
+
 - MODIFY src/adapters/kiro.ts pushUser/turn-construction helper: when adding results in immediately adjacent parsed messages, tracked separately from collapsed user turns, combine only adjacent results with identical normalized toolUseId. Append content in exact input order and propagate error if any constituent is error. Preserve images via the adapter's supported representation; ensure no image is dropped or reordered relative to supported content semantics.
 - Preserve the pendingToolUses.delete validation: call-a, call-b, call-a remains invalid. Do not globally deduplicate by id or merge across assistant/tool boundaries, intervening ordinary input, or unrelated result.
 - MODIFY tests/providers/kiro/kiro-adapter.test.ts and relevant kiro-images.test.ts fixtures for three adjacent results, error later in group, different ids and nonadjacent repeats, text+image preservation. No new fixture uses real call ids or messages.
@@ -11,16 +12,20 @@ Depends on task-input; class C4 for protocol identity. Fix #3734 from recorded C
 Before: pushUser appends each result, wire validation consumes the first matching toolUseId and rejects the next duplicate. After: consecutive same-call outputs become one ordered result before validation. Opaque encrypted output rejection remains unchanged.
 
 ## Activation / verifier
+
 CI tests feed one assistant exec call followed by notify/notify/final results; assert one toolResult and ordered content. Mixed error/success reduces to error; unrelated result boundaries cannot be crossed. Same-id nonadjacent repeat still throws matching error. Exercise retained images using existing adapter representation; enforce maximum/shape constraints already owned by Kiro wire. Run existing Kiro adapter/image suites through ci.yml, plus full typecheck/privacy. Saved local log shape is supporting evidence only; live Kiro correctness remains untested and explicitly reported.
 
 ## Non-goals
+
 No Kiro account/OAuth/quota changes, no aggressive malformed-history healing, no parser changes beyond prior layer, no global result deduplication.
 
 
 ## Source follow-up folded at roadmap lock
+
 Track adjacency in original message iteration; reset on every non-toolResult message including user/developer/assistant, even if pushUser collapses it into one user turn. Retain Kiro images on the current user image list as the existing wire format requires; do not promise unsupported text/image interleaving in the wire. Preserve Co-authored-by: Yrlan <71253160+yrlan-montagnier@users.noreply.github.com>. Local log metadata contains old Kiro activity and is not a current live reproduction.
 
 ## Kiro-cycle P refresh on parent b24ed35a
+
 Parent #3743 is verified and ready, still open as this branch base; fixture prerequisite #3745 is merged. Issue #3734 remains open without an author PR. kiroPayloadMessages currently returns parsed.context.messages unchanged, so tracking adjacency at the top of its loop observes original Ocx message barriers even when a reasoning-only assistant is later skipped or user/developer turns collapse.
 
 Concrete source edits in src/adapters/kiro.ts only: priorCalls values retain rawId alongside wireName; validate each result against that exact raw id after normalizing for wire lookup. This rejects different raw ids sharing a replacement/truncation result without banning legitimate paired non-wire ids. Track adjacentRawToolResultId, reset it for every non-toolResult before any early continue; for matching adjacent raw id and last user turn/last wire result, append text content and images, set status error if any constituent isError. Otherwise retain pushUser and final conversation validation. No global dedup, cross-turn merge or normalizer change.
@@ -34,6 +39,7 @@ Local evidence limit: saved Kiro conversation data and OCX diagnostic artifacts 
 Dispatch: main owns adapter/docs; bounded worker owns only kiro-adapter.test.ts. Independent A/C reviewers inspect raw identity, original-message adjacency, error/image propagation and unchanged encrypted rejection. Full runtime CI is remote only, including existing Kiro image/adapter tests; live Kiro is forbidden.
 
 ## Resumed P after verified guidance parent b7e67d84d
+
 The separate task-guidance cycle is complete, parent3743 P1 is resolved and CI34014313740 is green. Its verified head was merged into this preserved Kiro branch before implementation. Prior Euler review is folded below and must be rechecked before B.
 
 A contiguous group is finalized before any non-toolResult (including skipped reasoning-only assistant), before a different raw id, and after the loop. Track only local bookkeeping: rawId, reference to the fresh KiroToolResult, count, raw text parts and whether this group carried images; never put these fields on wire objects. A single-result group keeps the exact existing normalized text/fallback. For 2+ results, preserve ordered raw text parts except successful empty-exec wrappers, append images and keep any isError sticky. If the whole group has meaningful text, use those parts and remove any first-chunk empty fallback. Preserve whitespace text parts when meaningful text exists. If all text is empty, retain one existing fallback; use the neutral KIRO_EMPTY_TOOL_RESULT_MESSAGE when images or an error flag make an empty-success exec hint inappropriate. Failed exec wrappers are meaningful failure information and remain raw text in multi-result groups even when the incoming isError flag is false; preserve existing FAILED_EXEC_OUTPUT_MESSAGE for a single result. No new normalizer or message template.
@@ -43,5 +49,6 @@ Read evidence: normalizeEmptyExecToolResultText distinguishes EMPTY_EXEC_OUTPUT_
 Additional regressions: later image-only/empty/success-empty wrapper does not inject placeholders into an already-populated result; initial empty then real text removes the empty hint; all-empty groups retain a valid nonblank result; multi-result failed wrapper retains its failure signal; later encrypted adjacent result still rejects; whitespace between meaningful chunks survives. Existing single empty/failed exec normalization tests must pass unchanged.
 
 ## Resumed A dispositions
+
 Accept whitespace concern: collect a nonzero-length raw text part when trim is empty OR the shared normalizer did not classify it as EMPTY_EXEC_OUTPUT_MESSAGE. This preserves whitespace between/before actual text while discarding only true empty-success wrapper text; failed wrappers are never in that drop category. Finalization decides whether the aggregate has meaningful text.
 Rebut the need for duplicated tool-name bookkeeping: create the first fresh wire result using the EXISTING normalizeEmptyExecToolResultText(text,{toolName,toolNamespace}) call before registering the group. A one-result group is never rewritten at finalization, so its exact precomputed fallback is retained; no normalization without identity occurs. Multi-result finalization replaces that initial content only with raw aggregate parts (or neutral empty text for image/error groups). Tests pin the existing single-result behavior and no bookkeeping keys on wire.

--- a/devlog/_plan/260906_release_244_followups/032_review_doc_format.md
+++ b/devlog/_plan/260906_release_244_followups/032_review_doc_format.md
@@ -1,0 +1,11 @@
+# Review documentation formatting
+
+C0 follow-up for PR3743 review threads: add blank lines after headings, format
+replay-field identifiers as inline code, and correct the audit heading/references.
+The same heading pattern is normalized only within this release's two owned units.
+No runtime, test behavior or release gate changes. Validation is diff inspection
+and git diff --check; no local test suite is required or run.
+
+Publish as a documentation-only layer above the Kiro PR so the verified runtime
+heads remain stable. Resolve the parent formatting notes with this concrete fix
+and land the layer bottom-up before release.

--- a/devlog/_plan/260906_release_244_followups/040_opaque_recovery.md
+++ b/devlog/_plan/260906_release_244_followups/040_opaque_recovery.md
@@ -3,6 +3,7 @@
 Depends on parsed-input/Kiro integration; C4. Carry #3535 2396829bded6d2aaf319e67dddb5918d83d1d3a0 (base 7e7ab281cca35600b41f1f80222f3462a87dd4e1), Co-authored-by: yxr1995-maker <257504378+yxr1995-maker@users.noreply.github.com>.
 
 ## Exact diff map
+
 - MODIFY src/lib/errors.ts: one ENCRYPTED_FUNCTION_OUTPUT_REJECTION constant, flat error message extraction alongside existing nested form.
 - MODIFY src/server/responses/combo-stream-preflight.ts: optional narrow retryableTerminal predicate; existing two-argument callers retain default behavior. Bare error events count as uncommitted only where correctly retryable, not blanket authorization to replay effects.
 - MODIFY src/server/relay.ts createSseTerminalOutputBoundary/upstreamErrorTailFrame and src/server/relay-eager.ts: observe upstream error on their own bounded client frame reader; at repeated bare-error EOF emit response.failed carrying real error instead of adapter_eof. Avoid async inspection branch race.
@@ -13,9 +14,11 @@ Depends on parsed-input/Kiro integration; C4. Carry #3535 2396829bded6d2aaf319e6
 Before: encrypted function output rejection can terminate without Responses terminal and surface adapter_eof; recovery handles fewer opaque shapes. After: one narrow sanitize/rebuild attempt; a repeated error is surfaced as failed with the actual message from the reader that delivers output.
 
 ## Activation / review
+
 Remote tests: encrypted function-output or agent_message + exact decrypt failure permits one recovery; nondecrypt 502 stays unchanged; repeated flat/nested bare errors in tee and eager produce response.failed once; valid existing terminal wins; after client output commit no retry; raw-body identity/no-persist preserved; default combo caller compatibility maintained; caller cancellation remains cancellation.
 Existing maintainer CHANGES_REQUESTED targeted older 2d90f9684 reader race; independent review of port must confirm remedy rather than asserting GitHub approval was granted. Remaining review threads checked for substance against final head. No preemptive stripping of all previous_response_id history, no broader retry policy.
 
 ## Stack and proof
+
 Owner explicitly requests stacked PR workflow; use this relay foundation before combo-recovery and Grok terminal integration as an integration-validation stack, even though fixes are independently useful. Each layer remains independently tested via exact-head ci.yml runtime/gates. Security analysis stays scratch until public diff; no live Kiro.
 

--- a/devlog/_plan/260906_release_244_followups/050_combo_recovery.md
+++ b/devlog/_plan/260906_release_244_followups/050_combo_recovery.md
@@ -3,6 +3,7 @@
 Depends on opaque-recovery for tested preflight/terminal composition; class C4. Carry #3706 c311e9598f9c4f3daf8cccdf1e27ba913ba94b30, source base 6dd23d6314c41f1113639e042353aae9e6614e62. Co-authored-by: yxr1995-maker <257504378+yxr1995-maker@users.noreply.github.com>. Preserve source commit snapshots, avoid replaying obsolete source branch merge commit 97f453ab.
 
 ## Exact diff map
+
 - MODIFY src/combos/resolve.ts targetProviderIsUsable and pickComboTarget/pickComboTargetWithWait: canonical OpenAI account/model selector owns quota decisions, provider cached summary cannot veto canonical target; third-party/noncanonical provider quota still filters, including wait eligibility.
 - MODIFY src/server/responses/core.ts handleComboResponses: select actually payload-compatible target before deciding recovery; extract bounded recoverUnreadableEncryptedTask and encryptedTaskRecoveryAttempted; if native configured but disabled/cooling/no selectable native, recover once only when a usable routed target exists. Native model/account authorization exhaustion permits one recovered routed dispatch, excluding attempted targets. Preserve lastFailure and no-readable-target failures.
 - Preserve clientCancelledResponse mapping at BOTH recovery sites when recovery aborts. The source PR helper returning false must not turn caller cancellation into unreadable-task HTTP 400.
@@ -12,6 +13,7 @@ Depends on opaque-recovery for tested preflight/terminal composition; class C4. 
 Before: a merely configured native target suppresses recovery even when not usable; canonical provider summary may veto before account selection. After: native direct preference stays, usable routed recovery becomes reachable only once with explicit opt-in and no plaintext persistence.
 
 ## Activation / verifier
+
 Remote tests cover native disabled/cooldown, native 401 exhaustion, canonical summary exhausted with eligible account, noncanonical quota veto, caller eligibility, cooldown waiting, all targets unavailable skips recovery, recovery failure never dispatches plaintext/ciphertext, aborted recovery at both sites returns cancellation, no retry after client output. Preserve 32-inflight and no-persist safeguards where owned by recovery helper.
 CodeRabbit HTTPS-only suggestion is assessed against existing http provider policy: do not invent combo-only URL permission changes. Record evidence-backed rebuttal or a narrowly necessary fix during P/security audit. This carry does not change provider URL policy or credentials. Exact-head CI + independent security review required; no live Kiro or local suites.
 

--- a/devlog/_plan/260906_release_244_followups/060_grok_terminal.md
+++ b/devlog/_plan/260906_release_244_followups/060_grok_terminal.md
@@ -3,6 +3,7 @@
 Depends on composed relay stack; C3. Carry #3388 645180ceaf123c954ab5306969cf82da83566648, old base 3c920af5f7b18ecd98f87a589d21d299f5cbe172. Co-authored-by: Maple <hzlhu@qq.com> (zleo-ai). Preserve current dev f121348a9 sparse JSON function-repair fixture when resolving EOF conflict.
 
 ## Exact diff map
+
 - MODIFY src/server/responses-snapshot-repair.ts: add createGrokResponsesSparseTerminalBlockRewrite and narrow item validators; if file exceeds existing size significantly, extract separate src/server/grok-responses-snapshot-repair.ts for Grok-only tracker while retaining existing exports. Record extraction in P before B.
 - MODIFY src/server/responses/core.ts existing rewrite list: enable only logCtx.surface === grok and insert Grok terminal tracker immediately before createResponsesSnapshotBlockRewrite. Preserve current order custom-tool restore -> Copilot -> Grok -> provider snapshot -> field backfill -> function repair -> undeclared-tool guard.
 - MODIFY tests/responses/responses-snapshot-repair.test.ts and responses-snapshot-repair-server.test.ts; preserve existing sparse JSON function completion inference tests.
@@ -11,5 +12,6 @@ Depends on composed relay stack; C3. Carry #3388 645180ceaf123c954ab5306969cf82d
 Before: Grok Build renders deltas but sees empty completed.response.output and may retry. After: only marked Grok requests reconstruct empty/missing completed output from raw unique contiguous bounded semantically validated done items. Ordinary clients and default provider responsesSnapshotRepair flag unchanged. Require nonempty call_id on reconstructed function/custom calls; incomplete/failed/contradictory/gapped/duplicate/oversized shapes remain unchanged or fail closed according to current contract. No output fabrication from deltas alone.
 
 ## Activation / verifier
+
 Remote unit and server fixtures: Grok positive text/function/custom output, missing vs explicit-empty terminal, ordinary-client byte preservation, explicit provider snapshot + Grok coexistence, invalid item shapes/indexes/ids, duplicate/gap/bound checks, failed/incomplete terminal cannot become completed, raw done order retained. CI typecheck/privacy/runtime gates on final head; contributor reported old baseline failures are not accepted without current evidence. This is Grok Build terminal compatibility, not Cursor/Grok semantic no-progress issue #3506.
 

--- a/devlog/_plan/260906_release_244_followups/070_quota_proxy.md
+++ b/devlog/_plan/260906_release_244_followups/070_quota_proxy.md
@@ -3,6 +3,7 @@
 Depends on composed runtime; class C3 investigation and diagnostic documentation. #3644 remains a current-version evidence gap, not a proven entitlement or retry defect.
 
 ## Exact map / before-after
+
 - READ src/codex/auth-api.ts fetchMainAccountInfoWhileOwned and listCodexAuthAccountsSnapshot: WHAM uses Bun fetch; quotaRefresh result is identity-fenced. READ src/codex/quota-refresh-outcome.ts enum/projector, src/cli/account-api.ts fetchCodexRows, src/config.ts applyProxyEnvWith, src/lib/windows-system-proxy.ts readWindowsSystemProxy, src/server/index.ts applyProxyEnv call.
 - MODIFY docs-site/src/content/docs/reference/configuration/server.md and its seven existing translated counterparts: explain explicit proxy:auto/HTTP proxy versus an unset config and service-start environment; show privacy-bounded ocx account list openai --quota --refresh --json fields quotaRefresh.status and optional httpStatus. Do not paste account ids or credentials. Explain that WinINET/PAC/SOCKS and TUN are not equivalent transport evidence.
 - MODIFY numbered outcome record only if current docs already fully cover this; NO runtime policy change without a reproduced categorized failure. Existing diagnostic #3693 (71edeec8807d99e8e56a8c093f74da27d163d47a) already carries Ingwannu's implementation, so no redundant reimplementation.
@@ -11,5 +12,6 @@ Depends on composed runtime; class C3 investigation and diagnostic documentation
 Before: reporter's 2.43.0 output lacks newly landed quotaRefresh; system proxy mode null quota cannot distinguish direct network failure, HTTP failure or parsing. After: next release exposes already-implemented categories and explicit network setup guidance. A/B same machine/account: TUN on versus TUN off with explicit auto/HTTP configuration; observe status/HTTP code, not raw payload. No Windows environment is fabricated locally.
 
 ## Acceptance / completion
+
 Fresh source and CI show diagnostic fields travel enum -> main-account cache -> snapshot -> CLI, with malformed/unrecognized extras dropped and null not converted to zero. Document unsupported PAC/SOCKS-only behavior according to actual code. Leave issue open if reporter evidence is still absent and record FIELD_VALIDATION_PENDING, rather than calling the underlying incident fixed. This evidence-limited investigation outcome satisfies this named investigation slice, not a false runtime fix. No outbound credentials or system configuration changes here.
 

--- a/devlog/_plan/260906_release_244_followups/080_usage_source.md
+++ b/devlog/_plan/260906_release_244_followups/080_usage_source.md
@@ -3,6 +3,7 @@
 Depends on routing/replay changes; class C4 due credential-derived logging. Carry #3642 head 146ed679c9633e5d68726217fcadc8e0b107339b, preserving Co-authored-by: olddonkey <olddonkeyblog@gmail.com>. Refresh source head before carry.
 
 ## Exact map / field chain
+
 - MODIFY src/server/request-log.ts after sealRequestAttemptIdentity: recordAttemptCredentialSource clears stale value and derives only grok-oauth or xai-api-key from resolved canonical xAI transport and authMode. Require https, correct host/path policy and no userinfo/query/custom port; unknown/custom/provider mismatch omits.
 - MODIFY src/server/responses/core.ts after initial identity seal and every reseal that can change selected transport. Inspect later seals individually: OAuth retry same physical attempt retains source; new transport clears/rederives it.
 - MODIFY src/server/chat-native.ts buildActiveRequest: record from activeProvider at initial build and key-pool rebuild, after resolution.
@@ -13,5 +14,6 @@ Depends on routing/replay changes; class C4 due credential-derived logging. Carr
 Creation resolved runtime provider -> attempt helper; serialization usage append; deserialization normalizeUsageAttempt; consumers request history/management JSON/CodexBar integration read optional per-attempt value. No top-level combo attribution and no backfill from today's config. No UI enum interpretation added in this PR.
 
 ## Activation / verifier
+
 Remote tests prove canonical OAuth Responses 401/replay source with sendCount=2, native Chat API-key source, pool rebuild, combo mixed attempts, stale label clearing, unknown enum/custom host/query/userinfo/port/non-xai/historic omissions, privacy canary excluded. All schema fields existing default behavior retained. Run ci.yml runtime+gates and explicit security review; no local tests or xAI live traffic required. Proof records final PR head and source identity, not fork author attestation alone.
 

--- a/devlog/_plan/260906_release_244_followups/090_dashboard.md
+++ b/devlog/_plan/260906_release_244_followups/090_dashboard.md
@@ -3,6 +3,7 @@
 Depends on integrated runtime for final presentation; independent PR, class C2. Carry #3697 head 4c7d6a5e07a29f7ef833019304c11343b94d102f, preserving Co-authored-by: Robin Bially <7304732+RobinBially@users.noreply.github.com>. #3689 authless-default change is outside this train.
 
 ## Exact change map
+
 - MODIFY gui/src/styles-dashboard-workspace.css: shared label/control columns, --dash-controls-width around 26rem, container-based collapse, full-width delegation/sync rows.
 - MODIFY gui/src/styles.css: consistent status card alignment and responsive version badge behavior.
 - MODIFY gui/src/pages/dashboard-overview-head.tsx and dashboard-overview-sections.tsx: carry original layout classes only; preserve all handlers, state and new controls from current dev.
@@ -13,8 +14,10 @@ Depends on integrated runtime for final presentation; independent PR, class C2. 
 Before: uneven columns, two-up tool cards squeeze controls, version text can take product space. After: wide single label/control grid; narrow stacks preserve reading order and 320px selector fit. No visible strings added; any necessary additions require all locale modules.
 
 ## Acceptance / verifier
+
 Remote GUI lint/stylelint, GUI tests and Vite build from ci.yml; verify rendered wide/narrow state using existing browser tooling with CI-built/static artifact when available (no local suite/build). Inspect original screenshot at exact source SHA and do not claim it proves later changed content. New screenshots must show final UI, with no account info. Regression test alone is not visual proof; independently inspect UI screenshot and CSS breakpoints.
 
 ## Limits
+
 No authless setting, quota semantics or model management expansion. Preserve current state labels and accessibility. P rechecks any intervening same-file changes before carrying.
 

--- a/devlog/_plan/260906_release_244_followups/100_release.md
+++ b/devlog/_plan/260906_release_244_followups/100_release.md
@@ -3,6 +3,7 @@
 Depends on all preceding delivery criteria. Class C4. No local test/build/typecheck run.
 
 ## Exact actions and file map
+
 - MODIFY package.json via scripts/bump-dev-version.ts for pre-move: for target 2.44.0 dev must outrank target before publish (normally 2.45.0). Freeze feature RC before pre-move and pin it.
 - Use existing scripts/release.ts authority and .github/workflows/release.yml, ci.yml, service-lifecycle.yml. No changes planned unless an evidenced defect blocks this train; add a dedicated phase for such repairs.
 - Create bounded promotion branches from verified feature RC independently for preview/main; version-only preparation matches intended preview/stable targets. Never mix unrelated current-main state or overwrite the bound worktree. Reviewable promotion PRs include target exception and verified UI screenshot/link from current delta.
@@ -14,8 +15,10 @@ Depends on all preceding delivery criteria. Class C4. No local test/build/typech
 - MODIFY this unit's numbered evidence/closeout; archive to devlog/_fin only after outcome is public. Complete goal only after E8 criteria and every D closure succeeds.
 
 ## Failure activation / proof
+
 A failed exact-SHA run triggers log-based RCA and repair; newer dev invalidates ancestor assumptions and is fetched before merge. A missing service run is dispatched, not skipped. Registry already-published check prevents duplicate publication. Final source head, artifact head and tag head must match documented promotion topology. Rollback means redeploy prior known package/version; immutable npm version is not deleted or overwritten.
 
 ## Resources and security
+
 GitHub Actions/OIDC and existing registry read access, no static npm secret introduced. Existing main/preview protection retained; per-user admin merge authorization applies to this train. Commands bounded at 30 minutes, polls <=60s, continue across CI windows with persistent evidence. Source runtime and artifact validation use remote CI only.
 

--- a/devlog/_plan/260906_stateful_task_guidance/010_raw_boundary.md
+++ b/devlog/_plan/260906_stateful_task_guidance/010_raw_boundary.md
@@ -1,6 +1,7 @@
 # Align the stateful raw conversation boundary
 
 ## Exact diff map
+
 - MODIFY src/server/responses/collaboration.ts: import the existing pure
   externalTaskInputContent helper. In isConversationalItem, recognize a complete
   external task envelope with helper(item) !== undefined, alongside existing
@@ -23,6 +24,7 @@ role/content order agrees. Leading protocol results remain before guidance;
 historical replay-prefix items remain in place.
 
 ## Activation and boundary proof
+
 The new predicate executes only when stateful guidance inspects raw input. Tests
 set previous_response_id, invoke the real injector and assert raw/parsed/reparsed
 arrays. Ordinary tool outputs with call_id remain protocol items because the
@@ -34,5 +36,6 @@ validation -> raw insertion index -> stored raw input -> later parser is the ful
 data flow. The helper remains pure and adds no optional subsystem dependency.
 Review uses the actual diff; all runtime checks execute in GitHub Actions.
 
-## A audit amendment
-Use the parse-time previous_response_id pattern from multi-agent-compat.test.ts:1075-1089 for envelope-alone and leading-result cases. The raw body must contain that field before parseRequest and retain it during reparse; do not copy the post-hoc parsed.previousResponseId assignment fixture at1029. For historical-prefix coverage use the1043-1072 pattern with explicit _replayPrefixLen and _continuationConversationMessageIndex, and put an old external envelope inside that preserved prefix. Assert parsed boundary before injection as well as raw/parsed/reparsed ordering. This closes the auditor's false-green fixture concern.
+## An audit amendment
+
+Use the parse-time previous_response_id pattern from multi-agent-compat.test.ts:1075-1089 for envelope-alone and leading-result cases. The raw body must contain that field before parseRequest and retain it during reparse; do not copy the post-hoc parsed.previousResponseId assignment fixture at 1029. For historical-prefix coverage use the 1043-1072 pattern with explicit `_replayPrefixLen` and `_continuationConversationMessageIndex`, and put an old external envelope inside that preserved prefix. Assert parsed boundary before injection as well as raw/parsed/reparsed ordering. This closes the auditor's false-green fixture concern.


### PR DESCRIPTION
## Summary

- Fix the release-plan formatting comments from #3743: heading spacing, inline replay-field identifiers and the audit amendment wording/references.
- Normalize the same heading pattern only in this release's two owned planning units. Runtime and test behavior are unchanged.
- Stack (merge bottom-up): #3743 task-input compatibility and #3752 deadline fixture → #3750 Kiro output grouping → this documentation-only cleanup; prior layers are merged.

## Verification

- Inspected the documentation-only diff and ran git diff --check successfully.
- No local runtime tests, typecheck or build were run; hosted documentation-scope CI34017523755 passed on 5bc38d5cc7a3c3e97e03640504ee8f2a0c2e1e77. Parent #3750 passed full CI34017511752 and is merged.
- Recorded the C0 scope in 032_review_doc_format.md.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved readability across release and planning documentation with consistent spacing, clearer headings, corrected wording, and standardized references.
  - Added planning guidance covering external task-input handling, encrypted-task recovery, quota selection, dashboard alignment, and stateful conversation boundaries.
  - Clarified validation expectations, acceptance criteria, routing behavior, and recovery constraints without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->