### PR TITLE
fix(providers): refuse keychain restore across provider ownership

### DIFF
--- a/src/providers/key-store.ts
+++ b/src/providers/key-store.ts
@@ -64,6 +64,16 @@ function keychainAccount(reference: string): string {
   return reference.slice(KEYCHAIN_REFERENCE_PREFIX.length);
 }
 
+/**
+ * A reference belongs to `name` only when its account is that provider's own active account
+ * or one of its pool accounts. `storeProviderKeyInKeychain` writes exactly those two shapes,
+ * so anything else in a provider's config names another provider's secret.
+ */
+function keychainReferenceBelongsToProvider(reference: string, name: string): boolean {
+  const account = keychainAccount(reference);
+  return account === name || account.startsWith(`${name}/`);
+}
+
 function readKeychain(account: string): string | undefined {
   const cached = resolvedCache.get(account);
   if (cached !== undefined) return cached;
@@ -185,6 +195,18 @@ export function restoreProviderKeyFromKeychain(config: OcxConfig, name: string):
   const pool = provider.apiKeyPool ?? [];
   const resolved = new Map<string, string>();
   const refs = [provider.apiKey, ...pool.map(e => e.key)].filter(isKeychainReference);
+  // Restore reads a secret out of the keychain, writes it back to config as plaintext, and then
+  // DELETES the keychain item. Following a reference to another provider's account would both
+  // disclose that secret through this provider's config and destroy the real owner's credential,
+  // so refuse before anything is read or removed.
+  const foreign = refs.filter(ref => !keychainReferenceBelongsToProvider(ref, name));
+  if (foreign.length > 0) {
+    return {
+      ok: false,
+      error: `provider "${name}" references a keychain account it does not own (${foreign.length} reference(s)); config left unchanged`,
+      status: 400,
+    };
+  }
   for (const ref of refs) {
     const account = keychainAccount(ref);
     if (resolved.has(account)) continue;

--- a/tests/providers/provider-key-store.test.ts
+++ b/tests/providers/provider-key-store.test.ts
@@ -156,6 +156,37 @@ describe("store / restore", () => {
     expect(probeProviderKeychain().available).toBe(false);
   });
 
+  test("restore refuses a reference to another provider's keychain account", () => {
+    const { store, factory } = fakeKeychain();
+    setProviderKeychainEntryFactoryForTests(factory);
+    const config = loadConfig();
+    config.providers.other = { adapter: "openai-chat", baseUrl: "https://other.example/v1", apiKey: POOL_SECRET };
+    expect(storeProviderKeyInKeychain(config, "other")).toEqual({ ok: true, moved: 1 });
+    expect(config.providers.other!.apiKey).toBe("keychain:other");
+
+    // Point "relay" at the account "other" owns. Restore would otherwise read that secret,
+    // write it into relay's config as plaintext, and delete the owner's keychain item.
+    config.providers.relay!.apiKey = "keychain:other";
+    const result = restoreProviderKeyFromKeychain(config, "relay");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+
+    expect(config.providers.relay!.apiKey).toBe("keychain:other");
+    expect(readFileSync(join(testDir, "config.json"), "utf8")).not.toContain(POOL_SECRET);
+    // The real owner's secret is still in the keychain and still resolves for that provider.
+    expect(store.size).toBe(1);
+    expect(resolveProviderApiKey(config.providers.other!.apiKey)).toBe(POOL_SECRET);
+  });
+
+  test("restore still accepts a provider's own active and pool accounts", () => {
+    const { factory } = fakeKeychain();
+    setProviderKeychainEntryFactoryForTests(factory);
+    const config = loadConfig();
+    config.providers.relay!.apiKeyPool = [{ id: "a1", key: SECRET }, { id: "b2", key: POOL_SECRET }];
+    expect(storeProviderKeyInKeychain(config, "relay")).toEqual({ ok: true, moved: 2 });
+    expect(restoreProviderKeyFromKeychain(config, "relay")).toEqual({ ok: true, restored: 2 });
+  });
+
   test("management route: GET reports store kind, POST store/restore round-trips", async () => {
     const { factory } = fakeKeychain();
     setProviderKeychainEntryFactoryForTests(factory);
@@ -192,4 +223,3 @@ describe("store / restore", () => {
     }
   });
 });
-


### PR DESCRIPTION
## Summary

- refuse `restoreProviderKeyFromKeychain` when a provider's config references a keychain account it does not own
- keep every legitimate restore working, including a provider's own active and pool accounts

`storeProviderKeyInKeychain` writes exactly two account shapes for a provider: `<name>` for the active key and `<name>/<pool id>` for pool entries. `restoreProviderKeyFromKeychain` never checked that the references it follows match the provider it was asked to restore. It reads each referenced secret, writes it back into that provider's config as plaintext, and then deletes the keychain item.

So a config where provider `a` carries `keychain:b` turns one restore of `a` into two problems: `b`'s secret is disclosed as plaintext under `a`, and `b`'s credential is deleted from the OS keychain while `b`'s own config still points at the now-empty account. The refusal happens before anything is read or removed, so config and keychain are both left untouched.

This is deliberately scoped to the ownership check in one file. Threading a provider name through `resolveProviderApiKey` touches ~28 request-time call sites and belongs in a separate change; this one stands alone and needs no caller updates.

## Verification

Run on `agent/keychain-reference-owner-scope-20260907`, one commit ahead of `dev` `bf85e675484a2391b94b2135bbebe739813a9621` with nothing behind.

- `bun test ./tests/providers/provider-key-store.test.ts` — 8 pass, 0 fail
- `bun run typecheck` — passed
- `bun run privacy:scan` — passed
- `git diff --check` — passed

The new regression was confirmed to catch the defect: with `src/providers/key-store.ts` reverted to `dev`, the same file reports 7 pass / 1 fail, and passes with the fix in place. A second test asserts the ordinary own-account restore still round-trips.

No GUI change, so no screenshot applies.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Provider key restoration now rejects keychain references belonging to unrelated providers or accounts.
  - Invalid restoration attempts return an error without changing configuration or deleting existing credentials.
  - Valid references for the provider and its pool accounts continue to restore successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->