### PR TITLE
feat(cli): add JSONL output for provider list

### DIFF
--- a/docs-site/src/content/docs/reference/cli/providers-accounts.md
+++ b/docs-site/src/content/docs/reference/cli/providers-accounts.md
@@ -37,6 +37,10 @@ ocx models --provider anthropic --json
 ocx models live --provider ark --json
 ```
 
+`--jsonl` writes only configured providers, one JSON object per line, and omits the
+`registryCount` summary from `--json`. Use it for line-oriented scripts that should not
+buffer the whole provider list.
+
 :::caution[Custom headers are not a credential channel]
 `--headers` is for non-secret request metadata — routing hints, tenant or
 project selectors, tracing ids. It is **not** a place to put authentication

--- a/docs-site/src/content/docs/reference/cli/providers-accounts.md
+++ b/docs-site/src/content/docs/reference/cli/providers-accounts.md
@@ -14,7 +14,7 @@ both `--adapter` and `--base-url`.
 
 | Subcommand | Supported flags | Action |
 | --- | --- | --- |
-| `list` | `--json` | List configured providers and the remaining registry entries. |
+| `list` | `--json`, `--jsonl` | List configured providers and the remaining registry entries; `--jsonl` emits one configured provider object per line. |
 | `add <name>` | `--adapter <adapter>`, `--base-url <url>`, `--api-key <key>`, `--default-model <model>`, `--set-default`, `--force`, `--json`, `--sync` | Add a registry/custom provider. `--force` overwrites; `--sync` refreshes a running proxy in human-output mode. |
 | `edit <name>` | provider field flags, `--headers <json>`, `--json` | Edit validated live provider fields without replacing key pools. `--headers` merges custom request headers; pass `{}` or `-` to clear them. |
 | `test <name>` | `--json` | Probe the real upstream model endpoint. |
@@ -29,6 +29,7 @@ both `--adapter` and `--base-url`.
 
 ```bash
 ocx provider list --json
+ocx provider list --jsonl        # one configured provider object per line
 ocx provider test ark
 ocx provider add anthropic --api-key sk-ant-... --set-default --sync
 ocx provider add local-dev --adapter openai-chat --base-url http://localhost:11434/v1

--- a/skills/ocx/references/01_management_surface.md
+++ b/skills/ocx/references/01_management_surface.md
@@ -67,6 +67,7 @@ Drives no management route.
 | Flag | Value | Meaning |
 |---|---|---|
 | `--json` | boolean | Emit the provider list as JSON. |
+| `--jsonl` | boolean | Emit one configured provider per JSON line. |
 
 JSON mode: `envelope`.
 

--- a/skills/ocx/references/02_json_shapes.md
+++ b/skills/ocx/references/02_json_shapes.md
@@ -57,7 +57,7 @@ to `requestedModel` is how you get a wrong answer about which provider served it
 One configured provider per line. Each object has the same fields as an item in the
 `configured` array from `ocx provider list --json`; the `registryCount` summary is omitted.
 
