### PR TITLE
fix(code-mode): state the host contract for nested helpers and annotate host failures

### DIFF
--- a/devlog/_plan/260907_code_mode_host_contract/000_plan.md
+++ b/devlog/_plan/260907_code_mode_host_contract/000_plan.md
@@ -1,0 +1,141 @@
+# 000 — Code-mode host contract for routed models: plan
+
+## Loop-spec
+
+- Loop archetype: satisfy-spec repair (verifier-defined). No optimization loop.
+- Trigger: xai/grok-4.6 retrospective (2026-09-07) on a routed native-Responses Codex session. The
+  model hit four Codex host contracts that OpenCodex neither states before the first call nor
+  explains after the failure, then abandoned the right tools for shell heredocs and sleep loops.
+- Goal: a routed non-OpenAI model in Codex code mode learns the host's exact argument shape and
+  waiting protocol up front, and when it still trips, the tool result names the rule it broke.
+- Non-goals: rewriting model JavaScript; repairing payloads (`apply-patch-envelope.ts`,
+  `code-mode-helper-compat.ts`, `bridge.ts`, `parser.ts` untouched); changing OpenAI/ChatGPT
+  destinations or compaction requests; Lab; GUI; release/version bumps. No local test suite,
+  typecheck, build, or install in this worktree (user instruction). Merge/release out of scope.
+- Verifier: hosted `.github/workflows/ci.yml` on the exact PR head (test shards 1-4 + gates:
+  typecheck, privacy scan). Local: NOT RUN by instruction. Each conditional path names its
+  activation test in the decade docs; those tests ride the hosted shards.
+- Stop condition: PR open against `dev` with exact-head CI green and receipt bound; then DONE.
+- Memory artifact: this unit (`devlog/_plan/260907_code_mode_host_contract/`), the bound
+  goalplan `.codexclaw/goalplans/code-mode-host-contract-for-routed-models-shared/`, PR body.
+- Expected terminal outcomes: DONE (PR open, CI green); NOOP if the contract already exists
+  (ruled out below); BLOCKED if GitHub/CI infrastructure fails after retries; UNSAFE if a change
+  would rewrite JavaScript or widen a fail-open write; NEEDS_HUMAN for merge.
+- Escalation: main reclaims a slice after two distinct agents fail its packet; pushing a slice to
+  a worker requires a P-phase amendment. Every dispatch uses `gpt-6-astra` reasoning `high`.
+- HOTL bounds: write scope is this worktree on `codex/code-mode-host-contract`; tools are
+  git/gh/rg/read + `tools.apply_patch`; no token or wall-clock budget was set by the user.
+
+## Incident (what actually broke)
+
+All four strings below were read from the installed Codex 0.153.2 binaries
+(`codex` and `codex-code-mode-host`, `strings -n 8`), so the wording here is the host's, not a guess.
+
+| # | Model action | Host response | Where OpenCodex says nothing today |
+|---|---|---|---|
+| 1 | `tools.apply_patch({ input: "..." })` | `\`apply_patch\` expects a string input` | Nudge says "host-executed" and describes markers, never the argument type |
+| 2 | patch built in a template literal opening with a newline | `The first line of the patch must be '*** Begin Patch'` (also `The last line of the patch must be '*** End Patch'`) | Nudge says "begin exactly with" but not that leading whitespace/newline counts |
+| 3 | `for i in 1..20; sleep 1` inside one `exec_command` | (no error; the turn just blocks) | No sentence about `session_id` + `write_stdin` with empty `chars` |
+| 4 | `import x from "..."` inside the isolate | `Unsupported import in exec: ...` | Cursor normalize matches lowercase `unsupported import in exec` only; shared nudge silent |
+
+After 1 and 2 the model stopped using `apply_patch` entirely. That is the same pattern
+`devlog/_fin/260813_260813-nudge-apply-patch-forbid/` recorded: once the tool feels forbidden or
+broken, routed models fall back to `python3`/`cat <<EOF` writes that Codex cannot render as diffs.
+
+## Existing mechanism (what we extend, not invent)
+
+`src/adapters/exec-tool-result-normalize.ts` already owns one "pair": a pre-call sentence
+(`CODE_MODE_RESULT_ECHO_SENTENCE`) and a post-hoc repair (`EMPTY_EXEC_OUTPUT_MESSAGE`), kept in one
+file so the two never drift. The pre-call sentence is injected by three consumers:
+
+- `src/adapters/tool-catalog-nudge.ts:124` (shared: Anthropic, Google, Kiro, OpenAI-chat, command-code)
+- `src/adapters/cursor/tool-guidance.ts:187-190` (Cursor code-mode branch)
+- `src/adapters/responses-code-mode.ts:27,47` (native routed Responses instructions + exec input description)
+
+and the post-hoc repair runs at:
+
+- `src/adapters/responses-code-mode.ts:55` (paired exec outputs)
+- `src/adapters/kiro.ts:758` (toolResult translation)
+- `src/adapters/cursor/tool-result-normalize.ts:96-105` (Cursor wrapper; also owns `RUNTIME_FAILURE_GUIDANCE`)
+
+The Anthropic, Google, OpenAI-chat and command-code adapters do NOT run the empty-exec repair on
+tool results today (checked `anthropic.ts:786`, `google.ts:422`, `openai-chat.ts:835`,
+`command-code.ts:110`). Adding failure annotation there would be a new seam; this unit keeps to
+the three seams that already normalize exec results (scope discipline, PHASE-SPLIT-01).
+
+NOOP check: `rg -n 'expects a string input|first line of the patch|write_stdin' src` finds only
+`code-mode-helper-compat.ts:54` (compiles a helper alias) and `types/tools.ts:50` (name list). No
+guidance names the argument type, the whitespace rule, or the polling protocol. Not a NOOP.
+
+## Design
+
+One new export block in `exec-tool-result-normalize.ts`:
+
+1. `CODE_MODE_HOST_CONTRACT_SENTENCE` — the pre-call half. Three facts in host wording:
+   `tools.apply_patch` takes ONE string whose first line is exactly `*** Begin Patch` and last line
+   `*** End Patch` (no leading newline/indent); the isolate has no `import`/`require`; a command
+   that outlives `yield_time_ms` returns `session_id` and is polled with
+   `tools.write_stdin({session_id, chars: ""})`, never a shell sleep loop.
+2. `CODE_MODE_HOST_FAILURE_GUIDANCE` — the post-hoc half: a marker → recovery table keyed on the
+   four host strings, matched case-insensitively (host emits `Unsupported import in exec:`,
+   Cursor's existing marker is lowercase).
+3. `annotateCodeModeHostFailure(text, options)` — returns `text + "\n[recovery: ...]"` when the
+   result is an exec-bridge tool result (`isCodexExecBridgeTool`) containing a marker and not
+   already annotated; else `undefined`. Pure, idempotent, byte-identical on the negative path.
+
+Consumers: the three pre-call sites append sentence 1 next to the echo sentence; the three post-hoc
+sites try `annotateCodeModeHostFailure` after the empty-exec check. Cursor's
+`RUNTIME_FAILURE_GUIDANCE` import row is replaced by the shared table so the marker and hint have
+one owner.
+
+Why prose and not repair: `devlog/_plan/260905_apply_patch_envelope_gap/010_disposition.md` already
+refused rewriting JavaScript bodies (MODE B). An object argument or a leading newline inside a
+program has the same ambiguity. The fix that is safe here is telling the model the rule before
+the call and naming the rule after the failure. `code-mode-helper-compat.ts` keeps its existing
+`unwrapPatchInput` for the NAME-alias path; this unit does not touch it.
+
+## Work-phase map (dependency order, PHASE-SPLIT-01)
+
+| WP | Doc | Slice | Depends on | Independently verifiable by |
+|----|-----|-------|------------|-----------------------------|
+| wp0 | this file + 010/020/030 | docs-only roadmap | — | A-gate audit of the docs |
+| wp1 | 010_pre_call_contract.md | shared sentence + three injection sites + tests | wp0 | `tests/adapters/tool-catalog-nudge.test.ts`, `tests/providers/cursor/cursor-tool-definitions.test.ts`, `tests/responses/openai-responses-passthrough.test.ts`, `tests/providers/kiro/kiro-adapter.test.ts` on hosted CI |
+| wp2 | 020_post_hoc_annotation.md | shared annotate helper + three result seams + tests | wp1 | new `tests/adapters/exec-tool-result-normalize.test.ts` + updated Cursor/Kiro/passthrough tests on hosted CI |
+| wp3 | 030_docs_and_delivery.md | structure + docs-site sync, push, PR, exact-head CI receipt | wp2 | `gh run view <id> --exit-status` on the PR head SHA |
+
+Single PR (one reviewable diff, ~150 source lines + tests); no stack (DEV-STACK-OPT-IN-01).
+
+## Accept criteria (goalplan c1–c4)
+
+- c1: pre-call guidance present in all three code-mode injection sites, absent for flat/OpenAI catalogs.
+- c2: exec results carrying any of the four host markers are annotated on routed Responses, Kiro, Cursor; non-matching output byte-identical; already-annotated text not doubled.
+- c3: PR open against `dev` with the template body; exact-head hosted CI success; receipt bound.
+- c4: each A gate has an independent `gpt-6-astra` audit; `structure/04` and docs-site guide updated.
+
+## Verifiers (PLAN-VERIFIER-REAL-01)
+
+Local execution is forbidden for this unit, so every row below is NOT RUN locally and observed on
+hosted CI. "Reads the target" is proven by import paths in the named test files:
+
+- `bun test tests/adapters/tool-catalog-nudge.test.ts` — imports `../../src/adapters/tool-catalog-nudge` and `exec-tool-result-normalize` (file lines 2-7). Reads wp1 target.
+- `bun test tests/providers/cursor/cursor-tool-definitions.test.ts` — imports `tool-guidance` (line 762-ish `buildCursorToolGuidanceSystemNote`). Reads wp1 Cursor target.
+- `bun test tests/responses/openai-responses-passthrough.test.ts` — imports `responses-code-mode` (line 5). Reads wp1+wp2 native target.
+- `bun test tests/providers/kiro/kiro-adapter.test.ts` — imports `exec-tool-result-normalize` (line 16) and exercises `createKiroAdapter`. Reads wp1+wp2 Kiro target.
+- `bun test tests/providers/cursor/cursor-toolresult-normalize.test.ts` — imports `tool-result-normalize`. Reads wp2 Cursor target.
+- `bun test tests/adapters/exec-tool-result-normalize.test.ts` (NEW in wp2) — imports the shared module directly.
+- `bun test tests/test-layout-tooling.test.ts` — reads `scripts/test-layout/layout.json` and `tests/fixtures/test-layout-expected.json`; fails if the new file is unregistered.
+- `bun run typecheck`, `bun run privacy:scan` — CI `gates` job.
+
+## Enforcement bypass (PLAN-BYPASS-NAMED-01)
+
+This unit adds guidance, not enforcement. Tier: none (prose the model may ignore). Executing
+surface: request translation in the adapters. Known bypass: the model disregards the sentence;
+the host still rejects the call exactly as today. Residual risk: none beyond status quo; the
+post-hoc annotation cannot make a failed call succeed. Wording: this is an "early warning", not
+enforcement. Final layer: Codex host validation (unchanged).
+
+## SoT sync targets (SOT-SYNC-01)
+
+- `structure/04_transports-and-sidecars.md` paragraph at ~line 325 ("Native routed Responses code-mode turns also receive…") — extend with the host contract.
+- `docs-site/src/content/docs/guides/codex-integration.md` "Routed local tools" section (~line 315) — one paragraph; translated locales are not edited (they must not contradict, and adding text to English only is additive).
+

--- a/devlog/_plan/260907_code_mode_host_contract/000_plan.md
+++ b/devlog/_plan/260907_code_mode_host_contract/000_plan.md
@@ -77,18 +77,26 @@ New exports in `exec-tool-result-normalize.ts` (full text in 010/020):
    non-exhaustive), `session_id` + `write_stdin` polling.
 2. `CODE_MODE_HOST_FAILURE_GUIDANCE` — marker → recovery rows for the four host strings, matched
    case-insensitively.
-3. `annotateCodeModeHostFailure(text, {toolName, toolNamespace})` — gated by
-   `isCodexExecBridgeTool`, refuses text already carrying `[recovery: `, appends one recovery
-   line; else `undefined`. Pure, idempotent, byte-identical on the negative path.
+3. `annotateCodeModeHostFailure(text, {toolName, toolNamespace})` — gated by a new, narrower
+   `isCodexCodeModeExecResult` (bare `exec` or its `opencodex-responses` display alias; flat shell
+   bridges and foreign MCP namespaces excluded because the four strings originate only in the
+   isolate), refuses text already carrying the exported `CODE_MODE_HOST_RECOVERY_PREFIX`, appends
+   one recovery line; else `undefined`. Pure, idempotent, byte-identical on the negative path.
+   The empty-output repair keeps its wider `isCodexExecBridgeTool` gate.
 
 Cursor keeps its own `RUNTIME_FAILURE_GUIDANCE` table and its `isError` policy byte-identical;
 it gains one exec-gated branch that inserts the shared annotation WITHOUT changing `isError`
 (audit blockers 2 and 3). Kiro substitutes the annotation only where it would otherwise carry the
 raw text, leaving whitespace and failed-wrapper grouping untouched (blocker 1).
 
-Accepted residual: an exec result that legitimately prints one of the four phrases (e.g. `cat` of
-this devlog) gains a recovery line. The line is additive text on an exec result and never changes
-error status, and the gate excludes every non-exec tool.
+Accepted residual: a code-mode exec result that legitimately prints one of the four phrases (e.g.
+`cat` of this devlog) gains a recovery line. The line is additive text and never changes error
+status; the gate excludes every non-code-mode tool, shell bridge, and foreign namespace.
+
+Marker wording: the live probe shows the host tolerates blank lines and indentation around the
+markers and rejects a decorated or missing marker. Every sentence, recovery hint and doc paragraph
+says "opens/closes with the bare marker line … blank lines or indentation are tolerated" and never
+"the first character must be".
 
 Why prose and not repair: `devlog/_plan/260905_apply_patch_envelope_gap/010_disposition.md`
 refused rewriting JavaScript bodies (MODE B). An object argument inside a program has the same
@@ -157,3 +165,12 @@ quo. Wording: "early warning". Final layer: Codex host validation (unchanged).
 Root cause across 1-3: the roadmap treated "reuse the seam" as "spread into the seam" without
 re-reading each seam's own policy. Round 2 re-audits with the same reviewer.
 
+## Audit round 2 — synthesis
+
+| # | Sev | Disposition |
+|---|---|---|
+| 1 Cursor lowercase replay falls through to legacy loop | High | Folded: the exec-gated branch returns early on an already-annotated result; lowercase and capitalised replay tests assert text/isError/changed (020). |
+| 2 Namespace-negative test contradicts the predicate; flat shells annotated | Med | Folded: new `isCodexCodeModeExecResult` gate; shell-bridge, foreign-namespace and Cursor-alias tests; docs say flat catalogs untouched and mean it (020/030). |
+| 3 Responses replay `toBe(replayed)` cannot hold | Med | Folded: assert output-item and program identity plus deep-equal idempotence of successive passes (020). |
+| 4 Marker wording contradicts whitespace probe | Med | Folded: "bare marker line … blank lines or indentation tolerated" in sentence, hints, structure and docs-site text (010/020/030). |
+| 5 Off-by-one anchors | Low | Folded: 116, 32, 45-46, 97-106 (010/020). |

--- a/devlog/_plan/260907_code_mode_host_contract/000_plan.md
+++ b/devlog/_plan/260907_code_mode_host_contract/000_plan.md
@@ -1,141 +1,159 @@
 # 000 — Code-mode host contract for routed models: plan
 
+Revision 2 after audit round 1 (gpt-6-astra explorer, VERDICT: FAIL, 8 blockers). Synthesis and
+dispositions are in the "Audit round 1" section at the end; the body below is the amended plan.
+
 ## Loop-spec
 
 - Loop archetype: satisfy-spec repair (verifier-defined). No optimization loop.
 - Trigger: xai/grok-4.6 retrospective (2026-09-07) on a routed native-Responses Codex session. The
-  model hit four Codex host contracts that OpenCodex neither states before the first call nor
-  explains after the failure, then abandoned the right tools for shell heredocs and sleep loops.
-- Goal: a routed non-OpenAI model in Codex code mode learns the host's exact argument shape and
-  waiting protocol up front, and when it still trips, the tool result names the rule it broke.
-- Non-goals: rewriting model JavaScript; repairing payloads (`apply-patch-envelope.ts`,
-  `code-mode-helper-compat.ts`, `bridge.ts`, `parser.ts` untouched); changing OpenAI/ChatGPT
-  destinations or compaction requests; Lab; GUI; release/version bumps. No local test suite,
-  typecheck, build, or install in this worktree (user instruction). Merge/release out of scope.
-- Verifier: hosted `.github/workflows/ci.yml` on the exact PR head (test shards 1-4 + gates:
-  typecheck, privacy scan). Local: NOT RUN by instruction. Each conditional path names its
-  activation test in the decade docs; those tests ride the hosted shards.
-- Stop condition: PR open against `dev` with exact-head CI green and receipt bound; then DONE.
-- Memory artifact: this unit (`devlog/_plan/260907_code_mode_host_contract/`), the bound
-  goalplan `.codexclaw/goalplans/code-mode-host-contract-for-routed-models-shared/`, PR body.
-- Expected terminal outcomes: DONE (PR open, CI green); NOOP if the contract already exists
-  (ruled out below); BLOCKED if GitHub/CI infrastructure fails after retries; UNSAFE if a change
-  would rewrite JavaScript or widen a fail-open write; NEEDS_HUMAN for merge.
+  model hit Codex host contracts that OpenCodex neither states before the first call nor explains
+  after the failure, then abandoned the right tools for shell heredocs and sleep loops.
+- Goal: a routed non-OpenAI model in Codex code mode learns the host's argument shape and waiting
+  protocol up front, and when it still trips, the exec result names the rule it broke.
+- Non-goals: rewriting model JavaScript; new payload repair (`apply-patch-envelope.ts`,
+  `code-mode-helper-compat.ts`, `bridge.ts`, `parser.ts` untouched); OpenAI/ChatGPT destinations
+  or compaction requests; Lab; GUI; version bumps; annotation on Anthropic/Google/OpenAI-chat/
+  command-code result paths (they have no exec-result seam today). No local test suite, typecheck,
+  build, or install in this worktree (user instruction). Merge/release out of scope.
+- Verifier: hosted `.github/workflows/ci.yml` on the exact head of each pushed work-phase (PR
+  `pull_request` trigger; test shards 1-4 + `gates` typecheck/privacy). Local: NOT RUN.
+- Stop condition: PR ready-for-review against `dev` with exact-head CI green and receipt bound.
+- Memory artifact: this unit, the bound goalplan
+  `.codexclaw/goalplans/code-mode-host-contract-for-routed-models-shared/`, and the PR body.
+- Expected terminal outcomes: DONE (PR open, CI green); NOOP ruled out below; BLOCKED if
+  GitHub/CI fails after retries; UNSAFE if a change would rewrite JavaScript or widen a fail-open
+  write; NEEDS_HUMAN for merge.
 - Escalation: main reclaims a slice after two distinct agents fail its packet; pushing a slice to
-  a worker requires a P-phase amendment. Every dispatch uses `gpt-6-astra` reasoning `high`.
-- HOTL bounds: write scope is this worktree on `codex/code-mode-host-contract`; tools are
-  git/gh/rg/read + `tools.apply_patch`; no token or wall-clock budget was set by the user.
+  a worker requires a P-phase amendment. Every dispatch uses `gpt-6-astra`, reasoning `high`.
+- HOTL bounds: write scope is this worktree on `codex/code-mode-host-contract`; push of that branch
+  and PR creation are authorized by the user; no token or wall-clock budget was set.
 
-## Incident (what actually broke)
+## Incident and live host evidence
 
-All four strings below were read from the installed Codex 0.153.2 binaries
-(`codex` and `codex-code-mode-host`, `strings -n 8`), so the wording here is the host's, not a guess.
+Host strings were read from the installed Codex 0.153.2 binaries (`strings -n 8` on `codex` and
+`codex-code-mode-host`) and then re-probed live from this session's own code-mode isolate:
 
-| # | Model action | Host response | Where OpenCodex says nothing today |
-|---|---|---|---|
-| 1 | `tools.apply_patch({ input: "..." })` | `\`apply_patch\` expects a string input` | Nudge says "host-executed" and describes markers, never the argument type |
-| 2 | patch built in a template literal opening with a newline | `The first line of the patch must be '*** Begin Patch'` (also `The last line of the patch must be '*** End Patch'`) | Nudge says "begin exactly with" but not that leading whitespace/newline counts |
-| 3 | `for i in 1..20; sleep 1` inside one `exec_command` | (no error; the turn just blocks) | No sentence about `session_id` + `write_stdin` with empty `chars` |
-| 4 | `import x from "..."` inside the isolate | `Unsupported import in exec: ...` | Cursor normalize matches lowercase `unsupported import in exec` only; shared nudge silent |
+| Probe (`tools.apply_patch` argument) | Host result |
+|---|---|
+| `{ input: "*** Begin Patch…" }` (object) | throws `tool \`apply_patch\` expects a string input` |
+| `"*** Begin Patch ***\n…\n*** End Patch ***"` (decorated) | throws `apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'` |
+| `"\n\n*** Begin Patch\n…"` (leading newlines) | ACCEPTED, file written |
+| `"  *** Begin Patch\n…"` (indented) | ACCEPTED, file written |
+| `"…*** End Patch\n\n"` (trailing newlines) | ACCEPTED |
+| `import x from "y"` in the isolate | `Unsupported import in exec: <spec>` (host string; capital U) |
 
-After 1 and 2 the model stopped using `apply_patch` entirely. That is the same pattern
-`devlog/_fin/260813_260813-nudge-apply-patch-forbid/` recorded: once the tool feels forbidden or
-broken, routed models fall back to `python3`/`cat <<EOF` writes that Codex cannot render as diffs.
+So the Grok report's "blank line before the template literal" was not itself the rejection; the
+"first line" error fires for a decorated marker, a code fence, prose, or any non-marker first
+token. The pre-call sentence and recovery hints below describe exactly that and do not claim the
+host rejects surrounding whitespace.
 
-## Existing mechanism (what we extend, not invent)
+The fourth contract has no error string: a shell `for i in 1..20; sleep 1` inside one
+`exec_command` simply blocks the call, while the host's own protocol is to let the call return a
+`session_id` and poll with `tools.write_stdin({session_id, chars: ""})`.
 
-`src/adapters/exec-tool-result-normalize.ts` already owns one "pair": a pre-call sentence
-(`CODE_MODE_RESULT_ECHO_SENTENCE`) and a post-hoc repair (`EMPTY_EXEC_OUTPUT_MESSAGE`), kept in one
-file so the two never drift. The pre-call sentence is injected by three consumers:
+After the two apply_patch rejections the model stopped using apply_patch entirely — the pattern
+`devlog/_fin/260813_260813-nudge-apply-patch-forbid/` recorded: once the tool feels broken, routed
+models fall back to `python3`/`cat <<EOF` writes Codex cannot render as diffs.
 
-- `src/adapters/tool-catalog-nudge.ts:124` (shared: Anthropic, Google, Kiro, OpenAI-chat, command-code)
-- `src/adapters/cursor/tool-guidance.ts:187-190` (Cursor code-mode branch)
-- `src/adapters/responses-code-mode.ts:27,47` (native routed Responses instructions + exec input description)
+## Existing mechanism (extended, not invented)
 
