### PR TITLE
fix: restore Windows atomic temp-file creation (ENOENT)

### DIFF
--- a/src/config/atomic-write.ts
+++ b/src/config/atomic-write.ts
@@ -1,7 +1,6 @@
 import {
   chmodSync,
   closeSync,
-  constants,
   fchmodSync,
   fstatSync,
   lstatSync,
@@ -121,7 +120,7 @@ function writePrivateTempFile(
   timeoutMemoKey: string,
   onCreated: () => void,
 ): void {
-  const descriptor = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+  const descriptor = openSync(path, "wx", 0o600);
   onCreated();
   try {
     if (process.platform === "win32") {
@@ -142,7 +141,7 @@ async function writePrivateTempFileAsync(
   timeoutMemoKey: string,
   onCreated: () => void,
 ): Promise<void> {
-  const descriptor = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+  const descriptor = openSync(path, "wx", 0o600);
   onCreated();
   try {
     if (process.platform === "win32") {

--- a/tests/windows/windows-secret-acl.test.ts
+++ b/tests/windows/windows-secret-acl.test.ts
@@ -632,6 +632,18 @@ describe("icacls executable authority", () => {
   });
 });
 
+describe("atomic secret temp writer portability", () => {
+  test("sync and async secret temp writers use Bun-portable exclusive creation", async () => {
+    // Bun on Windows misinterpreted the equivalent numeric O_* combination as
+    // ENOENT, so every pid/config/oauth temp write failed during ocx start
+    // and on management-API config saves. Keep both writers on the portable
+    // exclusive-write spelling ("wx" keeps O_EXCL; 0o600 keeps the private
+    // mode) so the O_CREAT bit can never be dropped again.
+    const src = readFileSync(repoPath("src", "config", "atomic-write.ts"), "utf8");
+    expect(src.match(/openSync\(path, "wx", 0o600\)/g)).toHaveLength(2);
+  });
+});
+
 describe("diagnostics sanitization contract", () => {
   test("HardenResult diagnostics field is a plain string when present", () => {
     const filePath = join(testDir, "diag-test.json");


### PR DESCRIPTION
## Summary

- Restores working private temp-file creation in `src/config/atomic-write.ts`. `writePrivateTempFile` and `writePrivateTempFileAsync` built their flags numerically (`constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL`); Bun on Windows misreads that combination and drops the creation bit, so every private temp write fails with `ENOENT`.
- User-visible symptom: crashes like `ENOENT ... config.json.ocx.<pid>.tmp` under the OpenCodex home during `ocx start`, management-API config saves, and OAuth credential refreshes - the pid file, `config.json`, the codex runtime cache, and the OAuth credential store all write through this helper.
- The fix uses the portable exclusive-write spelling `openSync(path, "wx", 0o600)` in both writers. `"wx"` is exactly `O_WRONLY | O_CREAT | O_EXCL` (create-new, fail-if-exists preserved) and `0o600` keeps the private mode. No permission, exclusivity, or ownership semantics change - only the flag spelling that Bun miscompiles on Windows is replaced.
- Lineage: supersedes #3398 (closed without merging); the same fix was originally carried by #3383 (closed unmerged). This PR lands only the atomic-write repair plus its regression test.
- Credential-adjacent path (the OAuth store routes through this helper): security review requested per the repository policy. The explicit semantic-preservation analysis is the previous bullet.

## Verification

- Deterministic reproduction with a plain `bun` script against a fresh temp directory (no test harness): on pristine `dev` the atomic write throws `ENOENT ... config.json.ocx.<pid>.1.tmp`; with this commit the identical script writes and round-trips successfully. This is the reported production failure, reproduced and resolved.
- New regression test `sync and async secret temp writers use Bun-portable exclusive creation` in `tests/windows/windows-secret-acl.test.ts` pins both writers to the portable spelling so the numeric-flag form cannot return.
- `bun test tests/windows/windows-secret-acl.test.ts tests/oauth/oauth-refresh.test.ts` with the fix: 209 pass / 18 fail. Every failure is pre-existing or load-only: 13 are 5-second timeouts in timing-sensitive OAuth tests while sibling test runs saturated the machine (with the fix the same OAuth tests pass functionally - their writes succeed), and 5 are `native-main` hardening tests that fail with identical names on pristine `dev` (control run on pristine `dev`: 166 pass / 5 fail, same five tests). The change introduces zero new failures.
- `bun run typecheck` passes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No behavior or interface change beyond the repair; nothing to document.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. (Semantic-preservation analysis above: `O_EXCL` exclusivity and `0o600` private mode unchanged; no new logging; explicit maintainer security review requested in Summary.)

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved portability when creating temporary files used for secret configuration data, particularly on Windows and Bun.
  - Preserved exclusive file creation and restrictive `0o600` permissions, helping prevent accidental overwrites and unauthorized access.

- **Tests**
  - Added coverage to verify portable exclusive-write behavior for both synchronous and asynchronous secret temporary-file creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->