### PR TITLE
fix(responses): strip web_search fields for Muse Spark Contributor Free tiers

### DIFF
--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -2124,7 +2124,9 @@ export function stripOpenAiOnlyWebSearchFields(body: unknown): unknown {
  */
 const MUSE_SPARK_WEB_SEARCH_STRICT_MODELS = new Set([
   "muse-spark-1.3-contributor",
+  "muse-spark-1.3-contributor-free",
   "muse-spark-1.2-contributor",
+  "muse-spark-1.2-contributor-free",
 ]);
 
 const MUSE_SPARK_WEB_SEARCH_STRICT_RESPONSE_URLS = new Set([

--- a/tests/providers/muse-spark-web-search-compat.test.ts
+++ b/tests/providers/muse-spark-web-search-compat.test.ts
@@ -158,6 +158,22 @@ describe("#2617/#3378 Muse Spark web_search compatibility", () => {
     expect(Object.hasOwn(nested, "indexed_web_access")).toBe(false);
   });
 
+  /**
+   * The Contributor Free tiers ride the same Zen Responses wire with the same
+   * gateway contract, so a Codex `web_search` + refused-field body 400s for them
+   * exactly like the paid tiers.
+   */
+  test("Contributor Free tiers get the same web_search sanitization", () => {
+    for (const modelId of ["muse-spark-1.2-contributor-free", "muse-spark-1.3-contributor-free"]) {
+      const body = build(modelId, { tools: [webSearchTool()] });
+      const tool = toolsOf(body)[0]!;
+      expect(tool.type).toBe("web_search");
+      expect(tool.search_context_size).toBe("medium");
+      expect(Object.hasOwn(tool, "search_content_types")).toBe(false);
+      expect(Object.hasOwn(tool, "indexed_web_access")).toBe(false);
+    }
+  });
+
   test("OpenCode Go applies the same Muse compatibility guard", () => {
     const body = buildForProvider(ZEN_GO_PROVIDER, "muse-spark-1.3-contributor", {
       tools: [webSearchTool()],


### PR DESCRIPTION
The Contributor Free tiers (muse-spark-1.2-contributor-free, muse-spark-1.3-contributor-free) run on the same Zen Responses wire and gateway contract as the paid tiers, so a Codex web_search call with search_content_types or indexed_web_access 400s for them just like it did for paid before #2621.

This adds both -free ids to MUSE_SPARK_WEB_SEARCH_STRICT_MODELS and adds a compat test that mirrors the paid-tier assertions.

Verified with bun test tests/providers/muse-spark-web-search-compat.test.ts: 12 pass, 0 fail.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