-and the post-hoc repair runs at:
-
-- `src/adapters/responses-code-mode.ts:55` (paired exec outputs)
-- `src/adapters/kiro.ts:758` (toolResult translation)
-- `src/adapters/cursor/tool-result-normalize.ts:96-105` (Cursor wrapper; also owns `RUNTIME_FAILURE_GUIDANCE`)
-
-The Anthropic, Google, OpenAI-chat and command-code adapters do NOT run the empty-exec repair on
-tool results today (checked `anthropic.ts:786`, `google.ts:422`, `openai-chat.ts:835`,
-`command-code.ts:110`). Adding failure annotation there would be a new seam; this unit keeps to
-the three seams that already normalize exec results (scope discipline, PHASE-SPLIT-01).
+`src/adapters/exec-tool-result-normalize.ts` owns one pre-call/post-hoc pair
+(`CODE_MODE_RESULT_ECHO_SENTENCE` / `EMPTY_EXEC_OUTPUT_MESSAGE`) in one file so wording cannot drift.
+Pre-call consumers: `src/adapters/tool-catalog-nudge.ts:8,124`; `src/adapters/cursor/tool-guidance.ts:2,190`;
+`src/adapters/responses-code-mode.ts:3,46`. Post-hoc consumers: `responses-code-mode.ts:55`,
+`kiro.ts:758-771`, `cursor/tool-result-normalize.ts:96-112`.
 
 NOOP check: `rg -n 'expects a string input|first line of the patch|write_stdin' src` finds only
-`code-mode-helper-compat.ts:54` (compiles a helper alias) and `types/tools.ts:50` (name list). No
-guidance names the argument type, the whitespace rule, or the polling protocol. Not a NOOP.
+`code-mode-helper-compat.ts:54` (compiles a helper alias) and `types/tools.ts:50` (name list).
+Not a NOOP.
 
 ## Design
 
-One new export block in `exec-tool-result-normalize.ts`:
+New exports in `exec-tool-result-normalize.ts` (full text in 010/020):
 
-1. `CODE_MODE_HOST_CONTRACT_SENTENCE` — the pre-call half. Three facts in host wording:
-   `tools.apply_patch` takes ONE string whose first line is exactly `*** Begin Patch` and last line
-   `*** End Patch` (no leading newline/indent); the isolate has no `import`/`require`; a command
-   that outlives `yield_time_ms` returns `session_id` and is polled with
-   `tools.write_stdin({session_id, chars: ""})`, never a shell sleep loop.
-2. `CODE_MODE_HOST_FAILURE_GUIDANCE` — the post-hoc half: a marker → recovery table keyed on the
-   four host strings, matched case-insensitively (host emits `Unsupported import in exec:`,
-   Cursor's existing marker is lowercase).
-3. `annotateCodeModeHostFailure(text, options)` — returns `text + "\n[recovery: ...]"` when the
-   result is an exec-bridge tool result (`isCodexExecBridgeTool`) containing a marker and not
-   already annotated; else `undefined`. Pure, idempotent, byte-identical on the negative path.
+1. `CODE_MODE_HOST_CONTRACT_SENTENCE` — pre-call: one string argument, bare markers as first/last
+   line with nothing before or after them, no `import`/`require` (globals per the exec description,
+   non-exhaustive), `session_id` + `write_stdin` polling.
+2. `CODE_MODE_HOST_FAILURE_GUIDANCE` — marker → recovery rows for the four host strings, matched
+   case-insensitively.
+3. `annotateCodeModeHostFailure(text, {toolName, toolNamespace})` — gated by
+   `isCodexExecBridgeTool`, refuses text already carrying `[recovery: `, appends one recovery
+   line; else `undefined`. Pure, idempotent, byte-identical on the negative path.
 
-Consumers: the three pre-call sites append sentence 1 next to the echo sentence; the three post-hoc
-sites try `annotateCodeModeHostFailure` after the empty-exec check. Cursor's
-`RUNTIME_FAILURE_GUIDANCE` import row is replaced by the shared table so the marker and hint have
-one owner.
+Cursor keeps its own `RUNTIME_FAILURE_GUIDANCE` table and its `isError` policy byte-identical;
+it gains one exec-gated branch that inserts the shared annotation WITHOUT changing `isError`
+(audit blockers 2 and 3). Kiro substitutes the annotation only where it would otherwise carry the
+raw text, leaving whitespace and failed-wrapper grouping untouched (blocker 1).
 
-Why prose and not repair: `devlog/_plan/260905_apply_patch_envelope_gap/010_disposition.md` already
-refused rewriting JavaScript bodies (MODE B). An object argument or a leading newline inside a
-program has the same ambiguity. The fix that is safe here is telling the model the rule before
-the call and naming the rule after the failure. `code-mode-helper-compat.ts` keeps its existing
-`unwrapPatchInput` for the NAME-alias path; this unit does not touch it.
+Accepted residual: an exec result that legitimately prints one of the four phrases (e.g. `cat` of
+this devlog) gains a recovery line. The line is additive text on an exec result and never changes
+error status, and the gate excludes every non-exec tool.
+
+Why prose and not repair: `devlog/_plan/260905_apply_patch_envelope_gap/010_disposition.md`
+refused rewriting JavaScript bodies (MODE B). An object argument inside a program has the same
+ambiguity. Telling the rule before the call and naming it after the failure is the safe fix.
 
 ## Work-phase map (dependency order, PHASE-SPLIT-01)
 
-| WP | Doc | Slice | Depends on | Independently verifiable by |
-|----|-----|-------|------------|-----------------------------|
-| wp0 | this file + 010/020/030 | docs-only roadmap | — | A-gate audit of the docs |
-| wp1 | 010_pre_call_contract.md | shared sentence + three injection sites + tests | wp0 | `tests/adapters/tool-catalog-nudge.test.ts`, `tests/providers/cursor/cursor-tool-definitions.test.ts`, `tests/responses/openai-responses-passthrough.test.ts`, `tests/providers/kiro/kiro-adapter.test.ts` on hosted CI |
-| wp2 | 020_post_hoc_annotation.md | shared annotate helper + three result seams + tests | wp1 | new `tests/adapters/exec-tool-result-normalize.test.ts` + updated Cursor/Kiro/passthrough tests on hosted CI |
-| wp3 | 030_docs_and_delivery.md | structure + docs-site sync, push, PR, exact-head CI receipt | wp2 | `gh run view <id> --exit-status` on the PR head SHA |
+Each implementation phase ends with an authorized `git push --no-verify` and gets exact-head hosted
+CI as its C verifier (audit blocker 5). The PR is opened as a draft at wp1 so `pull_request` CI
+exists for every later head, and is marked ready in wp3.
 
-Single PR (one reviewable diff, ~150 source lines + tests); no stack (DEV-STACK-OPT-IN-01).
+| WP | Doc | Slice | Depends on | C verifier |
+|----|-----|-------|------------|-----------|
+| wp0 | this file + 010/020/030 | docs-only roadmap | — | audit of the docs |
+| wp1 | 010_pre_call_contract.md | shared sentence + three injection sites + tests; push; draft PR | wp0 | exact-head CI on the wp1 head |
+| wp2 | 020_post_hoc_annotation.md | shared annotate helper + three result seams + tests; push | wp1 | exact-head CI on the wp2 head |
+| wp3 | 030_docs_and_delivery.md | structure + docs-site sync, PR body, ready-for-review, receipt | wp2 | exact-head CI on the final head |
+
+Single PR; no stack (DEV-STACK-OPT-IN-01).
 
 ## Accept criteria (goalplan c1–c4)
 
 - c1: pre-call guidance present in all three code-mode injection sites, absent for flat/OpenAI catalogs.
-- c2: exec results carrying any of the four host markers are annotated on routed Responses, Kiro, Cursor; non-matching output byte-identical; already-annotated text not doubled.
-- c3: PR open against `dev` with the template body; exact-head hosted CI success; receipt bound.
+- c2: exec results carrying any of the four host markers are annotated on routed Responses, Kiro (single and grouped), Cursor (text only, `isError` unchanged); non-matching output byte-identical; already-annotated text not doubled on replay.
+- c3: PR ready against `dev` with the template body; exact-head hosted CI success; receipt bound.
 - c4: each A gate has an independent `gpt-6-astra` audit; `structure/04` and docs-site guide updated.
 
 ## Verifiers (PLAN-VERIFIER-REAL-01)
 
-Local execution is forbidden for this unit, so every row below is NOT RUN locally and observed on
-hosted CI. "Reads the target" is proven by import paths in the named test files:
+Local execution is forbidden for this unit, so every row is NOT RUN locally and observed on hosted
+CI. "Reads the target" is proven by import chains:
 
-- `bun test tests/adapters/tool-catalog-nudge.test.ts` — imports `../../src/adapters/tool-catalog-nudge` and `exec-tool-result-normalize` (file lines 2-7). Reads wp1 target.
-- `bun test tests/providers/cursor/cursor-tool-definitions.test.ts` — imports `tool-guidance` (line 762-ish `buildCursorToolGuidanceSystemNote`). Reads wp1 Cursor target.
-- `bun test tests/responses/openai-responses-passthrough.test.ts` — imports `responses-code-mode` (line 5). Reads wp1+wp2 native target.
-- `bun test tests/providers/kiro/kiro-adapter.test.ts` — imports `exec-tool-result-normalize` (line 16) and exercises `createKiroAdapter`. Reads wp1+wp2 Kiro target.
-- `bun test tests/providers/cursor/cursor-toolresult-normalize.test.ts` — imports `tool-result-normalize`. Reads wp2 Cursor target.
-- `bun test tests/adapters/exec-tool-result-normalize.test.ts` (NEW in wp2) — imports the shared module directly.
-- `bun test tests/test-layout-tooling.test.ts` — reads `scripts/test-layout/layout.json` and `tests/fixtures/test-layout-expected.json`; fails if the new file is unregistered.
+- `tests/adapters/tool-catalog-nudge.test.ts` imports `../../src/adapters/tool-catalog-nudge` (line 2) and `exec-tool-result-normalize` (line 7). wp1 target.
+- `tests/providers/cursor/cursor-tool-definitions.test.ts` imports `buildCursorToolGuidanceSystemNote` through `../../../src/adapters/cursor/tool-definitions` (lines 6-22), which re-exports `tool-guidance`. wp1 Cursor target.
+- `tests/responses/openai-responses-passthrough.test.ts` imports `responses-code-mode` (line 5). wp1+wp2 native target.
+- `tests/providers/kiro/kiro-adapter.test.ts` imports `exec-tool-result-normalize` (line 16) and drives `createKiroAdapter`. wp1+wp2 Kiro target.
+- `tests/providers/cursor/cursor-toolresult-normalize.test.ts` imports `tool-result-normalize` (line 5). wp2 Cursor target.
+- `tests/adapters/exec-tool-result-normalize.test.ts` (NEW, wp2) imports the shared module.
+- `tests/test-layout-tooling.test.ts` reads `scripts/test-layout/layout.json` and `tests/fixtures/test-layout-expected.json`.
 - `bun run typecheck`, `bun run privacy:scan` — CI `gates` job.
 
 ## Enforcement bypass (PLAN-BYPASS-NAMED-01)
 
-This unit adds guidance, not enforcement. Tier: none (prose the model may ignore). Executing
-surface: request translation in the adapters. Known bypass: the model disregards the sentence;
-the host still rejects the call exactly as today. Residual risk: none beyond status quo; the
-post-hoc annotation cannot make a failed call succeed. Wording: this is an "early warning", not
-enforcement. Final layer: Codex host validation (unchanged).
+Guidance, not enforcement. Tier: none. Executing surface: adapter request translation. Known
+bypass: the model ignores the sentence; the host rejects exactly as today. Residual risk: status
+quo. Wording: "early warning". Final layer: Codex host validation (unchanged).
 
 ## SoT sync targets (SOT-SYNC-01)
 
-- `structure/04_transports-and-sidecars.md` paragraph at ~line 325 ("Native routed Responses code-mode turns also receive…") — extend with the host contract.
-- `docs-site/src/content/docs/guides/codex-integration.md` "Routed local tools" section (~line 315) — one paragraph; translated locales are not edited (they must not contradict, and adding text to English only is additive).
+- `structure/04_transports-and-sidecars.md` paragraph at ~line 325 ("Native routed Responses code-mode turns also receive…") plus a Decision Log entry (full text in 030).
+- `docs-site/src/content/docs/guides/codex-integration.md` "Routed local tools" (~line 331); translated locales untouched.
+
+## Audit round 1 — synthesis (REVIEW-SYNTHESIS-01)
+
+| # | Sev | Disposition |
+|---|---|---|
+| 1 Kiro grouping clobbers raw text | High | Folded: only the host annotation substitutes; grouped activation test added (020). |
+| 2 Cursor false positives / case collisions | High | Folded: Cursor table untouched; exec-gated branch via shared helper; benign-content and case controls added (020). |
+| 3 Cursor idempotence | Med | Folded: shared `[recovery: ` guard reached from Cursor; replay test with `isError:false` (020). |
+| 4 Global whitelist false | Med | Folded: non-exhaustive list deferring to the exec description (010). |
+| 5 No CI before wp3 | Med | Folded: push + draft PR at wp1, push at wp2, ready at wp3 (this file, 030). |
+| 6 Elided strings | Med | Folded: full hunks and full Decision Log text (010/020/030). |
+| 7 Anchor drift | Low | Folded: anchors refreshed against ec799db26; test import chain corrected. |
+| 8 Docs overstate | Med | Folded: "this change" scope wording; three result paths named (030). |
+
+Root cause across 1-3: the roadmap treated "reuse the seam" as "spread into the seam" without
+re-reading each seam's own policy. Round 2 re-audits with the same reviewer.
 

--- a/devlog/_plan/260907_code_mode_host_contract/000_plan.md
+++ b/devlog/_plan/260907_code_mode_host_contract/000_plan.md
@@ -72,9 +72,10 @@ Not a NOOP.
 
 New exports in `exec-tool-result-normalize.ts` (full text in 010/020):
 
-1. `CODE_MODE_HOST_CONTRACT_SENTENCE` — pre-call: one string argument, bare markers as first/last
-   line with nothing before or after them, no `import`/`require` (globals per the exec description,
-   non-exhaustive), `session_id` + `write_stdin` polling.
+1. `CODE_MODE_HOST_CONTRACT_SENTENCE` — pre-call: one string argument; the patch opens and closes
+   with the bare marker lines (blank lines or indentation around them tolerated; decorated or
+   missing marker rejected); no `import`/`require` (globals per the exec description,
+   non-exhaustive); `session_id` + `write_stdin` polling.
 2. `CODE_MODE_HOST_FAILURE_GUIDANCE` — marker → recovery rows for the four host strings, matched
    case-insensitively.
 3. `annotateCodeModeHostFailure(text, {toolName, toolNamespace})` — gated by a new, narrower
@@ -89,9 +90,21 @@ it gains one exec-gated branch that inserts the shared annotation WITHOUT changi
 (audit blockers 2 and 3). Kiro substitutes the annotation only where it would otherwise carry the
 raw text, leaving whitespace and failed-wrapper grouping untouched (blocker 1).
 
+Code-mode context per seam: the native routed Responses seam already runs only after the body-level
+code-mode gate (`responses-code-mode.ts:35-37`), so its annotation is exact. Kiro has
+`codeModeExecName` in scope at the same call site (`kiro.ts:650`) and additionally requires it, so a
+structured `exec` or an `exec` beside a shell bridge is never annotated there. Cursor's
+`normalizeCursorToolResultText` is reached from six call sites without catalog context
+(`protobuf-request.ts:392,842,1062,1097,1158,1272`); threading code-mode context through them is a
+larger refactor than this unit, so Cursor coverage is name-based (exact `exec` under the
+`opencodex-responses` provider). That is an accepted residual, recorded here and in the
+structure doc: on Cursor a structured tool literally named `exec` whose output quotes one of the
+four phrases would gain an additive recovery line with no error flip.
+
 Accepted residual: a code-mode exec result that legitimately prints one of the four phrases (e.g.
 `cat` of this devlog) gains a recovery line. The line is additive text and never changes error
-status; the gate excludes every non-code-mode tool, shell bridge, and foreign namespace.
+status; the gate excludes every non-`exec` tool, every shell bridge, and every namespace other than
+the exact `opencodex-responses` display aliases.
 
 Marker wording: the live probe shows the host tolerates blank lines and indentation around the
 markers and rejects a decorated or missing marker. Every sentence, recovery hint and doc paragraph
@@ -174,3 +187,11 @@ re-reading each seam's own policy. Round 2 re-audits with the same reviewer.
 | 3 Responses replay `toBe(replayed)` cannot hold | Med | Folded: assert output-item and program identity plus deep-equal idempotence of successive passes (020). |
 | 4 Marker wording contradicts whitespace probe | Med | Folded: "bare marker line … blank lines or indentation tolerated" in sentence, hints, structure and docs-site text (010/020/030). |
 | 5 Off-by-one anchors | Low | Folded: 116, 32, 45-46, 97-106 (010/020). |
+
+## Audit round 3 — synthesis (GO-WITH-FIXES, blockers=3)
+
+| # | Sev | Disposition |
+|---|---|---|
+| 1 Bare `exec` name does not prove code mode | Med | Folded for Responses (body gate) and Kiro (`codeModeExecName` gate + structured/shell-bridge negative tests); accepted and narrowed for Cursor (name-based, additive text only) — see "Code-mode context per seam". |
+| 2 Namespace `includes` admits foreign tools | Med | Folded: exact equality against `opencodex-responses` / `mcp__opencodex-responses` and the two flattened aliases; `mcp__foreign-opencodex-responses` negative and both flattened positives added (020). |
+| 3 Summary retained the rejected whitespace claim | Low | Folded (this file, Design §1). |

--- a/devlog/_plan/260907_code_mode_host_contract/001_host_probe_evidence.md
+++ b/devlog/_plan/260907_code_mode_host_contract/001_host_probe_evidence.md
@@ -1,0 +1,53 @@
+# 001 — Live host probe evidence (Codex 0.153.2, 2026-09-07)
+
+Research record backing the incident table in 000_plan.md. Every row was executed from this
+session's own code-mode isolate (`custom_exec` → `tools.apply_patch`) against
+`/Users/jun/.codex/worktrees/ec3e/opencodex/.tmp/`; scratch files were deleted afterwards.
+
+## Binary strings
+
+`strings -n 8` over the installed binaries under
+`@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/`:
+
+| Binary | String |
+|---|---|
+| `codex` | `\` expects a string input` (preceded by the tool name) |
+| `codex` | `The first line of the patch must be '*** Begin Patch'` |
+| `codex` | `The last line of the patch must be '*** End Patch'` |
+| `codex` | `Script running with cell ID ` |
+| `codex` | `Session identifier to pass to write_stdin when the process is still running.` |
+| `codex` | `Bytes to write to stdin. Defaults to empty, which polls without writing.` |
+| `codex-code-mode-host` | `Unsupported import in exec: ` and `unsupported import in exec` |
+
+## apply_patch argument probes
+
+| Argument passed to `tools.apply_patch` | Result |
+|---|---|
+| `{ input: "*** Begin Patch\n*** End Patch" }` | throws `tool \`apply_patch\` expects a string input` |
+| `"*** Begin Patch ***\n*** Add File: …\n+z\n*** End Patch ***"` | throws `apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'` |
+| `"\n*** Begin Patch\n*** Add File: …\n+x\n*** End Patch"` | accepted; file written |
+| `"\n\n*** Begin Patch\n…"` | accepted; file written |
+| `"  *** Begin Patch\n…"` (two-space indent) | accepted; file written |
+| `"…*** End Patch\n\n"` | accepted; file written |
+| a patch with two operations on the same path | throws `invalid patch: multiple operations target <path>` |
+| two `*** End Patch` lines (envelope pasted twice) | throws `The last line of the patch must be '*** End Patch'` |
+
+Conclusion carried into the wording: the host strips surrounding whitespace before checking the
+marker lines, so "no leading newline" is not a rule. The rule is that the first non-blank line is
+exactly `*** Begin Patch` and the last is exactly `*** End Patch`, undecorated.
+
+## Long-running command protocol
+
+The `exec_command` schema in this session: `yield_time_ms` "Wait before yielding output. Defaults to
+10000 ms; effective range is 250-30000 ms"; `session_id` "Session identifier to pass to write_stdin
+when the process is still running". `write_stdin`: `chars` "Defaults to empty, which polls without
+writing"; empty polls wait 5000-300000 ms. A shell `for i in 1..20; sleep 1` inside one call
+produces no error string; it simply spends the call's yield budget blocked.
+
+## Isolate globals
+
+The `exec` description in this session lists `exit`, `text`, `image`, `audio`, `generatedImage`,
+`store`/`load`, `notify`, `setTimeout`/`clearTimeout`, `ALL_TOOLS`, `yield_control`, plus `tools.*`.
+The list varies by client version, which is why the pre-call sentence names a few examples and
+defers to the description rather than enumerating.
+

--- a/devlog/_plan/260907_code_mode_host_contract/010_pre_call_contract.md
+++ b/devlog/_plan/260907_code_mode_host_contract/010_pre_call_contract.md
@@ -1,0 +1,139 @@
+# 010 — wp1: pre-call host contract sentence and its three injection sites
+
+Depends on 000_plan.md. Class C2 (conventional slice across an existing shared module and its
+three known consumers; no new abstraction, no new seam). Loop archetype satisfy-spec.
+
+## MODIFY `src/adapters/exec-tool-result-normalize.ts`
+
+Append after `CODE_MODE_RESULT_ECHO_SENTENCE` (line ~117):
+
+```ts
+/**
+ * The host rules a routed model most often breaks on its first code-mode edit or wait, stated
+ * BEFORE the call. Wording tracks the Codex host (0.153.2): `apply_patch` rejects a non-string
+ * argument with "expects a string input" and a body whose first line is not the marker with
+ * "The first line of the patch must be '*** Begin Patch'"; the isolate rejects ES imports with
+ * "Unsupported import in exec"; a long command yields a session_id for write_stdin polling.
+ * Live 2026-09-07: xai/grok-4.6 hit the first two, abandoned apply_patch for heredoc writes,
+ * blocked a turn in a shell sleep loop, and died once on an import. None of that is a model
+ * defect the proxy can repair (see devlog/_plan/260905_apply_patch_envelope_gap/010 MODE B);
+ * it is a contract the proxy had not stated.
+ */
+export const CODE_MODE_HOST_CONTRACT_SENTENCE =
+  "Host contract for the nested helpers: `tools.apply_patch(patch)` takes exactly one string, never an object such as `{input: ...}`; the string's first line must be exactly `*** Begin Patch` and its last line `*** End Patch` with no leading newline, indentation, or extra asterisks, so start the literal at the marker. The isolate has no `import`, `require`, or module loader — use only the `tools`, `text`, `notify`, `store`/`load`, and `ALL_TOOLS` globals. For a command that may outlive `yield_time_ms`, let `tools.exec_command` return a `session_id` and poll it with `tools.write_stdin({session_id, chars: \"\"})` on later calls instead of blocking a shell in a sleep loop.";
+```
+
+## MODIFY `src/adapters/tool-catalog-nudge.ts`
+
+Line 7 import: `import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE } from "./exec-tool-result-normalize";`
+
+Line 124 code-mode branch. BEFORE (tail of the string):
+
+```
+... + CODE_MODE_RESULT_ECHO_SENTENCE + " Nested `tools.apply_patch(input)` is host-executed: ... rejected by Codex before the file is touched."
+```
+
+AFTER:
+
+```
+... + CODE_MODE_RESULT_ECHO_SENTENCE + " Nested `tools.apply_patch(input)` is host-executed: ... rejected by Codex before the file is touched. " + CODE_MODE_HOST_CONTRACT_SENTENCE
+```
+
+The flat-catalog branch (`If a listed tool exposes nested helpers…`) is unchanged: a shell bridge
+echoes stdout and has no isolate, so the sentence would be false there.
+
+## MODIFY `src/adapters/cursor/tool-guidance.ts`
+
+Line 2 import: add `CODE_MODE_HOST_CONTRACT_SENTENCE`.
+
+Line 190 (`codeMode ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no \`require\`, …"`). BEFORE:
+
+```ts
+codeMode
+  ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers."
+  : undefined,
+```
+
+AFTER:
+
+```ts
+codeMode
+  ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers. " + CODE_MODE_HOST_CONTRACT_SENTENCE
+  : undefined,
+```
+
+## MODIFY `src/adapters/responses-code-mode.ts`
+
+Line 3 import: add `CODE_MODE_HOST_CONTRACT_SENTENCE`.
+
+Instructions (line ~46). BEFORE:
+
+```ts
+instructions: instructions.includes(CODE_MODE_RESULT_ECHO_SENTENCE)
+  ? instructions : [instructions, CODE_MODE_RESULT_ECHO_SENTENCE].filter(Boolean).join("\n\n"),
+```
+
+AFTER (idempotent per sentence, so a replayed body that already carries the echo sentence but
+not the contract gains only the missing one):
+
+```ts
+instructions: appendMissing(instructions, [CODE_MODE_RESULT_ECHO_SENTENCE, CODE_MODE_HOST_CONTRACT_SENTENCE]),
+```
+
+with a module-local helper:
+
+```ts
+function appendMissing(instructions: string, sentences: readonly string[]): string {
+  return sentences.reduce(
+    (acc, sentence) => acc.includes(sentence) ? acc : [acc, sentence].filter(Boolean).join("\n\n"),
+    instructions,
+  );
+}
+```
+
+The exec `input` parameter description (line 27) keeps only the echo sentence: it is a schema
+string, and Kiro-style description limiters bound injected instructions, not parameter text, but
+the contract is long and belongs in `instructions` where the existing test already asserts.
+
+Activation scenario: any routed native Responses request whose visible catalog has a bare freeform
+`exec` and no bare shell bridge, to a non-OpenAI destination, not a compaction request — the
+exact gate at `responses-code-mode.ts:35-37`. Observable effect: `wire.instructions` ends with the
+contract sentence.
+
+## TESTS (updated in place; no new file in wp1)
+
+`tests/adapters/tool-catalog-nudge.test.ts`
+- In `"defines nested helper names as non-callable unless separately listed"` add:
+  `expect(note).toContain(CODE_MODE_HOST_CONTRACT_SENTENCE);` and
+  `expect(note).toContain("write_stdin({session_id, chars: \"\"})");`.
+- In `"keeps the generic nested-helper parent-tool rule when exec is not listed"` add
+  `expect(note).not.toContain("Host contract for the nested helpers");`.
+- Import the new constant on line 7.
+
+`tests/providers/cursor/cursor-tool-definitions.test.ts`
+- In `"teaches the nested-helper contract instead of a top-level shell bridge"` (line ~754) add
+  `expect(note).toContain("takes exactly one string");` and
+  `expect(note).toContain("write_stdin");`.
+- In `"keeps flat-catalog shell-bridge guidance when a bare bridge is advertised"` add
+  `expect(note).not.toContain("Host contract for the nested helpers");`.
+
+`tests/responses/openai-responses-passthrough.test.ts`
+- `"first native request carries the echo rule…"` line 54 BEFORE:
+  `expect(wire.instructions).toBe(\`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}\`);`
+  AFTER:
+  `expect(wire.instructions).toBe(\`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}\n\n${CODE_MODE_HOST_CONTRACT_SENTENCE}\`);`
+- `"does not duplicate instructions…"` already asserts idempotence; add a case where the body's
+  instructions already contain the echo sentence and assert exactly one contract sentence is appended.
+- `"official OpenAI and non-code-mode catalogs remain untouched"`: add
+  `expect(JSON.stringify(wire)).not.toContain("Host contract for the nested helpers")` inside the native loop.
+
+`tests/providers/kiro/kiro-adapter.test.ts`
+- In `"names ALL_TOOLS when a freeform exec is advertised…"` (line ~1817) add
+  `expect(content).toContain("Host contract for the nested helpers");` — proves the sentence
+  survives Kiro's `boundedInjectedInstruction` (16 384 chars) on the real wire prompt.
+
+## Verification (C, hosted only)
+
+NOT RUN locally by instruction. Hosted CI shards run the four files above; `gates` runs typecheck
+and privacy scan. Evidence: `gh run list --branch codex/code-mode-host-contract` + `gh run view <id> --exit-status`.
+

--- a/devlog/_plan/260907_code_mode_host_contract/010_pre_call_contract.md
+++ b/devlog/_plan/260907_code_mode_host_contract/010_pre_call_contract.md
@@ -1,88 +1,90 @@
 # 010 — wp1: pre-call host contract sentence and its three injection sites
 
-Depends on 000_plan.md. Class C2 (conventional slice across an existing shared module and its
-three known consumers; no new abstraction, no new seam). Loop archetype satisfy-spec.
+Depends on 000_plan.md (rev 2). Class C2. Anchors verified against ec799db26. Ends with an
+authorized push and a draft PR so exact-head CI exists for this and later heads.
 
 ## MODIFY `src/adapters/exec-tool-result-normalize.ts`
 
-Append after `CODE_MODE_RESULT_ECHO_SENTENCE` (line ~117):
+Insert after the `CODE_MODE_RESULT_ECHO_SENTENCE` declaration (its closing `;` is at line 117):
 
 ```ts
+
 /**
- * The host rules a routed model most often breaks on its first code-mode edit or wait, stated
- * BEFORE the call. Wording tracks the Codex host (0.153.2): `apply_patch` rejects a non-string
- * argument with "expects a string input" and a body whose first line is not the marker with
- * "The first line of the patch must be '*** Begin Patch'"; the isolate rejects ES imports with
- * "Unsupported import in exec"; a long command yields a session_id for write_stdin polling.
- * Live 2026-09-07: xai/grok-4.6 hit the first two, abandoned apply_patch for heredoc writes,
- * blocked a turn in a shell sleep loop, and died once on an import. None of that is a model
- * defect the proxy can repair (see devlog/_plan/260905_apply_patch_envelope_gap/010 MODE B);
- * it is a contract the proxy had not stated.
+ * Host rules a routed model most often breaks on its first code-mode edit or wait, stated BEFORE
+ * the call. Wording tracks the Codex host (0.153.2), probed live on 2026-09-07: a non-string
+ * argument to `apply_patch` throws "expects a string input"; a body whose first line is not the
+ * bare marker (decorated `*** Begin Patch ***`, a code fence, prose) throws "The first line of the
+ * patch must be '*** Begin Patch'" — surrounding newlines are tolerated; ES imports throw
+ * "Unsupported import in exec"; a command that outlives `yield_time_ms` returns `session_id` for
+ * `write_stdin` polling. xai/grok-4.6 hit the first two, abandoned apply_patch for heredoc writes,
+ * blocked a turn in a shell sleep loop, and died once on an import. None of that is repairable in
+ * the proxy (devlog/_plan/260905_apply_patch_envelope_gap/010 MODE B); it is a contract the proxy
+ * had not stated.
  */
 export const CODE_MODE_HOST_CONTRACT_SENTENCE =
-  "Host contract for the nested helpers: `tools.apply_patch(patch)` takes exactly one string, never an object such as `{input: ...}`; the string's first line must be exactly `*** Begin Patch` and its last line `*** End Patch` with no leading newline, indentation, or extra asterisks, so start the literal at the marker. The isolate has no `import`, `require`, or module loader — use only the `tools`, `text`, `notify`, `store`/`load`, and `ALL_TOOLS` globals. For a command that may outlive `yield_time_ms`, let `tools.exec_command` return a `session_id` and poll it with `tools.write_stdin({session_id, chars: \"\"})` on later calls instead of blocking a shell in a sleep loop.";
+  "Host contract for the nested helpers: `tools.apply_patch(patch)` takes exactly one string, never an object such as `{input: ...}`; that string's first line must be the bare marker `*** Begin Patch` and its last line `*** End Patch`, with no code fence, prose, or extra asterisks around either marker. The isolate has no `import`, `require`, or module loader; use the globals the exec tool description lists (for example `tools`, `text`, `notify`, `store`/`load`, `ALL_TOOLS`). For a command that may outlive `yield_time_ms`, let `tools.exec_command` return a `session_id` and poll it on later calls with `tools.write_stdin({session_id, chars: \"\"})` instead of blocking a shell in a sleep loop.";
 ```
 
 ## MODIFY `src/adapters/tool-catalog-nudge.ts`
 
-Line 7 import: `import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE } from "./exec-tool-result-normalize";`
-
-Line 124 code-mode branch. BEFORE (tail of the string):
-
+Line 8 BEFORE:
+```ts
+import { CODE_MODE_RESULT_ECHO_SENTENCE } from "./exec-tool-result-normalize";
 ```
-... + CODE_MODE_RESULT_ECHO_SENTENCE + " Nested `tools.apply_patch(input)` is host-executed: ... rejected by Codex before the file is touched."
-```
-
 AFTER:
-
+```ts
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE } from "./exec-tool-result-normalize";
 ```
-... + CODE_MODE_RESULT_ECHO_SENTENCE + " Nested `tools.apply_patch(input)` is host-executed: ... rejected by Codex before the file is touched. " + CODE_MODE_HOST_CONTRACT_SENTENCE
-```
 
-The flat-catalog branch (`If a listed tool exposes nested helpers…`) is unchanged: a shell bridge
-echoes stdout and has no isolate, so the sentence would be false there.
+Line 124 is one 1035-byte string ending in `rejected by Codex before the file is touched."`.
+BEFORE (tail):
+```ts
+OpenCodex does not rewrite JavaScript inside exec, so extra asterisks on a marker line are rejected by Codex before the file is touched."
+```
+AFTER (tail):
+```ts
+OpenCodex does not rewrite JavaScript inside exec, so extra asterisks on a marker line are rejected by Codex before the file is touched. " + CODE_MODE_HOST_CONTRACT_SENTENCE
+```
+The flat-catalog branch (`"If a listed tool exposes nested helpers such as a tools.* API…"`) is unchanged.
 
 ## MODIFY `src/adapters/cursor/tool-guidance.ts`
 
-Line 2 import: add `CODE_MODE_HOST_CONTRACT_SENTENCE`.
-
-Line 190 (`codeMode ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no \`require\`, …"`). BEFORE:
-
+Line 2 BEFORE:
 ```ts
-codeMode
-  ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers."
-  : undefined,
+import { CODE_MODE_RESULT_ECHO_SENTENCE } from "../exec-tool-result-normalize";
+```
+AFTER:
+```ts
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE } from "../exec-tool-result-normalize";
 ```
 
-AFTER:
-
+Lines 189-191 BEFORE (4-space indent as in source):
 ```ts
-codeMode
-  ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers. " + CODE_MODE_HOST_CONTRACT_SENTENCE
-  : undefined,
+    codeMode
+      ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers."
+      : undefined,
+```
+AFTER:
+```ts
+    codeMode
+      ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers. " + CODE_MODE_HOST_CONTRACT_SENTENCE
+      : undefined,
 ```
 
 ## MODIFY `src/adapters/responses-code-mode.ts`
 
-Line 3 import: add `CODE_MODE_HOST_CONTRACT_SENTENCE`.
-
-Instructions (line ~46). BEFORE:
-
+Line 3 BEFORE:
 ```ts
-instructions: instructions.includes(CODE_MODE_RESULT_ECHO_SENTENCE)
-  ? instructions : [instructions, CODE_MODE_RESULT_ECHO_SENTENCE].filter(Boolean).join("\n\n"),
+import { CODE_MODE_RESULT_ECHO_SENTENCE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
+```
+AFTER:
+```ts
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 ```
 
-AFTER (idempotent per sentence, so a replayed body that already carries the echo sentence but
-not the contract gains only the missing one):
-
+Insert before `/** Native routed Responses needs the same first-call/output contract… */` (line 33):
 ```ts
-instructions: appendMissing(instructions, [CODE_MODE_RESULT_ECHO_SENTENCE, CODE_MODE_HOST_CONTRACT_SENTENCE]),
-```
-
-with a module-local helper:
-
-```ts
+/** Append each sentence a replayed instructions string does not already carry, in order. */
 function appendMissing(instructions: string, sentences: readonly string[]): string {
   return sentences.reduce(
     (acc, sentence) => acc.includes(sentence) ? acc : [acc, sentence].filter(Boolean).join("\n\n"),
@@ -91,49 +93,95 @@ function appendMissing(instructions: string, sentences: readonly string[]): stri
 }
 ```
 
-The exec `input` parameter description (line 27) keeps only the echo sentence: it is a schema
-string, and Kiro-style description limiters bound injected instructions, not parameter text, but
-the contract is long and belongs in `instructions` where the existing test already asserts.
+Lines 46-47 BEFORE (4-space indent):
+```ts
+    instructions: instructions.includes(CODE_MODE_RESULT_ECHO_SENTENCE)
+      ? instructions : [instructions, CODE_MODE_RESULT_ECHO_SENTENCE].filter(Boolean).join("\n\n"),
+```
+AFTER:
+```ts
+    instructions: appendMissing(instructions, [CODE_MODE_RESULT_ECHO_SENTENCE, CODE_MODE_HOST_CONTRACT_SENTENCE]),
+```
 
-Activation scenario: any routed native Responses request whose visible catalog has a bare freeform
-`exec` and no bare shell bridge, to a non-OpenAI destination, not a compaction request — the
-exact gate at `responses-code-mode.ts:35-37`. Observable effect: `wire.instructions` ends with the
-contract sentence.
+The exec `input` parameter description (line 27) keeps only the echo sentence; the contract belongs in
+`instructions`, which the existing test asserts byte-exactly.
 
-## TESTS (updated in place; no new file in wp1)
+Activation: routed native Responses request whose visible catalog has a bare freeform `exec` and no
+bare shell bridge, non-OpenAI destination, not a compaction request (gate at lines 35-37).
+Observable: `wire.instructions` ends with the contract sentence.
+
+## TESTS (in place; no new file in wp1)
 
 `tests/adapters/tool-catalog-nudge.test.ts`
-- In `"defines nested helper names as non-callable unless separately listed"` add:
-  `expect(note).toContain(CODE_MODE_HOST_CONTRACT_SENTENCE);` and
-  `expect(note).toContain("write_stdin({session_id, chars: \"\"})");`.
-- In `"keeps the generic nested-helper parent-tool rule when exec is not listed"` add
-  `expect(note).not.toContain("Host contract for the nested helpers");`.
-- Import the new constant on line 7.
+- Line 7 import becomes `import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, EMPTY_EXEC_OUTPUT_MESSAGE } from "../../src/adapters/exec-tool-result-normalize";`
+- In `"defines nested helper names as non-callable unless separately listed"` append:
+```ts
+    // The host contract rides the same code-mode branch as the echo rule (Grok 2026-09-07).
+    expect(note).toContain(CODE_MODE_HOST_CONTRACT_SENTENCE);
+    expect(note).toContain("takes exactly one string");
+    expect(note).toContain("write_stdin({session_id, chars: \"\"})");
+```
+- In `"keeps the generic nested-helper parent-tool rule when exec is not listed"` append:
+```ts
+    expect(note).not.toContain("Host contract for the nested helpers");
+```
 
 `tests/providers/cursor/cursor-tool-definitions.test.ts`
-- In `"teaches the nested-helper contract instead of a top-level shell bridge"` (line ~754) add
-  `expect(note).toContain("takes exactly one string");` and
-  `expect(note).toContain("write_stdin");`.
-- In `"keeps flat-catalog shell-bridge guidance when a bare bridge is advertised"` add
-  `expect(note).not.toContain("Host contract for the nested helpers");`.
+- In `"teaches the nested-helper contract instead of a top-level shell bridge"` (starts line 754) append
+  after the `"OpenCodex does not rewrite JavaScript inside exec"` assertion:
+```ts
+    expect(note).toContain("Host contract for the nested helpers");
+    expect(note).toContain("takes exactly one string");
+    expect(note).toContain("write_stdin");
+```
+- In `"keeps flat-catalog shell-bridge guidance when a bare bridge is advertised"` append:
+```ts
+    expect(note).not.toContain("Host contract for the nested helpers");
+```
 
 `tests/responses/openai-responses-passthrough.test.ts`
-- `"first native request carries the echo rule…"` line 54 BEFORE:
-  `expect(wire.instructions).toBe(\`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}\`);`
+- Line 6 import adds `CODE_MODE_HOST_CONTRACT_SENTENCE`.
+- Line 54 BEFORE:
+```ts
+    expect(wire.instructions).toBe(`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}`);
+```
   AFTER:
-  `expect(wire.instructions).toBe(\`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}\n\n${CODE_MODE_HOST_CONTRACT_SENTENCE}\`);`
-- `"does not duplicate instructions…"` already asserts idempotence; add a case where the body's
-  instructions already contain the echo sentence and assert exactly one contract sentence is appended.
-- `"official OpenAI and non-code-mode catalogs remain untouched"`: add
-  `expect(JSON.stringify(wire)).not.toContain("Host contract for the nested helpers")` inside the native loop.
+```ts
+    expect(wire.instructions).toBe(`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}\n\n${CODE_MODE_HOST_CONTRACT_SENTENCE}`);
+```
+- New test after `"does not duplicate instructions or explain an unpaired or unrelated result"`:
+```ts
+  test("a replayed body that already carries the echo rule gains only the missing contract sentence", () => {
+    const body = { ...raw(), instructions: `Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}` };
+    const parsed = parseRequest(body);
+    const first = normalizeResponsesCodeMode(body, parsed, routed) as typeof body;
+    expect(first.instructions).toBe(`${body.instructions}\n\n${CODE_MODE_HOST_CONTRACT_SENTENCE}`);
+    expect(first.instructions.split(CODE_MODE_RESULT_ECHO_SENTENCE).length).toBe(2);
+    const second = normalizeResponsesCodeMode(first, parsed, routed) as typeof body;
+    expect(second.instructions).toBe(first.instructions);
+  });
+```
+- In `"official OpenAI and non-code-mode catalogs remain untouched"`, inside the `for (const native…)` loop
+  append `expect(JSON.stringify(wire)).not.toContain("Host contract for the nested helpers");`.
 
 `tests/providers/kiro/kiro-adapter.test.ts`
