### PR TITLE
fix(codex): settle reset-credit retry aliases canonically

### DIFF
--- a/docs-site/src/content/docs/reference/management-api.md
+++ b/docs-site/src/content/docs/reference/management-api.md
@@ -427,6 +427,13 @@ manager. Its routes are:
 | `POST /api/codex-auth/login/cancel` | Cancel a Codex login flow | — |
 | `GET /api/codex-auth/login-status` | Poll a flow or account login state. A completed new-account flow includes `catalogRefreshPending: true` only when recovery is needed. | Unknown flows report `expired`; no active flow reports `idle` |
 
+For reset-credit consumption, a different `operationId` supplied while the same physical
+account has an unfinished operation joins that operation as an alias. Its retry uses the
+original upstream request ID and records the outcome under that same identity, so later
+requests with the original ID or a known alias replay the stored result without another
+consume request. A previously unseen ID supplied after settlement starts a new explicit
+redemption; clients retrying an existing action should keep its ID.
+
 If a new account config row is saved but credential setup cannot finish, OAuth `login-status` reports
 `status: "error"` with
 `code: "codex_credential_persistence_failed"`, `accountId`, `needsReauth: true`, and optional

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -2341,7 +2341,7 @@ export async function handleCodexAuthAPI(
       const operation = await withResetCreditAuth(getRuntimeConfig(config), accountId, async auth => {
         // The ledger keys manual operations by the *physical* ChatGPT account, which is
         // only known after the auth wrapper resolves credentials. Open here, not earlier.
-        const identity = requestedOperationId === undefined
+        let identity = requestedOperationId === undefined
           ? undefined
           : {
             accountId,
@@ -2377,6 +2377,7 @@ export async function handleCodexAuthAPI(
             return response;
           }
           // Canonical id, which an alias join may map to an earlier caller id.
+          identity = { ...identity, operationId: opened.operationId };
           idempotencyKey = opened.operationId;
         } else {
           idempotencyKey = crypto.randomUUID();

--- a/tests/codex-integration/codex-auth-api.test.ts
+++ b/tests/codex-integration/codex-auth-api.test.ts
@@ -3280,6 +3280,13 @@ describe("codex-auth API", () => {
           config,
         );
         expect(retried!.status).toBe(200);
+        const replayed = await handleCodexAuthAPI(
+          consumeRequest({ accountId: "pool-alias", operationId: OTHER_OP_ID }),
+          new URL("http://localhost/api/codex-auth/reset-credits/consume"),
+          config,
+        );
+        expect(replayed!.status).toBe(200);
+        expect(await replayed!.json()).toEqual({ code: "reset", replayed: true });
         expect(upstream.redeemRequestIds).toEqual([OP_ID, OP_ID]);
       } finally {
         globalThis.fetch = previousFetch;


### PR DESCRIPTION
## Summary

A manual reset-credit retry can join an unfinished operation under a different caller ID. The upstream request already uses the original canonical ID, but the API was recording settlement with the alias ID. The ledger rejects that mismatch, so a later retry dispatches another consume request instead of replaying the stored result.

Use the ledger-returned canonical identity for settlement and ambiguous outcomes. Keep account ownership checks, failure handling, and the legacy path without an operation ID unchanged. The API reference clarifies alias replay and when a new ID represents a new redemption.

This carries the focused source commit `45ff81c25ed7636382fb0144409918067d44f616` onto current `dev`; unrelated release ancestry is excluded and the original authorship is retained. Scope is three files with 16 added lines and one removed line.

## Verification

Head `6f20c3d08cd202e43b8679de33674133bdc7f34c`, based on `dev` `273a3ab865cdd95f3ce08f5583c3e1661978301d`. Tested tree: `d7ca5f7f17e0acbdfd9d5b4fcf26171c7540834b`.

- `bun test tests/codex-integration/codex-auth-api.test.ts tests/codex-integration/codex-reset-credit-operation-ledger.test.ts --timeout 60000`: 299 passed with the project-pinned Bun 1.4.0 on Windows (and previously with Bun 1.4.2).
- The alias replay regression passed with the fix and failed when only the production fix was removed. The original candidate was restored and its SHA-256 verified.
- Test credentials, configuration homes, and upstream responses are fixtures; no real reset credit was consumed.
- `bun run typecheck`, `bun run privacy:scan`, and `git diff --check`: passed.
- Documentation build: 425 pages passed. Dependency declarations and frozen lockfiles match the reused installation.
- Independent read-only security review found no blocking issue: canonicalization happens after account ownership and execute admission, preserves both account identifiers, and does not change fail-closed or legacy behavior.

`bun run test:changed --timeout 60000` reached the repository runner's 900-second limit (exit 124), which discarded the captured output before emitting a selection summary. This is not a passing suite. Its owned runner and worker processes were confirmed absent afterward. [Full cross-platform contributor CI](https://github.com/luvs01/opencodex/actions/runs/34136111607) passed all 26 jobs on this exact head after one failed-job rerun. Contributor validation is complete; the PR remains in draft pending the required maintainer security review / `maintainer-sponsored` label for `src/codex/auth-api.ts`; the independent review above does not satisfy that maintainer gate.

The first CI attempt completed the macOS control with 21,405 passed, 16 skipped, and two Cursor stream-health timing assertion failures. Both cases passed in the other macOS lane on the same head, and the alias replay regression passed in the failed control. The single failed-job rerun passed on the same head without a source change; the initial attempt is retained here and is not counted as green.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified reset-credit redemption behavior when requests use different operation IDs.
  - Requests with a new ID during an unfinished redemption now follow the existing operation and reuse its result after completion.
  - Previously recognized aliases can replay the settled result, while new IDs submitted after settlement begin separate redemptions.

- **Bug Fixes**
  - Improved consistency for reset-credit redemption retries by preserving the original operation’s outcome across supported aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->