### PR TITLE
fix(release): strip enforcement prefix from release notes

### DIFF
--- a/devlog/_plan/260907_release_note_prefix/010_implementation.md
+++ b/devlog/_plan/260907_release_note_prefix/010_implementation.md
@@ -1,0 +1,25 @@
+# Issue #3895: implementation plan
+
+Satisfy-spec work, triggered by issue #3895 and the request to implement separate draft PRs. Goal: remove the exact leading enforcement marker from release summaries and full changelogs. Non-goals: changing workflow enforcement, publishing a release, modifying historical releases, or generic bracket stripping. Stop after verified draft PR; report unresolved gates. Escalate if renderer changes require workflow/security-policy changes. This file records plan and evidence.
+
+Class C2: pure formatting behavior, without modifying release authorization or execution. Independent branch from 522ce5f8c.
+
+File map:
+- MODIFY scripts/release-notes.ts: introduce a private exact-prefix normalization helper next to cleanPrTitle. Trim whitespace, remove one leading "[WRONG BRANCH] " marker, retain the rest. Call it before conventional-prefix parsing and for full-changelog titles. Preserve conventional prefixes and author/PR attribution in changelog entries.
+- MODIFY tests/ci-workflows/release-notes.test.ts: helper expected scope/casing; complete renderer on generated and carried notes; same-scope grouping; preservation of unrelated bracket tags, nonleading marker, author and PR references. Assert both category and Changelog output.
+- MODIFY structure/06_docs-and-release.md: record known-marker handling and preservation of original conventional titles in full changelogs.
+
+Verification: release-notes tests directly import changed helpers; typecheck covers src only and is not represented as script type checking; full prepush is required by scripts/AGENTS.md; privacy scan. Baseline on unchanged code: 71 passed. Regression expectations come from the published issue, not from cleanPrTitle itself.
+
+Audit: cleaning only cleanPrTitle was rejected because changelog emits the raw title. General bracket normalization would remove meaningful content. Private helper is shared by exactly two consumers and adds no runtime dependency. Explicit maintainer review for release-related changes remains pending at draft handoff.
+
+## Verification before draft publication
+
+- `bun install --frozen-lockfile`: passed; lockfile unchanged.
+- Before the production change, four new assertions failed for marker leakage: helper cleanup, delta renderer, carried renderer, and same-scope grouping. Existing baseline: 71 passed.
+- `bun test tests/ci-workflows/release-notes.test.ts`: 81 passed, 0 failed after expanding preservation cases.
+- `bun run typecheck`: passed during prepush.
+- `bun x tsc --ignoreConfig --noEmit --strict --target ESNext --module ESNext --moduleResolution bundler --skipLibCheck --types bun scripts/release-notes.ts`: passed; this explicitly covers the script outside the root tsconfig.
+- `bun run privacy:scan`: passed.
+- `bun run prepush`: not green. The parallel test lane exceeded its repository-defined 900-second deadline and exited 124; later lanes/stages did not run. Eleven failures were emitted before termination: six timeout cases across combo management, Claude messages, loopback injection, integration restore and Responses overflow; one Claude compatibility assertion failure; four Aside file-symlink EPERM cases. The full suite is incomplete, and no successful full-suite count is claimed. These files are outside the renderer change; causes other than the explicit symlink errors remain unverified. Raw local evidence is in ignored `.tmp/prepush.log`.
+- Focused independent review found no concrete production blocker; it was limited and did not replace maintainer security review or complete-suite verification. Linux and macOS were not run locally.

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -546,8 +546,14 @@ export function parseGeneratedNotes(body: string): ReleaseNoteCategory[] {
 const CONVENTIONAL_COMMIT_PREFIX =
   /^(?:feat|fix|docs|chore|refactor|perf|test|build|ci|style|revert|merge|release)(?:\(([^)]+)\))?:\s*(.+)$/i;
 