-## `ocx logs explain <request-id`
+## `ocx logs explain <request-id>`
 
 ```json
 {"requestId":"ocx-…","routeDecision":{"version":1,"decisionId":"…","requestedModel":"kiro/claude-opus-5",

--- a/skills/ocx/references/02_json_shapes.md
+++ b/skills/ocx/references/02_json_shapes.md
@@ -52,7 +52,12 @@ to `requestedModel` is how you get a wrong answer about which provider served it
 `displayMetrics.cost.estimate.estimateReasons` lists why — for example `usage_estimated`,
 `cache_detail_missing`, `expected_price_overlay`.
 
-## `ocx logs explain <request-id>`
+## `ocx provider list --jsonl`
+
+One configured provider per line. Each object has the same fields as an item in the
+`configured` array from `ocx provider list --json`; the `registryCount` summary is omitted.
+
+## `ocx logs explain <request-id`
 
 ```json
 {"requestId":"ocx-…","routeDecision":{"version":1,"decisionId":"…","requestedModel":"kiro/claude-opus-5",

--- a/skills/ocx/references/03_recipes.md
+++ b/skills/ocx/references/03_recipes.md
@@ -116,6 +116,7 @@ exist for them — do not attribute usage to either.
 
 ```bash
 ocx provider list --json
+ocx provider list --jsonl                   # one configured provider per line
 ocx provider add <name> --json                # registry providers auto-configure by name
 ocx provider test <name> --json
 ocx provider set-default <name> --json

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -148,7 +148,10 @@ export const CAPABILITIES: readonly Capability[] = [
     summary: "Configured providers with connectivity and selected models.",
     // Local config + PROVIDER_REGISTRY. Does not call GET /api/providers.
     routes: [],
-    flags: [{ name: "--json", value: "boolean", summary: "Emit the provider list as JSON." }],
+    flags: [
+      { name: "--json", value: "boolean", summary: "Emit the provider list as JSON." },
+      { name: "--jsonl", value: "boolean", summary: "Emit one configured provider per JSON line." },
+    ],
     mutates: false,
     json: "envelope",
     details: ["Reads local config; drives no management API route."],

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -444,6 +444,7 @@ Subcommands:
 
 Examples:
   ocx provider list
+  ocx provider list --jsonl
   ocx provider add anthropic --api-key sk-ant-...
   ocx provider add my-ollama --adapter openai-chat --base-url http://localhost:11434/v1
   ocx provider show anthropic --json

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -79,26 +79,37 @@ function validateAndSave(config: ReturnType<typeof loadConfig>): void {
 
 function handleList(args: string[]): void {
   const wantsJson = consumeFlag(args, "--json");
-  rejectUnknownArgs(args, "Usage: ocx provider list [--json]");
+  const wantsJsonl = consumeFlag(args, "--jsonl");
+  rejectUnknownArgs(args, "Usage: ocx provider list [--json|--jsonl]");
+
+  if (wantsJson && wantsJsonl) {
+    console.error("Use only one of --json or --jsonl.");
+    process.exit(1);
+  }
 
   const config = loadConfig();
   const configured = Object.keys(config.providers);
+  const entries = configured.map(name => {
+    const prov = config.providers[name];
+    const registryEntry = getProviderRegistryEntry(name);
+    return {
+      name,
+      adapter: prov.adapter,
+      baseUrl: prov.baseUrl,
+      authMode: prov.authMode ?? "key",
+      defaultModel: prov.defaultModel ?? null,
+      isDefault: name === config.defaultProvider,
+      source: registryEntry ? "registry" : "custom",
+      models: prov.models ?? [],
+    };
+  });
+
+  if (wantsJsonl) {
+    for (const entry of entries) console.log(JSON.stringify(entry));
+    return;
+  }
 
   if (wantsJson) {
-    const entries = configured.map(name => {
-      const prov = config.providers[name];
-      const registryEntry = getProviderRegistryEntry(name);
-      return {
-        name,
-        adapter: prov.adapter,
-        baseUrl: prov.baseUrl,
-        authMode: prov.authMode ?? "key",
-        defaultModel: prov.defaultModel ?? null,
-        isDefault: name === config.defaultProvider,
-        source: registryEntry ? "registry" : "custom",
-        models: prov.models ?? [],
-      };
-    });
     console.log(JSON.stringify({ configured: entries, registryCount: PROVIDER_REGISTRY.length }, null, 2));
     return;
   }

--- a/tests/cli/cli-provider.test.ts
+++ b/tests/cli/cli-provider.test.ts
@@ -109,6 +109,32 @@ describe("ocx provider", () => {
     }
   });
 
+  test("provider list --jsonl emits one configured provider per line", () => {
+    const { dir } = freshConfig();
+    try {
+      const result = runCli(["provider", "list", "--jsonl"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(0);
+      const lines = result.stdout.trim().split(/\r?\n/);
+      expect(lines).toHaveLength(1);
+      const parsed = JSON.parse(lines[0] ?? "");
+      expect(parsed).toMatchObject({ name: "openai", isDefault: true });
+      expect(parsed).not.toHaveProperty("registryCount");
+    } finally {
+      removeTreeWithRetry(dir);
+    }
+  });
+
+  test("provider list rejects --json and --jsonl together", () => {
+    const { dir } = freshConfig();
+    try {
+      const result = runCli(["provider", "list", "--json", "--jsonl"], { OPENCODEX_HOME: dir });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Use only one of --json or --jsonl");
+    } finally {
+      removeTreeWithRetry(dir);
+    }
+  });
+
   test("provider add registry provider seeds config", () => {
     const { dir } = freshConfig();
     try {


### PR DESCRIPTION
## Summary

- Add `ocx provider list --jsonl` for line-oriented automation.
- Emit one configured-provider JSON object per line, using the same fields as an item in the existing `--json` `configured` array.
- Preserve the existing `--json` envelope and reject ambiguous use of `--json` with `--jsonl`.
- Update the capability surface, focused CLI regression tests, public CLI docs, and the agent recipes.

## Verification

- The fork branch is based directly on the latest upstream `dev` commit `bd1cda99c162e3b4b41b14f6ad5ca2cf6f1a1f03`; it is 0 commits behind and 2 commits ahead.
- Added focused coverage for one-line JSON output and the mutually-exclusive flags.
- Local Bun execution is pending because the current Work Mode checkout has no repository working tree; no local test or typecheck result is claimed.
- The pull request is opened as a draft so upstream CI and maintainer review can validate the branch.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] No authentication, credential, or unsafe-default behavior was changed.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--jsonl` option to `ocx provider list`, outputting one configured provider as a JSON object per line.
  * Added validation to prevent using `--json` and `--jsonl` together.

* **Documentation**
  * Updated command references, examples, and JSON shape documentation with `--jsonl` usage and output details.

* **Tests**
  * Added coverage for line-delimited output and incompatible option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->