### PR TITLE
fix(release): recover registry smoke after acknowledged publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,40 +334,56 @@ jobs:
           }
 
       - name: Publish (or dry-run)
+        id: publication
         env:
           DRY_RUN: ${{ inputs.dry-run }}
           NPM_DIST_TAG: ${{ inputs.tag }}
         run: |
+          set -euo pipefail
           if [ "$DRY_RUN" = "true" ]; then
             echo "::notice::DRY RUN — building + packing, not publishing"
             npm run prepublishOnly
             npm pack --dry-run
           else
             npm publish --tag "$NPM_DIST_TAG" --access public
+            echo "published=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Confirm the registry actually has the new version (real publishes only).
+      # Publication is acknowledged before registry reads, which can lag or fail.
+      # Recover only observation failures in this run; never retry npm publish.
       - name: Post-publish registry smoke
-        if: ${{ inputs.dry-run != true }}
+        id: registry-smoke
+        if: ${{ inputs.dry-run != true && steps.publication.outputs.published == 'true' }}
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          PUBLISHED: ${{ steps.publication.outputs.published }}
         run: |
-          for attempt in $(seq 1 30); do
-            if VERSION=$(npm view "@bitkyc08/opencodex@${RELEASE_VERSION}" version 2>/dev/null); then
+          set -euo pipefail
+          test "$PUBLISHED" = "true" || {
+            echo "::error::No successful publication receipt; refusing registry recovery"
+            exit 1
+          }
+          for attempt in $(seq 1 6); do
+            if VERSION=$(timeout --kill-after=2s 10s npm view "@bitkyc08/opencodex@${RELEASE_VERSION}" version --fetch-retries=0 --fetch-timeout=8000 2>/dev/null); then
+              if [ "$VERSION" != "$RELEASE_VERSION" ]; then
+                echo "::error::Registry returned an unexpected version; refusing to create a release"
+                exit 1
+              fi
               echo "registry version=$VERSION"
-              test "$VERSION" = "$RELEASE_VERSION"
-              npm dist-tag ls @bitkyc08/opencodex
+              echo "verification=verified" >> "$GITHUB_OUTPUT"
+              echo "Registry verified @bitkyc08/opencodex@${RELEASE_VERSION}." >> "$GITHUB_STEP_SUMMARY"
+              timeout --kill-after=2s 10s npm dist-tag ls @bitkyc08/opencodex --fetch-retries=0 --fetch-timeout=8000 || echo "::warning::Could not read npm dist-tags; exact version was verified"
               exit 0
             fi
-            echo "::notice::@bitkyc08/opencodex@${RELEASE_VERSION} not visible in npm registry yet (attempt $attempt/30)"
-            sleep 10
+            echo "::notice::Registry lookup not confirmed (attempt $attempt/6)"
+            if [ "$attempt" -lt 6 ]; then sleep 5; fi
           done