-- In `"names ALL_TOOLS when a freeform exec is advertised…"` (line ~1817) add
-  `expect(content).toContain("Host contract for the nested helpers");` — proves the sentence
-  survives Kiro's `boundedInjectedInstruction` (16 384 chars) on the real wire prompt.
+- In `"names ALL_TOOLS when a freeform exec is advertised without a bare shell bridge"` (line 1817) append:
+```ts
+    // Survives Kiro's 16 384-char injected-instruction bound on the real wire prompt.
+    expect(content).toContain("Host contract for the nested helpers");
+```
+
+## Delivery for this phase
+
+`git add` only the files above; `git diff --cached --stat` first; commit `--no-verify`; then
+`git push --no-verify -u origin codex/code-mode-host-contract` and
+`gh pr create --draft --base dev --title "fix(code-mode): state the host contract for nested helpers and annotate host failures" --body-file .tmp/pr-body.md`
+(body per template; Verification section says local checks NOT RUN, hosted CI is the verifier;
+wp2/wp3 will extend it).
 
 ## Verification (C, hosted only)
 
-NOT RUN locally by instruction. Hosted CI shards run the four files above; `gates` runs typecheck
-and privacy scan. Evidence: `gh run list --branch codex/code-mode-host-contract` + `gh run view <id> --exit-status`.
+NOT RUN locally by instruction. Poll `gh run list --branch codex/code-mode-host-contract --json databaseId,headSha,status,conclusion,name`
+in short `exec_command` calls; when the Cross-platform CI run for `git rev-parse HEAD` completes,
+`cxc receipt test --session <id> --cwd <worktree> -- gh run view <id> --exit-status`.
 

--- a/devlog/_plan/260907_code_mode_host_contract/010_pre_call_contract.md
+++ b/devlog/_plan/260907_code_mode_host_contract/010_pre_call_contract.md
@@ -5,7 +5,7 @@ authorized push and a draft PR so exact-head CI exists for this and later heads.
 
 ## MODIFY `src/adapters/exec-tool-result-normalize.ts`
 
