### PR TITLE
fix(kiro): gate request diagnostics behind the debug check

### DIFF
--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -1,6 +1,7 @@
 import { decodeEventStream } from "../lib/eventstream-decoder";
 import { estimateTokens } from "../lib/token-estimate";
 import { debugProviderDiagnostic } from "../lib/debug";
+import { isDebugEnabled } from "../lib/debug-settings";
 import { resolveKiroApiRegion, resolveKiroRequestProfile } from "../oauth/kiro";
 import { KIRO_MODEL_CONTEXT_WINDOWS, normalizeKiroModelId } from "../providers/kiro-models";
 import { modelRecordValue } from "../reasoning-effort";
@@ -2114,17 +2115,21 @@ export function createKiroAdapter(provider: OcxProviderConfig): ProviderAdapter 
     const rawContextInputEstimate = estimateKiroPayloadInputTokens(built.payload, parsed.modelId);
     const contextInputEstimate = calibrateKiroEstimate(built.conversationId, rawContextInputEstimate);
     const body = JSON.stringify(built.payload);
-    debugProviderDiagnostic("kiro", "request", {
-      region,
-      requestedModel: parsed.modelId,
-      completionMode: built.completionMode,
-      bodyBytes: new TextEncoder().encode(body).length,
-      messageCount: kiroPayloadMessages(parsed).length,
-      toolCount: parsed.context.tools?.length ?? 0,
-      hasProfileArn: Boolean(profileArn),
-      wireClient,
-      hasPreviousResponseId: Boolean(parsed.previousResponseId),
-    });
+    // Every field below is evaluated before the call, so an unguarded call re-encodes the
+    // whole request body on each request even when provider debug is off. Gate the details.
+    if (isDebugEnabled()) {
+      debugProviderDiagnostic("kiro", "request", {
+        region,
+        requestedModel: parsed.modelId,
+        completionMode: built.completionMode,
+        bodyBytes: new TextEncoder().encode(body).length,
+        messageCount: kiroPayloadMessages(parsed).length,
+        toolCount: parsed.context.tools?.length ?? 0,
+        hasProfileArn: Boolean(profileArn),
+        wireClient,
+        hasPreviousResponseId: Boolean(parsed.previousResponseId),
+      });
+    }
     return {
       request: {
         url: kiroRuntimeEndpoint(provider, region),

--- a/tests/providers/kiro/kiro-stream.test.ts
+++ b/tests/providers/kiro/kiro-stream.test.ts
@@ -196,6 +196,21 @@ describe("kiro adapter — parseStream", () => {
     expect(providerState).toEqual({ kiro: { conversationId: "returned-conversation-1" } });
   });
 
+  test("request diagnostics do not re-encode the body when provider debug is off", async () => {
+    const encodeSpy = spyOn(TextEncoder.prototype, "encode");
+    try {
+      const adapter = createKiroAdapter(provider);
+      const before = encodeSpy.mock.calls.length;
+      await adapter.buildRequest(parsedWith([{ role: "user", content: "hi" }]));
+      const during = encodeSpy.mock.calls.slice(before);
+      // The diagnostic argument list is evaluated eagerly, so an unguarded call encodes the
+      // full serialized request body on every request even with diagnostics disabled.
+      expect(during.some(([value]) => typeof value === "string" && value.includes("conversationState"))).toBe(false);
+    } finally {
+      encodeSpy.mockRestore();
+    }
+  });
+
   test("invalid returned message metadata cannot poison continuation state", async () => {
     const adapter = createKiroAdapter(provider);
     const request = await adapter.buildRequest(parsedWith([{ role: "user", content: "hi" }]));


### PR DESCRIPTION
## Summary

- gate the Kiro request diagnostic behind `isDebugEnabled()` so its details are only built when they can actually be emitted
- stop encoding the entire serialized request body on every Kiro request when provider debug is off

`debugProviderDiagnostic` already returns early when provider debug is disabled, but the caller builds its argument object first. In `src/adapters/kiro.ts` that object included:

```ts
bodyBytes: new TextEncoder().encode(body).length,
```

`body` is the full `JSON.stringify(built.payload)` request payload, so every Kiro request ran a UTF-8 encode over the whole serialized conversation and then discarded the result inside the callee. The larger the conversation, the more work was thrown away.

`src/adapters/openai-chat.ts` already guards its diagnostics with `isDebugEnabled()`, so this follows the existing pattern rather than introducing a new one.

## Verification

Run on `agent/kiro-debug-gate-20260907`, one commit ahead of `dev` `bf85e675484a2391b94b2135bbebe739813a9621` with nothing behind.

- `bun test ./tests/providers/kiro/` — 418 pass, 0 fail across 15 files
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- `git diff --check` — passed

The new regression was confirmed to actually catch the defect: with the production guard reverted it fails, and with the guard in place it passes.

No GUI change, so no screenshot applies.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Provider diagnostic details for Kiro requests are now collected only when debugging is enabled.
  - Disabled diagnostics no longer trigger unnecessary request-body processing.

- **Tests**
  - Added regression coverage to verify that request data is not encoded when provider debugging is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