+function stripPrEnforcementPrefix(title: string): string {
+  const text = title.trim();
+  const prefix = "[WRONG BRANCH] ";
+  return text.startsWith(prefix) ? text.slice(prefix.length).trim() : text;
+}
+
 export function cleanPrTitle(title: string, prNumber: number | null = null): { scope: string | null; text: string } {
-  let text = title.trim();
+  let text = stripPrEnforcementPrefix(title);
   let scope: string | null = null;
   const prefix = CONVENTIONAL_COMMIT_PREFIX.exec(text);
   if (prefix) {
@@ -689,7 +695,7 @@ export function renderReleaseNotes(input: {
       changelog.push(`Full Changelog: https://github.com/${repo}/compare/${from}...${to}`, "");
     }
     for (const pr of allPrs) {
-      changelog.push(`- #${pr.number} ${pr.title.trim()} @${pr.author}`);
+      changelog.push(`- #${pr.number} ${stripPrEnforcementPrefix(pr.title)} @${pr.author}`);
     }
     parts.push(changelog.join("\n"));
   }

--- a/structure/06_docs-and-release.md
+++ b/structure/06_docs-and-release.md
@@ -227,6 +227,11 @@ so stable notes are the aggregate of their preview train. The raw commit dump is
 intentionally gone — non-PR commits stay reachable via the Full Changelog compare link when
 that link is available.
 
+Both summary bullets and full-changelog titles strip the exact leading `[WRONG BRANCH] `
+enforcement marker. Other bracketed text is preserved. Summary bullets still remove conventional
+commit prefixes and group by scope; full-changelog entries keep those conventional prefixes,
+PR numbers, and author attribution. This normalization does not change PR-target enforcement.
+
 The deterministic renderer produces the structure but not curated prose. Maintainers who want
 the OpenAI-style grouped summaries can run the optional local polish step against the rendered
 body (needs an OpenAI-compatible API key):

--- a/tests/ci-workflows/release-notes.test.ts
+++ b/tests/ci-workflows/release-notes.test.ts
@@ -455,6 +455,20 @@ describe("rewriteTakeoverCredits", () => {
 });
 
 describe("cleanPrTitle", () => {
+  test("removes the enforcement marker before extracting scope and sentence casing", () => {
+    expect(cleanPrTitle("  [WRONG BRANCH] chore(release): promote validated 2.45.0 to main (#3813)  ", 3813)).toEqual({
+      scope: "release",
+      text: "Promote validated 2.45.0 to main",
+    });
+  });
+
+  test.each([
+    ["[Preview] chore(release): keep this marker", "[Preview] chore(release): keep this marker"],
+    ["fix: document [WRONG BRANCH] markers", "Document [WRONG BRANCH] markers"],
+    ["[WRONG BRANCH]ish: keep this title", "[WRONG BRANCH]ish: keep this title"],
+  ])("preserves meaningful title text: %s", (title, text) => {
+    expect(cleanPrTitle(title).text).toBe(text);
+  });
   test("strips conventional prefix, keeps scope, and sentence-cases the title", () => {
     expect(cleanPrTitle("feat(providers): add Baseten Model APIs preset", 653)).toEqual({
       scope: "providers",
@@ -488,6 +502,55 @@ describe("cleanPrTitle", () => {
 });
 
 describe("renderReleaseNotes", () => {
+  test.each(["delta", "carried"])("removes the bot marker from summaries and full changelogs (%s)", source => {
+    const body = [
+      "## What's Changed",
+      "### Chores",
+      "* [WRONG BRANCH] chore(release): promote validated 2.45.0 to main by @lidge-jun in https://github.com/lidge-jun/opencodex/pull/3813",
+    ].join("\n");
+    const notes = renderReleaseNotes({
+      npmMetadata: "",
+      ...(source === "delta" ? { deltaPrNotes: body } : { carriedPreviewNotes: [
+        "## Chores", "",
+        "- [WRONG BRANCH] chore(release): promote validated 2.45.0 to main (#3813)", "",
+        "## Changelog", "",
+        "- #3813 [WRONG BRANCH] chore(release): promote validated 2.45.0 to main @lidge-jun",
+      ].join("\n") }),
+    });
+    expect(notes).toBe([
+      "## Chores", "",
+      "- Promote validated 2.45.0 to main (#3813)", "",
+      "## Changelog", "",
+      "- #3813 chore(release): promote validated 2.45.0 to main @lidge-jun", "",
+    ].join("\n"));
+  });
+
+  test("groups a bot-prefixed title with ordinary titles of the same scope", () => {
+    const notes = renderReleaseNotes({
+      npmMetadata: "",
+      deltaPrNotes: [
+        "## What's Changed", "### Chores",
+        "* [WRONG BRANCH] chore(release): promote verified version by @maintainer in https://github.com/lidge-jun/opencodex/pull/10",
+        "* chore(release): update notes by @contributor in https://github.com/lidge-jun/opencodex/pull/11",
+      ].join("\n"),
+    });
+    expect(notes).toContain("- Release: Promote verified version; Update notes (#10, #11)");
+    expect(notes).toContain("- #10 chore(release): promote verified version @maintainer");
+    expect(notes).toContain("- #11 chore(release): update notes @contributor");
+    expect(notes).not.toContain("[WRONG BRANCH]");
+  });
+
+  test.each([
+    "[Preview] chore(release): retain the preview marker",
+    "fix: document [WRONG BRANCH] markers (#99)",
+    "[WRONG BRANCH]ish: retain this title",
+  ])("preserves meaningful full-changelog title text: %s", title => {
+    const notes = renderReleaseNotes({
+      npmMetadata: "",
+      deltaPrNotes: `## What's Changed\n### Chores\n* ${title} by @contributor in https://github.com/lidge-jun/opencodex/pull/12`,
+    });
+    expect(notes).toContain(`- #12 ${title} @contributor`);
+  });
   const carried = [
     "<!-- Release notes generated using configuration in .github/release.yml at abc -->",
     "",


### PR DESCRIPTION
## Summary

Closes #3895.

Release notes can inherit the PR-enforcement bot's `[WRONG BRANCH] ` title marker. Strip this exact leading prefix before summary scope extraction and when rendering full changelog entries. A prefixed `chore(release): promote validated 2.45.0 to main` now produces a clean summary while its changelog keeps the conventional title, PR number, and author.

Complete-renderer regressions cover generated notes, carried preview notes, same-scope grouping, and preservation of unrelated bracketed text or nonleading markers. The release structure document records the normalization rule. Enforcement workflows and release execution are unchanged.

## Verification

Windows, Bun 1.4.0; independent branch from `dev` at `522ce5f8c8527d1e6c479a0090af14e390214bcb`.

- `bun test tests/ci-workflows/release-notes.test.ts`: 81 passed, 0 failed. Before the production change, four new helper/renderer assertions failed for the reported marker leak; the original baseline had 71 passing tests.
- `bun run typecheck`: passed during prepush. The repository config covers runtime source, so the script was also checked separately.
- `bun x tsc --ignoreConfig --noEmit --strict --target ESNext --module ESNext --moduleResolution bundler --skipLibCheck --types bun scripts/release-notes.ts`: passed.
- `bun run privacy:scan`: passed.

`bun run prepush` did **not** pass: the repository's parallel test lane reached its 900-second deadline and exited 124. The suite and later prepush stages were not completed. Before termination, 11 failures were emitted outside the changed renderer:

- Six timeout cases in combo management, Claude messages (two), loopback injection, integration restore, and Responses overflow.
- One Claude compatibility assertion failure.
- Four Aside profile file-symlink cases reporting `EPERM` on this Windows host.

The timeout/assertion causes have not been established, and this is not a claim that all failures are environmental or pre-existing. No full-suite passing count is claimed. The successful privacy scan above was a separate invocation. Local logs remain in ignored `.tmp/prepush.log`; plan and evidence are in `devlog/_plan/260907_release_note_prefix/010_implementation.md`. Linux and macOS were not tested locally.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer security review of release-related changes remains pending. This draft does not attest full local CI or readiness to merge.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release notes now remove the exact leading `[WRONG BRANCH]` marker from summary bullets and full changelog titles.
  * Other bracketed text and similar title content remain unchanged.
  * Titles with the marker now group consistently with other entries sharing the same scope.

* **Documentation**
  * Updated release-notes documentation to describe the revised title formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->