### PR TITLE
docs(readme): one-line Sponsors slot, sponsorship summary and contact at the bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,8 @@ once the others are drained.
 
 ### Sponsors
 
-Sponsors keep the proxy maintained across every upstream protocol change. Two tiers, one
-[rule set](./SPONSORS.md): **Main** is reserved for model developers and takes the banner
-below; **Standard** is for relays and gateways and takes a table row plus a built-in preset near
-the top of the provider picker. Pricing is by inquiry and rises after 20,000 stars — early
-sponsors keep their rate. Ask on [X](https://x.com/claudeebum),
-[Discord](https://discord.gg/JEaPEtkHwh) (`#sponsors`), or jun@lidgeai.com.
+Sponsors keep opencodex maintained across every upstream protocol change — see
+[Sponsorship](#sponsorship) at the bottom of this page.
 
 <!-- sponsors:main — one banner, model developers only; empty until a Main sponsor signs -->
 
@@ -394,6 +390,17 @@ where the commit does not name its original author, is recorded in
 opencodex is an independent, community-maintained project and is **not affiliated with or endorsed by OpenAI, Anthropic, or any other provider**.
 
 Some providers — notably Anthropic (Claude) — may suspend or restrict accounts that route API traffic through third-party proxies. **Use at your own risk (UAYOR).** Before connecting a provider, review its Terms of Service to confirm that proxy-based access is permitted. The opencodex maintainers are not responsible for any account actions taken by upstream providers.
+
+## Sponsorship
+
+Two tiers, one [rule set](./SPONSORS.md): **Main** is reserved for model developers and takes
+the banner above the sponsor table; **Standard** is for relays and gateways and takes a table
+row plus a built-in preset near the top of the provider picker. Pricing is by inquiry and rises
+after 20,000 stars — early sponsors keep their rate. Sponsors never influence routing, defaults,
+or security review.
+
+To sponsor, ask on [X](https://x.com/claudeebum), [Discord](https://discord.gg/JEaPEtkHwh)
+(`#sponsors`), or jun@lidgeai.com, and read [SPONSORS.md](./SPONSORS.md) first.
 
 ## License
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -57,10 +57,14 @@ sponsor receives:
 ## Placement
 
 The README sponsor section sits directly under **Quick start**, before the Docker Compose
-details, so it is on screen before a first-time visitor scrolls. Inside the section:
+details, so it is on screen before a first-time visitor scrolls. It carries one line of context
+and the placements themselves:
 
 1. One Main banner (empty until a Main sponsor signs).
 2. The Standard table, one row per sponsor, in order of signing date.
+
+The tier summary and the contact channels live in a **Sponsorship** section at the bottom of the
+README, just above the license, and point here for the full rule set.
 
 The translated READMEs under [`readme/`](./readme) carry one linking line right after their
 own quick-start block instead of duplicating the section, so a sponsor change is one edit in


### PR DESCRIPTION
## Summary

The Sponsors block under Quick start now carries one line plus the placement slots. The tier summary and contact channels (X, Discord #sponsors, email) move to a new **Sponsorship** section directly above License, pointing at SPONSORS.md. SPONSORS.md Placement describes the split.

## Verification

- bun run privacy:scan — passed
- Docs-only change; no code paths touched. Full suite NOT RUN locally; CI on this head is the gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README’s Sponsors section with a shorter introduction and a link to the new Sponsorship section.
  - Added sponsorship details covering tiers, pricing, sponsor boundaries, and contact instructions.
  - Clarified placement guidance in `SPONSORS.md`, including references to the README’s Sponsorship section and the full sponsorship rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->