### PR TITLE
fix(management): expose the effective web-search sidecar enabled state (reimplements #2033)

### DIFF
--- a/src/providers/key-store.ts
+++ b/src/providers/key-store.ts
@@ -64,6 +64,16 @@ function keychainAccount(reference: string): string {
   return reference.slice(KEYCHAIN_REFERENCE_PREFIX.length);
 }
 
+/**
+ * A reference belongs to `name` only when its account is that provider's own active account
+ * or one of its pool accounts. `storeProviderKeyInKeychain` writes exactly those two shapes,
+ * so anything else in a provider's config names another provider's secret.
+ */
+function keychainReferenceBelongsToProvider(reference: string, name: string): boolean {
+  const account = keychainAccount(reference);
+  return account === name || account.startsWith(`${name}/`);
+}
+
 function readKeychain(account: string): string | undefined {
   const cached = resolvedCache.get(account);
   if (cached !== undefined) return cached;
@@ -185,6 +195,18 @@ export function restoreProviderKeyFromKeychain(config: OcxConfig, name: string):
   const pool = provider.apiKeyPool ?? [];
   const resolved = new Map<string, string>();
   const refs = [provider.apiKey, ...pool.map(e => e.key)].filter(isKeychainReference);
+  // Restore reads a secret out of the keychain, writes it back to config as plaintext, and then
+  // DELETES the keychain item. Following a reference to another provider's account would both
+  // disclose that secret through this provider's config and destroy the real owner's credential,
+  // so refuse before anything is read or removed.
+  const foreign = refs.filter(ref => !keychainReferenceBelongsToProvider(ref, name));
+  if (foreign.length > 0) {
+    return {
+      ok: false,
+      error: `provider "${name}" references a keychain account it does not own (${foreign.length} reference(s)); config left unchanged`,
+      status: 400,
+    };
+  }
   for (const ref of refs) {
     const account = keychainAccount(ref);
     if (resolved.has(account)) continue;

--- a/src/server/management/config-routes.ts
+++ b/src/server/management/config-routes.ts
@@ -701,6 +701,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
     const webSearchCandidates = await webSearchCandidateRows(config);
     return jsonResponse({
       webSearch: {
+        enabled: ws.enabled !== false,
         model: ws.model ?? "gpt-5.6-luna",
         backend: ws.backend,
         streamRoutedModelOutput: ws.streamRoutedModelOutput === true,
@@ -939,6 +940,7 @@ export async function handleConfigRoutes(ctx: ManagementContext): Promise<Respon
     return jsonResponse({
       ok: true,
       webSearch: {
+        enabled: ws.enabled !== false,
         model: ws.model ?? "gpt-5.6-luna",
         backend: ws.backend,
         streamRoutedModelOutput: ws.streamRoutedModelOutput === true,

--- a/tests/providers/provider-key-store.test.ts
+++ b/tests/providers/provider-key-store.test.ts
@@ -156,6 +156,37 @@ describe("store / restore", () => {
     expect(probeProviderKeychain().available).toBe(false);
   });
 
+  test("restore refuses a reference to another provider's keychain account", () => {
+    const { store, factory } = fakeKeychain();
+    setProviderKeychainEntryFactoryForTests(factory);
+    const config = loadConfig();
+    config.providers.other = { adapter: "openai-chat", baseUrl: "https://other.example/v1", apiKey: POOL_SECRET };
+    expect(storeProviderKeyInKeychain(config, "other")).toEqual({ ok: true, moved: 1 });
+    expect(config.providers.other!.apiKey).toBe("keychain:other");
+
+    // Point "relay" at the account "other" owns. Restore would otherwise read that secret,
+    // write it into relay's config as plaintext, and delete the owner's keychain item.
+    config.providers.relay!.apiKey = "keychain:other";
+    const result = restoreProviderKeyFromKeychain(config, "relay");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+
+    expect(config.providers.relay!.apiKey).toBe("keychain:other");
+    expect(readFileSync(join(testDir, "config.json"), "utf8")).not.toContain(POOL_SECRET);
+    // The real owner's secret is still in the keychain and still resolves for that provider.
+    expect(store.size).toBe(1);
+    expect(resolveProviderApiKey(config.providers.other!.apiKey)).toBe(POOL_SECRET);
+  });
+
+  test("restore still accepts a provider's own active and pool accounts", () => {
+    const { factory } = fakeKeychain();
+    setProviderKeychainEntryFactoryForTests(factory);
+    const config = loadConfig();
+    config.providers.relay!.apiKeyPool = [{ id: "a1", key: SECRET }, { id: "b2", key: POOL_SECRET }];
+    expect(storeProviderKeyInKeychain(config, "relay")).toEqual({ ok: true, moved: 2 });
+    expect(restoreProviderKeyFromKeychain(config, "relay")).toEqual({ ok: true, restored: 2 });
+  });
+
   test("management route: GET reports store kind, POST store/restore round-trips", async () => {
     const { factory } = fakeKeychain();
     setProviderKeychainEntryFactoryForTests(factory);
@@ -192,4 +223,3 @@ describe("store / restore", () => {
     }
   });
 });
-

--- a/tests/vision/sidecar-settings-vision-controls.test.ts
+++ b/tests/vision/sidecar-settings-vision-controls.test.ts
@@ -222,6 +222,18 @@ describe("sidecar-settings remaining vision controls", () => {
     expect(config.visionSidecar).toEqual({ ...FULL_VISION, enabled: false });
   });
 
+  test("GET and PUT expose the effective web-search enabled state", async () => {
+    const unset = await getSidecarSettings(emptyConfig());
+    expect((await unset.json() as { webSearch: { enabled: boolean } }).webSearch.enabled).toBe(true);
+
+    const config = emptyConfig({ webSearchSidecar: { enabled: false } });
+    const disabled = await getSidecarSettings(config);
+    expect((await disabled.json() as { webSearch: { enabled: boolean } }).webSearch.enabled).toBe(false);
+
+    const response = await putSidecarSettings(config, { webSearch: { streamRoutedModelOutput: true } });
+    expect((await response.json() as { webSearch: { enabled: boolean } }).webSearch.enabled).toBe(false);
+  });
+
   test("timeoutMs validation reuses the runtime bounds rather than a second contract", async () => {
     expect(resolveVisionTimeoutMs(undefined)).toBe(DEFAULT_VISION_TIMEOUT_MS);
     expect(resolveVisionTimeoutMs(MIN_VISION_TIMEOUT_MS)).toBe(MIN_VISION_TIMEOUT_MS);

--- a/tests/vision/vision-anthropic.test.ts
+++ b/tests/vision/vision-anthropic.test.ts
@@ -339,7 +339,7 @@ describe("Anthropic vision planning and management config", () => {
         config,
       );
       const getBody = await get!.json() as Record<string, any>;
-      expect(getBody.webSearch).toEqual({ model: "claude-haiku-4-5", backend: "anthropic", streamRoutedModelOutput: false });
+      expect(getBody.webSearch).toEqual({ enabled: true, model: "claude-haiku-4-5", backend: "anthropic", streamRoutedModelOutput: false });
       expect(getBody.vision).toEqual({
         enabled: true,
         model: "claude-sonnet-5",
@@ -363,7 +363,7 @@ describe("Anthropic vision planning and management config", () => {
       );
       expect(clear.status).toBe(200);
       const clearBody = await clear.json() as Record<string, any>;
-      expect(clearBody.webSearch).toEqual({ model: "gpt-5.6-luna", streamRoutedModelOutput: false });
+      expect(clearBody.webSearch).toEqual({ enabled: true, model: "gpt-5.6-luna", streamRoutedModelOutput: false });
       expect(clearBody.vision).toEqual({
         enabled: true,
         model: "gpt-5.4-mini",


### PR DESCRIPTION
## Summary

Reimplements #2033 by @louis-tepe on current dev (the original is 1364 commits behind and its test moved under `tests/vision/`). GET and PUT `/api/sidecar-settings` now return `webSearch.enabled` (unset reads as enabled) so the dashboard can tell whether the sidecar master switch is off. Chain top: this head carries the full Cross-platform CI run for the cumulative tree.

(carried/reimplemented from https://github.com/lidge-jun/opencodex/pull/2033; Co-authored-by trailer in the commit)

## Verification

- Regression: `tests/vision/sidecar-settings-vision-controls.test.ts` "GET and PUT expose the effective web-search enabled state".
- Chain-top Cross-platform CI (lane=all, Windows included): https://github.com/lidge-jun/opencodex/actions/runs/34106345180 at head 6eadb1658; result recorded before merge.
- Local checks NOT RUN by maintainer instruction.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

**Manual review chain (integrate bottom-up; stack: null, no native stack)**

| Layer | Branch | Base | Source |
|---|---|---|---|
| 1 | `codex/rt-m1-3532` | `dev` | #3532 (Ingwannu) |
| 2 | `codex/rt-m2-3840` | layer 1 | #3840 (chilung-cgu) |
| 3 | `codex/rt-m3-3837` | layer 2 | #3837 (luvs01) + test isolation fix |
| 4 | `codex/rt-m4-3843` | layer 3 | #3843 (luvs01) + same-delta fix |
| 5 | `codex/rt-m5-3845` | layer 4 | #3845 (luvs01) |
| 6 | `codex/rt-m6-2033` | layer 5 | #2033 (louis-tepe) reimplemented — chain top |

Verification policy (maintainer instruction, this train): local test suite / typecheck / build were **NOT RUN**; branches pushed with `--no-verify`. Lower layers carry `[skip ci]`; the full Cross-platform CI (lane=all, Windows shards included) runs once at the chain top head and is the exact-head evidence for the cumulative tree.

Layer 6 of 6. Review this PR's diff only.




---

**Maintainer integration decision (MAINTAINERS.md, dev-only admin integration):** @lidge-jun integrates this manual chain into `dev` bottom-up. Exact chain-top evidence: Cross-platform CI run [34106345180](https://github.com/lidge-jun/opencodex/actions/runs/34106345180) at head `6eadb1658` (lane=all: Linux 4/4, macOS 2/2 + control, Windows 6/6, gates, storage policy, api usage, keyring ×3, npm-global ×3, docker smoke, aggregate `ci` = success). Tested tree `7621cac89` equals the prospective merge tree of `origin/dev@ece556a6e` + chain top. Independent chain review PASS; #3845 security review PASS (see #3869). Local suites NOT RUN by maintainer instruction. This is maintainer integration, not self-approval. Lower-layer PR runs are skipped/cancelled by design (`[skip ci]`); they are not passing evidence on their own.
