### PR TITLE
fix(responses): bound the streaming citation marker span

### DIFF
--- a/src/responses/citation-markers.ts
+++ b/src/responses/citation-markers.ts
@@ -69,12 +69,24 @@ export interface CitationMarkerFilter {
 }
 
 /**
+ * Upper bound on the text withheld for one unterminated START.
+ *
+ * A real span is `cite` plus a few turn-scoped ids, so it is far under this. Without a
+ * bound, a backend that emits a START and never terminates it makes `held` grow for the
+ * whole response, and every later delta re-scans that accumulated prefix.
+ */
+const MAX_STREAMING_MARKER_SPAN_LENGTH = 4_096;
+
+/**
  * Streaming filter.
  *
  * A marker can straddle a delta boundary — `\uE200cite` in one chunk and the rest in the
  * next — so a stateless per-delta strip would emit the tail of a span it never recognized.
  * This holds back the text from an unterminated START and releases it once the END arrives
  * (removed) or the stream ends (verbatim, so nothing the model actually said is lost).
+ *
+ * A span that grows past `MAX_STREAMING_MARKER_SPAN_LENGTH` is malformed ordinary text, so
+ * it is released verbatim instead of withheld; a later START can still open a valid span.
  */
 export function createCitationMarkerFilter(): CitationMarkerFilter {
   // Text from an open START that has not been terminated yet.
@@ -87,6 +99,11 @@ export function createCitationMarkerFilter(): CitationMarkerFilter {
       if (start === -1) return stripCitationMarkers(combined);
       const endAfterStart = combined.indexOf(CITATION_MARKER_END, start + 1);
       if (endAfterStart !== -1) return stripCitationMarkers(combined);
+      // Over the bound: this is not a citation span we will ever close. Emit it verbatim
+      // so neither the retained text nor the per-delta rescan grows without limit.
+      if (combined.length - start > MAX_STREAMING_MARKER_SPAN_LENGTH) {
+        return stripCitationMarkers(combined.slice(0, start)) + combined.slice(start);
+      }
       // The trailing span is still open: emit everything before it, hold the rest.
       held = combined.slice(start);
       return stripCitationMarkers(combined.slice(0, start));

--- a/tests/responses/citation-markers.test.ts
+++ b/tests/responses/citation-markers.test.ts
@@ -87,4 +87,26 @@ describe("streaming citation marker filter (#3150)", () => {
     const filter = createCitationMarkerFilter();
     expect(filter.push(`visible now ${S}cite`)).toBe("visible now ");
   });
+
+  test("an unterminated span past the bound is released instead of retained", () => {
+    // A backend that opens a span and never closes it must not make the filter accumulate
+    // the rest of the response, which every later delta would then re-scan.
+    const filter = createCitationMarkerFilter();
+    let out = filter.push(`kept ${S}cite`);
+    expect(out).toBe("kept ");
+    for (let i = 0; i < 5_000; i += 1) out += filter.push("x");
+
+    // Everything after the malformed START is emitted verbatim, so nothing is lost, and
+    // flush() has nothing left to release.
+    expect(out).toBe(`kept ${S}cite${"x".repeat(5_000)}`);
+    expect(filter.flush()).toBe("");
+  });
+
+  test("a later START still opens a valid span after a released malformed one", () => {
+    const filter = createCitationMarkerFilter();
+    let out = filter.push(`a${S}${"y".repeat(5_000)}`);
+    out += filter.push(`${S}cite${P}turn1view0${E} tail`);
+    expect(out).toBe(`a${S}${"y".repeat(5_000)} tail`);
+    expect(filter.flush()).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

- bound the text a streaming citation filter withholds for one unterminated `\uE200` START
- release an over-bound span verbatim instead of retaining it, so a later START can still open a valid span

`createCitationMarkerFilter` withholds the text after an unterminated START so a span split across deltas is still recognized (#3150). Nothing bounds that hold. A backend that emits a START and never terminates it makes `held` grow for the whole response, and every later delta re-joins and re-scans the accumulated prefix — unbounded retained text plus quadratic scanning driven entirely by upstream content.

A real span is `cite` plus a few turn-scoped ids, so anything past a few KiB is malformed ordinary text rather than a citation. Past the 4 KiB bound the filter emits the held text exactly as received, which matches the existing contract in `stripCitationMarkers` and `flush()`: unterminated markers are kept verbatim so nothing the model actually said is lost. The change is additive — the split-span, per-character, and mid-stream-close paths keep their current behaviour.

## Verification

Run on `agent/citation-marker-span-bound-20260907`, one commit ahead of `dev` `bf85e675484a2391b94b2135bbebe739813a9621` with nothing behind.

- `bun test ./tests/responses/citation-markers.test.ts` — 12 pass, 0 fail
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed

The two new regressions were confirmed to catch the defect: with `src/responses/citation-markers.ts` reverted to `dev`, the same file reports 10 pass / 2 fail on exactly those tests, and passes with the fix in place.

No GUI change, so no screenshot applies.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->