### PR TITLE
fix(grok): hide Codex metadata frames from strict Responses clients

### DIFF
--- a/src/server/grok-responses-control-frame.ts
+++ b/src/server/grok-responses-control-frame.ts
@@ -1,0 +1,38 @@
+import { sseDataPayload, type SseBlockRewrite } from "./sse-payload-rewrite";
+
+const GROK_CONTROL_FRAME_TYPES: Record<string, true> = {
+  "codex.rate_limits": true,
+  "codex.response.metadata": true,
+};
+
+/**
+ * Hide Codex-only control frames from Grok's strict Responses decoder.
+ *
+ * The inspection branch still sees these frames before this client-facing
+ * rewrite, so quota accounting and response metadata remain available to the
+ * proxy while Grok receives only its declared Responses event variants.
+ */
+export function createGrokResponsesControlFrameBlockRewrite(): SseBlockRewrite {
+  return (block) => {
+    const eventName = block
+      .split(/\r?\n/)
+      .find(line => line.startsWith("event:"))
+      ?.slice("event:".length)
+      .trim();
+    if (GROK_CONTROL_FRAME_TYPES[eventName ?? ""] === true) return [];
+
+    const payload = sseDataPayload(block);
+    if (payload === null || payload === "[DONE]") return [block];
+
+    let event: unknown;
+    try {
+      event = JSON.parse(payload);
+    } catch {
+      return [block];
+    }
+    if (!event || typeof event !== "object" || Array.isArray(event) || !("type" in event)) return [block];
+    return typeof event.type === "string" && GROK_CONTROL_FRAME_TYPES[event.type] === true
+      ? []
+      : [block];
+  };
+}

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -374,6 +374,7 @@ import {
   type UpstreamHostAdmissionLease,
 } from "../../codex/upstream-host-health";
 import { createGrokResponsesSparseTerminalBlockRewrite } from "../grok-responses-snapshot-repair";
