### PR TITLE
docs: keep delivery attribution without contact addresses

### DIFF
--- a/devlog/_fin/260907_axis5_display_cli/020_delivery.md
+++ b/devlog/_fin/260907_axis5_display_cli/020_delivery.md
@@ -33,8 +33,10 @@ One Mac shard reached its 20-minute limit after an unchanged history-lock test. 
 
 ## Attribution
 
-- Éverton Toffanetto <evertondgn@hotmail.com>
-- 투린 <me@turin.my>
-- Zig Zag <shafishahin786@proton.me>
+- Éverton Toffanetto
+- 투린
+- Zig Zag
+
+Original author identities remain in the landed commits; this note lists names without contact addresses.
 
 The preceding numbered files are the historical roadmap and audits; their original _plan locations refer to the planning phase before this closeout.


### PR DESCRIPTION
## Summary

Remove raw contact addresses from the axis-five delivery note while retaining all three author names. Original commit identities and Co-authored-by trailers remain untouched. This fixes the deterministic privacy-scan failure introduced by the documentation closeout in #3835.

## Verification

- `bun scripts/privacy-scan.ts` — passed after the one-file documentation edit. This is a privacy scan, not a local test suite.
- `git diff --check` — passed.
- The failing combined CI identified this exact delivery-note line; no scanner rule or allowlist was changed.
- No runtime code, tests, typecheck or build was executed or changed. Owner authorized admin delivery and no-verify pushes for this work.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
