### PR TITLE
fix(responses): bound the streaming citation marker span (carry #3843)

### DIFF
--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -1,6 +1,7 @@
 import { decodeEventStream } from "../lib/eventstream-decoder";
 import { estimateTokens } from "../lib/token-estimate";
 import { debugProviderDiagnostic } from "../lib/debug";
+import { isDebugEnabled } from "../lib/debug-settings";
 import { resolveKiroApiRegion, resolveKiroRequestProfile } from "../oauth/kiro";
 import { KIRO_MODEL_CONTEXT_WINDOWS, normalizeKiroModelId } from "../providers/kiro-models";
 import { modelRecordValue } from "../reasoning-effort";
@@ -2120,17 +2121,21 @@ export function createKiroAdapter(provider: OcxProviderConfig): ProviderAdapter 
     const rawContextInputEstimate = estimateKiroPayloadInputTokens(built.payload, parsed.modelId);
     const contextInputEstimate = calibrateKiroEstimate(built.conversationId, rawContextInputEstimate);
     const body = JSON.stringify(built.payload);
-    debugProviderDiagnostic("kiro", "request", {
-      region,
-      requestedModel: parsed.modelId,
-      completionMode: built.completionMode,
-      bodyBytes: new TextEncoder().encode(body).length,
-      messageCount: kiroPayloadMessages(parsed).length,
-      toolCount: parsed.context.tools?.length ?? 0,
-      hasProfileArn: Boolean(profileArn),
-      wireClient,
-      hasPreviousResponseId: Boolean(parsed.previousResponseId),
-    });
+    // Every field below is evaluated before the call, so an unguarded call re-encodes the
+    // whole request body on each request even when provider debug is off. Gate the details.
+    if (isDebugEnabled()) {
+      debugProviderDiagnostic("kiro", "request", {
+        region,
+        requestedModel: parsed.modelId,
+        completionMode: built.completionMode,
+        bodyBytes: new TextEncoder().encode(body).length,
+        messageCount: kiroPayloadMessages(parsed).length,
+        toolCount: parsed.context.tools?.length ?? 0,
+        hasProfileArn: Boolean(profileArn),
+        wireClient,
+        hasPreviousResponseId: Boolean(parsed.previousResponseId),
+      });
+    }
     return {
       request: {
         url: kiroRuntimeEndpoint(provider, region),

--- a/src/responses/citation-markers.ts
+++ b/src/responses/citation-markers.ts
@@ -69,12 +69,24 @@ export interface CitationMarkerFilter {
 }
 
 /**
+ * Upper bound on the text withheld for one unterminated START.
+ *
+ * A real span is `cite` plus a few turn-scoped ids, so it is far under this. Without a
+ * bound, a backend that emits a START and never terminates it makes `held` grow for the
+ * whole response, and every later delta re-scans that accumulated prefix.
+ */
+const MAX_STREAMING_MARKER_SPAN_LENGTH = 4_096;
+
+/**
  * Streaming filter.
  *
  * A marker can straddle a delta boundary — `\uE200cite` in one chunk and the rest in the
  * next — so a stateless per-delta strip would emit the tail of a span it never recognized.
  * This holds back the text from an unterminated START and releases it once the END arrives
  * (removed) or the stream ends (verbatim, so nothing the model actually said is lost).
+ *
+ * A span that grows past `MAX_STREAMING_MARKER_SPAN_LENGTH` is malformed ordinary text, so
+ * it is released verbatim instead of withheld; a later START can still open a valid span.
  */
 export function createCitationMarkerFilter(): CitationMarkerFilter {
   // Text from an open START that has not been terminated yet.
@@ -87,6 +99,11 @@ export function createCitationMarkerFilter(): CitationMarkerFilter {
       if (start === -1) return stripCitationMarkers(combined);
       const endAfterStart = combined.indexOf(CITATION_MARKER_END, start + 1);
       if (endAfterStart !== -1) return stripCitationMarkers(combined);
+      // Over the bound: this is not a citation span we will ever close. Emit it verbatim
+      // so neither the retained text nor the per-delta rescan grows without limit.
+      if (combined.length - start > MAX_STREAMING_MARKER_SPAN_LENGTH) {
+        return stripCitationMarkers(combined.slice(0, start)) + combined.slice(start);
+      }
       // The trailing span is still open: emit everything before it, hold the rest.
       held = combined.slice(start);
       return stripCitationMarkers(combined.slice(0, start));

--- a/src/responses/citation-markers.ts
+++ b/src/responses/citation-markers.ts
@@ -95,18 +95,29 @@ export function createCitationMarkerFilter(): CitationMarkerFilter {
     push(delta: string): string {
       const combined = held + delta;
       held = "";
-      const start = combined.lastIndexOf(CITATION_MARKER_START);
-      if (start === -1) return stripCitationMarkers(combined);
-      const endAfterStart = combined.indexOf(CITATION_MARKER_END, start + 1);
-      if (endAfterStart !== -1) return stripCitationMarkers(combined);
-      // Over the bound: this is not a citation span we will ever close. Emit it verbatim
-      // so neither the retained text nor the per-delta rescan grows without limit.
-      if (combined.length - start > MAX_STREAMING_MARKER_SPAN_LENGTH) {
-        return stripCitationMarkers(combined.slice(0, start)) + combined.slice(start);
+      let start = combined.indexOf(CITATION_MARKER_START);
+      if (start === -1) return combined;
+      let out = combined.slice(0, start);
+      // Walk START-delimited segments independently so an earlier malformed START is never
+      // paired with a later span's END (the whole-string strip would do exactly that).
+      while (start !== -1) {
+        const nextStart = combined.indexOf(CITATION_MARKER_START, start + 1);
+        const segment = combined.slice(start, nextStart === -1 ? combined.length : nextStart);
+        const end = segment.indexOf(CITATION_MARKER_END, 1);
+        if (end !== -1) {
+          // A complete span: drop it, keep whatever trails it inside this segment.
+          out += segment.slice(end + 1);
+        } else if (nextStart === -1 && segment.length <= MAX_STREAMING_MARKER_SPAN_LENGTH) {
+          // Only a bounded trailing span can still be completed by a later delta.
+          held = segment;
+        } else {
+          // Superseded by a later START, or over the bound: ordinary text, emitted verbatim
+          // so neither the retained text nor the per-delta rescan grows without limit.
+          out += segment;
+        }
+        start = nextStart;
       }
-      // The trailing span is still open: emit everything before it, hold the rest.
-      held = combined.slice(start);
-      return stripCitationMarkers(combined.slice(0, start));
+      return out;
     },
     flush(): string {
       const rest = held;
@@ -115,4 +126,3 @@ export function createCitationMarkerFilter(): CitationMarkerFilter {
     },
   };
 }
-

--- a/tests/providers/kiro/kiro-stream.test.ts
+++ b/tests/providers/kiro/kiro-stream.test.ts
@@ -16,6 +16,11 @@ import { parseKiroEvent } from "../../../src/adapters/kiro-events";
 import { resetKiroThrottleStateForTests } from "../../../src/adapters/kiro-retry";
 import { resetKiroCalibration } from "../../../src/adapters/kiro-calibration";
 import { buildResponseJSON } from "../../../src/bridge";
+import {
+  clearDebugSetting,
+  getDebugSettings,
+  setDebugSettings,
+} from "../../../src/lib/debug-settings";
 import { encodeMessage } from "../../../src/lib/eventstream-decoder";
 import { estimateTokens } from "../../../src/lib/token-estimate";
 import { createTranslatorBudget } from "../../../src/lib/translator-budget";
@@ -34,11 +39,16 @@ const origApiRegion = process.env.KIRO_API_REGION;
 const origArn = process.env.KIRO_PROFILE_ARN;
 const origCredsFile = process.env.KIRO_CREDS_FILE;
 const origCredentialsFile = process.env.KIRO_CREDENTIALS_FILE;
-const origDebugFrames = process.env.OCX_DEBUG_FRAMES;
+let origDebug: string | undefined;
+let origDebugFrames: string | undefined;
+let origDebugOverride: boolean | undefined;
 const realFetch = globalThis.fetch;
 let tmp: string;
 
 beforeEach(() => {
+  origDebug = process.env.OCX_DEBUG;
+  origDebugFrames = process.env.OCX_DEBUG_FRAMES;
+  origDebugOverride = getDebugSettings().runtimeOverride.debug;
   tmp = mkdtempSync(join(tmpdir(), "kiro-stream-"));
   process.env.HOME = tmp;
   process.env.KIRO_REGION = "us-east-1";
@@ -46,7 +56,9 @@ beforeEach(() => {
   delete process.env.KIRO_PROFILE_ARN;
   delete process.env.KIRO_CREDS_FILE;
   delete process.env.KIRO_CREDENTIALS_FILE;
+  delete process.env.OCX_DEBUG;
   delete process.env.OCX_DEBUG_FRAMES;
+  clearDebugSetting("debug");
 });
 afterEach(() => {
   globalThis.fetch = realFetch;
@@ -57,7 +69,10 @@ afterEach(() => {
   if (origArn === undefined) delete process.env.KIRO_PROFILE_ARN; else process.env.KIRO_PROFILE_ARN = origArn;
   if (origCredsFile === undefined) delete process.env.KIRO_CREDS_FILE; else process.env.KIRO_CREDS_FILE = origCredsFile;
   if (origCredentialsFile === undefined) delete process.env.KIRO_CREDENTIALS_FILE; else process.env.KIRO_CREDENTIALS_FILE = origCredentialsFile;
+  if (origDebug === undefined) delete process.env.OCX_DEBUG; else process.env.OCX_DEBUG = origDebug;
   if (origDebugFrames === undefined) delete process.env.OCX_DEBUG_FRAMES; else process.env.OCX_DEBUG_FRAMES = origDebugFrames;
+  if (origDebugOverride === undefined) clearDebugSetting("debug");
+  else setDebugSettings({ debug: origDebugOverride });
   removeTreeWithRetry(tmp);
 });
 

--- a/tests/providers/kiro/kiro-stream.test.ts
+++ b/tests/providers/kiro/kiro-stream.test.ts
@@ -196,6 +196,21 @@ describe("kiro adapter — parseStream", () => {
     expect(providerState).toEqual({ kiro: { conversationId: "returned-conversation-1" } });
   });
 
+  test("request diagnostics do not re-encode the body when provider debug is off", async () => {
+    const encodeSpy = spyOn(TextEncoder.prototype, "encode");
+    try {
+      const adapter = createKiroAdapter(provider);
+      const before = encodeSpy.mock.calls.length;
+      await adapter.buildRequest(parsedWith([{ role: "user", content: "hi" }]));
+      const during = encodeSpy.mock.calls.slice(before);
+      // The diagnostic argument list is evaluated eagerly, so an unguarded call encodes the
+      // full serialized request body on every request even with diagnostics disabled.
+      expect(during.some(([value]) => typeof value === "string" && value.includes("conversationState"))).toBe(false);
+    } finally {
+      encodeSpy.mockRestore();
+    }
+  });
+
   test("invalid returned message metadata cannot poison continuation state", async () => {
     const adapter = createKiroAdapter(provider);
     const request = await adapter.buildRequest(parsedWith([{ role: "user", content: "hi" }]));

--- a/tests/responses/citation-markers.test.ts
+++ b/tests/responses/citation-markers.test.ts
@@ -87,4 +87,26 @@ describe("streaming citation marker filter (#3150)", () => {
     const filter = createCitationMarkerFilter();
     expect(filter.push(`visible now ${S}cite`)).toBe("visible now ");
   });
+
+  test("an unterminated span past the bound is released instead of retained", () => {
+    // A backend that opens a span and never closes it must not make the filter accumulate
+    // the rest of the response, which every later delta would then re-scan.
+    const filter = createCitationMarkerFilter();
+    let out = filter.push(`kept ${S}cite`);
+    expect(out).toBe("kept ");
+    for (let i = 0; i < 5_000; i += 1) out += filter.push("x");
+
+    // Everything after the malformed START is emitted verbatim, so nothing is lost, and
+    // flush() has nothing left to release.
+    expect(out).toBe(`kept ${S}cite${"x".repeat(5_000)}`);
+    expect(filter.flush()).toBe("");
+  });
+
+  test("a later START still opens a valid span after a released malformed one", () => {
+    const filter = createCitationMarkerFilter();
+    let out = filter.push(`a${S}${"y".repeat(5_000)}`);
+    out += filter.push(`${S}cite${P}turn1view0${E} tail`);
+    expect(out).toBe(`a${S}${"y".repeat(5_000)} tail`);
+    expect(filter.flush()).toBe("");
+  });
 });

--- a/tests/responses/citation-markers.test.ts
+++ b/tests/responses/citation-markers.test.ts
@@ -109,4 +109,12 @@ describe("streaming citation marker filter (#3150)", () => {
     expect(out).toBe(`a${S}${"y".repeat(5_000)} tail`);
     expect(filter.flush()).toBe("");
   });
+
+  test("an oversized malformed span survives a later valid marker in the same delta", () => {
+    const filter = createCitationMarkerFilter();
+    const malformed = `${S}${"y".repeat(5_000)}`;
+    expect(filter.push(`a${span}${malformed}${S}cite${P}turn1view0${E} tail`))
+      .toBe(`a${malformed} tail`);
+    expect(filter.flush()).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

Carries #3843 by @luvs01: the streaming citation-marker filter retains at most 4096 characters for an unterminated START. Adds the fix for the unresolved major finding (discussion_r3946034145): START-delimited segments are now walked independently, so an oversized malformed span followed by a valid marker in the same delta is emitted verbatim instead of being paired with the later END and dropped.

(carried/reimplemented from https://github.com/lidge-jun/opencodex/pull/3843; Co-authored-by trailer in the commit)

## Verification

- Regression: `tests/responses/citation-markers.test.ts` (existing bound/recovery tests plus the new same-delta case) runs in the chain-top CI.
- Local checks NOT RUN by maintainer instruction.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

**Manual review chain (integrate bottom-up; stack: null, no native stack)**

| Layer | Branch | Base | Source |
|---|---|---|---|
| 1 | `codex/rt-m1-3532` | `dev` | #3532 (Ingwannu) |
| 2 | `codex/rt-m2-3840` | layer 1 | #3840 (chilung-cgu) |
| 3 | `codex/rt-m3-3837` | layer 2 | #3837 (luvs01) + test isolation fix |
| 4 | `codex/rt-m4-3843` | layer 3 | #3843 (luvs01) + same-delta fix |
| 5 | `codex/rt-m5-3845` | layer 4 | #3845 (luvs01) |
| 6 | `codex/rt-m6-2033` | layer 5 | #2033 (louis-tepe) reimplemented — chain top |

Verification policy (maintainer instruction, this train): local test suite / typecheck / build were **NOT RUN**; branches pushed with `--no-verify`. Lower layers carry `[skip ci]`; the full Cross-platform CI (lane=all, Windows shards included) runs once at the chain top head and is the exact-head evidence for the cumulative tree.

Layer 4 of 6. Review this PR's diff only.



---

**Maintainer integration decision (MAINTAINERS.md, dev-only admin integration):** @lidge-jun integrates this manual chain into `dev` bottom-up. Exact chain-top evidence: Cross-platform CI run [34106345180](https://github.com/lidge-jun/opencodex/actions/runs/34106345180) at head `6eadb1658` (lane=all: Linux 4/4, macOS 2/2 + control, Windows 6/6, gates, storage policy, api usage, keyring ×3, npm-global ×3, docker smoke, aggregate `ci` = success). Tested tree `7621cac89` equals the prospective merge tree of `origin/dev@ece556a6e` + chain top. Independent chain review PASS; #3845 security review PASS (see #3869). Local suites NOT RUN by maintainer instruction. This is maintainer integration, not self-approval. Lower-layer PR runs are skipped/cancelled by design (`[skip ci]`); they are not passing evidence on their own.
