### PR TITLE
fix: admit reasoning envelope allocations before materialization

### DIFF
--- a/docs-site/src/content/docs/reference/proxy-formats.md
+++ b/docs-site/src/content/docs/reference/proxy-formats.md
@@ -278,6 +278,12 @@ These endpoints speak the Anthropic Messages dialect used by Claude Code and com
 Most requests are translated to Responses, routed normally, then translated back to Anthropic JSON
 or Anthropic SSE.
 
+On translated Messages requests, reasoning replay shares the request's translation budget.
+Envelope admission includes encoding/decoding copy overhead, not just the original signature
+length. Requests exceeding this budget return HTTP 413 with `translation_buffer_limit`;
+signatures and opaque reasoning data are never truncated to make a request fit. Native
+Anthropic passthrough retains its separate body-size contract.
+
 Base64 and URL image sources are translated in user messages and nested tool results. File-backed
 images (`source.type: "file"`) require native Anthropic passthrough; translated routes return a
 fixed HTTP 400 error asking for base64 or URL input. OpenCodex does not resolve another provider's

--- a/src/claude/inbound.ts
+++ b/src/claude/inbound.ts
@@ -18,6 +18,7 @@ import { AnthropicRequestError, isRec, type Rec } from "./inbound-records";
 import { resolveInboundModel, effortForThinkingBudget, effortFromOutputConfig, formatFromOutputConfig } from "./inbound-model-options";
 import { systemToInstructions, toolsToResponses, toolChoiceToResponses } from "./inbound-content-options";
 import { decodeReasoningEnvelope, encodeReasoningEnvelope, OCX_REASONING_PREFIX } from "../responses/reasoning-envelope";
+import { createTranslatorBudget, type TranslatorBudget } from "../lib/translator-budget";
 
 
 
@@ -210,7 +211,7 @@ function userMessageToItems(content: unknown, input: Rec[], elide: SkillElisionC
   pushUserMessage(input, pending);
 }
 