-          echo "::error::npm registry smoke failed after 30 attempts"
-          npm view @bitkyc08/opencodex versions dist-tags --json || true
-          exit 1
+          echo "verification=pending" >> "$GITHUB_OUTPUT"
+          echo "::warning::npm publish succeeded, but registry verification remains pending; continuing GitHub release creation without republishing"
+          echo "Publication acknowledged for @bitkyc08/opencodex@${RELEASE_VERSION}; registry verification pending after bounded reads. Inspect the registry before announcing availability. Do not republish this version." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub release
-        if: ${{ inputs.dry-run != true }}
+        if: ${{ inputs.dry-run != true && steps.publication.outputs.published == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,16 +363,17 @@ jobs:
             echo "::error::No successful publication receipt; refusing registry recovery"
             exit 1
           }
+          pkg_name="$(node -p "require('./package.json').name")"
           for attempt in $(seq 1 6); do
-            if VERSION=$(timeout --kill-after=2s 10s npm view "@bitkyc08/opencodex@${RELEASE_VERSION}" version --fetch-retries=0 --fetch-timeout=8000 2>/dev/null); then
+            if VERSION=$(timeout --kill-after=2s 10s npm view "${pkg_name}@${RELEASE_VERSION}" version --fetch-retries=0 --fetch-timeout=8000 2>/dev/null); then
               if [ "$VERSION" != "$RELEASE_VERSION" ]; then
                 echo "::error::Registry returned an unexpected version; refusing to create a release"
                 exit 1
               fi
               echo "registry version=$VERSION"
               echo "verification=verified" >> "$GITHUB_OUTPUT"
-              echo "Registry verified @bitkyc08/opencodex@${RELEASE_VERSION}." >> "$GITHUB_STEP_SUMMARY"
-              timeout --kill-after=2s 10s npm dist-tag ls @bitkyc08/opencodex --fetch-retries=0 --fetch-timeout=8000 || echo "::warning::Could not read npm dist-tags; exact version was verified"
+              echo "Registry verified ${pkg_name}@${RELEASE_VERSION}." >> "$GITHUB_STEP_SUMMARY"
+              timeout --kill-after=2s 10s npm dist-tag ls "$pkg_name" --fetch-retries=0 --fetch-timeout=8000 || echo "::warning::Could not read npm dist-tags; exact version was verified"
               exit 0
             fi
             echo "::notice::Registry lookup not confirmed (attempt $attempt/6)"
@@ -380,7 +381,7 @@ jobs:
           done
           echo "verification=pending" >> "$GITHUB_OUTPUT"
           echo "::warning::npm publish succeeded, but registry verification remains pending; continuing GitHub release creation without republishing"
-          echo "Publication acknowledged for @bitkyc08/opencodex@${RELEASE_VERSION}; registry verification pending after bounded reads. Inspect the registry before announcing availability. Do not republish this version." >> "$GITHUB_STEP_SUMMARY"
+          echo "Publication acknowledged for ${pkg_name}@${RELEASE_VERSION}; registry verification pending after bounded reads. Inspect the registry before announcing availability. Do not republish this version." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub release
         if: ${{ inputs.dry-run != true && steps.publication.outputs.published == 'true' }}

--- a/tests/ci-workflows/ci-workflows.test.ts
+++ b/tests/ci-workflows/ci-workflows.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "node:url";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   SCRIPT_BINDINGS,
   callsTo,
@@ -5513,4 +5516,106 @@ describe("gui exhaustive-deps suppression stays scoped and effective", () => {
     // reappears, the config route has been misunderstood.
     expect(models).not.toContain("react-doctor-disable-next-line");
   });
+});
+
+
+interface PublicationStep { name: string; id?: string; if?: string; run?: string }
+async function publicationSteps(): Promise<PublicationStep[]> {
+  const yaml = Bun.YAML.parse(await readText(".github/workflows/release.yml")) as {
+    jobs: { publish: { steps: PublicationStep[] } };
+  };
+  return yaml.jobs.publish.steps;
+}
+
+test("release recovery requires same-run publication and preserves successful-step gating", async () => {
+  const steps = await publicationSteps();
+  const publish = steps.find(step => step.name === "Publish (or dry-run)")!;
+  const smoke = steps.find(step => step.name === "Post-publish registry smoke")!;
+  const release = steps.find(step => step.name === "Create GitHub release")!;
+  expect(publish.id).toBe("publication");
+  expect(smoke.id).toBe("registry-smoke");
+  for (const step of [smoke, release]) {
+    expect(step.if).toBe("${{ inputs.dry-run != true && steps.publication.outputs.published == 'true' }}");
+  }
+  expect(steps.indexOf(publish)).toBeLessThan(steps.indexOf(smoke));
+  expect(steps.indexOf(smoke)).toBeLessThan(steps.indexOf(release));
+});
+
+// This executes the ubuntu-latest release job's Bash, not the Windows runtime.
+// Structural workflow guards above still execute on every platform.
+test.skipIf(process.platform === "win32")("release shell recovers only unverified reads after acknowledged publication", async () => {
+  const steps = await publicationSteps();
+  const publish = steps.find(step => step.name === "Publish (or dry-run)")!.run!;
+  const smoke = steps.find(step => step.name === "Post-publish registry smoke")!.run!;
+  const scenarios = [
+    { mode: "match", dry: false, status: 0, receipt: true, verification: "verified", reads: 1 },
+    { mode: "delayed", dry: false, status: 0, receipt: true, verification: "verified", reads: 3 },
+    { mode: "unavailable", dry: false, status: 0, receipt: true, verification: "pending", reads: 6 },
+    { mode: "timeout", dry: false, status: 0, receipt: true, verification: "pending", reads: 6 },
+    { mode: "wrong", dry: false, status: 1, receipt: true, verification: "", reads: 1 },
+    { mode: "empty", dry: false, status: 1, receipt: true, verification: "", reads: 1 },
+    { mode: "dist-failure", dry: false, status: 0, receipt: true, verification: "verified", reads: 1 },
+    { mode: "publish-failure", dry: false, status: 23, receipt: false, verification: "", reads: 0 },
+    { mode: "match", dry: true, status: 0, receipt: false, verification: "", reads: 0 },
+    { mode: "missing-receipt", dry: false, status: 1, receipt: false, verification: "", reads: 0 },
+  ];
+  for (const scenario of scenarios) {
+    const dir = mkdtempSync(join(tmpdir(), "ocx-publication-"));
+    const output = join(dir, "output");
+    const summary = join(dir, "summary");
+    const calls = join(dir, "calls");
+    for (const path of [output, summary, calls]) writeFileSync(path, "");
+    const prelude = String.raw`
+      npm() {
+        echo "$*" >> "$CALLS"
+        case "$1" in
+          publish) [ "$SCENARIO" != "publish-failure" ] || return 23 ;;
+          view)
+            count=$(cat "$COUNTER" 2>/dev/null || echo 0)
+            count=$((count + 1)); echo "$count" > "$COUNTER"
+            case "$SCENARIO" in
+              unavailable) return 1 ;;
+              timeout) return 124 ;;
+              delayed) [ "$count" -ge 3 ] || return 1 ;;
+              wrong) echo 0.0.0; return 0 ;;
+              empty) return 0 ;;
+            esac
+            echo "$RELEASE_VERSION" ;;
+          dist-tag) [ "$SCENARIO" != "dist-failure" ] || return 1 ;;
+        esac
+      }
+      timeout() {
+        # The wrapper is stubbed, but its production process bounds are asserted.
+        [ "$1" = "--kill-after=2s" ] && [ "$2" = "10s" ] || return 99
+        shift 2; "$@"
+      }
+      sleep() { echo "sleep $*" >> "$CALLS"; }
+    `;
+    try {
+      const script = prelude + (scenario.mode === "missing-receipt" ? "" : publish) + '\n'
+        + (scenario.dry ? "" : `PUBLISHED=$(sed -n 's/^published=//p' "$GITHUB_OUTPUT")\n${smoke}`);
+      const child = Bun.spawn(["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script], {
+        env: { ...process.env, SCENARIO: scenario.mode, DRY_RUN: String(scenario.dry),
+          NPM_DIST_TAG: "latest", RELEASE_VERSION: "9.8.7", GITHUB_OUTPUT: output,
+          GITHUB_STEP_SUMMARY: summary, CALLS: calls, COUNTER: join(dir, "counter") },
+        stdin: "ignore", stdout: "pipe", stderr: "pipe",
+      });
+      const [status, stdout, stderr] = await Promise.all([
+        child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+      ]);
+      expect({ scenario: scenario.mode, status, stderr }).toEqual({ scenario: scenario.mode, status: scenario.status, stderr: "" });
+      const receipt = readFileSync(output, "utf8");
+      const log = readFileSync(calls, "utf8").trim().split("\n");
+      expect(receipt.includes("published=true")).toBe(scenario.receipt);
+      expect(receipt.includes("verification=")).toBe(scenario.verification !== "");
+      if (scenario.verification) expect(receipt).toContain(`verification=${scenario.verification}`);
+      expect(log.filter(line => line.startsWith("view "))).toHaveLength(scenario.reads);
+      expect(log.filter(line => line.startsWith("publish "))).toHaveLength(scenario.dry || scenario.mode === "missing-receipt" ? 0 : 1);
+      if (scenario.verification === "pending") {
+        expect(stdout).toContain("::warning::npm publish succeeded");
+        expect(readFileSync(summary, "utf8")).toContain("registry verification pending");
+        expect(log.filter(line => line === "sleep 5")).toHaveLength(5);
+      }
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  }
 });

--- a/tests/ci-workflows/ci-workflows.test.ts
+++ b/tests/ci-workflows/ci-workflows.test.ts
@@ -5519,7 +5519,7 @@ describe("gui exhaustive-deps suppression stays scoped and effective", () => {
 });
 
 
-interface PublicationStep { name: string; id?: string; if?: string; run?: string }
+interface PublicationStep { name: string; id?: string; if?: string; run?: string; env?: Record<string, string> }
 async function publicationSteps(): Promise<PublicationStep[]> {
   const yaml = Bun.YAML.parse(await readText(".github/workflows/release.yml")) as {
     jobs: { publish: { steps: PublicationStep[] } };
@@ -5534,6 +5534,7 @@ test("release recovery requires same-run publication and preserves successful-st
   const release = steps.find(step => step.name === "Create GitHub release")!;
   expect(publish.id).toBe("publication");
   expect(smoke.id).toBe("registry-smoke");
+  expect(smoke.env?.PUBLISHED).toBe("${{ steps.publication.outputs.published }}");
   for (const step of [smoke, release]) {
     expect(step.if).toBe("${{ inputs.dry-run != true && steps.publication.outputs.published == 'true' }}");
   }
@@ -5566,6 +5567,7 @@ test.skipIf(process.platform === "win32")("release shell recovers only unverifie
     const calls = join(dir, "calls");
     for (const path of [output, summary, calls]) writeFileSync(path, "");
     const prelude = String.raw`
+      node() { echo "@fixture/renamed"; }
       npm() {
         echo "$*" >> "$CALLS"
         case "$1" in
@@ -5609,7 +5611,12 @@ test.skipIf(process.platform === "win32")("release shell recovers only unverifie
       expect(receipt.includes("published=true")).toBe(scenario.receipt);
       expect(receipt.includes("verification=")).toBe(scenario.verification !== "");
       if (scenario.verification) expect(receipt).toContain(`verification=${scenario.verification}`);
-      expect(log.filter(line => line.startsWith("view "))).toHaveLength(scenario.reads);
+      const reads = log.filter(line => line.startsWith("view "));
+      expect(reads).toHaveLength(scenario.reads);
+      for (const read of reads) expect(read).toBe("view @fixture/renamed@9.8.7 version --fetch-retries=0 --fetch-timeout=8000");
+      const tags = log.filter(line => line.startsWith("dist-tag "));
+      expect(tags).toEqual(scenario.verification === "verified"
+        ? ["dist-tag ls @fixture/renamed --fetch-retries=0 --fetch-timeout=8000"] : []);
       expect(log.filter(line => line.startsWith("publish "))).toHaveLength(scenario.dry || scenario.mode === "missing-receipt" ? 0 : 1);
       if (scenario.verification === "pending") {
         expect(stdout).toContain("::warning::npm publish succeeded");


### PR DESCRIPTION
## Summary

- After `npm publish` succeeds, bounded registry reads now distinguish an exact verified version from pending verification. Exhausted reads warn and allow GitHub Release creation without publishing again; an unexpected successful version response remains fatal.
- Publication is recorded only after the real publish command exits zero. Both later steps require that same-run receipt and normal successful-step gating. Dispatch, exact-SHA, preflight, tag-target, provenance and permission boundaries remain unchanged.

## Verification

- Local suite, typecheck, build, install and privacy scan: **NOT RUN** by instruction; hosted CI is the verifier.
- Current head `56f356d65f153533164e52c549e77baa0e7a8650`, based on `dev@d0fca4a9b689bff389f85d4433e17969fa93e685`.
- Central Cross-platform CI: [run 34119094967](https://github.com/lidge-jun/opencodex/actions/runs/34119094967), `lane=all`, **all 16 required per-chain jobs SUCCESS** at the exact head (attempt 1). Linux 4, macOS 2, gates, storage, api usage, all keyring/npm jobs and Docker passed.
- Source/merge preflight: fetched dev remains `d0fca4a9b`; `git merge-tree --write-tree origin/dev HEAD` and tested `HEAD^{tree}` both equal `8fad52f291323853fd1e9b6f1c244d9407e4ba25`. No unresolved review threads or outstanding maintainer change requests at this snapshot.
- Per-chain acceptance follows the owner's updated policy: Linux 4 shards, macOS 2 shards, gates/storage/api/keyring/npm/docker must pass. Windows 6 shards and macOS control are excluded from this per-chain gate under the explicit owner policy. They are still running in this dispatch at the snapshot; the full workflow is not claimed green. The main session owns their cancellation/final-train verification.
- Independent final Astra security review (Bernoulli): **PASS, blocking_issues: []**, on `d0fca4a9b..56f356d65`. Receipt timing, implicit successful-step gating, fatal mismatch handling, bounded reads, no republishing, and exact renamed-package assertions remain intact. Source inspection only; runtime NOT RUN by reviewer.
- Both CodeRabbit findings addressed/resolved: package.json supplies registry package names; tests assert smoke `env.PUBLISHED` and renamed-package view/dist-tag commands.
- The extracted Bash scenarios cover accepted/failed publication, dry-run, missing receipt, delayed/exhausted reads, wrong/empty versions and non-fatal diagnostics. No assertion was weakened.
- Historical run 34105804531 passed 26 jobs at old head `0fd3408b9`; superseded runs 34109791077/34110307528 were cancelled by the central scheduler. None certifies this current head.
- No Release workflow, package publication, tag or merge action performed.

Manual chain (`stack: null`):

| Layer | Base | Scope |
|---|---|---|
| 1 (standalone) | dev | Publication-aware registry smoke |

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (workflow summary distinguishes pending from verified).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



---

**Maintainer integration decision (MAINTAINERS.md, dev-only admin integration; release-automation surface → security review attached in body):** @lidge-jun integrates #3864 into `dev`. Exact-head evidence at `56f356d65`: Cross-platform CI run [34119094967](https://github.com/lidge-jun/opencodex/actions/runs/34119094967) — Linux test 1/4–4/4, macOS 1/2, 2/2, gates, storage policy, api usage, keyring ×3, npm-global ×3, docker smoke = success; Windows shards and macos control deferred to the final release-train head by maintainer policy. Prospective merge tree of `origin/dev@d0fca4a9b` + head = `8fad52f29` = tested tree. Independent security review PASS (0 blockers) at this head; CodeRabbit findings resolved. Local suites NOT RUN. Maintainer integration, not self-approval.
