### PR TITLE
fix(transport): admit Mihomo IPv6 fake-IP under TUN transparency exception for canonical URLs

### DIFF
--- a/src/lib/provider-outbound.ts
+++ b/src/lib/provider-outbound.ts
@@ -143,11 +143,12 @@ async function providerOutboundRequest(
   // below reason about the same value. `null` here means "no proxy fetch would actually use",
   // even if some other proxy variable is set.
   const effectiveProxy = effectiveProxyFor(parsed);
-  const allowMihomoIpv6FakeIp = effectiveProxy !== null && !noProxyMatches(parsed);
+  const isCanonicalUrl = dependencies.isCanonicalUrl ?? (() => false);
+  const allowMihomoIpv6FakeIp = (effectiveProxy !== null && !noProxyMatches(parsed))
+    || transparentFakeIpException(url, parsed, isCanonicalUrl, name);
   const resolveAddresses = dependencies.resolveAddresses ?? resolvePublicAddresses;
   const pinnedGet = dependencies.pinnedGet ?? pinnedHttpGet;
   const pinnedPost = dependencies.pinnedPost ?? pinnedHttpPost;
-  const isCanonicalUrl = dependencies.isCanonicalUrl ?? (() => false);
   const allowPrivate = providerAllowsPrivateNetwork(name, provider);
   let resolved: Awaited<ReturnType<typeof resolvePublicAddresses>>;
   try {
@@ -169,11 +170,9 @@ async function providerOutboundRequest(
       // pinned to the registry destination independently.
       allowBenchmarkAddresses: (proxyConfigured && !noProxyMatches(parsed))
         || transparentFakeIpException(url, parsed, isCanonicalUrl, name),
-      // Mihomo IPv6 fake-IP (fdfe:dcba:9876::/48) answers are admitted on a stricter gate
-      // than the benchmark range: the proxy must be the one fetch will use for this URL's
-      // scheme, and the request below is then bound to it explicitly (#3462). A ULA answer
-      // is otherwise indistinguishable from a real private host, so proxy presence alone
-      // is not enough.
+      // Mihomo IPv6 fake-IP (fdfe:dcba:9876::/48) answers are admitted either when bound
+      // to a scheme-matched proxy (#3462) or under the TUN transparency exception for a
+      // canonical registry/accounting destination.
       allowMihomoIpv6FakeIp,
     });
   } catch (error) {
@@ -191,7 +190,7 @@ async function providerOutboundRequest(
     warnProxyBoundaryOnce();
     // When the Mihomo exception could have admitted an answer, pin the transport to the
     // proxy the admission assumed instead of letting fetch re-infer it from the environment.
-    const proxy = allowMihomoIpv6FakeIp ? effectiveProxy : undefined;
+    const proxy = (allowMihomoIpv6FakeIp && effectiveProxy) ? effectiveProxy : undefined;
     return globalThis.fetch(url, { ...init, method, redirect: "manual", ...(proxy ? { proxy } : {}) });
   }
   if (proxyConfigured && resolved.privateNetwork && !noProxyMatches(parsed)) {

--- a/tests/providers/provider-account-quota.test.ts
+++ b/tests/providers/provider-account-quota.test.ts
@@ -796,8 +796,8 @@ describe("google-antigravity per-account quota (#1082)", () => {
       expect(posted).toHaveLength(urls.length * 2);
       for (const url of urls) {
         expect(resolved.filter(row => row.url === url)).toEqual([
-          { url, benchmark: true, private: false, mihomo: false },
-          { url, benchmark: true, private: false, mihomo: false },
+          { url, benchmark: true, private: false, mihomo: true },
+          { url, benchmark: true, private: false, mihomo: true },
         ]);
       }
       for (const [auth, project] of [["Bearer agy-first", "proj-first"], ["Bearer agy-second", "proj-second"]]) {

--- a/tests/providers/provider-outbound.test.ts
+++ b/tests/providers/provider-outbound.test.ts
@@ -501,6 +501,23 @@ describe("#3462 Mihomo IPv6 fake-IP admission is gated on the scheme-matched pro
     expect(resolveOptions).toEqual([{ allowMihomoIpv6FakeIp: false }]);
     expect(fetchInits).toHaveLength(0);
   });
+
+  test("canonical destination without proxy env: admitted under TUN transparentFakeIpException", async () => {
+    for (const key of proxyKeys) delete process.env[key];
+    const { providerOutboundGet } = await import("../../src/lib/provider-outbound");
+    const resolveOptions: Captured[] = [];
+    const { dependencies, captured } = directDependencies(new Response(null, { status: 200 }));
+    dependencies.isCanonicalUrl = (name, url) => name === "opencode-go" && url === target;
+    dependencies.resolveAddresses = mock(async (_url: string, options?: Captured) => {
+      resolveOptions.push({ allowMihomoIpv6FakeIp: options?.allowMihomoIpv6FakeIp });
+      return { hostname: "opencode.ai", addresses: [{ address: ULA, family: 6 }, { address: "198.18.0.1", family: 4 }], privateNetwork: false };
+    }) as ProviderOutboundDependencies["resolveAddresses"];
+
+    const response = await providerOutboundGet("opencode-go", { baseUrl: "https://opencode.ai/zen/v1" }, target, {}, dependencies);
+    expect(response.status).toBe(200);
+    expect(resolveOptions).toEqual([{ allowMihomoIpv6FakeIp: true }]);
+    expect(captured.address).toBe("198.18.0.1");
+  });
 });
 
 describe("effectiveProxyFor picks the variable Bun fetch actually honours", () => {

--- a/tests/providers/provider-quota.test.ts
+++ b/tests/providers/provider-quota.test.ts
@@ -3159,7 +3159,7 @@ describe("fetchProviderQuotaReports", () => {
         });
         const result = await fetchProviderQuotaReports(config(), true);
         const urls = fallback ? [summaryUrl, modelsUrl] : [summaryUrl];
-        expect(resolved).toEqual(urls.map(url => ({ url, benchmark: true, private: false, mihomo: false })));
+        expect(resolved).toEqual(urls.map(url => ({ url, benchmark: true, private: false, mihomo: true })));
         expect(posted).toEqual(urls.map(url => ({ url, address: "198.18.56.214", tls: true, auth: "Bearer agy-canonical-access", body: JSON.stringify({ project: "agy-canonical-project" }), signal: true })));
         expect(result.reports[0]?.source).toBe(fallback ? "google-antigravity:fetchAvailableModels" : "google-antigravity:retrieveUserQuotaSummary");
         expect(result.reports[0]?.quota.customWindows).toEqual([{ label: "Gem", percent: fallback ? 25 : 40 }]);


### PR DESCRIPTION
## Summary

Fixes an issue where Google Antigravity (and other canonical endpoints) fail to retrieve quotas or discover models when the client environment runs under Clash / Mihomo in **TUN mode with IPv6 Fake-IP enabled** (`fake-ip-range6: fdfe:dcba:9876::/48`) without an explicit `HTTP(S)_PROXY` environment variable.

## Root Cause

In `src/lib/provider-outbound.ts`, `resolveAddresses` validates target IP addresses against private-network SSRF risks:
- For **IPv4 Fake-IP** (`198.18.0.0/15`), TUN mode has an explicit transparency bypass via `transparentFakeIpException(url, parsed, isCanonicalUrl, name)`:
  ```ts
  allowBenchmarkAddresses: (proxyConfigured && !noProxyMatches(parsed))
    || transparentFakeIpException(url, parsed, isCanonicalUrl, name),
  ```
- However, for **Mihomo IPv6 Fake-IP** (`fdfe:dcba:9876::/48`, added in #3462), the admission was strictly gated behind `effectiveProxy !== null`:
  ```ts
  const allowMihomoIpv6FakeIp = effectiveProxy !== null && !noProxyMatches(parsed);
  ```

When running in TUN mode without `HTTP(S)_PROXY` (e.g. background services managed by `launchd` / `systemd` or transparent TUN proxies), DNS queries for canonical endpoints like `daily-cloudcode-pa.googleapis.com` return both IPv4 Fake-IP (`198.18.x.x`) and IPv6 Fake-IP (`fdfe:dcba:9876::xx`). Because `allowMihomoIpv6FakeIp` evaluated to `false`, the IPv6 ULA address was flagged as an unsafe private network address:
```
ProviderOutboundPolicyError: provider URL hostname daily-cloudcode-pa.googleapis.com resolves to private-network address (fdfe:dcba:9876::a9)
```
This aborted the request and caused Antigravity quota retrieval (`retrieveUserQuotaSummary`) to fail.

## Fix

1. **Admit IPv6 Fake-IP under TUN transparency exception (`src/lib/provider-outbound.ts`):**
   ```ts
   const isCanonicalUrl = dependencies.isCanonicalUrl ?? (() => false);
   const allowMihomoIpv6FakeIp = (effectiveProxy !== null && !noProxyMatches(parsed))
     || transparentFakeIpException(url, parsed, isCanonicalUrl, name);
   ```
2. **Safeguard proxy option:**
   Ensure `proxy` passed to `globalThis.fetch` is only set when `effectiveProxy` is non-null.
3. **Tests:**
   - Added unit test in `tests/providers/provider-outbound.test.ts` verifying that canonical URLs admit Mihomo IPv6 Fake-IP without proxy environment variables.
   - Updated quota test expectations in `tests/providers/provider-quota.test.ts` and `tests/providers/provider-account-quota.test.ts` (`mihomo: true`).

## Verification

- `bun test tests/providers/provider-quota.test.ts tests/providers/provider-account-quota.test.ts tests/routing/destination-policy-resolved.test.ts tests/providers/command-code-fakeip-discovery.test.ts`: **250 pass, 0 fail**.
- Verified in a live Mihomo TUN environment with IPv6 Fake-IP: `fetchAntigravityUsageQuota` successfully retrieves live Antigravity 5h and weekly quota without setting `HTTPS_PROXY`.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connectivity for canonical service requests using TUN-mode transparent fake-IP handling.
  - IPv6 fake-IP admission is now enabled when applicable, including requests without proxy environment variables.
  - Requests can resolve both IPv6 and IPv4 addresses and use a reachable IPv4 connection when needed.
  - Prevented connection pinning when no effective proxy is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->