-function assistantMessageToItems(content: unknown, input: Rec[]): void {
+function assistantMessageToItems(content: unknown, input: Rec[], budget: TranslatorBudget): void {
   if (typeof content === "string") {
     if (content.length > 0) input.push({ type: "message", role: "assistant", content: [{ type: "output_text", text: content }] });
     return;
@@ -240,11 +241,12 @@ function assistantMessageToItems(content: unknown, input: Rec[]): void {
         const thinking = typeof raw.thinking === "string" ? raw.thinking : "";
         const signature = typeof raw.signature === "string" ? raw.signature : "";
         if (signature.startsWith(OCX_REASONING_PREFIX)) {
-          const owned = decodeReasoningEnvelope(signature);
+          const owned = decodeReasoningEnvelope(signature, budget);
           if (!owned) throw new AnthropicRequestError("malformed ocxr1 reasoning signature");
           if (Object.hasOwn(owned, "sig")) throw new AnthropicRequestError("OpenCodex reasoning continuity cannot be replayed as an Anthropic signature");
         }
-        const encrypted = signature.length === 0 ? undefined : signature.startsWith(OCX_REASONING_PREFIX) ? signature : encodeReasoningEnvelope({ sig: signature });
+        const encrypted = signature.length === 0 ? undefined : signature.startsWith(OCX_REASONING_PREFIX) ? signature : encodeReasoningEnvelope({ sig: signature }, budget);
+        if (encrypted) budget.chargeRetained(2 * encrypted.length, { kind: "reasoning" });
         if (thinking.length === 0 && !encrypted) break;
         input.push({ type: "reasoning", id: `rs_${crypto.randomUUID().replace(/-/g, "")}`, summary: thinking.length > 0 ? [{ type: "summary_text", text: thinking }] : [], ...(encrypted ? { encrypted_content: encrypted } : {}) });
         break;
@@ -252,7 +254,11 @@ function assistantMessageToItems(content: unknown, input: Rec[]): void {
       case "redacted_thinking": {
         flush();
         const data = typeof raw.data === "string" ? raw.data : "";
-        if (data.length > 0) input.push({ type: "reasoning", id: `rs_${crypto.randomUUID().replace(/-/g, "")}`, summary: [], encrypted_content: encodeReasoningEnvelope({ red: [data] }) });
+        if (data.length > 0) {
+          const encrypted = encodeReasoningEnvelope({ red: [data] }, budget);
+          budget.chargeRetained(2 * encrypted.length, { kind: "reasoning" });
+          input.push({ type: "reasoning", id: `rs_${crypto.randomUUID().replace(/-/g, "")}`, summary: [], encrypted_content: encrypted });
+        }
         break;
       }
       default:
@@ -294,7 +300,16 @@ export function anthropicToResponsesBody(raw: unknown, cc?: OcxClaudeCodeConfig)
  * OUT-OF-BODY tuple (audit 133 R3#1 — an in-body marker would leak upstream through
  * the native Responses forward and 400).
  */
-export function anthropicToResponsesTranslation(raw: unknown, cc?: OcxClaudeCodeConfig): ClaudeInboundTranslation {
+export function anthropicToResponsesTranslation(raw: unknown, cc?: OcxClaudeCodeConfig, budget?: TranslatorBudget): ClaudeInboundTranslation {
+  const activeBudget = budget ?? createTranslatorBudget();
+  try {
+    return translateAnthropicRequest(raw, cc, activeBudget);
+  } finally {
+    if (!budget) activeBudget.dispose();
+  }
+}
+
+function translateAnthropicRequest(raw: unknown, cc: OcxClaudeCodeConfig | undefined, budget: TranslatorBudget): ClaudeInboundTranslation {
   if (!isRec(raw)) throw new AnthropicRequestError("request body must be a JSON object");
   if (typeof raw.model !== "string" || raw.model.length === 0) {
     throw new AnthropicRequestError("model is required");
@@ -315,7 +330,7 @@ export function anthropicToResponsesTranslation(raw: unknown, cc?: OcxClaudeCode
   for (const msg of raw.messages) {
     if (!isRec(msg)) throw new AnthropicRequestError("each message must be an object");
     if (msg.role === "user") userMessageToItems(msg.content, input, elide);
-    else if (msg.role === "assistant") assistantMessageToItems(msg.content, input);
+    else if (msg.role === "assistant") assistantMessageToItems(msg.content, input, budget);
     else if (msg.role === "system") {
       const text = systemMessageText(msg.content);
       if (text.length > 0) systemParts.push(text);

--- a/src/lib/json-byte-size.ts
+++ b/src/lib/json-byte-size.ts
@@ -1,0 +1,61 @@
+import { TRANSLATOR_MAX_TURN_BYTES, TranslatorBudgetExceededError } from "./translator-budget";
+
+/** Measure plain JSON data without allocating its serialized string or UTF-8 copy. */
+export function jsonUtf8Bytes(value: unknown, limit = TRANSLATOR_MAX_TURN_BYTES): number {
+  let bytes = 0;
+  const add = (count: number) => {
+    if (count > limit - bytes) throw new TranslatorBudgetExceededError("request_copies", limit);
+    bytes += count;
+  };
+  const string = (text: string) => {
+    // Every UTF-16 code unit needs at least one JSON UTF-8 byte; reject large inputs
+    // before walking them. Escapes and unpaired surrogates are counted below.
+    if (text.length + 2 > limit - bytes) throw new TranslatorBudgetExceededError("request_copies", limit);
+    add(2);
+    for (let i = 0; i < text.length; i++) {
+      const code = text.charCodeAt(i);
+      if (code === 0x22 || code === 0x5c || code === 8 || code === 9 || code === 10 || code === 12 || code === 13) add(2);
+      else if (code < 0x20) add(6);
+      else if (code < 0x80) add(1);
+      else if (code < 0x800) add(2);
+      else if (code >= 0xd800 && code <= 0xdbff) {
+        const next = text.charCodeAt(i + 1);
+        if (next >= 0xdc00 && next <= 0xdfff) { add(4); i++; }
+        else add(6);
+      } else if (code >= 0xdc00 && code <= 0xdfff) add(6);
+      else add(3);
+    }
+  };
+  const visit = (item: unknown): void => {
+    if (item === null) { add(4); return; }
+    if (typeof item === "string") { string(item); return; }
+    if (typeof item === "boolean") { add(item ? 4 : 5); return; }
+    if (typeof item === "number") { add(Number.isFinite(item) ? String(item).length : 4); return; }
+    if (Array.isArray(item)) {
+      add(2);
+      for (let i = 0; i < item.length; i++) {
+        if (i > 0) add(1);
+        if (item[i] === undefined) add(4);
+        else visit(item[i]);
+      }
+      return;
+    }
+    if (typeof item === "object" && item !== null) {
+      add(2);
+      let first = true;
+      for (const key of Object.keys(item)) {
+        const field = (item as Record<string, unknown>)[key];
+        if (field === undefined) continue;
+        if (!first) add(1);
+        first = false;
+        string(key);
+        add(1);
+        visit(field);
+      }
+      return;
+    }
+    throw new TypeError("Expected plain JSON data for translation sizing");
+  };
+  visit(value);
+  return bytes;
+}

--- a/src/responses/reasoning-envelope.ts
+++ b/src/responses/reasoning-envelope.ts
@@ -12,6 +12,9 @@
  * passthrough scrub strips ocxr1 envelopes before native forwarding.
  */
 
+import { createTranslatorBudget, type TranslatorBudget } from "../lib/translator-budget";
+import { jsonUtf8Bytes } from "../lib/json-byte-size";
+
 export const OCX_REASONING_PREFIX = "ocxr1:";
 
 export interface ReasoningEnvelope {
@@ -32,30 +35,61 @@ export interface ReasoningEnvelope {
   krc?: string;
 }
 
-export function encodeReasoningEnvelope(envelope: ReasoningEnvelope): string {
-  return OCX_REASONING_PREFIX + Buffer.from(JSON.stringify(envelope), "utf-8").toString("base64");
+export function encodeReasoningEnvelope(envelope: ReasoningEnvelope, budget?: TranslatorBudget): string {
+  const activeBudget = budget ?? createTranslatorBudget();
+  try {
+    const jsonBytes = jsonUtf8Bytes(envelope);
+    const base64Bytes = 4 * Math.ceil(jsonBytes / 3);
+    // Reserve before materialization: UTF-16 JSON, UTF-8 buffer, base64 string,
+    // and the prefixed result may coexist. Returned-value ownership stays with
+    // callers, whose existing retained accounting must not be charged twice here.
+    const reservation = activeBudget.reserveTransient(
+      Math.max(
+        3 * jsonBytes + 4 * base64Bytes + 2 * OCX_REASONING_PREFIX.length,
+        8 * (OCX_REASONING_PREFIX.length + base64Bytes),
+      ),
+      { kind: "reasoning" },
+    );
+    try {
+      return OCX_REASONING_PREFIX + Buffer.from(JSON.stringify(envelope), "utf-8").toString("base64");
+    } finally {
+      reservation.release();
+    }
+  } finally {
+    if (!budget) activeBudget.dispose();
+  }
 }
 
 /** Decode an ocxr1 envelope; returns null for native (OpenAI-encrypted) blobs or garbage. */
-export function decodeReasoningEnvelope(encryptedContent: string): ReasoningEnvelope | null {
+export function decodeReasoningEnvelope(encryptedContent: string, budget?: TranslatorBudget): ReasoningEnvelope | null {
   if (!encryptedContent.startsWith(OCX_REASONING_PREFIX)) return null;
+  const activeBudget = budget ?? createTranslatorBudget();
   try {
-    const parsed: unknown = JSON.parse(Buffer.from(encryptedContent.slice(OCX_REASONING_PREFIX.length), "base64").toString("utf-8"));
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    const obj = parsed as { sig?: unknown; red?: unknown };
-    const envelope: ReasoningEnvelope = {};
-    if (typeof obj.sig === "string") envelope.sig = obj.sig;
-    if (Array.isArray(obj.red)) {
-      const red = obj.red.filter((r): r is string => typeof r === "string");
-      if (red.length > 0) envelope.red = red;
+    // Also bound already-encoded replay before slicing, decoding, or parsing it.
+    // Eight bytes per code unit conservatively covers the string/buffer copies.
+    const reservation = activeBudget.reserveTransient(8 * encryptedContent.length, { kind: "reasoning" });
+    try {
+      const parsed: unknown = JSON.parse(Buffer.from(encryptedContent.slice(OCX_REASONING_PREFIX.length), "base64").toString("utf-8"));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+      const obj = parsed as { sig?: unknown; red?: unknown };
+      const envelope: ReasoningEnvelope = {};
+      if (typeof obj.sig === "string") envelope.sig = obj.sig;
+      if (Array.isArray(obj.red)) {
+        const red = obj.red.filter((r): r is string => typeof r === "string");
+        if (red.length > 0) envelope.red = red;
+      }
+      const txt = (parsed as { txt?: unknown }).txt;
+      const hasTxt = typeof txt === "string";
+      if (hasTxt) envelope.txt = txt;
+      const krc = (parsed as { krc?: unknown }).krc;
+      if (typeof krc === "string" && krc.length > 0) envelope.krc = krc;
+      return envelope.sig || envelope.red || hasTxt || envelope.krc ? envelope : null;
+    } catch {
+      return null;
+    } finally {
+      reservation.release();
     }
-    const txt = (parsed as { txt?: unknown }).txt;
-    const hasTxt = typeof txt === "string";
-    if (hasTxt) envelope.txt = txt;
-    const krc = (parsed as { krc?: unknown }).krc;
-    if (typeof krc === "string" && krc.length > 0) envelope.krc = krc;
-    return envelope.sig || envelope.red || hasTxt || envelope.krc ? envelope : null;
-  } catch {
-    return null;
+  } finally {
+    if (!budget) activeBudget.dispose();
   }
 }

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -7,6 +7,7 @@
  * unchanged. The Responses output (SSE or JSON) is converted back to Anthropic shape.
  */
 import { FORWARD_HEADERS } from "../adapters/openai-responses";
+import { jsonUtf8Bytes } from "../lib/json-byte-size";
 import { sseFieldValue } from "../lib/sse-decoder";
 import { enforceAnthropicImageLimits, sniffImageDimensions } from "../adapters/anthropic-image-guard";
 import { normalizeAnthropicImages } from "../adapters/anthropic-image-normalize";
@@ -753,13 +754,13 @@ async function handleClaudeMessagesWithBudget(
       };
       delete anthropicBody.thinking;
     }
-    const translation = anthropicToResponsesTranslation(anthropicBody, config.claudeCode);
+    const translation = anthropicToResponsesTranslation(anthropicBody, config.claudeCode, translatorBudget);
     internalBody = translation.body;
     // The Anthropic translator builds its body from model/input/store/stream plus sampling
     // fields only, so the caller intent is applied to the TRANSLATED body rather than the
     // inbound one.
     if (fastRow) internalBody.service_tier = "priority";
-    translatorBudget.chargeRetained(new TextEncoder().encode(JSON.stringify(internalBody)).byteLength, { kind: "request_copies" });
+    translatorBudget.chargeRetained(jsonUtf8Bytes(internalBody), { kind: "request_copies" });
     cacheKeySource = translation.cacheKeySource;
   } catch (err) {
     const overflow = isTranslatorBudgetExceededError(err);

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -1452,6 +1452,23 @@ Unsupported constraints remain in `description` as model guidance instead of dis
 
 ## Reasoning display parity (hideThinkingSummary)
 
+Reasoning-envelope serialization uses preflight byte sizing and transient reservations before
+creating JSON, UTF-8, or base64 copies. Encoding also admits the matching decode projection, so
+a successfully encoded standalone envelope fits the standalone decoder's limit. Callers retain
+ownership of returned values; the helper releases only its temporary reservation. Inbound
+Anthropic translation carries one budget across all assistant blocks and accounts for retained
+envelopes until the response lifecycle disposes it. Standalone translation owns a temporary
+budget and disposes it on success or failure. Final translated-request sizing uses plain-JSON
+measurement rather than allocating a serialized copy just to measure it.
+
+[Decision Log]
+- 목적과 의도: Keep reasoning replay bounded while preserving opaque values exactly.
+- 기존 구현 및 제약 조건: Reasoning continuity needs JSON/base64 envelopes, and existing callers already own retained accounting and typed overflow handling.
+- 검토한 주요 대안: Per-field truncation, an independent fixed field limit, or shared transient admission plus cumulative inbound ownership.
+- 선택한 방식: Reserve conservative copy projections in the envelope helpers and use the existing request budget across inbound blocks.
+- 다른 대안 대신 이 방식을 선택한 이유: Truncation changes signed values; one field limit does not describe aggregate ownership. Existing budget errors retain the established HTTP and stream error contracts.
+- 장점, 단점 및 영향: Normal replay is unchanged; envelope admission includes copy overhead and is stricter than a raw-string length ceiling. These are translator accounting limits, not a process-wide RSS guarantee.
+
 `hideThinkingSummary` (request reasoning summary absent/"none" — the routed catalog default) is
 honored by BOTH reasoning paths: anthropic `thinking_delta` AND raw `reasoning_raw_delta`
 (openai-chat `reasoning_content`, kiro tags). Hidden reasoning emits an envelope-only reasoning

--- a/tests/responses/reasoning-envelope.test.ts
+++ b/tests/responses/reasoning-envelope.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, test } from "bun:test";
-import { anthropicToResponsesBody } from "../../src/claude/inbound";
-import { decodeReasoningEnvelope, encodeReasoningEnvelope } from "../../src/responses/reasoning-envelope";
+import { describe, expect, spyOn, test } from "bun:test";
+import { anthropicToResponsesBody, anthropicToResponsesTranslation } from "../../src/claude/inbound";
+import { decodeReasoningEnvelope, encodeReasoningEnvelope, OCX_REASONING_PREFIX, type ReasoningEnvelope } from "../../src/responses/reasoning-envelope";
 import { responsesJsonToAnthropicMessage } from "../../src/claude/outbound";
+import { createTranslatorBudget, TranslatorBudgetExceededError, translatorObservedBufferSnapshot } from "../../src/lib/translator-budget";
+import { jsonUtf8Bytes } from "../../src/lib/json-byte-size";
+import * as budgets from "../../src/lib/translator-budget";
 
 describe("reasoning and tool/result envelopes", () => {
   test("preserves ordered thinking blocks and genuine signatures", () => {
@@ -75,5 +78,107 @@ describe("reasoning and tool/result envelopes", () => {
       output: [{ type: "reasoning", summary: [], encrypted_content: encodeReasoningEnvelope({ sig: "sig-only" }) }],
     }, "m") as any;
     expect(message.content).toEqual([{ type: "thinking", thinking: "", signature: "sig-only" }]);
+  });
+});
+
+describe("reasoning allocation admission", () => {
+  test.each(["ascii", "\"\\\n\u0000", "한글😀", "\ud800", "\udc00", ""])('sizes JSON strings exactly: %j', value => {
+    const data = { sig: value, red: [value, ""], txt: value, krc: value, omitted: undefined };
+    const expected = Buffer.byteLength(JSON.stringify(data));
+    expect(jsonUtf8Bytes(data, expected)).toBe(expected);
+    expect(() => jsonUtf8Bytes(data, expected - 1)).toThrow(TranslatorBudgetExceededError);
+  });
+
+  test("sizes the translated plain-JSON vocabulary", () => {
+    const data = { arr: [undefined, null, true, false, 0, -0, 1e30, NaN, Infinity, { text: "x" }], absent: undefined };
+    expect(jsonUtf8Bytes(data)).toBe(Buffer.byteLength(JSON.stringify(data)));
+  });
+
+  test.each<ReasoningEnvelope>([{ sig: "opaque" }, { red: ["one", "two"] }, { txt: "hidden" }, { krc: "opaque" }, { sig: "s", red: ["r"], txt: "t", krc: "k" }])(
+    "rejects before JSON/Buffer materialization and admits the exact projected boundary: %j", envelope => {
+      const json = JSON.stringify(envelope);
+      const size = Buffer.byteLength(json);
+      const base64Bytes = 4 * Math.ceil(size / 3);
+      const limit = Math.max(3 * size + 4 * base64Bytes + 2 * OCX_REASONING_PREFIX.length, 8 * (OCX_REASONING_PREFIX.length + base64Bytes));
+      const budget = createTranslatorBudget({ maxTurnBytes: limit - 1 });
+      const stringify = spyOn(JSON, "stringify");
+      const from = spyOn(Buffer, "from");
+      let error: unknown;
+      let serializations = 0;
+      let allocations = 0;
+      try { encodeReasoningEnvelope(envelope, budget); } catch (caught) { error = caught; }
+      finally {
+        serializations = stringify.mock.calls.length;
+        allocations = from.mock.calls.length;
+        stringify.mockRestore(); from.mockRestore();
+      }
+      expect(error).toBeInstanceOf(TranslatorBudgetExceededError);
+      expect(serializations).toBe(0);
+      expect(allocations).toBe(0);
+      expect(budget.snapshot().currentBytes).toBe(0);
+      budget.dispose();
+      const exact = createTranslatorBudget({ maxTurnBytes: limit });
+      try {
+        const encoded = encodeReasoningEnvelope(envelope, exact);
+        expect(encoded).toBe(OCX_REASONING_PREFIX + Buffer.from(json).toString("base64"));
+        expect(decodeReasoningEnvelope(encoded, exact)).toEqual(envelope);
+        expect(exact.snapshot().currentBytes).toBe(0);
+      } finally { exact.dispose(); }
+    },
+  );
+
+  test("bounds preencoded replay before decoding and preserves native blobs", () => {
+    const encoded = encodeReasoningEnvelope({ txt: "" });
+    const budget = createTranslatorBudget({ maxTurnBytes: encoded.length * 8 - 1 });
+    const from = spyOn(Buffer, "from");
+    let error: unknown;
+    let allocations = 0;
+    try { decodeReasoningEnvelope(encoded, budget); } catch (caught) { error = caught; }
+    finally { allocations = from.mock.calls.length; from.mockRestore(); }
+    expect(error).toBeInstanceOf(TranslatorBudgetExceededError);
+    expect(allocations).toBe(0);
+    expect(decodeReasoningEnvelope("native-opaque", budget)).toBeNull();
+    expect(budget.snapshot().currentBytes).toBe(0);
+    budget.dispose();
+    const exact = createTranslatorBudget({ maxTurnBytes: encoded.length * 8 });
+    try { expect(decodeReasoningEnvelope(encoded, exact)).toEqual({ txt: "" }); }
+    finally { exact.dispose(); }
+  });
+
+  test.each(["thinking", "redacted_thinking", "owned"])('accounts cumulatively for %s blocks across messages', type => {
+    const before = translatorObservedBufferSnapshot().currentBytes;
+    const block = type === "redacted_thinking" ? { type, data: "r" }
+      : { type: "thinking", thinking: "", signature: type === "owned" ? encodeReasoningEnvelope({ txt: "t" }) : "s" };
+    const budget = createTranslatorBudget({ maxTurnBytes: 256 });
+    try {
+      expect(() => anthropicToResponsesTranslation({ model: "m", messages: Array.from({ length: 8 }, () => ({ role: "assistant", content: [block] })) }, undefined, budget))
+        .toThrow(TranslatorBudgetExceededError);
+      expect(budget.snapshot().highWaterBytes).toBeLessThanOrEqual(256);
+    } finally { budget.dispose(); }
+    expect(translatorObservedBufferSnapshot().currentBytes).toBe(before);
+  });
+
+  test.each(["thinking", "redacted_thinking", "owned"])("handler maps %s admission failure to 413 without dispatch and disposes its budget", async type => {
+    const { handleClaudeMessages } = await import("../../src/server/claude-messages");
+    const signature = type === "owned" ? encodeReasoningEnvelope({ txt: "fixture" }) : "fixture";
+    const content = type === "redacted_thinking" ? { type, data: "fixture" }
+      : { type: "thinking", thinking: "", signature };
+    const request = new Request("http://localhost/v1/messages", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "fixture/model", messages: [{ role: "assistant", content: [content] }] }),
+    });
+    const beforeBytes = budgets.translatorObservedBufferSnapshot().currentBytes;
+    const beforeCount = budgets.translatorLiveBudgetCountForTests();
+    const create = budgets.createTranslatorBudget;
+    const factory = spyOn(budgets, "createTranslatorBudget").mockImplementation(() => create({ maxTurnBytes: 64 }));
+    const upstream = spyOn(globalThis, "fetch").mockImplementation(async () => { throw new Error("unexpected upstream dispatch"); });
+    try {
+      const response = await handleClaudeMessages(request, { port: 0, providers: {} }, { model: "", provider: "" });
+      expect(response.status).toBe(413);
+      expect(await response.json()).toMatchObject({ type: "error", error: { type: "request_too_large", code: "translation_buffer_limit" } });
+      expect(upstream).not.toHaveBeenCalled();
+      expect(budgets.translatorObservedBufferSnapshot().currentBytes).toBe(beforeBytes);
+      expect(budgets.translatorLiveBudgetCountForTests()).toBe(beforeCount);
+    } finally { factory.mockRestore(); upstream.mockRestore(); }
   });
 });


### PR DESCRIPTION
## Summary

- Bound reasoning-envelope materialization with preflight size measurement and transient admission; preserve ordinary opaque reasoning replay without truncation.
- Share inbound accounting across blocks/messages, and measure translated JSON without allocating a second serialized body just to determine its size.
- Keep existing typed overflow handling, native passthrough, routing, credentials, configuration and retry behavior unchanged.
- Update the relevant protocol reference and architecture decision record.

Closes #3861.

Base tested locally: `6cf38b59a3bfe92bcf9c40b1ec1be97d19f063d3`. Patch head: `9bcb7748facfd5495f641044adcf8e0627f9fb26`.
The affected production files have no intervening changes in freshly fetched `dev` (`ece556a6e`). Hosted exact-head and integration checks remain pending.

## Verification

- Bun 1.4.0, fresh isolated HOME/OPENCODEX_HOME/CODEX_HOME and synthetic fixtures only.
- TypeScript: passed.
- Focused reasoning/inbound/outbound/bridge/parser/budget suite: 272 pass, zero fail.
- Additional handler cases: three pass (413, zero upstream dispatch, disposal).
- Small-fixture negative control on the unchanged base: nine expected failures.
- Privacy scan and diff check: passed.
- Documentation build: 425 pages, completed successfully with existing warnings.
- Independent read-only scoped review: no concrete bypass or regression reported.
- Full repository CI and Windows/macOS execution remain pending. Keep Draft; do not merge before required checks and independent maintainer review.
- Production settings and daemons were not changed. No memory-exhaustion or external-provider test was performed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Local review completed; final maintainer security sign-off pending.

@lidge-jun **긴급 보안 검토 부탁드립니다.** 추론 데이터를 변환할 때 먼저 메모리 사용량을 계산하고, 한도를 확인한 뒤에만 복사본을 만들도록 고쳤습니다. 여러 블록의 합산 사용량과 기존 인코딩 데이터도 같은 경계로 검사합니다. 정상 서명은 자르거나 바꾸지 않습니다. 작은 테스트 한도로 수정 전 실패와 수정 후 통과를 확인했으며, 아직 전체·플랫폼 CI 및 최종 보안 리뷰 전입니다. 관련 이슈는 #3861이며, 검토 전 자동 병합은 하지 않겠습니다.
