### PR TITLE
test(state): isolate shutdown fallback from host clock delays

### DIFF
--- a/devlog/_plan/260906_release_244_followups/052_shutdown_fixture.md
+++ b/devlog/_plan/260906_release_244_followups/052_shutdown_fixture.md
@@ -1,0 +1,19 @@
+# Shutdown fallback fixture clock
+
+CI34021352755 on the documentation-only combo closeout failed one macOS test:
+shutdown drain cap expiry enters the synchronous spill fallback. The run had
+10,050 passes and one failure. This file and production state.ts were unchanged
+from the previously green e1f5a5b8d runtime.
+
+The fixture freezes ACL and spill clocks but the shutdown reserve uses Date.now.
+An 80 ms reserve therefore still races host disk/scheduling latency (the failure
+was ETIMEDOUT inside fallbackPendingResponseSpills). Freeze that third clock only
+around flush, using the existing spy pattern from the neighboring ordering test.
+The real 40 ms drain timer still expires while the async publication gate stays
+held; positive synchronous-call, empty-pending and installed-stub assertions remain.
+Release the gate, await the publication tail and restore the clock in finally.
+
+This C1 verifier repair changes one fixture, no production timeout, skip or retry
+policy. Budget-exhaustion/watchdog cases remain untouched. Land as a separate
+prerequisite PR and cascade the combo branch. Independent fixture review and new
+exact parent/child hosted CI are required; no local suite/typecheck/build runs.

--- a/tests/responses/responses-state.test.ts
+++ b/tests/responses/responses-state.test.ts
@@ -1427,16 +1427,27 @@ describe("Responses previous_response_id state", () => {
       return { success: true, exitCode: 0, timedOut: false, stdout: "" };
     });
     setResponseStateByteCapForTests(1_024);
-    rememberLarge("resp_shutdown_fallback", "f".repeat(2 * 1024 * 1024 + 4_096));
-    await started;
-
+    let restoreClock: (() => void) | undefined;
     try {
+      rememberLarge("resp_shutdown_fallback", "f".repeat(2 * 1024 * 1024 + 4_096));
+      await started;
+      // ACL/spill clocks alone do not control the shutdown reserve: state.ts
+      // uses Date.now(). Keep its 80 ms budget independent of real disk latency.
+      // The real 40 ms drain timer still fires while publication stays gated.
+      const shutdownNow = Date.now();
+      const nowSpy = spyOn(Date, "now").mockReturnValue(shutdownNow);
+      restoreClock = () => { nowSpy.mockRestore(); };
       await flushResponseState();
       expect(synchronousCalls).toBeGreaterThan(0);
       expect(pendingResponseSpillMetricsForTests()).toEqual({ count: 0, bytes: 0 });
       expect(responseStateMetrics()).toMatchObject({ residentCount: 0, spillStubCount: 1 });
     } finally {
       release();
+      try {
+        await awaitResponseSpillPublicationTailForTests();
+      } finally {
+        restoreClock?.();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- Freeze the shutdown clock in the existing drain-cap fixture, alongside its already controlled ACL/spill clocks. Keep the real drain timer and unchanged 120/80 ms test budget.
- The async publication stays gated until the synchronous fallback has been asserted. Release the gate, await its publication tail, and restore the clock in finally.
- Production state handling, deadlines and separate budget-exhaustion/watchdog cases are unchanged. This prerequisite addresses the unrelated macOS validation failure seen by #3754.

## Verification

- CI34021352755 observed ETIMEDOUT in the shutdown fallback test (10,050 pass / 1 fail); its source was identical to previously green e1f5a5b8d.
- Compared the fixture clocks with state.ts: the outer reserve uses Date.now, which the existing two test clocks did not control.
- git diff --check passed. Independent xai/grok-4.6 fixture review passed. Exact-head hosted CI34021866383 passed on d26e726d30ac3d609fa70030eb803af21221e6b3: https://github.com/lidge-jun/opencodex/actions/runs/34021866383 (Linux four shards, macOS two shards and gates).
- No local test suite, typecheck or build was run; no skip, threshold increase or retry-until-green was introduced.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer integration: the repository owner authorized admin integration without a second approval. This is a fixture-only change; runtime and production budgets are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved shutdown fallback test stability by isolating shutdown timing from disk latency.
  - Preserved validation that the drain timer expires and the pending publication completes before cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->