-Insert after the `CODE_MODE_RESULT_ECHO_SENTENCE` declaration (its closing `;` is at line 117):
+Insert after the `CODE_MODE_RESULT_ECHO_SENTENCE` declaration (its closing `;` is at line 116):
 
 ```ts
 
@@ -22,7 +22,7 @@ Insert after the `CODE_MODE_RESULT_ECHO_SENTENCE` declaration (its closing `;` i
  * had not stated.
  */
 export const CODE_MODE_HOST_CONTRACT_SENTENCE =
-  "Host contract for the nested helpers: `tools.apply_patch(patch)` takes exactly one string, never an object such as `{input: ...}`; that string's first line must be the bare marker `*** Begin Patch` and its last line `*** End Patch`, with no code fence, prose, or extra asterisks around either marker. The isolate has no `import`, `require`, or module loader; use the globals the exec tool description lists (for example `tools`, `text`, `notify`, `store`/`load`, `ALL_TOOLS`). For a command that may outlive `yield_time_ms`, let `tools.exec_command` return a `session_id` and poll it on later calls with `tools.write_stdin({session_id, chars: \"\"})` instead of blocking a shell in a sleep loop.";
+  "Host contract for the nested helpers: `tools.apply_patch(patch)` takes exactly one string, never an object such as `{input: ...}`; the patch text opens with the bare marker line `*** Begin Patch` and closes with the bare marker line `*** End Patch`, written without a code fence, prose, or extra asterisks on those lines (blank lines or indentation around the markers are tolerated; a decorated or missing marker is rejected). The isolate has no `import`, `require`, or module loader; use the globals the exec tool description lists (for example `tools`, `text`, `notify`, `store`/`load`, `ALL_TOOLS`). For a command that may outlive `yield_time_ms`, let `tools.exec_command` return a `session_id` and poll it on later calls with `tools.write_stdin({session_id, chars: \"\"})` instead of blocking a shell in a sleep loop.";
 ```
 
 ## MODIFY `src/adapters/tool-catalog-nudge.ts`
@@ -82,7 +82,7 @@ AFTER:
 import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 ```
 
-Insert before `/** Native routed Responses needs the same first-call/output contract… */` (line 33):
+Insert before `/** Native routed Responses needs the same first-call/output contract… */` (line 32):
 ```ts
 /** Append each sentence a replayed instructions string does not already carry, in order. */
 function appendMissing(instructions: string, sentences: readonly string[]): string {
@@ -93,7 +93,7 @@ function appendMissing(instructions: string, sentences: readonly string[]): stri
 }
 ```
 
-Lines 46-47 BEFORE (4-space indent):
+Lines 45-46 BEFORE (4-space indent):
 ```ts
     instructions: instructions.includes(CODE_MODE_RESULT_ECHO_SENTENCE)
       ? instructions : [instructions, CODE_MODE_RESULT_ECHO_SENTENCE].filter(Boolean).join("\n\n"),
@@ -184,4 +184,3 @@ wp2/wp3 will extend it).
 NOT RUN locally by instruction. Poll `gh run list --branch codex/code-mode-host-contract --json databaseId,headSha,status,conclusion,name`
 in short `exec_command` calls; when the Cross-platform CI run for `git rev-parse HEAD` completes,
 `cxc receipt test --session <id> --cwd <worktree> -- gh run view <id> --exit-status`.
-

--- a/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
+++ b/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
@@ -37,18 +37,26 @@ export const CODE_MODE_HOST_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; gu
 /** Prefix of every recovery line this module appends; callers use it to recognise replayed annotations. */
 export const CODE_MODE_HOST_RECOVERY_PREFIX = "[recovery: ";
 
+/** Namespaces under which Cursor displays Codex's own Responses tools (see cursor/tool-naming.ts). */
+const CODEX_RESPONSES_DISPLAY_NAMESPACES: ReadonlySet<string> = new Set(["opencodex-responses", "mcp__opencodex-responses"]);
+/** Flattened spellings of the same code-mode exec when a client folds the namespace into the name. */
+const CODEX_CODE_MODE_EXEC_ALIASES: ReadonlySet<string> = new Set(["exec", "mcp__opencodex-responses__exec", "mcp_opencodex-responses_exec"]);
+
 /**
- * The code-mode `exec` tool itself — bare, or under Cursor's `opencodex-responses` display namespace.
- * The four host strings above originate only in that isolate, so flat shell bridges
- * (`exec_command`, `shell`, …) and every foreign MCP namespace (`mcp__docker__exec`) are excluded: an
- * unrelated server's output that happens to contain the phrase must not receive Codex guidance.
- * Narrower than `isCodexExecBridgeTool` on purpose; the empty-output repair keeps the wider gate.
+ * The code-mode `exec` tool by NAME — bare, or under Codex's own `opencodex-responses` display
+ * namespace, matched exactly. The four host strings above originate only in that isolate, so flat
+ * shell bridges (`exec_command`, `shell`, …) and every other namespace (`mcp__docker`,
+ * `mcp__foreign-opencodex-responses`) are excluded: an unrelated server's output that quotes the
+ * phrase must not receive Codex guidance. Narrower than `isCodexExecBridgeTool` on purpose; the
+ * empty-output repair keeps the wider gate. Callers that KNOW the catalog shape (Kiro's
+ * `codeModeExecName`, the Responses body gate) add that check on top; this predicate alone cannot
+ * tell a structured tool named `exec` from the freeform one.
  */
 export function isCodexCodeModeExecResult(toolName?: string, toolNamespace?: string): boolean {
   if (!toolName) return false;
   const lower = toolName.toLowerCase();
-  if (toolNamespace) return toolNamespace.includes("opencodex-responses") && lower === "exec";
-  return lower === "exec" || lower === "mcp__opencodex-responses__exec" || lower === "mcp_opencodex-responses_exec";
+  if (toolNamespace !== undefined) return CODEX_RESPONSES_DISPLAY_NAMESPACES.has(toolNamespace) && lower === "exec";
+  return CODEX_CODE_MODE_EXEC_ALIASES.has(lower);
 }
 
 /**
@@ -122,10 +130,14 @@ AFTER:
 ```ts
       const execOptions = { toolName: tr.toolName, toolNamespace: tr.toolNamespace };
       const normalizedExecText = normalizeEmptyExecToolResultText(text, execOptions);
-      // A host failure string inside a non-empty exec result gets the rule it broke appended. This
-      // is the only substitution the grouping path below also carries: whitespace and empty/failed
+      // A host failure string inside a non-empty exec result gets the rule it broke appended, but
+      // only when this request's emitted catalog is genuinely code mode (`codeModeExecName` above):
+      // a structured tool named exec, or exec beside a shell bridge, never ran the isolate. This is
+      // the only substitution the grouping path below also carries: whitespace and empty/failed
       // wrappers keep their existing raw policy.
-      const annotatedExecText = normalizedExecText === undefined ? annotateCodeModeHostFailure(text, execOptions) : undefined;
+      const annotatedExecText = normalizedExecText === undefined && codeModeExecName !== undefined
+        ? annotateCodeModeHostFailure(text, execOptions)
+        : undefined;
       const resultText = normalizedExecText ?? annotatedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
       const images = extractKiroImages(tr.content);
       const toolUseId = normalizeToolId(tr.toolCallId);
@@ -222,10 +234,19 @@ describe("code-mode host failure annotation", () => {
     expect(annotateCodeModeHostFailure("expects a string input", { toolName: "read_file" })).toBeUndefined();
     // Flat shell bridges never run the isolate, so the four strings cannot be theirs.
     expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec_command" })).toBeUndefined();
-    // A foreign MCP server's own exec is not Codex's, even when its output quotes the phrase.
+    // A foreign MCP server's own exec is not Codex's, even when its output quotes the phrase, and a
+    // namespace that merely CONTAINS the provider name is still foreign.
     expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec", toolNamespace: "mcp__docker" })).toBeUndefined();
-    // Cursor's display namespace for the same code-mode tool still counts.
-    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec", toolNamespace: "mcp__opencodex-responses" })).toContain("[recovery:");
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec", toolNamespace: "mcp__foreign-opencodex-responses" })).toBeUndefined();
+    // Codex's own display namespaces and flattened aliases for the same code-mode tool still count.
+    for (const options of [
+      { toolName: "exec", toolNamespace: "opencodex-responses" },
+      { toolName: "exec", toolNamespace: "mcp__opencodex-responses" },
+      { toolName: "mcp__opencodex-responses__exec" },
+      { toolName: "mcp_opencodex-responses_exec" },
+    ]) {
+      expect(annotateCodeModeHostFailure("expects a string input", options)).toContain("[recovery:");
+    }
     expect(annotateCodeModeHostFailure("all good", { toolName: "exec" })).toBeUndefined();
     const once = annotateCodeModeHostFailure("expects a string input", { toolName: "exec" });
     if (!once) throw new Error("expected one annotation");
@@ -275,7 +296,8 @@ entry is required and `tests/test-layout-tooling.test.ts` names it if missing.
 - After `"an empty code-mode exec result carries the actionable reason…"` (line 323) add:
 ```ts
   test("a code-mode exec result carrying a host failure string names the broken rule", async () => {
-    const execTool = { name: "exec", description: "Run JavaScript", parameters: { type: "object" } };
+    // freeform: the Kiro seam annotates only when the emitted catalog is genuinely code mode.
+    const execTool = { name: "exec", description: "Run JavaScript", freeform: true, parameters: { type: "object" } };
     const failure = "apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'";
     const messages = [
       { role: "user", content: "run it" },
@@ -286,6 +308,29 @@ entry is required and `tests/test-layout-tooling.test.ts` names it if missing.
     const resultText = JSON.parse(body).conversationState.currentMessage.userInputMessage
       .userInputMessageContext.toolResults[0].content[0].text;
     expect(resultText).toBe(`${failure}\n[recovery: The patch text must open with the bare marker line \`*** Begin Patch\`: no code fence, prose, or extra asterisks on that line (blank lines or indentation before it are tolerated).]`);
+  });
+
+  test("a host failure string on a non-code-mode catalog stays raw", async () => {
+    const failure = "tool `apply_patch` expects a string input";
+    const messages = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-x", name: "exec", arguments: {} }] },
+      { role: "toolResult", toolCallId: "call-x", toolName: "exec", content: failure, isError: false },
+    ];
+    for (const tools of [
+      // A structured tool that merely shares the name exec.
+      [{ name: "exec", description: "Run a shell string", parameters: { type: "object" } }],
+      // Freeform exec beside a bare shell bridge is the flat-catalog shape, not code mode.
+      [
+        { name: "exec", description: "Run JavaScript", freeform: true, parameters: { type: "object" } },
+        { name: "exec_command", description: "Run", parameters: { type: "object" } },
+      ],
+    ]) {
+      const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, tools));
+      const resultText = JSON.parse(body).conversationState.currentMessage.userInputMessage
+        .userInputMessageContext.toolResults[0].content[0].text;
+      expect(resultText).toBe(failure);
+    }
   });
 ```
 - In the grouped-result table (the `execResult` cases around lines 1195-1262) add one case:

--- a/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
+++ b/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
@@ -1,19 +1,19 @@
 # 020 — wp2: post-hoc annotation of host failures on exec results
 
-Depends on 010 (the pre-call sentence names the same rules this half explains after the fact; the
-two must share wording, which is why both live in one module). Class C2.
+Depends on 010 (same module, same wording). Class C2. Anchors verified against ec799db26 plus
+the wp1 delta. Ends with an authorized push; the draft PR from wp1 picks up the new head.
 
 ## MODIFY `src/adapters/exec-tool-result-normalize.ts`
 
-Append after `CODE_MODE_HOST_CONTRACT_SENTENCE`:
+Insert after `CODE_MODE_HOST_CONTRACT_SENTENCE` (added in wp1):
 
 ```ts
