### PR TITLE
docs(devlog): make CI completion check fail closed (carry #3532)

### DIFF
--- a/devlog/_fin/260905_always_on_429_failover/090_outcome.md
+++ b/devlog/_fin/260905_always_on_429_failover/090_outcome.md
@@ -18,7 +18,7 @@ the tree rather than against the plan — the plan's own criteria were satisfied
 Two were defects the fix itself created (#3499, #3503), three were surfaces still describing the
 old contract (#3517, #3520, #3523), one closed the structural gap that let this unit ship two
 subset-rotator loops (#3512), and one cleaned up after a collision with concurrent maintainer
-work (#3526). All are recorded in `091`.
+work (#3526). The runtime post-merge findings and CI lessons are recorded in `091`.
 
 ## What changed
 

--- a/devlog/_fin/260905_always_on_429_failover/091_post_merge_audit.md
+++ b/devlog/_fin/260905_always_on_429_failover/091_post_merge_audit.md
@@ -67,14 +67,37 @@ The post-merge run on `dev` then showed `ci failure`, which was a genuinely alar
 out. It turned out to be cancellation by the maintainer's next merge two minutes later, not a
 real failure — every job read `cancelled`, not `failure`.
 
-**Rule:** verify with the check-runs API and require zero `null` conclusions, not a pass count:
+**Rule:** use the exact head SHA, require every expected aggregate or policy gate by name, and
+also require zero non-terminal check runs. A missing check is not success. Paginate before treating
+the returned set as complete:
 
 ```bash
-gh api repos/<owner>/<repo>/commits/<sha>/check-runs \
-  --jq '[.check_runs[] | .conclusion] | group_by(.) | map({(.[0]//"null"): length}) | add'
+set -o pipefail
+gh api --paginate repos/<owner>/<repo>/commits/<sha>/check-runs \
+  | jq -se '
+      [.[].check_runs[]] as $runs
+      | ["ci", "enforce-target", "hygiene", "react-doctor"] as $expected
+      | ($expected - [
+          $runs[]
+          | select(.status == "completed" and .conclusion == "success")
+          | .name
+        ]) as $missing
+      | [
+          $runs[]
+          | select(.status != "completed" or .conclusion == null)
+          | .name
+        ] as $pending
+      | if ($missing | length) == 0 and ($pending | length) == 0
+        then {ready: true, expected: $expected}
+        else error("missing=\($missing) pending=\($pending)")
+        end'
 ```
 
-A clean result looks like `{"skipped":3,"success":24}` — no `null` key at all.
+A clean result is `{"ready":true,...}` with exit status 0. This does not replace review-policy
+checks such as confirming the approval belongs to the same head. Every `$expected` value is an
+exact Checks API `.check_runs[].name`, not a workflow title or workflow-run name. If those required
+check-run names change, update this list with the policy; silently accepting an absent name
+recreates the original bug.
 
 The near-miss paid for itself: sweeping `dev` afterwards found a real defect. #3511 and #3513
 landed concurrently, one moving `anthropic-quorum-cache.test.ts` into `tests/routing/` and the


### PR DESCRIPTION
## Summary

Carries #3532 by @Ingwannu onto current dev: the devlog CI-completion audit instruction now requires complete paginated check evidence and fails closed on partial results. Docs only.

(carried/reimplemented from https://github.com/lidge-jun/opencodex/pull/3532; Co-authored-by trailer in the commit)

## Verification

- Docs-only layer; no runtime change.
- Local checks NOT RUN by maintainer instruction; remote CI at the chain top (layer 6) is the evidence.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

**Manual review chain (integrate bottom-up; stack: null, no native stack)**

| Layer | Branch | Base | Source |
|---|---|---|---|
| 1 | `codex/rt-m1-3532` | `dev` | #3532 (Ingwannu) |
| 2 | `codex/rt-m2-3840` | layer 1 | #3840 (chilung-cgu) |
| 3 | `codex/rt-m3-3837` | layer 2 | #3837 (luvs01) + test isolation fix |
| 4 | `codex/rt-m4-3843` | layer 3 | #3843 (luvs01) + same-delta fix |
| 5 | `codex/rt-m5-3845` | layer 4 | #3845 (luvs01) |
| 6 | `codex/rt-m6-2033` | layer 5 | #2033 (louis-tepe) reimplemented — chain top |

Verification policy (maintainer instruction, this train): local test suite / typecheck / build were **NOT RUN**; branches pushed with `--no-verify`. Lower layers carry `[skip ci]`; the full Cross-platform CI (lane=all, Windows shards included) runs once at the chain top head and is the exact-head evidence for the cumulative tree.

Layer 1 of 6. Review this PR's diff only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that runtime post-merge findings and CI lessons are recorded in the audit documentation.
  * Added stricter verification guidance requiring all expected checks to complete successfully, with no pending or non-terminal runs.
  * Documented that missing checks do not count as successful and that expected check names must be kept current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**Maintainer integration decision (MAINTAINERS.md, dev-only admin integration):** @lidge-jun integrates this manual chain into `dev` bottom-up. Exact chain-top evidence: Cross-platform CI run [34106345180](https://github.com/lidge-jun/opencodex/actions/runs/34106345180) at head `6eadb1658` (lane=all: Linux 4/4, macOS 2/2 + control, Windows 6/6, gates, storage policy, api usage, keyring ×3, npm-global ×3, docker smoke, aggregate `ci` = success). Tested tree `7621cac89` equals the prospective merge tree of `origin/dev@ece556a6e` + chain top. Independent chain review PASS; #3845 security review PASS (see #3869). Local suites NOT RUN by maintainer instruction. This is maintainer integration, not self-approval. Lower-layer PR runs are skipped/cancelled by design (`[skip ci]`); they are not passing evidence on their own.
