### PR TITLE
fix(responses): disable Lite transport for Spark

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2501,6 +2501,13 @@ export function createResponsesPassthroughAdapter(provider: OcxProviderConfig): 
         parsed.modelId,
       );
       if (isCanonicalOpenAiForwardProvider(provider)) {
+        // Spark closes Responses Lite streams before a terminal completion. Select compatibility
+        // from the final wire model so aliases cannot leave the caller or a static header enabled.
+        if (isPlainObject(finalBody) && finalBody.model === "gpt-5.3-codex-spark") {
+          for (const name of Object.keys(headers)) {
+            if (name.toLowerCase() === CODEX_RESPONSES_LITE_HEADER) delete headers[name];
+          }
+        }
         const routingHeaders = new Headers(headers);
         applyCodexRoutingHint(routingHeaders, finalBody);
         // Static headers may use mixed casing. Remove every stale spelling

--- a/tests/codex-integration/codex-metadata-integrity.test.ts
+++ b/tests/codex-integration/codex-metadata-integrity.test.ts
@@ -208,6 +208,35 @@ describe("Codex request transport metadata", () => {
     expect(new Headers(dropped.headers).get(hintHeader)).toBe("model=gpt-5.6-sol");
   });
 
+  test("canonical adapter drops Lite only for the Spark wire model", async () => {
+    const adapter = createResponsesPassthroughAdapter({
+      adapter: "openai-responses", authMode: "forward", baseUrl: "https://chatgpt.com/backend-api/codex",
+      headers: { "X-OpenAI-Internal-Codex-Responses-Lite": "true" },
+    });
+
+    for (const [model, incomingLite, expectedLite] of [
+      ["gpt-5.3-codex-spark", "true", null],
+      ["gpt-5.3-codex-spark", undefined, null],
+      ["gpt-5.6-sol", "true", "true"],
+    ] as const) {
+      const parsed = minimalParsed();
+      parsed.modelId = model;
+      parsed._rawBody = { model, input: [], stream: true };
+      const incoming = new Headers();
+      if (incomingLite !== undefined) incoming.set(liteHeader, incomingLite);
+      const request = await adapter.buildRequest(parsed, {
+        headers: incoming,
+      });
+      expect(new Headers(request.headers).get(liteHeader)).toBe(expectedLite);
+    }
+
+    const routed = minimalParsed();
+    routed.modelId = "spark-alias";
+    routed._rawBody = { model: "gpt-5.3-codex-spark", input: [], stream: true };
+    const request = await adapter.buildRequest(routed, { headers: new Headers({ [liteHeader]: "true" }) });
+    expect(new Headers(request.headers).get(liteHeader)).toBeNull();
+  });
+
   test("noncanonical adapters neither forward caller Lite nor synthesize a routing hint", async () => {
     for (const authMode of ["forward", "key"] as const) {
       const adapter = createResponsesPassthroughAdapter({


### PR DESCRIPTION
## Summary

- Fixes the canonical `gpt-5.3-codex-spark` stream ending as `response.incomplete` / `adapter_eof` when Codex sends `x-openai-internal-codex-responses-lite: true`.
- Remove the Lite header only when the final serialized wire model is exactly `gpt-5.3-codex-spark`. Both caller-provided and mixed-case static spellings are removed.
- Preserve the existing header path for every other canonical model. Noncanonical providers, authentication, routing, relay terminal handling, and retry behavior are unchanged.

The final body is authoritative because routing or aliases may make `parsed.modelId` differ from the model sent upstream. Suppressing the header at that boundary also covers both the initial WebSocket preparation and its HTTP fallback without manufacturing a successful terminal after an upstream EOF.

Closes #3885.

## Verification

- Red-before-fix: `canonical adapter drops Lite only for the Spark wire model` failed with `Expected: null / Received: "true"` before the source change.
- `bun test tests/codex-integration/codex-metadata-integrity.test.ts tests/responses/ws-upstream.test.ts tests/responses/ws-upstream-reuse.test.ts` — 171 pass / 0 fail after rebasing onto current `dev`.
- `bun test --rerun-each 3 tests/codex-integration/codex-metadata-integrity.test.ts` — 54 pass / 0 fail.
- `bun run typecheck` — passed.
- `bun run privacy:scan` — passed.
- `bun run test:changed` selected the central adapter dependency set but reached the repository runner's 900-second suite ceiling (exit 124) without emitting an assertion failure. Full-suite completion remains deferred to CI; this result is not claimed as green.

No GUI, configuration, or public API changes; docs and i18n are unaffected.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Requests routed to `gpt-5.3-codex-spark` now correctly remove the internal Lite header, regardless of capitalization.
  - The header remains preserved for other models, ensuring model-specific routing behavior continues to work as expected.
  - Requests using aliases that resolve to `gpt-5.3-codex-spark` now receive the same corrected handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->