+import { createGrokResponsesControlFrameBlockRewrite } from "../grok-responses-control-frame";
 import {
   createResponsesSnapshotBlockRewrite,
   hasResponsesSnapshotRepair,
@@ -5494,9 +5495,9 @@ async function handleResponsesInner(
       // Grok Build renders deltas live but reconstructs its durable assistant
       // turn from the completed response snapshot. Native Responses streams
       // may instead carry the complete items in output_item.done, so the
-      // explicit Grok compatibility marker enables strict terminal-only repair.
+      // explicit Grok compatibility marker enables strict client compatibility rewrites.
       // The provider's broader snapshot/lifecycle repair remains opt-in.
-      const grokClientSnapshotRepairEnabled = logCtx.surface === "grok";
+      const grokClientCompatibilityEnabled = logCtx.surface === "grok";
       const snapshotRepairEnabled = hasResponsesSnapshotRepair(route.provider.responsesSnapshotRepair);
       const githubCopilotRepairEnabled = route.providerName === "github-copilot";
       const responseModelRewrite = parsed._responseModelId !== undefined
@@ -5545,7 +5546,10 @@ async function handleResponsesInner(
         githubCopilotRepairEnabled
           ? createGithubCopilotResponsesBlockRewrite(translatorBudget)
           : undefined,
-        grokClientSnapshotRepairEnabled
+        grokClientCompatibilityEnabled
+          ? createGrokResponsesControlFrameBlockRewrite()
+          : undefined,
+        grokClientCompatibilityEnabled
           ? createGrokResponsesSparseTerminalBlockRewrite(translatorBudget)
           : undefined,
         snapshotRepairEnabled

--- a/tests/responses/responses-snapshot-repair-server.test.ts
+++ b/tests/responses/responses-snapshot-repair-server.test.ts
@@ -58,12 +58,26 @@ const CODEX_SPARSE_TERMINAL_EVENTS = [
   },
 ];
 
-function sparseSseBody(events: readonly Record<string, unknown>[] = SPARSE_EVENTS): ReadableStream<Uint8Array> {
+const GROK_CONTROL_FRAME_EVENTS = [
+  {
+    type: "codex.rate_limits",
+    rate_limits: { primary: { used_percent: 12, window_minutes: 60, reset_at: 123 } },
+  },
+  { type: "codex.response.metadata", headers: { "x-models-etag": "fixture" } },
+  { type: "response.created", response: { id: "resp_control" } },
+  { type: "response.completed", response: { id: "resp_control", status: "completed", output: [] } },
+];
+
+function sparseSseBody(
+  events: readonly Record<string, unknown>[] = SPARSE_EVENTS,
+  includeEventNames = false,
+): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {
       const encoder = new TextEncoder();
       for (const event of events) {
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+        const eventLine = includeEventNames ? `event: ${event.type}\n` : "";
+        controller.enqueue(encoder.encode(`${eventLine}data: ${JSON.stringify(event)}\n\n`));
       }
       controller.enqueue(encoder.encode("data: [DONE]\n\n"));
       controller.close();
@@ -74,6 +88,7 @@ function sparseSseBody(events: readonly Record<string, unknown>[] = SPARSE_EVENT
 function stubSparseGateway(
   origin: string,
   events: readonly Record<string, unknown>[] = SPARSE_EVENTS,
+  includeEventNames = false,
 ): void {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const requestUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
@@ -82,7 +97,7 @@ function stubSparseGateway(
       return Response.json({ data: [] });
     }
     if (url.origin === origin && url.pathname.endsWith("/responses")) {
-      return new Response(sparseSseBody(events), {
+      return new Response(sparseSseBody(events, includeEventNames), {
         status: 200,
         headers: { "content-type": "text/event-stream" },
       });
@@ -322,6 +337,49 @@ describe("responsesSnapshotRepair through /v1/responses", () => {
         status: "completed",
         content: [{ type: "output_text", text: "hello", annotations: [] }],
       });
+    } finally {
+      await server.stop(true);
+    }
+  });
+  test("the Grok marker filters Codex control frames at the client boundary", async () => {
+    const gateway = "https://grok-control-frame.example.test";
+    stubSparseGateway(gateway, GROK_CONTROL_FRAME_EVENTS, true);
+    saveConfig({
+      port: 0,
+      defaultProvider: "sparse",
+      providers: {
+        sparse: {
+          adapter: "openai-responses",
+          baseUrl: `${gateway}/v1`,
+          authMode: "key",
+          apiKey: "test-key",
+        },
+      },
+    } as OcxConfig);
+
+    const server = startServer(0);
+    try {
+      const request = (grokMarker: boolean) => originalFetch(new URL("/v1/responses", server.url), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(grokMarker ? { "x-opencodex-grok": "1" } : {}),
+        },
+        body: JSON.stringify({ model: "sparse-model", input: "hi", stream: true }),
+      });
+
+      const grokResponse = await request(true);
+      expect(grokResponse.status).toBe(200);
+      const grokText = await grokResponse.text();
+      expect(grokText).not.toContain("codex.rate_limits");
+      expect(grokText).not.toContain("codex.response.metadata");
+      expect(grokText).toContain('"type":"response.completed"');
+
+      const ordinaryResponse = await request(false);
+      expect(ordinaryResponse.status).toBe(200);
+      const ordinaryText = await ordinaryResponse.text();
+      expect(ordinaryText).toContain("codex.rate_limits");
+      expect(ordinaryText).toContain("codex.response.metadata");
     } finally {
       await server.stop(true);
     }


### PR DESCRIPTION
## Summary
- Hide `codex.rate_limits` and `codex.response.metadata` SSE control frames from Grok's strict Responses decoder.
- Keep quota and response metadata available to the proxy inspection path.
- Leave ordinary Responses clients unchanged.

## Verification
- `bun run test -- tests/responses/responses-snapshot-repair-server.test.ts tests/responses/sse-payload-rewrite.test.ts tests/responses/ws-upstream.test.ts` — 128 passed, 2 skipped.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `bun run test:changed` — attempted; the changed lane exceeded its 900-second Windows timeout before emitting a suite summary.
- `bun run test` — attempted; the full Windows run exceeded its 900-second parallel-lane timeout with unrelated ACL hardening and Claude Desktop integration failures.

## Checklist
- [x] Scope focused on the Grok Responses compatibility boundary.
- [x] Docs/release notes updated when needed; this internal wire-compatibility fix needs no documentation change.
- [x] No security-sensitive behavior or credentials changed.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for Grok Responses streaming by filtering internal control events that could interfere with client-side processing.
  - Preserved standard completion and streaming behavior, including terminal events and valid response data.
  - Non-Grok requests continue to receive their existing event streams unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->