+
 /**
  * Post-hoc half of the host contract: the four host strings a routed model reads inside a
- * non-error exec result, each paired with the rule it broke. Markers are compared
- * case-insensitively because the host writes "Unsupported import in exec: <spec>" while
- * earlier Cursor guidance matched the lowercase form; one table, one owner, so the
- * recovery text can never drift from the pre-call sentence above.
+ * non-error exec result, each paired with the rule it broke. Matched case-insensitively because
+ * the host writes "Unsupported import in exec: <spec>" while Cursor's earlier marker was
+ * lowercase; one table, one owner, so this text and the pre-call sentence cannot drift.
  */
 export const CODE_MODE_HOST_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; guidance: string }> = [
   {
@@ -22,11 +22,11 @@ export const CODE_MODE_HOST_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; gu
   },
   {
     marker: "the first line of the patch must be",
-    guidance: "The patch string must begin at `*** Begin Patch` with no leading newline, indentation, or extra asterisks; start the literal on the marker line.",
+    guidance: "The patch string's first line must be the bare marker `*** Begin Patch` with no code fence, prose, or extra asterisks around it.",
   },
   {
     marker: "the last line of the patch must be",
-    guidance: "The patch string must end with `*** End Patch` as its final line, with no trailing text or extra asterisks.",
+    guidance: "The patch string's last line must be the bare marker `*** End Patch` with no trailing text or extra asterisks.",
   },
   {
     marker: "unsupported import in exec",
@@ -38,8 +38,9 @@ const HOST_FAILURE_RECOVERY_PREFIX = "[recovery: ";
 
 /**
  * Append a one-line recovery hint when an exec-bridge result carries a known host failure string.
- * Returns undefined when the result is not an exec-bridge tool, no marker matches, or a recovery
- * line is already present, so callers keep their own fallback and never double-annotate.
+ * Returns undefined when the tool is not an exec bridge, no marker matches, or a recovery line is
+ * already present (a replayed annotated result must not grow a second one). Never touches error
+ * status: the host already decided whether the call failed.
  */
 export function annotateCodeModeHostFailure(
   text: string,
@@ -53,86 +54,114 @@ export function annotateCodeModeHostFailure(
 }
 ```
 
-The Cursor guidance string for the import row is kept byte-identical to today's
-(`"Imports are not available in this exec context; use the injected globals instead."` extended with
-the global list) so `cursor-toolresult-normalize.test.ts:101` (`"injected globals"`) still matches.
-
 ## MODIFY `src/adapters/responses-code-mode.ts`
 
-Line 55 BEFORE:
+Line 3 import gains `annotateCodeModeHostFailure`.
 
+Line 55 BEFORE (6-space indent):
 ```ts
-const normalized = text === undefined ? undefined : normalizeEmptyExecToolResultText(text, { toolName: "exec" });
+      const normalized = text === undefined ? undefined : normalizeEmptyExecToolResultText(text, { toolName: "exec" });
 ```
-
 AFTER:
-
 ```ts
-const normalized = text === undefined
-  ? undefined
-  : normalizeEmptyExecToolResultText(text, { toolName: "exec" })
-    ?? annotateCodeModeHostFailure(text, { toolName: "exec" });
+      const normalized = text === undefined
+        ? undefined
+        : normalizeEmptyExecToolResultText(text, { toolName: "exec" })
+          ?? annotateCodeModeHostFailure(text, { toolName: "exec" });
 ```
-
-Import `annotateCodeModeHostFailure` on line 3. Empty-wrapper first: an empty result can never
-carry a marker, so the order is only for clarity. Activation: paired `custom_tool_call_output`
-whose text contains e.g. `\`apply_patch\` expects a string input`; observable effect: output ends
-with `[recovery: tools.apply_patch takes exactly one string argument…]`, and `input[0]` (the
-program) is the same object reference as before.
+Activation: paired `custom_tool_call_output` whose text contains `\`apply_patch\` expects a string input`;
+observable: output ends with the recovery line, `input[0]` is the same object reference.
 
 ## MODIFY `src/adapters/kiro.ts`
 
-Line 47 import: add `annotateCodeModeHostFailure`.
-
-Lines 758-762 BEFORE:
-
+Line 47 BEFORE:
 ```ts
-const normalizedExecText = normalizeEmptyExecToolResultText(text, {
-  toolName: tr.toolName,
-  toolNamespace: tr.toolNamespace,
-});
-const resultText = normalizedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+import { EMPTY_EXEC_OUTPUT_MESSAGE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 ```
-
 AFTER:
-
 ```ts
-const execOptions = { toolName: tr.toolName, toolNamespace: tr.toolNamespace };
-const normalizedExecText = normalizeEmptyExecToolResultText(text, execOptions)
-  ?? annotateCodeModeHostFailure(text, execOptions);
-const resultText = normalizedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+import { EMPTY_EXEC_OUTPUT_MESSAGE, annotateCodeModeHostFailure, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 ```
 
-`rawGroupText` (line 774) already keeps `text` whenever `normalizedExecText !== EMPTY_EXEC_OUTPUT_MESSAGE`,
-so the adjacent-result grouping path carries the RAW failure text; the annotated text is what the
-single-result path emits. Line 774 is changed so a grouped result carries the annotated text too:
-
-BEFORE: `? text : undefined;`  AFTER: `? (normalizedExecText ?? text) : undefined;`
-
-(For the empty-wrapper case `normalizedExecText === EMPTY_EXEC_OUTPUT_MESSAGE` short-circuits the
-outer condition first, so that branch is unchanged.)
+Lines 758-771 BEFORE (6-space indent):
+```ts
+      const normalizedExecText = normalizeEmptyExecToolResultText(text, {
+        toolName: tr.toolName,
+        toolNamespace: tr.toolNamespace,
+      });
+      const resultText = normalizedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+      const images = extractKiroImages(tr.content);
+      const toolUseId = normalizeToolId(tr.toolCallId);
+      const call = priorCalls.get(toolUseId);
+      if (!call || call.rawId !== tr.toolCallId) {
+        throw new Error(`Kiro history contains an orphaned tool result for call ${JSON.stringify(tr.toolCallId)}`);
+      }
+      // Keep real whitespace and failed wrappers, but no empty-success wrapper boilerplate.
+      const rawGroupText = text.length > 0 && (!text.trim() || normalizedExecText !== EMPTY_EXEC_OUTPUT_MESSAGE)
+        ? text : undefined;
+```
+AFTER:
+```ts
+      const execOptions = { toolName: tr.toolName, toolNamespace: tr.toolNamespace };
+      const normalizedExecText = normalizeEmptyExecToolResultText(text, execOptions);
+      // A host failure string inside a non-empty exec result gets the rule it broke appended. This
+      // is the only substitution the grouping path below also carries: whitespace and empty/failed
+      // wrappers keep their existing raw policy.
+      const annotatedExecText = normalizedExecText === undefined ? annotateCodeModeHostFailure(text, execOptions) : undefined;
+      const resultText = normalizedExecText ?? annotatedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+      const images = extractKiroImages(tr.content);
+      const toolUseId = normalizeToolId(tr.toolCallId);
+      const call = priorCalls.get(toolUseId);
+      if (!call || call.rawId !== tr.toolCallId) {
+        throw new Error(`Kiro history contains an orphaned tool result for call ${JSON.stringify(tr.toolCallId)}`);
+      }
+      // Keep real whitespace and failed wrappers, but no empty-success wrapper boilerplate.
+      const rawGroupText = text.length > 0 && (!text.trim() || normalizedExecText !== EMPTY_EXEC_OUTPUT_MESSAGE)
+        ? (annotatedExecText ?? text) : undefined;
+```
+`annotatedExecText` is defined only when `normalizedExecText` is undefined, i.e. the text is neither an
+empty-success nor a failed-empty wrapper, so every existing grouping expectation
+(`kiro-adapter.test.ts:1209` whitespace, `1252` raw failed wrapper) is unchanged by construction.
 
 ## MODIFY `src/adapters/cursor/tool-result-normalize.ts`
 
-Import `CODE_MODE_HOST_FAILURE_GUIDANCE` from `../exec-tool-result-normalize`.
+Imports (lines 12-18) gain `annotateCodeModeHostFailure`. `RUNTIME_FAILURE_GUIDANCE` (lines 50-67) and its
+loop (lines 107-113) stay byte-identical: Cursor's marker semantics, case sensitivity and
+`isError:true` policy are its own.
 
-`RUNTIME_FAILURE_GUIDANCE` (lines 50-67): DELETE the `unsupported import in exec` entry and spread
-the shared table instead:
-
+Lines 96-105 BEFORE (2-space indent):
 ```ts
-const RUNTIME_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; guidance: string }> = [
-  { marker: "SkyComputerUseError", guidance: "…" },
-  { marker: "sky is not defined", guidance: "…" },
-  { marker: "has already been declared", guidance: "…" },
-  ...CODE_MODE_HOST_FAILURE_GUIDANCE,
-];
+  if (isCodexExecBridgeTool(options.toolName, options.toolNamespace) && isEmptyOrFailedExecWrapper(text.trim())) {
+    return {
+      // A `Script failed` wrapper is empty but NOT a success: reporting it as an empty success
+      // would erase the only failure signal. Text classification stays separate from Cursor's
+      // isError policy, which the Computer Use branch above owns.
+      text: isFailedEmptyExecWrapper(text.trim()) ? FAILED_EXEC_OUTPUT_MESSAGE : EMPTY_EXEC_OUTPUT_MESSAGE,
+      isError: false,
+      changed: true,
+    };
+  }
 ```
-
-Loop at line 109 BEFORE: `if (text.includes(marker))` AFTER: compare against `text.toLowerCase()`
-for the shared rows only — simplest correct form is to lowercase both sides for every row, since the
-three Cursor markers contain no case-sensitive collisions (`SkyComputerUseError` lowercased still
-matches only itself). Cursor policy (`isError: true` on a match) is unchanged; the shared helper is
-not used here because Cursor owns its `isError` decision.
+AFTER (append one branch directly after that block):
+```ts
+  if (isCodexExecBridgeTool(options.toolName, options.toolNamespace) && isEmptyOrFailedExecWrapper(text.trim())) {
+    return {
+      // A `Script failed` wrapper is empty but NOT a success: reporting it as an empty success
+      // would erase the only failure signal. Text classification stays separate from Cursor's
+      // isError policy, which the Computer Use branch above owns.
+      text: isFailedEmptyExecWrapper(text.trim()) ? FAILED_EXEC_OUTPUT_MESSAGE : EMPTY_EXEC_OUTPUT_MESSAGE,
+      isError: false,
+      changed: true,
+    };
+  }
+  // A host failure string inside an exec-bridge result gets the rule it broke appended. The
+  // helper is exec-gated and refuses already-annotated text, so a replayed result does not grow
+  // a second line; Cursor's isError decision is left exactly as the caller passed it.
+  const hostFailure = annotateCodeModeHostFailure(text, options);
+  if (hostFailure !== undefined) return { text: hostFailure, isError, changed: true };
+```
+The existing `unsupported import in exec` row in `RUNTIME_FAILURE_GUIDANCE` still serves node_repl /
+Computer Use tools; for exec-bridge tools the new branch runs first and carries the shared hint.
 
 ## NEW `tests/adapters/exec-tool-result-normalize.test.ts`
 
@@ -144,65 +173,128 @@ import {
   annotateCodeModeHostFailure,
 } from "../../src/adapters/exec-tool-result-normalize";
 
+// Live host strings (Codex 0.153.2, probed 2026-09-07) and the rule each one names. The pre-call
+// sentence and these rows are one contract in one module; a model must never be told one thing
+// before the call and another after.
 describe("code-mode host failure annotation", () => {
-  test.each(CODE_MODE_HOST_FAILURE_GUIDANCE.map(row => [row.marker, row.guidance]))(
-    "annotates an exec result carrying %p", (marker, guidance) => {
-      const text = `Script failed\nOutput:\nError: ${marker.toUpperCase()}`;
-      const out = annotateCodeModeHostFailure(text, { toolName: "exec" });
-      expect(out).toBe(`${text}\n[recovery: ${guidance}]`);
-    });
+  test.each(CODE_MODE_HOST_FAILURE_GUIDANCE.map(row => [row.marker, row.guidance] as const))(
+    "annotates an exec result carrying %p regardless of case",
+    (marker, guidance) => {
+      const text = `Script failed\nWall time 0.1 seconds\nOutput:\nError: ${marker.toUpperCase()}`;
+      expect(annotateCodeModeHostFailure(text, { toolName: "exec" })).toBe(`${text}\n[recovery: ${guidance}]`);
+    },
+  );
 
-  test("matches the host's real capitalisation for imports", () => {
-    const out = annotateCodeModeHostFailure("Unsupported import in exec: node:fs", { toolName: "exec" });
-    expect(out).toContain("injected globals");
+  test("matches the host's real capitalisation and argument text", () => {
+    expect(annotateCodeModeHostFailure("Unsupported import in exec: node:fs", { toolName: "exec" })).toContain("injected globals");
+    expect(annotateCodeModeHostFailure("Script error:\ntool `apply_patch` expects a string input", { toolName: "exec" })).toContain("exactly one string");
+    expect(annotateCodeModeHostFailure(
+      "apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'",
+      { toolName: "exec_command" },
+    )).toContain("bare marker `*** Begin Patch`");
   });
 
-  test("leaves non-exec tools, non-matching text and already-annotated text alone", () => {
+  test("leaves non-exec tools, non-matching text and already-annotated text byte-identical", () => {
     expect(annotateCodeModeHostFailure("expects a string input", { toolName: "read_file" })).toBeUndefined();
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec_command", toolNamespace: "mcp__docker" })).toBeUndefined();
     expect(annotateCodeModeHostFailure("all good", { toolName: "exec" })).toBeUndefined();
-    const once = annotateCodeModeHostFailure("expects a string input", { toolName: "exec" })!;
+    const once = annotateCodeModeHostFailure("expects a string input", { toolName: "exec" });
+    if (!once) throw new Error("expected one annotation");
     expect(annotateCodeModeHostFailure(once, { toolName: "exec" })).toBeUndefined();
   });
 
   test("every failure row is a rule the pre-call sentence already states", () => {
-    // One owner, two halves: a model must never be told one thing before the call and another after.
-    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("exactly one string");
-    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("*** Begin Patch");
-    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("*** End Patch");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("takes exactly one string");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("`*** Begin Patch`");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("`*** End Patch`");
     expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("no `import`");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("write_stdin");
+    // Never shows the decorated marker as a copyable literal (same rule as the nudge tests).
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).not.toContain("*** Begin Patch ***");
   });
 });
 ```
 
-Register: `scripts/test-layout/layout.json` → `explicit`: `"exec-tool-result-normalize.test.ts": "adapters"`
-(alphabetical, after `"exec-…"` neighbours or before `"identity-…"`); same key in
-`tests/fixtures/test-layout-expected.json`. `tests/test-layout-tooling.test.ts` names a missing one.
+Register in `scripts/test-layout/layout.json` `explicit` between
+`"empty-tool-output-annotation.test.ts": "adapters",` (line 620) and its successor:
+`"exec-tool-result-normalize.test.ts": "adapters",`; same key/value in
+`tests/fixtures/test-layout-expected.json` in alphabetical position. The name matches no regex seed
+(`"adapters"` seed is `^(?:bridge\.test\.ts|buffered|identity|run|tool|translator)-`), so the explicit
+entry is required and `tests/test-layout-tooling.test.ts` names it if missing.
 
 ## Updated tests
 
-`tests/responses/openai-responses-passthrough.test.ts` — add to the code-mode describe:
-
+`tests/responses/openai-responses-passthrough.test.ts` — add inside the code-mode describe:
 ```ts
-test("annotates a paired exec result that carries a host failure string", () => {
-  const failure = "Script failed\nWall time 0.1 seconds\nOutput:\nError: `apply_patch` expects a string input";
-  const body = raw(failure);
-  const wire = JSON.parse(createResponsesPassthroughAdapter(routed).buildRequest(parseRequest(body)).body);
-  expect(wire.input[1].output).toBe(`${failure}\n[recovery: tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.]`);
-  expect(JSON.parse(wire.input[0].arguments).input).toBe(body.input[0].input);
-});
+  test("annotates a paired exec result that carries a host failure string without touching the program", () => {
+    const failure = "Script failed\nWall time 0.1 seconds\nOutput:\nScript error:\ntool `apply_patch` expects a string input";
+    const body = raw(failure);
+    const wire = JSON.parse(createResponsesPassthroughAdapter(routed).buildRequest(parseRequest(body)).body);
+    expect(wire.input[1].output).toBe(`${failure}\n[recovery: tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.]`);
+    expect(JSON.parse(wire.input[0].arguments).input).toBe(body.input[0].input);
+    // Replayed history already carrying the hint is not annotated twice.
+    const replayed = raw(wire.input[1].output);
+    expect(normalizeResponsesCodeMode(replayed, parseRequest(replayed), routed)).toBe(replayed);
+  });
 ```
 
-`tests/providers/kiro/kiro-adapter.test.ts` — beside the `EMPTY_EXEC_OUTPUT_MESSAGE` case at
-line ~336, add one toolResult with `toolName: "exec"` and content
-`"The first line of the patch must be '*** Begin Patch'"`; assert the emitted Kiro tool-result
-text ends with `[recovery: The patch string must begin at …]`.
+`tests/providers/kiro/kiro-adapter.test.ts`
+- After `"an empty code-mode exec result carries the actionable reason…"` (line 323) add:
+```ts
+  test("a code-mode exec result carrying a host failure string names the broken rule", async () => {
+    const execTool = { name: "exec", description: "Run JavaScript", parameters: { type: "object" } };
+    const failure = "apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'";
+    const messages = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-x", name: "exec", arguments: {} }] },
+      { role: "toolResult", toolCallId: "call-x", toolName: "exec", content: failure, isError: false },
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [execTool]));
+    const resultText = JSON.parse(body).conversationState.currentMessage.userInputMessage
+      .userInputMessageContext.toolResults[0].content[0].text;
+    expect(resultText).toBe(`${failure}\n[recovery: The patch string's first line must be the bare marker \`*** Begin Patch\` with no code fence, prose, or extra asterisks around it.]`);
+  });
+```
+- In the grouped-result table (the `execResult` cases around lines 1195-1262) add one case:
+```ts
+      {
+        name: "host failure chunk in a multi group carries its recovery line beside raw siblings",
+        id: "call-host-failure-multi",
+        results: [execResult("call-host-failure-multi", "  "), execResult("call-host-failure-multi", "tool `apply_patch` expects a string input"), execResult("call-host-failure-multi", failedExecWrapper)],
+        content: [{ text: "  " }, { text: "tool `apply_patch` expects a string input\n[recovery: tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.]" }, { text: failedExecWrapper }],
+        status: "success",
+        forbidden: [EMPTY_EXEC_OUTPUT_MESSAGE, FAILED_EXEC_OUTPUT_MESSAGE, KIRO_EMPTY_TOOL_RESULT_MESSAGE],
+      },
+```
+  This drives the grouping path with whitespace, an annotated chunk and a raw failed wrapper in one
+  group — the exact combination blocker 1 said the single-result test could not exercise.
 
-`tests/providers/cursor/cursor-toolresult-normalize.test.ts` — line 101 row stays; add
-`["Unsupported import in exec: node:fs", "injected globals"]` and
-`["\`apply_patch\` expects a string input", "exactly one string"]` to the `test.each` table.
+`tests/providers/cursor/cursor-toolresult-normalize.test.ts` — add after the `test.each` runtime-failure table:
+```ts
+  test("an exec-bridge result carrying a host failure string gains the shared hint and keeps its isError", () => {
+    const out = normalizeCursorToolResultText("Unsupported import in exec: node:fs", { toolName: "exec" });
+    expect(out.changed).toBe(true);
+    expect(out.isError).toBe(false);
+    expect(out.text).toContain("[recovery: Imports are not available in this exec context");
+    // Replay of the annotated text with isError=false must not grow a second line.
+    expect(normalizeCursorToolResultText(out.text, { toolName: "exec" }).changed).toBe(false);
+  });
+
+  test("a non-exec tool whose successful output merely mentions a host phrase stays byte-identical", () => {
+    const doc = "The docs say apply_patch expects a string input.";
+    const out = normalizeCursorToolResultText(doc, { toolName: "read_file" });
+    expect(out.changed).toBe(false);
+    expect(out.isError).toBe(false);
+    expect(out.text).toBe(doc);
+  });
+```
+
+## Delivery for this phase
+
+Stage only the files above (`git diff --cached --stat` first); commit `--no-verify`; push `--no-verify`.
 
 ## Verification (C, hosted only)
 
-NOT RUN locally. Hosted shards run the new and updated files; `tests/test-layout-tooling.test.ts`
-proves registration. Activation for each conditional row is the marker-specific test above.
+NOT RUN locally. Exact-head Cross-platform CI on the wp2 head; receipt via
+`cxc receipt test --session <id> --cwd <worktree> -- gh run view <id> --exit-status`.
 

--- a/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
+++ b/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
@@ -1,0 +1,208 @@
+# 020 — wp2: post-hoc annotation of host failures on exec results
+
+Depends on 010 (the pre-call sentence names the same rules this half explains after the fact; the
+two must share wording, which is why both live in one module). Class C2.
+
+## MODIFY `src/adapters/exec-tool-result-normalize.ts`
+
+Append after `CODE_MODE_HOST_CONTRACT_SENTENCE`:
+
+```ts
+/**
+ * Post-hoc half of the host contract: the four host strings a routed model reads inside a
+ * non-error exec result, each paired with the rule it broke. Markers are compared
+ * case-insensitively because the host writes "Unsupported import in exec: <spec>" while
+ * earlier Cursor guidance matched the lowercase form; one table, one owner, so the
+ * recovery text can never drift from the pre-call sentence above.
+ */
+export const CODE_MODE_HOST_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; guidance: string }> = [
+  {
+    marker: "expects a string input",
+    guidance: "tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.",
+  },
+  {
+    marker: "the first line of the patch must be",
+    guidance: "The patch string must begin at `*** Begin Patch` with no leading newline, indentation, or extra asterisks; start the literal on the marker line.",
+  },
+  {
+    marker: "the last line of the patch must be",
+    guidance: "The patch string must end with `*** End Patch` as its final line, with no trailing text or extra asterisks.",
+  },
+  {
+    marker: "unsupported import in exec",
+    guidance: "Imports are not available in this exec context; use the injected globals (tools, text, notify, store, load, ALL_TOOLS) instead.",
+  },
+];
+
+const HOST_FAILURE_RECOVERY_PREFIX = "[recovery: ";
+
+/**
+ * Append a one-line recovery hint when an exec-bridge result carries a known host failure string.
+ * Returns undefined when the result is not an exec-bridge tool, no marker matches, or a recovery
+ * line is already present, so callers keep their own fallback and never double-annotate.
+ */
+export function annotateCodeModeHostFailure(
+  text: string,
+  options: { toolName?: string; toolNamespace?: string } = {},
+): string | undefined {
+  if (!isCodexExecBridgeTool(options.toolName, options.toolNamespace)) return undefined;
+  if (text.includes(HOST_FAILURE_RECOVERY_PREFIX)) return undefined;
+  const lower = text.toLowerCase();
+  const hit = CODE_MODE_HOST_FAILURE_GUIDANCE.find(({ marker }) => lower.includes(marker));
+  return hit ? `${text}\n${HOST_FAILURE_RECOVERY_PREFIX}${hit.guidance}]` : undefined;
+}
+```
+
+The Cursor guidance string for the import row is kept byte-identical to today's
+(`"Imports are not available in this exec context; use the injected globals instead."` extended with
+the global list) so `cursor-toolresult-normalize.test.ts:101` (`"injected globals"`) still matches.
+
+## MODIFY `src/adapters/responses-code-mode.ts`
+
+Line 55 BEFORE:
+
+```ts
+const normalized = text === undefined ? undefined : normalizeEmptyExecToolResultText(text, { toolName: "exec" });
+```
+
+AFTER:
+
+```ts
+const normalized = text === undefined
+  ? undefined
+  : normalizeEmptyExecToolResultText(text, { toolName: "exec" })
+    ?? annotateCodeModeHostFailure(text, { toolName: "exec" });
+```
+
+Import `annotateCodeModeHostFailure` on line 3. Empty-wrapper first: an empty result can never
+carry a marker, so the order is only for clarity. Activation: paired `custom_tool_call_output`
+whose text contains e.g. `\`apply_patch\` expects a string input`; observable effect: output ends
+with `[recovery: tools.apply_patch takes exactly one string argument…]`, and `input[0]` (the
+program) is the same object reference as before.
+
+## MODIFY `src/adapters/kiro.ts`
+
+Line 47 import: add `annotateCodeModeHostFailure`.
+
+Lines 758-762 BEFORE:
+
+```ts
+const normalizedExecText = normalizeEmptyExecToolResultText(text, {
+  toolName: tr.toolName,
+  toolNamespace: tr.toolNamespace,
+});
+const resultText = normalizedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+```
+
+AFTER:
+
+```ts
+const execOptions = { toolName: tr.toolName, toolNamespace: tr.toolNamespace };
+const normalizedExecText = normalizeEmptyExecToolResultText(text, execOptions)
+  ?? annotateCodeModeHostFailure(text, execOptions);
+const resultText = normalizedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+```
+
+`rawGroupText` (line 774) already keeps `text` whenever `normalizedExecText !== EMPTY_EXEC_OUTPUT_MESSAGE`,
+so the adjacent-result grouping path carries the RAW failure text; the annotated text is what the
+single-result path emits. Line 774 is changed so a grouped result carries the annotated text too:
+
+BEFORE: `? text : undefined;`  AFTER: `? (normalizedExecText ?? text) : undefined;`
+
+(For the empty-wrapper case `normalizedExecText === EMPTY_EXEC_OUTPUT_MESSAGE` short-circuits the
+outer condition first, so that branch is unchanged.)
+
+## MODIFY `src/adapters/cursor/tool-result-normalize.ts`
+
+Import `CODE_MODE_HOST_FAILURE_GUIDANCE` from `../exec-tool-result-normalize`.
+
+`RUNTIME_FAILURE_GUIDANCE` (lines 50-67): DELETE the `unsupported import in exec` entry and spread
+the shared table instead:
+
+```ts
+const RUNTIME_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; guidance: string }> = [
+  { marker: "SkyComputerUseError", guidance: "…" },
+  { marker: "sky is not defined", guidance: "…" },
+  { marker: "has already been declared", guidance: "…" },
+  ...CODE_MODE_HOST_FAILURE_GUIDANCE,
+];
+```
+
+Loop at line 109 BEFORE: `if (text.includes(marker))` AFTER: compare against `text.toLowerCase()`
+for the shared rows only — simplest correct form is to lowercase both sides for every row, since the
+three Cursor markers contain no case-sensitive collisions (`SkyComputerUseError` lowercased still
+matches only itself). Cursor policy (`isError: true` on a match) is unchanged; the shared helper is
+not used here because Cursor owns its `isError` decision.
+
+## NEW `tests/adapters/exec-tool-result-normalize.test.ts`
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  CODE_MODE_HOST_CONTRACT_SENTENCE,
+  CODE_MODE_HOST_FAILURE_GUIDANCE,
+  annotateCodeModeHostFailure,
+} from "../../src/adapters/exec-tool-result-normalize";
+
+describe("code-mode host failure annotation", () => {
+  test.each(CODE_MODE_HOST_FAILURE_GUIDANCE.map(row => [row.marker, row.guidance]))(
+    "annotates an exec result carrying %p", (marker, guidance) => {
+      const text = `Script failed\nOutput:\nError: ${marker.toUpperCase()}`;
+      const out = annotateCodeModeHostFailure(text, { toolName: "exec" });
+      expect(out).toBe(`${text}\n[recovery: ${guidance}]`);
+    });
+
+  test("matches the host's real capitalisation for imports", () => {
+    const out = annotateCodeModeHostFailure("Unsupported import in exec: node:fs", { toolName: "exec" });
+    expect(out).toContain("injected globals");
+  });
+
+  test("leaves non-exec tools, non-matching text and already-annotated text alone", () => {
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "read_file" })).toBeUndefined();
+    expect(annotateCodeModeHostFailure("all good", { toolName: "exec" })).toBeUndefined();
+    const once = annotateCodeModeHostFailure("expects a string input", { toolName: "exec" })!;
+    expect(annotateCodeModeHostFailure(once, { toolName: "exec" })).toBeUndefined();
+  });
+
+  test("every failure row is a rule the pre-call sentence already states", () => {
+    // One owner, two halves: a model must never be told one thing before the call and another after.
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("exactly one string");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("*** Begin Patch");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("*** End Patch");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("no `import`");
+  });
+});
+```
+
+Register: `scripts/test-layout/layout.json` → `explicit`: `"exec-tool-result-normalize.test.ts": "adapters"`
+(alphabetical, after `"exec-…"` neighbours or before `"identity-…"`); same key in
+`tests/fixtures/test-layout-expected.json`. `tests/test-layout-tooling.test.ts` names a missing one.
+
+## Updated tests
+
+`tests/responses/openai-responses-passthrough.test.ts` — add to the code-mode describe:
+
+```ts
+test("annotates a paired exec result that carries a host failure string", () => {
+  const failure = "Script failed\nWall time 0.1 seconds\nOutput:\nError: `apply_patch` expects a string input";
+  const body = raw(failure);
+  const wire = JSON.parse(createResponsesPassthroughAdapter(routed).buildRequest(parseRequest(body)).body);
+  expect(wire.input[1].output).toBe(`${failure}\n[recovery: tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.]`);
+  expect(JSON.parse(wire.input[0].arguments).input).toBe(body.input[0].input);
+});
+```
+
+`tests/providers/kiro/kiro-adapter.test.ts` — beside the `EMPTY_EXEC_OUTPUT_MESSAGE` case at
+line ~336, add one toolResult with `toolName: "exec"` and content
+`"The first line of the patch must be '*** Begin Patch'"`; assert the emitted Kiro tool-result
+text ends with `[recovery: The patch string must begin at …]`.
+
+`tests/providers/cursor/cursor-toolresult-normalize.test.ts` — line 101 row stays; add
+`["Unsupported import in exec: node:fs", "injected globals"]` and
+`["\`apply_patch\` expects a string input", "exactly one string"]` to the `test.each` table.
+
+## Verification (C, hosted only)
+
+NOT RUN locally. Hosted shards run the new and updated files; `tests/test-layout-tooling.test.ts`
+proves registration. Activation for each conditional row is the marker-specific test above.
+

--- a/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
+++ b/devlog/_plan/260907_code_mode_host_contract/020_post_hoc_annotation.md
@@ -22,11 +22,11 @@ export const CODE_MODE_HOST_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; gu
   },
   {
     marker: "the first line of the patch must be",
-    guidance: "The patch string's first line must be the bare marker `*** Begin Patch` with no code fence, prose, or extra asterisks around it.",
+    guidance: "The patch text must open with the bare marker line `*** Begin Patch`: no code fence, prose, or extra asterisks on that line (blank lines or indentation before it are tolerated).",
   },
   {
     marker: "the last line of the patch must be",
-    guidance: "The patch string's last line must be the bare marker `*** End Patch` with no trailing text or extra asterisks.",
+    guidance: "The patch text must close with the bare marker line `*** End Patch`: no trailing text or extra asterisks on that line (blank lines after it are tolerated).",
   },
   {
     marker: "unsupported import in exec",
@@ -34,11 +34,26 @@ export const CODE_MODE_HOST_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; gu
   },
 ];
 
-const HOST_FAILURE_RECOVERY_PREFIX = "[recovery: ";
+/** Prefix of every recovery line this module appends; callers use it to recognise replayed annotations. */
+export const CODE_MODE_HOST_RECOVERY_PREFIX = "[recovery: ";
 
 /**
- * Append a one-line recovery hint when an exec-bridge result carries a known host failure string.
- * Returns undefined when the tool is not an exec bridge, no marker matches, or a recovery line is
+ * The code-mode `exec` tool itself — bare, or under Cursor's `opencodex-responses` display namespace.
+ * The four host strings above originate only in that isolate, so flat shell bridges
+ * (`exec_command`, `shell`, …) and every foreign MCP namespace (`mcp__docker__exec`) are excluded: an
+ * unrelated server's output that happens to contain the phrase must not receive Codex guidance.
+ * Narrower than `isCodexExecBridgeTool` on purpose; the empty-output repair keeps the wider gate.
+ */
+export function isCodexCodeModeExecResult(toolName?: string, toolNamespace?: string): boolean {
+  if (!toolName) return false;
+  const lower = toolName.toLowerCase();
+  if (toolNamespace) return toolNamespace.includes("opencodex-responses") && lower === "exec";
+  return lower === "exec" || lower === "mcp__opencodex-responses__exec" || lower === "mcp_opencodex-responses_exec";
+}
+
+/**
+ * Append a one-line recovery hint when a code-mode exec result carries a known host failure string.
+ * Returns undefined when the tool is not the code-mode exec, no marker matches, or a recovery line is
  * already present (a replayed annotated result must not grow a second one). Never touches error
  * status: the host already decided whether the call failed.
  */
@@ -46,13 +61,16 @@ export function annotateCodeModeHostFailure(
   text: string,
   options: { toolName?: string; toolNamespace?: string } = {},
 ): string | undefined {
-  if (!isCodexExecBridgeTool(options.toolName, options.toolNamespace)) return undefined;
-  if (text.includes(HOST_FAILURE_RECOVERY_PREFIX)) return undefined;
+  if (!isCodexCodeModeExecResult(options.toolName, options.toolNamespace)) return undefined;
+  if (text.includes(CODE_MODE_HOST_RECOVERY_PREFIX)) return undefined;
   const lower = text.toLowerCase();
   const hit = CODE_MODE_HOST_FAILURE_GUIDANCE.find(({ marker }) => lower.includes(marker));
-  return hit ? `${text}\n${HOST_FAILURE_RECOVERY_PREFIX}${hit.guidance}]` : undefined;
+  return hit ? `${text}\n${CODE_MODE_HOST_RECOVERY_PREFIX}${hit.guidance}]` : undefined;
 }
 ```
+
+Flat shell tools are deliberately not annotated: the strings come from the code-mode host, and the
+"flat catalogs untouched" statement in the docs is therefore literally true.
 
 ## MODIFY `src/adapters/responses-code-mode.ts`
 
@@ -125,11 +143,12 @@ empty-success nor a failed-empty wrapper, so every existing grouping expectation
 
 ## MODIFY `src/adapters/cursor/tool-result-normalize.ts`
 
-Imports (lines 12-18) gain `annotateCodeModeHostFailure`. `RUNTIME_FAILURE_GUIDANCE` (lines 50-67) and its
+Imports (lines 12-18) gain `CODE_MODE_HOST_RECOVERY_PREFIX`, `annotateCodeModeHostFailure` and
+`isCodexCodeModeExecResult`. `RUNTIME_FAILURE_GUIDANCE` (lines 50-67) and its
 loop (lines 107-113) stay byte-identical: Cursor's marker semantics, case sensitivity and
 `isError:true` policy are its own.
 
-Lines 96-105 BEFORE (2-space indent):
+Lines 97-106 BEFORE (2-space indent):
 ```ts
   if (isCodexExecBridgeTool(options.toolName, options.toolNamespace) && isEmptyOrFailedExecWrapper(text.trim())) {
     return {
@@ -154,14 +173,19 @@ AFTER (append one branch directly after that block):
       changed: true,
     };
   }
-  // A host failure string inside an exec-bridge result gets the rule it broke appended. The
-  // helper is exec-gated and refuses already-annotated text, so a replayed result does not grow
-  // a second line; Cursor's isError decision is left exactly as the caller passed it.
-  const hostFailure = annotateCodeModeHostFailure(text, options);
-  if (hostFailure !== undefined) return { text: hostFailure, isError, changed: true };
+  // A host failure string inside a code-mode exec result gets the rule it broke appended, with
+  // Cursor's isError decision left exactly as the caller passed it. A replayed result that already
+  // carries a recovery line returns here unchanged: falling through would let the legacy loop
+  // below match the lowercase import marker a second time and flip isError.
+  if (isCodexCodeModeExecResult(options.toolName, options.toolNamespace)) {
+    if (text.includes(CODE_MODE_HOST_RECOVERY_PREFIX)) return { text, isError, changed: false };
+    const hostFailure = annotateCodeModeHostFailure(text, options);
+    if (hostFailure !== undefined) return { text: hostFailure, isError, changed: true };
+  }
 ```
 The existing `unsupported import in exec` row in `RUNTIME_FAILURE_GUIDANCE` still serves node_repl /
-Computer Use tools; for exec-bridge tools the new branch runs first and carries the shared hint.
+Computer Use tools; for the code-mode exec the new branch runs first, carries the shared hint, and
+terminates replay before the legacy loop can see it.
 
 ## NEW `tests/adapters/exec-tool-result-normalize.test.ts`
 
@@ -190,13 +214,18 @@ describe("code-mode host failure annotation", () => {
     expect(annotateCodeModeHostFailure("Script error:\ntool `apply_patch` expects a string input", { toolName: "exec" })).toContain("exactly one string");
     expect(annotateCodeModeHostFailure(
       "apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'",
-      { toolName: "exec_command" },
-    )).toContain("bare marker `*** Begin Patch`");
+      { toolName: "exec" },
+    )).toContain("bare marker line `*** Begin Patch`");
   });
 
-  test("leaves non-exec tools, non-matching text and already-annotated text byte-identical", () => {
+  test("leaves non-exec tools, shell bridges, foreign namespaces, non-matching text and already-annotated text alone", () => {
     expect(annotateCodeModeHostFailure("expects a string input", { toolName: "read_file" })).toBeUndefined();
-    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec_command", toolNamespace: "mcp__docker" })).toBeUndefined();
+    // Flat shell bridges never run the isolate, so the four strings cannot be theirs.
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec_command" })).toBeUndefined();
+    // A foreign MCP server's own exec is not Codex's, even when its output quotes the phrase.
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec", toolNamespace: "mcp__docker" })).toBeUndefined();
+    // Cursor's display namespace for the same code-mode tool still counts.
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec", toolNamespace: "mcp__opencodex-responses" })).toContain("[recovery:");
     expect(annotateCodeModeHostFailure("all good", { toolName: "exec" })).toBeUndefined();
     const once = annotateCodeModeHostFailure("expects a string input", { toolName: "exec" });
     if (!once) throw new Error("expected one annotation");
@@ -232,9 +261,13 @@ entry is required and `tests/test-layout-tooling.test.ts` names it if missing.
     const wire = JSON.parse(createResponsesPassthroughAdapter(routed).buildRequest(parseRequest(body)).body);
     expect(wire.input[1].output).toBe(`${failure}\n[recovery: tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.]`);
     expect(JSON.parse(wire.input[0].arguments).input).toBe(body.input[0].input);
-    // Replayed history already carrying the hint is not annotated twice.
+    // Replayed history already carrying the hint is not annotated twice: the output item and the
+    // program keep their identity, and a second pass over the normalized body is a deep no-op.
     const replayed = raw(wire.input[1].output);
-    expect(normalizeResponsesCodeMode(replayed, parseRequest(replayed), routed)).toBe(replayed);
+    const once = normalizeResponsesCodeMode(replayed, parseRequest(replayed), routed) as typeof replayed;
+    expect(once.input[1]).toBe(replayed.input[1]);
+    expect(once.input[0]).toBe(replayed.input[0]);
+    expect(normalizeResponsesCodeMode(once, parseRequest(once), routed)).toEqual(once);
   });
 ```
 
@@ -252,7 +285,7 @@ entry is required and `tests/test-layout-tooling.test.ts` names it if missing.
     const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [execTool]));
     const resultText = JSON.parse(body).conversationState.currentMessage.userInputMessage
       .userInputMessageContext.toolResults[0].content[0].text;
-    expect(resultText).toBe(`${failure}\n[recovery: The patch string's first line must be the bare marker \`*** Begin Patch\` with no code fence, prose, or extra asterisks around it.]`);
+    expect(resultText).toBe(`${failure}\n[recovery: The patch text must open with the bare marker line \`*** Begin Patch\`: no code fence, prose, or extra asterisks on that line (blank lines or indentation before it are tolerated).]`);
   });
 ```
 - In the grouped-result table (the `execResult` cases around lines 1195-1262) add one case:
@@ -271,13 +304,24 @@ entry is required and `tests/test-layout-tooling.test.ts` names it if missing.
 
 `tests/providers/cursor/cursor-toolresult-normalize.test.ts` — add after the `test.each` runtime-failure table:
 ```ts
-  test("an exec-bridge result carrying a host failure string gains the shared hint and keeps its isError", () => {
-    const out = normalizeCursorToolResultText("Unsupported import in exec: node:fs", { toolName: "exec" });
-    expect(out.changed).toBe(true);
-    expect(out.isError).toBe(false);
-    expect(out.text).toContain("[recovery: Imports are not available in this exec context");
-    // Replay of the annotated text with isError=false must not grow a second line.
-    expect(normalizeCursorToolResultText(out.text, { toolName: "exec" }).changed).toBe(false);
+  test.each(["Unsupported import in exec: node:fs", "unsupported import in exec: node:fs"])(
+    "a code-mode exec result carrying %p gains the shared hint, keeps its isError, and is not re-annotated on replay",
+    (payload) => {
+      const out = normalizeCursorToolResultText(payload, { toolName: "exec" });
+      expect(out.changed).toBe(true);
+      expect(out.isError).toBe(false);
+      expect(out.text).toBe(`${payload}\n[recovery: Imports are not available in this exec context; use the injected globals (tools, text, notify, store, load, ALL_TOOLS) instead.]`);
+      // Replay through Responses history arrives with isError=false; the legacy lowercase marker
+      // row must not get a second look at it.
+      const replay = normalizeCursorToolResultText(out.text, { toolName: "exec", isError: false });
+      expect(replay).toEqual({ text: out.text, isError: false, changed: false });
+    },
+  );
+
+  test("the legacy node_repl import row keeps its own isError policy", () => {
+    const out = normalizeCursorToolResultText("unsupported import in exec", { toolName: "js", toolNamespace: "mcp__node_repl" });
+    expect(out.isError).toBe(true);
+    expect(out.text).toContain("injected globals");
   });
 
   test("a non-exec tool whose successful output merely mentions a host phrase stays byte-identical", () => {
@@ -297,4 +341,3 @@ Stage only the files above (`git diff --cached --stat` first); commit `--no-veri
 
 NOT RUN locally. Exact-head Cross-platform CI on the wp2 head; receipt via
 `cxc receipt test --session <id> --cwd <worktree> -- gh run view <id> --exit-status`.
-

--- a/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
+++ b/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
@@ -1,12 +1,13 @@
-# 030 — wp3: SoT sync, push, PR, exact-head CI receipt
+# 030 — wp3: SoT sync, ready-for-review, exact-head CI receipt
 
-Depends on 020. Class C2 for the docs; the push/PR step is external state and is authorized by
-the user for this branch only ("no verify로 푸시", "pr올려봐"). Merge is not authorized.
+Depends on 020. Class C2 for the docs. Push and PR creation are authorized by the user for this
+branch ("no verify로 푸시", "pr올려봐"); the draft PR already exists from wp1. Merge is not authorized.
 
 ## MODIFY `structure/04_transports-and-sidecars.md`
 
-After the paragraph ending "…or reconstruct output that the code-mode host never emitted." (~line 331)
-add one paragraph:
+Insert after the paragraph that ends "…or reconstruct output that the code-mode host never
+emitted." (line 331), before the `[Decision Log]` that begins "목적과 의도: Keep Codex hosted web
+search usable on xAI's public Responses endpoint…":
 
 ```
 Routed code-mode turns also carry the host contract for the nested helpers, stated in the same three
@@ -14,31 +15,37 @@ injection sites as the result-emission rule (shared catalog nudge, Cursor code-m
 routed Responses instructions): `tools.apply_patch` takes one string whose first and last lines are
 the bare patch markers, the isolate has no `import`/`require`, and a command that outlives
 `yield_time_ms` is polled through `write_stdin` with empty `chars` rather than a shell sleep loop.
-When a paired exec result still carries one of the host's failure strings ("expects a string
+When an exec-bridge result still carries one of the host's failure strings ("expects a string
 input", "The first line of the patch must be", "The last line of the patch must be", "Unsupported
-import in exec"), the routed Responses, Kiro, and Cursor result paths append a one-line recovery
-hint naming the broken rule. Both halves live in `src/adapters/exec-tool-result-normalize.ts` so
-the pre-call and post-hoc wording cannot drift. Nothing rewrites the model's JavaScript or its
-patch payload; the host still rejects the call exactly as before.
-```
+import in exec"), the native routed Responses, Kiro, and Cursor result paths append a one-line
+recovery hint naming the broken rule; Cursor's error classification and Kiro's whitespace and
+failed-wrapper grouping are unchanged. Both halves live in `src/adapters/exec-tool-result-normalize.ts`
+so the pre-call and post-hoc wording cannot drift. This guidance and annotation change rewrites
+neither the model's JavaScript nor its patch payload; the existing name-alias delimiter
+normalization in `src/responses/code-mode-helper-compat.ts` is unchanged, and the host still rejects a
+malformed call exactly as before. Anthropic, Google, OpenAI-chat and command-code result paths
+have no exec-result seam today and are not annotated.
 
-Add a Decision Log entry in the file's existing format (목적과 의도 / 기존 구현 및 제약 조건 /
-검토한 주요 대안 / 선택한 방식 / 장점, 단점 및 영향) recording: purpose = stop routed models
-abandoning apply_patch after two host rejections; alternatives = repair the argument shape in the
-proxy (rejected: MODE B ambiguity, fail-open write), Cursor-only fix (rejected: incident was native
-Responses); chosen = shared pair in one module; impact = longer system prompt on code-mode turns
-(~600 chars), no behaviour change for OpenAI destinations or flat catalogs.
+[Decision Log]
+- 목적과 의도: Stop routed models from abandoning `apply_patch` after the Codex host rejects an object argument or a decorated marker, and from blocking a turn in a shell sleep loop when the host offers `session_id` polling.
+- 기존 구현 및 제약 조건: The shared nudge, Cursor guidance and native Responses instructions already carry the result-emission rule from `exec-tool-result-normalize.ts`, but none stated the helper's argument type, the marker rule, the import ban, or the polling protocol; `260905_apply_patch_envelope_gap` refused to rewrite JavaScript bodies (MODE B), so payload repair is off the table.
+- 검토한 주요 대안: Repair the argument shape inside the proxy (rejected: same body ambiguity as MODE B and it turns a rejected write into a performed one); Cursor-only guidance (rejected: the incident was native routed Responses on xAI); annotate every adapter's tool results (rejected: Anthropic/Google/OpenAI-chat/command-code have no exec-result seam and would need a new one).
+- 선택한 방식: One pre-call sentence and one marker→recovery table in the module that already owns the echo pair; inject the sentence at the three existing code-mode sites; annotate at the three existing exec-result seams with an exec-gated, idempotent helper that never changes error status.
+- 다른 대안 대신 이 방식을 선택한 이유: The safe repair for a host contract the model broke is to state it before the call and name it after the failure; keeping both halves in one file is what keeps them consistent.
+- 장점, 단점 및 영향: Code-mode system prompts grow by roughly 600 characters on routed turns; OpenAI destinations, flat catalogs and compaction requests are untouched. An exec result that legitimately prints one of the four phrases gains a recovery line, which is additive text and never an error flip. The effect on the live Grok defect rate is unmeasured until a re-probe.
+```
 
 ## MODIFY `docs-site/src/content/docs/guides/codex-integration.md`
 
-In "Routed local tools" after the apply_patch conversion paragraph (~line 331) add:
+Insert after the paragraph ending "…and unrelated native custom payloads stay unchanged." (line 331):
 
 ```
 Routed code-mode turns are also told the host's rules for the nested helpers before the first
-call — `tools.apply_patch` takes one string starting at `*** Begin Patch`, the isolate has no
-`import`, and long-running commands are polled with `write_stdin` — and when a result still
-carries one of the host's failure messages, opencodex appends a one-line hint naming the rule.
-The model's code and patch text are never rewritten.
+call: `tools.apply_patch` takes one string whose first and last lines are the bare patch markers,
+the isolate has no `import`, and long-running commands are polled through `write_stdin`. When an
+exec result on the native routed Responses, Kiro, or Cursor path still carries one of the host's
+failure messages, opencodex appends a one-line hint naming the rule. This change does not rewrite
+the model's code or its patch text.
 ```
 
 Translated locales (7 files) are not edited; the English source gains a paragraph they do not
@@ -46,18 +53,17 @@ contradict.
 
 ## Delivery steps (t3b)
 
-1. `git add -A devlog/_plan/260907_code_mode_host_contract src tests scripts structure docs-site`
-   — inspect `git diff --cached --stat` before every commit; only this unit's paths.
-2. Commits already made per work-phase with `--no-verify` (wp0 docs, wp1, wp2, wp3 docs).
-3. `git push --no-verify -u origin codex/code-mode-host-contract`.
-4. `gh pr create --base dev --title "fix(code-mode): state the host contract for nested helpers and annotate host failures" --body-file .tmp/pr-body.md`
-   — body follows `.github/PULL_REQUEST_TEMPLATE.md` (Summary / Verification / Checklist), lists
-   local checks as NOT RUN, names hosted CI as the verifier. No `gui` mention (no screenshot rule).
-5. Poll: `gh run list --branch codex/code-mode-host-contract --json databaseId,headSha,status,conclusion`
-   via `exec_command` short calls (each < 30 s); `gh run watch` is NOT used inside one call.
-6. Receipt: at phase C, `cxc receipt test --session <id> --cwd <worktree> -- gh run view <run-id> --exit-status`
-   where `<run-id>` is the Cross-platform CI run whose `headSha` equals `git rev-parse HEAD`.
-   If the head moves (review fix), a fresh run and fresh receipt are required.
+1. Stage only `structure/04_transports-and-sidecars.md`, `docs-site/.../codex-integration.md` and this unit's
+   devlog; inspect `git diff --cached --stat`; commit `--no-verify`; `git push --no-verify`.
+2. Rewrite the PR body (`gh pr edit --body-file .tmp/pr-body.md`) to the final template: Summary
+   (problem, before/after, the four host strings), Verification (hosted CI run ids per head; local
+   suite/typecheck/build NOT RUN by instruction), Checklist ticked truthfully. No `gui` mention.
+3. Poll `gh run list --branch codex/code-mode-host-contract --json databaseId,headSha,status,conclusion,name`
+   in short `exec_command` calls (each < 30 s) until the Cross-platform CI run whose `headSha` equals
+   `git rev-parse HEAD` completes; `gh run watch` is not used inside one call.
+4. Receipt at phase C: `cxc receipt test --session <id> --cwd <worktree> -- gh run view <run-id> --exit-status`.
+5. `gh pr ready <n>` only after that receipt exists. If the head moves later, a fresh run and fresh
+   receipt are required before any further ready claim.
 
 ## Verification (C)
 

--- a/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
+++ b/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
@@ -20,8 +20,10 @@ When a code-mode exec result still carries one of the host's failure strings ("e
 input", "The first line of the patch must be", "The last line of the patch must be", "Unsupported
 import in exec"), the native routed Responses, Kiro, and Cursor result paths append a one-line
 recovery hint naming the broken rule; flat shell bridges and foreign MCP namespaces are never
-annotated, and Cursor's error classification and Kiro's whitespace and failed-wrapper grouping are
-unchanged. Both halves live in `src/adapters/exec-tool-result-normalize.ts`
+annotated, Responses and Kiro additionally require the request's verified code-mode catalog, Cursor
+matches the exact `exec` name under its `opencodex-responses` provider without catalog context, and
+Cursor's error classification and Kiro's whitespace and failed-wrapper grouping are unchanged. Both
+halves live in `src/adapters/exec-tool-result-normalize.ts`
 so the pre-call and post-hoc wording cannot drift. This guidance and annotation change rewrites
 neither the model's JavaScript nor its patch payload; the existing name-alias delimiter
 normalization in `src/responses/code-mode-helper-compat.ts` is unchanged, and the host still rejects a

--- a/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
+++ b/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
@@ -12,14 +12,16 @@ search usable on xAI's public Responses endpoint…":
 ```
 Routed code-mode turns also carry the host contract for the nested helpers, stated in the same three
 injection sites as the result-emission rule (shared catalog nudge, Cursor code-mode guidance, native
-routed Responses instructions): `tools.apply_patch` takes one string whose first and last lines are
-the bare patch markers, the isolate has no `import`/`require`, and a command that outlives
+routed Responses instructions): `tools.apply_patch` takes one string that opens and closes with the
+bare patch marker lines (blank lines or indentation around them are tolerated; a decorated or missing
+marker is rejected), the isolate has no `import`/`require`, and a command that outlives
 `yield_time_ms` is polled through `write_stdin` with empty `chars` rather than a shell sleep loop.
-When an exec-bridge result still carries one of the host's failure strings ("expects a string
+When a code-mode exec result still carries one of the host's failure strings ("expects a string
 input", "The first line of the patch must be", "The last line of the patch must be", "Unsupported
 import in exec"), the native routed Responses, Kiro, and Cursor result paths append a one-line
-recovery hint naming the broken rule; Cursor's error classification and Kiro's whitespace and
-failed-wrapper grouping are unchanged. Both halves live in `src/adapters/exec-tool-result-normalize.ts`
+recovery hint naming the broken rule; flat shell bridges and foreign MCP namespaces are never
+annotated, and Cursor's error classification and Kiro's whitespace and failed-wrapper grouping are
+unchanged. Both halves live in `src/adapters/exec-tool-result-normalize.ts`
 so the pre-call and post-hoc wording cannot drift. This guidance and annotation change rewrites
 neither the model's JavaScript nor its patch payload; the existing name-alias delimiter
 normalization in `src/responses/code-mode-helper-compat.ts` is unchanged, and the host still rejects a
@@ -41,9 +43,9 @@ Insert after the paragraph ending "…and unrelated native custom payloads stay 
 
 ```
 Routed code-mode turns are also told the host's rules for the nested helpers before the first
-call: `tools.apply_patch` takes one string whose first and last lines are the bare patch markers,
-the isolate has no `import`, and long-running commands are polled through `write_stdin`. When an
-exec result on the native routed Responses, Kiro, or Cursor path still carries one of the host's
+call: `tools.apply_patch` takes one string that opens and closes with the bare patch marker lines,
+the isolate has no `import`, and long-running commands are polled through `write_stdin`. When a
+code-mode exec result on the native routed Responses, Kiro, or Cursor path still carries one of the host's
 failure messages, opencodex appends a one-line hint naming the rule. This change does not rewrite
 the model's code or its patch text.
 ```
@@ -77,4 +79,3 @@ Append `040_delivery_record.md` with PR number, head SHA, CI run id, per-job res
 improve (LOOP-PESSIMIST-01: prose cannot force compliance; effect on real Grok defect rate is
 unmeasured until a live re-probe), and the residual: Anthropic/Google/OpenAI-chat/command-code
 tool-result paths do not annotate host failures because they have no exec-result seam today.
-

--- a/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
+++ b/devlog/_plan/260907_code_mode_host_contract/030_docs_and_delivery.md
@@ -1,0 +1,74 @@
+# 030 — wp3: SoT sync, push, PR, exact-head CI receipt
+
+Depends on 020. Class C2 for the docs; the push/PR step is external state and is authorized by
+the user for this branch only ("no verify로 푸시", "pr올려봐"). Merge is not authorized.
+
+## MODIFY `structure/04_transports-and-sidecars.md`
+
+After the paragraph ending "…or reconstruct output that the code-mode host never emitted." (~line 331)
+add one paragraph:
+
+```
+Routed code-mode turns also carry the host contract for the nested helpers, stated in the same three
+injection sites as the result-emission rule (shared catalog nudge, Cursor code-mode guidance, native
+routed Responses instructions): `tools.apply_patch` takes one string whose first and last lines are
+the bare patch markers, the isolate has no `import`/`require`, and a command that outlives
+`yield_time_ms` is polled through `write_stdin` with empty `chars` rather than a shell sleep loop.
+When a paired exec result still carries one of the host's failure strings ("expects a string
+input", "The first line of the patch must be", "The last line of the patch must be", "Unsupported
+import in exec"), the routed Responses, Kiro, and Cursor result paths append a one-line recovery
+hint naming the broken rule. Both halves live in `src/adapters/exec-tool-result-normalize.ts` so
+the pre-call and post-hoc wording cannot drift. Nothing rewrites the model's JavaScript or its
+patch payload; the host still rejects the call exactly as before.
+```
+
+Add a Decision Log entry in the file's existing format (목적과 의도 / 기존 구현 및 제약 조건 /
+검토한 주요 대안 / 선택한 방식 / 장점, 단점 및 영향) recording: purpose = stop routed models
+abandoning apply_patch after two host rejections; alternatives = repair the argument shape in the
+proxy (rejected: MODE B ambiguity, fail-open write), Cursor-only fix (rejected: incident was native
+Responses); chosen = shared pair in one module; impact = longer system prompt on code-mode turns
+(~600 chars), no behaviour change for OpenAI destinations or flat catalogs.
+
+## MODIFY `docs-site/src/content/docs/guides/codex-integration.md`
+
+In "Routed local tools" after the apply_patch conversion paragraph (~line 331) add:
+
+```
+Routed code-mode turns are also told the host's rules for the nested helpers before the first
+call — `tools.apply_patch` takes one string starting at `*** Begin Patch`, the isolate has no
+`import`, and long-running commands are polled with `write_stdin` — and when a result still
+carries one of the host's failure messages, opencodex appends a one-line hint naming the rule.
+The model's code and patch text are never rewritten.
+```
+
+Translated locales (7 files) are not edited; the English source gains a paragraph they do not
+contradict.
+
+## Delivery steps (t3b)
+
+1. `git add -A devlog/_plan/260907_code_mode_host_contract src tests scripts structure docs-site`
+   — inspect `git diff --cached --stat` before every commit; only this unit's paths.
+2. Commits already made per work-phase with `--no-verify` (wp0 docs, wp1, wp2, wp3 docs).
+3. `git push --no-verify -u origin codex/code-mode-host-contract`.
+4. `gh pr create --base dev --title "fix(code-mode): state the host contract for nested helpers and annotate host failures" --body-file .tmp/pr-body.md`
+   — body follows `.github/PULL_REQUEST_TEMPLATE.md` (Summary / Verification / Checklist), lists
+   local checks as NOT RUN, names hosted CI as the verifier. No `gui` mention (no screenshot rule).
+5. Poll: `gh run list --branch codex/code-mode-host-contract --json databaseId,headSha,status,conclusion`
+   via `exec_command` short calls (each < 30 s); `gh run watch` is NOT used inside one call.
+6. Receipt: at phase C, `cxc receipt test --session <id> --cwd <worktree> -- gh run view <run-id> --exit-status`
+   where `<run-id>` is the Cross-platform CI run whose `headSha` equals `git rev-parse HEAD`.
+   If the head moves (review fix), a fresh run and fresh receipt are required.
+
+## Verification (C)
+
+- `gh run view <id> --exit-status` exit 0 on the exact head; `gh pr view --json headRefOid` equals HEAD.
+- `gh pr checks <n>` lists test 1/4..4/4, gates, storage policy, api usage as pass.
+- Local suite / typecheck / build: NOT RUN (instruction).
+
+## D record
+
+Append `040_delivery_record.md` with PR number, head SHA, CI run id, per-job results, what did not
+improve (LOOP-PESSIMIST-01: prose cannot force compliance; effect on real Grok defect rate is
+unmeasured until a live re-probe), and the residual: Anthropic/Google/OpenAI-chat/command-code
+tool-result paths do not annotate host failures because they have no exec-result seam today.
+

--- a/docs-site/src/content/docs/guides/codex-integration.md
+++ b/docs-site/src/content/docs/guides/codex-integration.md
@@ -330,6 +330,13 @@ Codex. Native custom calls and converted function calls use the same completion 
 patch previews are held while their executable form is unresolved. JavaScript that merely
 contains patch text and unrelated native custom payloads stay unchanged.
 
+Routed code-mode turns are also told the host's rules for the nested helpers before the first
+call: `tools.apply_patch` takes one string that opens and closes with the bare patch marker lines,
+the isolate has no `import`, and long-running commands are polled through `write_stdin`. When a
+code-mode exec result on the native routed Responses, Kiro, or Cursor path still carries one of the host's
+failure messages, opencodex appends a one-line hint naming the rule. This change does not rewrite
+the model's code or its patch text.
+
 Ordinary routed Responses function calls also use the original declared parameter schema at
 completion: integral floats in integer fields and integral numbers in string-only fields are
 normalized, while fractions and numeric unions stay unchanged. An explicitly empty completed

--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -618,6 +618,7 @@
     "empty-completion-guard.test.ts": "responses",
     "empty-completion-hardening.test.ts": "responses",
     "empty-tool-output-annotation.test.ts": "adapters",
+    "exec-tool-result-normalize.test.ts": "adapters",
     "ensure-desired-integrations-race.test.ts": "cli",
     "error-fidelity.test.ts": "server",
     "errors-adapter-failure.test.ts": "server",

--- a/src/adapters/cursor/tool-guidance.ts
+++ b/src/adapters/cursor/tool-guidance.ts
@@ -1,5 +1,5 @@
 import type { OcxRequestOptions, OcxTool } from "../../types";
-import { CODE_MODE_RESULT_ECHO_SENTENCE } from "../exec-tool-result-normalize";
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE } from "../exec-tool-result-normalize";
 import { CODEX_SHELL_BRIDGE_TOOL_NAMES, CODEX_TOOL_SEARCH_TOOL, CODEX_UNIFIED_EXEC_TOOL, clientSemanticToolNameFromCursorWire, cursorRequestAdvertisesApplyPatch, cursorRequestHasExecutionPath, cursorRequestHasShellAlias, cursorRequestUsesCodeMode, cursorToolAllowedByChoice, cursorToolWireName, isCodexShellBridgeToolName, isCursorExecutionPathTool, isCursorStructuredEditToolName } from "./tool-naming";
 
 export const CURSOR_SHELL_ALIAS_SYSTEM_NOTE =
@@ -187,7 +187,7 @@ export function buildCursorToolGuidanceSystemNote(
       ? `\`${CODEX_UNIFIED_EXEC_TOOL}\` is Codex code mode: its body is JavaScript evaluated in a V8 isolate, not a shell command and not Node. Shell, file edits, and MCP are nested helpers called INSIDE that body as \`await tools.<name>(...)\`, for example \`await tools.exec_command({cmd: \"ls\"})\`. Read the tool description and the isolate global \`ALL_TOOLS\` (not \`tools.ALL_TOOLS\`) for helpers this turn provides; absence from the top-level catalog or from \`exec\`'s description is not absence. Those nested helpers are not themselves top-level tools, so do not call \`exec_command\` or \`shell_command\` at the top level here${codeModeOtherTopLevelNames.length > 0 ? `; every other tool this turn lists, including ${quotedNames(codeModeOtherTopLevelNames)}, remains callable at the top level as usual` : ""}. Nested \`tools.apply_patch(input)\` is host-executed: the string must begin exactly with \`*** Begin Patch\` and end with \`*** End Patch\`, each marker line being three asterisks, one space, the two words, then end of line with no further asterisks. OpenCodex does not rewrite JavaScript inside exec, so extra asterisks on a marker line are rejected by Codex before the file is touched.`
       : undefined,
     codeMode
-      ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers."
+      ? CODE_MODE_RESULT_ECHO_SENTENCE + " There is no `require`, no `module`, and no filesystem or network globals; reach the host only through the nested helpers. " + CODE_MODE_HOST_CONTRACT_SENTENCE
       : undefined,
     codeMode
       ? "NEVER attempt Cursor-native Shell, Read, Grep, List, or any tool absent from the catalog — they are not executed in this environment and every probe wastes a turn. The exec code cell (with its nested helpers) is the ONLY execution surface; go to it directly on the FIRST attempt and do not narrate switching surfaces."

--- a/src/adapters/cursor/tool-result-normalize.ts
+++ b/src/adapters/cursor/tool-result-normalize.ts
@@ -10,9 +10,12 @@
  */
 
 import {
+  CODE_MODE_HOST_RECOVERY_PREFIX,
   EMPTY_EXEC_OUTPUT_MESSAGE,
   EMPTY_EXEC_OUTPUT_REGEX,
   FAILED_EXEC_OUTPUT_MESSAGE,
+  annotateCodeModeHostFailure,
+  isCodexCodeModeExecResult,
   isFailedEmptyExecWrapper,
   isCodexExecBridgeTool,
 } from "../exec-tool-result-normalize";
@@ -103,6 +106,15 @@ export function normalizeCursorToolResultText(
       isError: false,
       changed: true,
     };
+  }
+  // A host failure string inside a code-mode exec result gets the rule it broke appended, with
+  // Cursor's isError decision left exactly as the caller passed it. A replayed result that already
+  // carries a recovery line returns here unchanged: falling through would let the legacy loop
+  // below match the lowercase import marker a second time and flip isError.
+  if (isCodexCodeModeExecResult(options.toolName, options.toolNamespace)) {
+    if (text.includes(CODE_MODE_HOST_RECOVERY_PREFIX)) return { text, isError, changed: false };
+    const hostFailure = annotateCodeModeHostFailure(text, options);
+    if (hostFailure !== undefined) return { text: hostFailure, isError, changed: true };
   }
   if (!isError) {
     for (const { marker, guidance } of RUNTIME_FAILURE_GUIDANCE) {

--- a/src/adapters/exec-tool-result-normalize.ts
+++ b/src/adapters/exec-tool-result-normalize.ts
@@ -131,6 +131,73 @@ export const CODE_MODE_HOST_CONTRACT_SENTENCE =
   "Host contract for the nested helpers: `tools.apply_patch(patch)` takes exactly one string, never an object such as `{input: ...}`; the patch text opens with the bare marker line `*** Begin Patch` and closes with the bare marker line `*** End Patch`, written without a code fence, prose, or extra asterisks on those lines (blank lines or indentation around the markers are tolerated; a decorated or missing marker is rejected). The isolate has no `import`, `require`, or module loader; use the globals the exec tool description lists (for example `tools`, `text`, `notify`, `store`/`load`, `ALL_TOOLS`). For a command that may outlive `yield_time_ms`, let `tools.exec_command` return a `session_id` and poll it on later calls with `tools.write_stdin({session_id, chars: \"\"})` instead of blocking a shell in a sleep loop.";
 
 /**
+ * Post-hoc half of the host contract: the four host strings a routed model reads inside a
+ * non-error exec result, each paired with the rule it broke. Matched case-insensitively because
+ * the host writes "Unsupported import in exec: <spec>" while Cursor's earlier marker was
+ * lowercase; one table, one owner, so this text and the pre-call sentence cannot drift.
+ */
+export const CODE_MODE_HOST_FAILURE_GUIDANCE: ReadonlyArray<{ marker: string; guidance: string }> = [
+  {
+    marker: "expects a string input",
+    guidance: "tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.",
+  },
+  {
+    marker: "the first line of the patch must be",
+    guidance: "The patch text must open with the bare marker line `*** Begin Patch`: no code fence, prose, or extra asterisks on that line (blank lines or indentation before it are tolerated).",
+  },
+  {
+    marker: "the last line of the patch must be",
+    guidance: "The patch text must close with the bare marker line `*** End Patch`: no trailing text or extra asterisks on that line (blank lines after it are tolerated).",
+  },
+  {
+    marker: "unsupported import in exec",
+    guidance: "Imports are not available in this exec context; use the injected globals (tools, text, notify, store, load, ALL_TOOLS) instead.",
+  },
+];
+
+/** Prefix of every recovery line this module appends; callers use it to recognise replayed annotations. */
+export const CODE_MODE_HOST_RECOVERY_PREFIX = "[recovery: ";
+
+/** Namespaces under which Cursor displays Codex's own Responses tools (see cursor/tool-naming.ts). */
+const CODEX_RESPONSES_DISPLAY_NAMESPACES: ReadonlySet<string> = new Set(["opencodex-responses", "mcp__opencodex-responses"]);
+/** Flattened spellings of the same code-mode exec when a client folds the namespace into the name. */
+const CODEX_CODE_MODE_EXEC_ALIASES: ReadonlySet<string> = new Set(["exec", "mcp__opencodex-responses__exec", "mcp_opencodex-responses_exec"]);
+
+/**
+ * The code-mode `exec` tool by NAME — bare, or under Codex's own `opencodex-responses` display
+ * namespace, matched exactly. The four host strings above originate only in that isolate, so flat
+ * shell bridges (`exec_command`, `shell`, …) and every other namespace (`mcp__docker`,
+ * `mcp__foreign-opencodex-responses`) are excluded: an unrelated server's output that quotes the
+ * phrase must not receive Codex guidance. Narrower than `isCodexExecBridgeTool` on purpose; the
+ * empty-output repair keeps the wider gate. Callers that KNOW the catalog shape (Kiro's
+ * `codeModeExecName`, the Responses body gate) add that check on top; this predicate alone cannot
+ * tell a structured tool named `exec` from the freeform one.
+ */
+export function isCodexCodeModeExecResult(toolName?: string, toolNamespace?: string): boolean {
+  if (!toolName) return false;
+  const lower = toolName.toLowerCase();
+  if (toolNamespace !== undefined) return CODEX_RESPONSES_DISPLAY_NAMESPACES.has(toolNamespace) && lower === "exec";
+  return CODEX_CODE_MODE_EXEC_ALIASES.has(lower);
+}
+
+/**
+ * Append a one-line recovery hint when a code-mode exec result carries a known host failure string.
+ * Returns undefined when the tool is not the code-mode exec, no marker matches, or a recovery line is
+ * already present (a replayed annotated result must not grow a second one). Never touches error
+ * status: the host already decided whether the call failed.
+ */
+export function annotateCodeModeHostFailure(
+  text: string,
+  options: { toolName?: string; toolNamespace?: string } = {},
+): string | undefined {
+  if (!isCodexCodeModeExecResult(options.toolName, options.toolNamespace)) return undefined;
+  if (text.includes(CODE_MODE_HOST_RECOVERY_PREFIX)) return undefined;
+  const lower = text.toLowerCase();
+  const hit = CODE_MODE_HOST_FAILURE_GUIDANCE.find(({ marker }) => lower.includes(marker));
+  return hit ? `${text}\n${CODE_MODE_HOST_RECOVERY_PREFIX}${hit.guidance}]` : undefined;
+}
+
+/**
  * Codex exec / shell-bridge tool names (flat and MCP-prefixed display aliases). An empty result
  * here is almost always a code-mode cell that never called text()/notify().
  */

--- a/src/adapters/exec-tool-result-normalize.ts
+++ b/src/adapters/exec-tool-result-normalize.ts
@@ -116,6 +116,21 @@ export const CODE_MODE_RESULT_ECHO_SENTENCE =
   "Nothing in the isolate is echoed automatically: a bare trailing `await tools.<name>(...)` or final expression value is DISCARDED, and the cell reports empty output. Pass anything you need to read to `text(...)` (or `notify(...)`) in the same cell — for example `text(JSON.stringify(await tools.exec_command({cmd: 'ls'})))` — and treat an empty result as your own missing `text(...)` call rather than a failed command or lost context.";
 
 /**
+ * Host rules a routed model most often breaks on its first code-mode edit or wait, stated BEFORE
+ * the call. Wording tracks the Codex host (0.153.2), probed live on 2026-09-07: a non-string
+ * argument to `apply_patch` throws "expects a string input"; a body whose first line is not the
+ * bare marker (decorated `*** Begin Patch ***`, a code fence, prose) throws "The first line of the
+ * patch must be '*** Begin Patch'" — surrounding newlines are tolerated; ES imports throw
+ * "Unsupported import in exec"; a command that outlives `yield_time_ms` returns `session_id` for
+ * `write_stdin` polling. xai/grok-4.6 hit the first two, abandoned apply_patch for heredoc writes,
+ * blocked a turn in a shell sleep loop, and died once on an import. None of that is repairable in
+ * the proxy (devlog/_plan/260905_apply_patch_envelope_gap/010 MODE B); it is a contract the proxy
+ * had not stated.
+ */
+export const CODE_MODE_HOST_CONTRACT_SENTENCE =
+  "Host contract for the nested helpers: `tools.apply_patch(patch)` takes exactly one string, never an object such as `{input: ...}`; the patch text opens with the bare marker line `*** Begin Patch` and closes with the bare marker line `*** End Patch`, written without a code fence, prose, or extra asterisks on those lines (blank lines or indentation around the markers are tolerated; a decorated or missing marker is rejected). The isolate has no `import`, `require`, or module loader; use the globals the exec tool description lists (for example `tools`, `text`, `notify`, `store`/`load`, `ALL_TOOLS`). For a command that may outlive `yield_time_ms`, let `tools.exec_command` return a `session_id` and poll it on later calls with `tools.write_stdin({session_id, chars: \"\"})` instead of blocking a shell in a sleep loop.";
+
+/**
  * Codex exec / shell-bridge tool names (flat and MCP-prefixed display aliases). An empty result
  * here is almost always a code-mode cell that never called text()/notify().
  */

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -44,7 +44,7 @@ import { extractKiroImages, normalizeKiroImages, type KiroImage } from "./kiro-i
 import { sniffImageDimensions } from "./anthropic-image-guard";
 import { fetchKiroWithRetry, noteKiroTransientThrottle } from "./kiro-retry";
 import { convertKiroToolContext } from "./kiro-tools";
-import { EMPTY_EXEC_OUTPUT_MESSAGE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
+import { EMPTY_EXEC_OUTPUT_MESSAGE, annotateCodeModeHostFailure, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 import { identifyRoutedModel } from "./identity";
 import { buildNonOpenAIToolCatalogNudgeFromNames, isBareShellBridgeTool, isCodexCodeModeExecTool } from "./tool-catalog-nudge";
 import {
@@ -755,11 +755,17 @@ export function buildKiroPayload(
       // the task instead of calling text()/notify(). Checked before `text.trim()` because the
       // wrapper form ("Script completed\nWall time ...\nOutput:\n") is non-blank and would
       // otherwise pass through as if it were real output.
-      const normalizedExecText = normalizeEmptyExecToolResultText(text, {
-        toolName: tr.toolName,
-        toolNamespace: tr.toolNamespace,
-      });
-      const resultText = normalizedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
+      const execOptions = { toolName: tr.toolName, toolNamespace: tr.toolNamespace };
+      const normalizedExecText = normalizeEmptyExecToolResultText(text, execOptions);
+      // A host failure string inside a non-empty exec result gets the rule it broke appended, but
+      // only when this request's emitted catalog is genuinely code mode (`codeModeExecName` above):
+      // a structured tool named exec, or exec beside a shell bridge, never ran the isolate. This is
+      // the only substitution the grouping path below also carries: whitespace and empty/failed
+      // wrappers keep their existing raw policy.
+      const annotatedExecText = normalizedExecText === undefined && codeModeExecName !== undefined
+        ? annotateCodeModeHostFailure(text, execOptions)
+        : undefined;
+      const resultText = normalizedExecText ?? annotatedExecText ?? (text.trim() ? text : KIRO_EMPTY_TOOL_RESULT_MESSAGE);
       const images = extractKiroImages(tr.content);
       const toolUseId = normalizeToolId(tr.toolCallId);
       const call = priorCalls.get(toolUseId);
@@ -768,7 +774,7 @@ export function buildKiroPayload(
       }
       // Keep real whitespace and failed wrappers, but no empty-success wrapper boilerplate.
       const rawGroupText = text.length > 0 && (!text.trim() || normalizedExecText !== EMPTY_EXEC_OUTPUT_MESSAGE)
-        ? text : undefined;
+        ? (annotatedExecText ?? text) : undefined;
       const last = turns.at(-1);
       if (
         adjacentResult?.rawId === tr.toolCallId

--- a/src/adapters/responses-code-mode.ts
+++ b/src/adapters/responses-code-mode.ts
@@ -1,6 +1,6 @@
 import { toolChoiceToolPredicate, type OcxParsedRequest, type OcxProviderConfig } from "../types";
 import { isOpenAiOperatedResponsesDestination } from "../providers/openai-tiers";
-import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, annotateCodeModeHostFailure, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 import { isBareShellBridgeTool, isCodexCodeModeExecTool } from "./tool-catalog-nudge";
 
 function record(value: unknown): value is Record<string, unknown> {
@@ -59,7 +59,10 @@ export function normalizeResponsesCodeMode(body: unknown, parsed: OcxParsedReque
       }
       if ((item.type !== "function_call_output" && item.type !== "custom_tool_call_output") || !execCalls.has(item.call_id)) return item;
       const text = textOnlyOutput(item.output);
-      const normalized = text === undefined ? undefined : normalizeEmptyExecToolResultText(text, { toolName: "exec" });
+      const normalized = text === undefined
+        ? undefined
+        : normalizeEmptyExecToolResultText(text, { toolName: "exec" })
+          ?? annotateCodeModeHostFailure(text, { toolName: "exec" });
       return normalized === undefined ? item : { ...item, output: normalized };
     }) } : {}),
   };

--- a/src/adapters/responses-code-mode.ts
+++ b/src/adapters/responses-code-mode.ts
@@ -1,6 +1,6 @@
 import { toolChoiceToolPredicate, type OcxParsedRequest, type OcxProviderConfig } from "../types";
 import { isOpenAiOperatedResponsesDestination } from "../providers/openai-tiers";
-import { CODE_MODE_RESULT_ECHO_SENTENCE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, normalizeEmptyExecToolResultText } from "./exec-tool-result-normalize";
 import { isBareShellBridgeTool, isCodexCodeModeExecTool } from "./tool-catalog-nudge";
 
 function record(value: unknown): value is Record<string, unknown> {
@@ -29,6 +29,14 @@ function withExecInputGuidance(tool: unknown): unknown {
   } } };
 }
 
+/** Append each sentence a replayed instructions string does not already carry, in order. */
+function appendMissing(instructions: string, sentences: readonly string[]): string {
+  return sentences.reduce(
+    (acc, sentence) => acc.includes(sentence) ? acc : [acc, sentence].filter(Boolean).join("\n\n"),
+    instructions,
+  );
+}
+
 /** Native routed Responses needs the same first-call/output contract as translated adapters. */
 export function normalizeResponsesCodeMode(body: unknown, parsed: OcxParsedRequest, provider: OcxProviderConfig): unknown {
   if (!record(body) || parsed._compactionRequest || isOpenAiOperatedResponsesDestination(provider)) return body;
@@ -42,8 +50,7 @@ export function normalizeResponsesCodeMode(body: unknown, parsed: OcxParsedReque
     .map(item => item.call_id));
   return {
     ...body,
-    instructions: instructions.includes(CODE_MODE_RESULT_ECHO_SENTENCE)
-      ? instructions : [instructions, CODE_MODE_RESULT_ECHO_SENTENCE].filter(Boolean).join("\n\n"),
+    instructions: appendMissing(instructions, [CODE_MODE_RESULT_ECHO_SENTENCE, CODE_MODE_HOST_CONTRACT_SENTENCE]),
     ...(Array.isArray(body.tools) ? { tools: body.tools.map(withExecInputGuidance) } : {}),
     ...(input ? { input: input.map(item => {
       if (!record(item)) return item;

--- a/src/adapters/tool-catalog-nudge.ts
+++ b/src/adapters/tool-catalog-nudge.ts
@@ -5,7 +5,7 @@ import {
   type OcxTool,
   type OcxProviderConfig,
 } from "../types";
-import { CODE_MODE_RESULT_ECHO_SENTENCE } from "./exec-tool-result-normalize";
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE } from "./exec-tool-result-normalize";
 
 // Tool names that exist only in OTHER agent harnesses (Claude Code and friends). Naming one
 // here tells a routed model not to call it unless this turn's catalog really lists it.
@@ -121,7 +121,7 @@ export function buildNonOpenAIToolCatalogNudgeFromNames(
     "Call only listed names with their listed argument keys; do not invent, translate, or rename tools.",
     "Names mentioned only in instructions, tool descriptions, argument descriptions, or nested helper APIs are not additional top-level tools.",
     verifiedCodeModeExecName
-      ? "`" + verifiedCodeModeExecName + "` is Codex code mode: its body is JavaScript evaluated in a V8 isolate. Nested helpers are called INSIDE that body as `await tools.<name>(...)`, for example `await tools.exec_command({cmd: \"ls\"})` or `await tools.codex_app__list_threads({})`. Absence from the top-level catalog or from `" + verifiedCodeModeExecName + "`'s description is not absence: deferred helpers stay callable on `tools.<name>`. Discover them from the isolate global `ALL_TOOLS`, not `tools.ALL_TOOLS`. Do not skip an available nested helper because it is omitted from the listed top-level names. " + CODE_MODE_RESULT_ECHO_SENTENCE + " Nested `tools.apply_patch(input)` is host-executed: the string must begin exactly with `*** Begin Patch` and end with `*** End Patch`, each marker line being three asterisks, one space, the two words, then end of line with no further asterisks. OpenCodex does not rewrite JavaScript inside exec, so extra asterisks on a marker line are rejected by Codex before the file is touched."
+      ? "`" + verifiedCodeModeExecName + "` is Codex code mode: its body is JavaScript evaluated in a V8 isolate. Nested helpers are called INSIDE that body as `await tools.<name>(...)`, for example `await tools.exec_command({cmd: \"ls\"})` or `await tools.codex_app__list_threads({})`. Absence from the top-level catalog or from `" + verifiedCodeModeExecName + "`'s description is not absence: deferred helpers stay callable on `tools.<name>`. Discover them from the isolate global `ALL_TOOLS`, not `tools.ALL_TOOLS`. Do not skip an available nested helper because it is omitted from the listed top-level names. " + CODE_MODE_RESULT_ECHO_SENTENCE + " Nested `tools.apply_patch(input)` is host-executed: the string must begin exactly with `*** Begin Patch` and end with `*** End Patch`, each marker line being three asterisks, one space, the two words, then end of line with no further asterisks. OpenCodex does not rewrite JavaScript inside exec, so extra asterisks on a marker line are rejected by Codex before the file is touched. " + CODE_MODE_HOST_CONTRACT_SENTENCE
       : "If a listed tool exposes nested helpers such as a tools.* API, call the listed parent tool and use those helpers only inside that tool's input.",
     unavailableNeighborNames.length > 0
       ? "Do not use neighboring-agent tool names " + quoteNames(unavailableNeighborNames) + " unless this turn's catalog lists those exact names."

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -330,6 +330,34 @@ whole result is examined; populated text, image/file parts, unpaired results, sh
 compaction and OpenAI-operated destinations are untouched. This does not rewrite valid JavaScript
 or reconstruct output that the code-mode host never emitted.
 
+Routed code-mode turns also carry the host contract for the nested helpers, stated in the same three
+injection sites as the result-emission rule (shared catalog nudge, Cursor code-mode guidance, native
+routed Responses instructions): `tools.apply_patch` takes one string that opens and closes with the
+bare patch marker lines (blank lines or indentation around them are tolerated; a decorated or missing
+marker is rejected), the isolate has no `import`/`require`, and a command that outlives
+`yield_time_ms` is polled through `write_stdin` with empty `chars` rather than a shell sleep loop.
+When a code-mode exec result still carries one of the host's failure strings ("expects a string
+input", "The first line of the patch must be", "The last line of the patch must be", "Unsupported
+import in exec"), the native routed Responses, Kiro, and Cursor result paths append a one-line
+recovery hint naming the broken rule; flat shell bridges and foreign MCP namespaces are never
+annotated, Responses and Kiro additionally require the request's verified code-mode catalog, Cursor
+matches the exact `exec` name under its `opencodex-responses` provider without catalog context, and
+Cursor's error classification and Kiro's whitespace and failed-wrapper grouping are unchanged. Both
+halves live in `src/adapters/exec-tool-result-normalize.ts`
+so the pre-call and post-hoc wording cannot drift. This guidance and annotation change rewrites
+neither the model's JavaScript nor its patch payload; the existing name-alias delimiter
+normalization in `src/responses/code-mode-helper-compat.ts` is unchanged, and the host still rejects a
+malformed call exactly as before. Anthropic, Google, OpenAI-chat and command-code result paths
+have no exec-result seam today and are not annotated.
+
+[Decision Log]
+- 목적과 의도: Stop routed models from abandoning `apply_patch` after the Codex host rejects an object argument or a decorated marker, and from blocking a turn in a shell sleep loop when the host offers `session_id` polling.
+- 기존 구현 및 제약 조건: The shared nudge, Cursor guidance and native Responses instructions already carry the result-emission rule from `exec-tool-result-normalize.ts`, but none stated the helper's argument type, the marker rule, the import ban, or the polling protocol; `260905_apply_patch_envelope_gap` refused to rewrite JavaScript bodies (MODE B), so payload repair is off the table.
+- 검토한 주요 대안: Repair the argument shape inside the proxy (rejected: same body ambiguity as MODE B and it turns a rejected write into a performed one); Cursor-only guidance (rejected: the incident was native routed Responses on xAI); annotate every adapter's tool results (rejected: Anthropic/Google/OpenAI-chat/command-code have no exec-result seam and would need a new one).
+- 선택한 방식: One pre-call sentence and one marker→recovery table in the module that already owns the echo pair; inject the sentence at the three existing code-mode sites; annotate at the three existing exec-result seams with an exec-gated, idempotent helper that never changes error status.
+- 다른 대안 대신 이 방식을 선택한 이유: The safe repair for a host contract the model broke is to state it before the call and name it after the failure; keeping both halves in one file is what keeps them consistent.
+- 장점, 단점 및 영향: Code-mode system prompts grow by roughly 600 characters on routed turns; OpenAI destinations, flat catalogs and compaction requests are untouched. An exec result that legitimately prints one of the four phrases gains a recovery line, which is additive text and never an error flip. On Cursor, a structured tool literally named `exec` whose output quotes one of those phrases would also gain that line. The effect on the live Grok defect rate is unmeasured until a re-probe.
+
 [Decision Log]
 - 목적과 의도: Keep Codex hosted web search usable on xAI's public Responses endpoint without forwarding private OpenAI-only fields that xAI rejects.
 - 기존 구현 및 제약 조건: Codex emits `external_web_access`, `search_context_size`, `search_content_types`, and `user_location`; xAI documents a live-only `web_search` tool with domain filters and image flags, while Codex cached mode explicitly forbids external access.

--- a/tests/adapters/exec-tool-result-normalize.test.ts
+++ b/tests/adapters/exec-tool-result-normalize.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CODE_MODE_HOST_CONTRACT_SENTENCE,
+  CODE_MODE_HOST_FAILURE_GUIDANCE,
+  annotateCodeModeHostFailure,
+} from "../../src/adapters/exec-tool-result-normalize";
+
+// Live host strings (Codex 0.153.2, probed 2026-09-07) and the rule each one names. The pre-call
+// sentence and these rows are one contract in one module; a model must never be told one thing
+// before the call and another after.
+describe("code-mode host failure annotation", () => {
+  test.each(CODE_MODE_HOST_FAILURE_GUIDANCE.map(row => [row.marker, row.guidance] as const))(
+    "annotates an exec result carrying %p regardless of case",
+    (marker, guidance) => {
+      const text = `Script failed\nWall time 0.1 seconds\nOutput:\nError: ${marker.toUpperCase()}`;
+      expect(annotateCodeModeHostFailure(text, { toolName: "exec" })).toBe(`${text}\n[recovery: ${guidance}]`);
+    },
+  );
+
+  test("matches the host's real capitalisation and argument text", () => {
+    expect(annotateCodeModeHostFailure("Unsupported import in exec: node:fs", { toolName: "exec" })).toContain("injected globals");
+    expect(annotateCodeModeHostFailure("Script error:\ntool `apply_patch` expects a string input", { toolName: "exec" })).toContain("exactly one string");
+    expect(annotateCodeModeHostFailure(
+      "apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'",
+      { toolName: "exec" },
+    )).toContain("bare marker line `*** Begin Patch`");
+  });
+
+  test("leaves non-exec tools, shell bridges, foreign namespaces, non-matching text and already-annotated text alone", () => {
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "read_file" })).toBeUndefined();
+    // Flat shell bridges never run the isolate, so the four strings cannot be theirs.
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec_command" })).toBeUndefined();
+    // A foreign MCP server's own exec is not Codex's, even when its output quotes the phrase, and a
+    // namespace that merely CONTAINS the provider name is still foreign.
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec", toolNamespace: "mcp__docker" })).toBeUndefined();
+    expect(annotateCodeModeHostFailure("expects a string input", { toolName: "exec", toolNamespace: "mcp__foreign-opencodex-responses" })).toBeUndefined();
+    // Codex's own display namespaces and flattened aliases for the same code-mode tool still count.
+    for (const options of [
+      { toolName: "exec", toolNamespace: "opencodex-responses" },
+      { toolName: "exec", toolNamespace: "mcp__opencodex-responses" },
+      { toolName: "mcp__opencodex-responses__exec" },
+      { toolName: "mcp_opencodex-responses_exec" },
+    ]) {
+      expect(annotateCodeModeHostFailure("expects a string input", options)).toContain("[recovery:");
+    }
+    expect(annotateCodeModeHostFailure("all good", { toolName: "exec" })).toBeUndefined();
+    const once = annotateCodeModeHostFailure("expects a string input", { toolName: "exec" });
+    if (!once) throw new Error("expected one annotation");
+    expect(annotateCodeModeHostFailure(once, { toolName: "exec" })).toBeUndefined();
+  });
+
+  test("every failure row is a rule the pre-call sentence already states", () => {
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("takes exactly one string");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("`*** Begin Patch`");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("`*** End Patch`");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("no `import`");
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).toContain("write_stdin");
+    // Never shows the decorated marker as a copyable literal (same rule as the nudge tests).
+    expect(CODE_MODE_HOST_CONTRACT_SENTENCE).not.toContain("*** Begin Patch ***");
+  });
+});
+

--- a/tests/adapters/tool-catalog-nudge.test.ts
+++ b/tests/adapters/tool-catalog-nudge.test.ts
@@ -4,7 +4,7 @@ import {
   buildNonOpenAIToolCatalogNudgeFromNames,
   shouldInjectNonOpenAIToolCatalogNudge,
 } from "../../src/adapters/tool-catalog-nudge";
-import { CODE_MODE_RESULT_ECHO_SENTENCE, EMPTY_EXEC_OUTPUT_MESSAGE } from "../../src/adapters/exec-tool-result-normalize";
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, EMPTY_EXEC_OUTPUT_MESSAGE } from "../../src/adapters/exec-tool-result-normalize";
 import type { OcxTool } from "../../src/types";
 
 describe("non-OpenAI tool catalog nudge", () => {
@@ -80,6 +80,10 @@ describe("non-OpenAI tool catalog nudge", () => {
     expect(note).toContain("OpenCodex does not rewrite JavaScript inside exec");
     expect(note).toContain("Nested `tools.apply_patch(input)` is host-executed");
     expect(note).not.toContain("call the listed parent tool and use those helpers only inside that tool's input");
+    // The host contract rides the same code-mode branch as the echo rule (Grok 2026-09-07).
+    expect(note).toContain(CODE_MODE_HOST_CONTRACT_SENTENCE);
+    expect(note).toContain("takes exactly one string");
+    expect(note).toContain("write_stdin({session_id, chars: \"\"})");
   });
 
   test("keeps the generic nested-helper parent-tool rule when exec is not listed", () => {
@@ -88,6 +92,7 @@ describe("non-OpenAI tool catalog nudge", () => {
     expect(note).toContain("call the listed parent tool and use those helpers only inside that tool's input");
     expect(note).not.toContain("is Codex code mode");
     expect(note).not.toContain("tools.ALL_TOOLS");
+    expect(note).not.toContain("Host contract for the nested helpers");
   });
 
   test("detects a wire-renamed exec as code mode", () => {

--- a/tests/fixtures/test-layout-expected.json
+++ b/tests/fixtures/test-layout-expected.json
@@ -458,6 +458,7 @@
   "errors-adapter-failure.test.ts": "server",
   "eventstream-decoder.test.ts": "responses",
   "exa-web-search.test.ts": "providers",
+  "exec-tool-result-normalize.test.ts": "adapters",
   "expand-user-path.test.ts": "config",
   "fast-row-ingress.test.ts": "providers",
   "fast-row-listing.test.ts": "codex-integration",

--- a/tests/providers/cursor/cursor-tool-definitions.test.ts
+++ b/tests/providers/cursor/cursor-tool-definitions.test.ts
@@ -771,6 +771,9 @@ describe("Cursor code mode tool guidance", () => {
     expect(note).toContain("no further asterisks");
     expect(note).not.toContain("*** Begin Patch ***");
     expect(note).toContain("OpenCodex does not rewrite JavaScript inside exec");
+    expect(note).toContain("Host contract for the nested helpers");
+    expect(note).toContain("takes exactly one string");
+    expect(note).toContain("write_stdin");
 
     // The flat-catalog shell-bridge guidance must NOT appear: naming a top-level
     // `exec_command` in code mode sends the model after a tool that does not exist.
@@ -819,6 +822,7 @@ describe("Cursor code mode tool guidance", () => {
     expect(note).toContain("is the Codex Responses shell bridge for this turn");
     expect(note).not.toContain("is Codex code mode");
     expect(note).not.toContain("V8 isolate");
+    expect(note).not.toContain("Host contract for the nested helpers");
   });
 });
 

--- a/tests/providers/cursor/cursor-toolresult-normalize.test.ts
+++ b/tests/providers/cursor/cursor-toolresult-normalize.test.ts
@@ -106,6 +106,34 @@ describe("normalizeCursorToolResultText (#1920/#1866 unit rows)", () => {
     expect(out.text).toContain(hint);
   });
 
+  test.each(["Unsupported import in exec: node:fs", "unsupported import in exec: node:fs"])(
+    "a code-mode exec result carrying %p gains the shared hint, keeps its isError, and is not re-annotated on replay",
+    (payload) => {
+      const out = normalizeCursorToolResultText(payload, { toolName: "exec" });
+      expect(out.changed).toBe(true);
+      expect(out.isError).toBe(false);
+      expect(out.text).toBe(`${payload}\n[recovery: Imports are not available in this exec context; use the injected globals (tools, text, notify, store, load, ALL_TOOLS) instead.]`);
+      // Replay through Responses history arrives with isError=false; the legacy lowercase marker
+      // row must not get a second look at it.
+      const replay = normalizeCursorToolResultText(out.text, { toolName: "exec", isError: false });
+      expect(replay).toEqual({ text: out.text, isError: false, changed: false });
+    },
+  );
+
+  test("the legacy node_repl import row keeps its own isError policy", () => {
+    const out = normalizeCursorToolResultText("unsupported import in exec", { toolName: "js", toolNamespace: "mcp__node_repl" });
+    expect(out.isError).toBe(true);
+    expect(out.text).toContain("injected globals");
+  });
+
+  test("a non-exec tool whose successful output merely mentions a host phrase stays byte-identical", () => {
+    const doc = "The docs say apply_patch expects a string input.";
+    const out = normalizeCursorToolResultText(doc, { toolName: "read_file" });
+    expect(out.changed).toBe(false);
+    expect(out.isError).toBe(false);
+    expect(out.text).toBe(doc);
+  });
+
   test("a non-computer-use tool with empty output stays byte-identical", () => {
     const out = normalizeCursorToolResultText("", { toolName: "read_file" });
     expect(out.changed).toBe(false);

--- a/tests/providers/kiro/kiro-adapter.test.ts
+++ b/tests/providers/kiro/kiro-adapter.test.ts
@@ -339,6 +339,68 @@ describe("kiro adapter — buildRequest", () => {
     }
   });
 
+  test("a code-mode exec result carrying a host failure string names the broken rule", async () => {
+    // freeform: the Kiro seam annotates only when the emitted catalog is genuinely code mode.
+    const execTool = { name: "exec", description: "Run JavaScript", freeform: true, parameters: { type: "object" } };
+    const failure = "apply_patch verification failed: invalid patch: The first line of the patch must be '*** Begin Patch'";
+    const messages = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-x", name: "exec", arguments: {} }] },
+      { role: "toolResult", toolCallId: "call-x", toolName: "exec", content: failure, isError: false },
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [execTool]));
+    const resultText = JSON.parse(body).conversationState.currentMessage.userInputMessage
+      .userInputMessageContext.toolResults[0].content[0].text;
+    expect(resultText).toBe(`${failure}\n[recovery: The patch text must open with the bare marker line \`*** Begin Patch\`: no code fence, prose, or extra asterisks on that line (blank lines or indentation before it are tolerated).]`);
+  });
+
+  test("a host failure string on a non-code-mode catalog stays raw", async () => {
+    const failure = "tool `apply_patch` expects a string input";
+    const messages = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-x", name: "exec", arguments: {} }] },
+      { role: "toolResult", toolCallId: "call-x", toolName: "exec", content: failure, isError: false },
+    ];
+    for (const tools of [
+      // A structured tool that merely shares the name exec.
+      [{ name: "exec", description: "Run a shell string", parameters: { type: "object" } }],
+      // Freeform exec beside a bare shell bridge is the flat-catalog shape, not code mode.
+      [
+        { name: "exec", description: "Run JavaScript", freeform: true, parameters: { type: "object" } },
+        { name: "exec_command", description: "Run", parameters: { type: "object" } },
+      ],
+    ]) {
+      const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, tools));
+      const resultText = JSON.parse(body).conversationState.currentMessage.userInputMessage
+        .userInputMessageContext.toolResults[0].content[0].text;
+      expect(resultText).toBe(failure);
+    }
+  });
+
+  test("a host failure chunk in a coalesced group carries its recovery line beside raw siblings", async () => {
+    // Whitespace and a failed-empty wrapper keep their raw grouping policy; only the chunk that
+    // carries a host failure string is substituted (the exact combination review round 1 named).
+    const execTool = { name: "exec", description: "Run JavaScript", freeform: true, parameters: { type: "object" } };
+    const failedExecWrapper = "Script failed\nWall time 0.1 seconds\nOutput:\n";
+    const hostFailure = "tool `apply_patch` expects a string input";
+    const result = (content: string) => ({ role: "toolResult", toolCallId: "call-g", toolName: "exec", content, isError: false });
+    const messages = [
+      { role: "user", content: "run it" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-g", name: "exec", arguments: {} }] },
+      result("  "), result(hostFailure), result(failedExecWrapper),
+    ];
+    const { body } = await createKiroAdapter(provider).buildRequest(parsedWith(messages, [execTool]));
+    const toolResults = JSON.parse(body).conversationState.currentMessage.userInputMessage
+      .userInputMessageContext.toolResults as Array<{ content: Array<{ text: string }>; status: string }>;
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].status).toBe("success");
+    expect(toolResults[0].content).toEqual([
+      { text: "  " },
+      { text: `${hostFailure}\n[recovery: tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.]` },
+      { text: failedExecWrapper },
+    ]);
+  });
+
   test("real exec output and empty non-exec results are left alone", async () => {
     // Review finding (Codex P2): a failed cell with no output is empty but NOT a success. The
     // success guidance would erase the only failure signal — reachable via Responses history,

--- a/tests/providers/kiro/kiro-adapter.test.ts
+++ b/tests/providers/kiro/kiro-adapter.test.ts
@@ -1823,6 +1823,8 @@ describe("kiro code-mode catalog nudge", () => {
     // Reaches the ACTUAL Kiro wire prompt, not just the builder: the live 2026-08-28 session that
     // misread a blank result was a routed Kiro turn.
     expect(content).toContain("Nothing in the isolate is echoed automatically");
+    // Survives Kiro's 16 384-char injected-instruction bound on the real wire prompt.
+    expect(content).toContain("Host contract for the nested helpers");
     // The generic fallback must be gone, not merely accompanied.
     expect(content).not.toContain("If a listed tool exposes nested helpers such as a tools.* API");
   });

--- a/tests/responses/openai-responses-passthrough.test.ts
+++ b/tests/responses/openai-responses-passthrough.test.ts
@@ -103,6 +103,21 @@ describe("native routed code-mode result visibility", () => {
     expect(second.instructions).toBe(first.instructions);
   });
 
+  test("annotates a paired exec result that carries a host failure string without touching the program", () => {
+    const failure = "Script failed\nWall time 0.1 seconds\nOutput:\nScript error:\ntool `apply_patch` expects a string input";
+    const body = raw(failure);
+    const wire = JSON.parse(createResponsesPassthroughAdapter(routed).buildRequest(parseRequest(body)).body);
+    expect(wire.input[1].output).toBe(`${failure}\n[recovery: tools.apply_patch takes exactly one string argument; pass the patch text itself, not an object such as {input: ...}.]`);
+    expect(JSON.parse(wire.input[0].arguments).input).toBe(body.input[0].input);
+    // Replayed history already carrying the hint is not annotated twice: the output item and the
+    // program keep their identity, and a second pass over the normalized body is a deep no-op.
+    const replayed = raw(wire.input[1].output);
+    const once = normalizeResponsesCodeMode(replayed, parseRequest(replayed), routed) as typeof replayed;
+    expect(once.input[1]).toBe(replayed.input[1]);
+    expect(once.input[0]).toBe(replayed.input[0]);
+    expect(normalizeResponsesCodeMode(once, parseRequest(once), routed)).toEqual(once);
+  });
+
   test("a replayed body that already carries the echo rule gains only the missing contract sentence", () => {
     const body = { ...raw(), instructions: `Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}` };
     const parsed = parseRequest(body);

--- a/tests/responses/openai-responses-passthrough.test.ts
+++ b/tests/responses/openai-responses-passthrough.test.ts
@@ -3,7 +3,7 @@ import { createOpenAIChatAdapter } from "../../src/adapters/openai-chat";
 import { createResponsesPassthroughAdapter as createResponsesPassthroughAdapterProduction } from "../../src/adapters/openai-responses";
 import { openaiResponsesUrl } from "../../src/adapters/openai-responses-url";
 import { normalizeResponsesCodeMode } from "../../src/adapters/responses-code-mode";
-import { CODE_MODE_RESULT_ECHO_SENTENCE, EMPTY_EXEC_OUTPUT_MESSAGE, FAILED_EXEC_OUTPUT_MESSAGE } from "../../src/adapters/exec-tool-result-normalize";
+import { CODE_MODE_HOST_CONTRACT_SENTENCE, CODE_MODE_RESULT_ECHO_SENTENCE, EMPTY_EXEC_OUTPUT_MESSAGE, FAILED_EXEC_OUTPUT_MESSAGE } from "../../src/adapters/exec-tool-result-normalize";
 import { chatCompletionsToResponsesBody } from "../../src/chat/inbound";
 import { anthropicToResponsesBody } from "../../src/claude/inbound";
 import { parseRequest } from "../../src/responses/parser";
@@ -51,7 +51,7 @@ describe("native routed code-mode result visibility", () => {
     const before = JSON.stringify(body);
     const request = createResponsesPassthroughAdapter(routed).buildRequest(parseRequest(body));
     const wire = JSON.parse(request.body);
-    expect(wire.instructions).toBe(`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}`);
+    expect(wire.instructions).toBe(`Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}\n\n${CODE_MODE_HOST_CONTRACT_SENTENCE}`);
     expect(wire.tools.find((tool: { name: string }) => tool.name === "exec").parameters.properties.input.description)
       .toContain(CODE_MODE_RESULT_ECHO_SENTENCE);
     expect(JSON.stringify(body)).toBe(before);
@@ -103,6 +103,16 @@ describe("native routed code-mode result visibility", () => {
     expect(second.instructions).toBe(first.instructions);
   });
 
+  test("a replayed body that already carries the echo rule gains only the missing contract sentence", () => {
+    const body = { ...raw(), instructions: `Keep this instruction.\n\n${CODE_MODE_RESULT_ECHO_SENTENCE}` };
+    const parsed = parseRequest(body);
+    const first = normalizeResponsesCodeMode(body, parsed, routed) as typeof body;
+    expect(first.instructions).toBe(`${body.instructions}\n\n${CODE_MODE_HOST_CONTRACT_SENTENCE}`);
+    expect(first.instructions.split(CODE_MODE_RESULT_ECHO_SENTENCE).length).toBe(2);
+    const second = normalizeResponsesCodeMode(first, parsed, routed) as typeof body;
+    expect(second.instructions).toBe(first.instructions);
+  });
+
   test("official OpenAI and non-code-mode catalogs remain untouched", () => {
     const body = raw();
     for (const native of [provider, { ...routed, baseUrl: "https://api.openai.com/v1" }]) {
@@ -110,6 +120,7 @@ describe("native routed code-mode result visibility", () => {
       const wire = JSON.parse(createResponsesPassthroughAdapter(native).buildRequest(parseRequest(body)).body);
       expect(wire.instructions).toBe(body.instructions);
       expect(JSON.stringify(wire.tools)).not.toContain(CODE_MODE_RESULT_ECHO_SENTENCE);
+      expect(JSON.stringify(wire)).not.toContain("Host contract for the nested helpers");
     }
     for (const tools of [
       [{ type: "function", name: "exec", parameters: { type: "object" } }],


### PR DESCRIPTION
## Summary

Routed non-OpenAI models in Codex code mode kept tripping on host conventions the proxy never stated. On 2026-09-07 an `xai/grok-4.6` session on native routed Responses:

- called `tools.apply_patch({ input: "..." })` and was rejected with `expects a string input`;
- sent a decorated envelope and was rejected with `The first line of the patch must be '*** Begin Patch'`;
- after those two rejections stopped using `apply_patch` and wrote files with `python3`/`cat <<EOF`;
- blocked a turn with `for i in 1..20; sleep 1` inside one `exec_command` instead of polling the returned `session_id` with `write_stdin`;
- used an ES `import` in the isolate and died with `Unsupported import in exec`.

All four strings were verified against the installed Codex 0.153.2 binaries and re-probed live (`devlog/_plan/260907_code_mode_host_contract/001_host_probe_evidence.md`).

**Before:** code-mode guidance described patch markers but not the argument type, the import ban, or the polling protocol, and a host failure came back as bare text.

**After:** one shared `CODE_MODE_HOST_CONTRACT_SENTENCE` (beside the existing echo rule in `src/adapters/exec-tool-result-normalize.ts`) is injected at the three existing code-mode sites (shared catalog nudge, Cursor code-mode guidance, native routed Responses instructions). Exec results carrying one of the four host strings gain a one-line recovery hint on the native routed Responses, Kiro, and Cursor result paths. Responses and Kiro additionally require the verified code-mode catalog; Cursor matches the exact `exec` name under its `opencodex-responses` provider and keeps its `isError` policy. Flat shell bridges, foreign namespaces, whitespace/failed-wrapper grouping, and replayed annotations are untouched.

No JavaScript or patch payload is rewritten. OpenAI/ChatGPT destinations, flat catalogs, and compaction requests are untouched. Design and audit record: `devlog/_plan/260907_code_mode_host_contract/` (three independent gpt-6-astra audit rounds folded).

## Verification

- Local `bun run typecheck` / `bun run test` / build: **NOT RUN** in this worktree by maintainer instruction; hosted Cross-platform CI on the exact PR head is the verifier.
- wp1 head `adafd12f7`: Cross-platform CI run 34088322976 success (gates, test 1/4–4/4, macos 1/2 and 2/2).
- Final-head CI: recorded on this PR after the docs commit; merge waits for that exact SHA.
- Focused regressions: `tests/adapters/tool-catalog-nudge.test.ts`, `tests/providers/cursor/cursor-tool-definitions.test.ts`, `tests/responses/openai-responses-passthrough.test.ts`, `tests/providers/kiro/kiro-adapter.test.ts`, `tests/adapters/exec-tool-result-normalize.test.ts`, `tests/providers/cursor/cursor-toolresult-normalize.test.ts`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (`structure/04_transports-and-sidecars.md`, `docs-site/src/content/docs/guides/codex-integration.md`)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (prose injection and result annotation only; no auth/credential paths touched)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added code-mode guidance for valid patch formatting, import restrictions, and polling long-running commands.
  - Added targeted recovery hints when recognized host errors occur in routed Responses, Kiro, and Cursor workflows.
  - Prevented duplicate recovery guidance from appearing during replayed or repeated tool results.

- **Documentation**
  - Updated Codex integration and architecture documentation with the supported code-mode host rules and recovery behavior.

- **Tests**
  - Added coverage for guidance injection, error annotation, replay handling, and exclusions for unrelated tools and catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->