### PR TITLE
docs(readme): one sponsor line pointing at SPONSORS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ once the others are drained.
 
 ### Sponsors
 
-Sponsors keep opencodex maintained across every upstream protocol change — see
-[Sponsorship](#sponsorship) at the bottom of this page.
+Sponsors keep opencodex maintained across every upstream protocol change. Interested?
+See [SPONSORS.md](./SPONSORS.md).
 
 <!-- sponsors:main — one banner, model developers only; empty until a Main sponsor signs -->
 
@@ -390,17 +390,6 @@ where the commit does not name its original author, is recorded in
 opencodex is an independent, community-maintained project and is **not affiliated with or endorsed by OpenAI, Anthropic, or any other provider**.
 
 Some providers — notably Anthropic (Claude) — may suspend or restrict accounts that route API traffic through third-party proxies. **Use at your own risk (UAYOR).** Before connecting a provider, review its Terms of Service to confirm that proxy-based access is permitted. The opencodex maintainers are not responsible for any account actions taken by upstream providers.
-
-## Sponsorship
-
-Two tiers, one [rule set](./SPONSORS.md): **Main** is reserved for model developers and takes
-the banner above the sponsor table; **Standard** is for relays and gateways and takes a table
-row plus a built-in preset near the top of the provider picker. Pricing is by inquiry and rises
-after 20,000 stars — early sponsors keep their rate. Sponsors never influence routing, defaults,
-or security review.
-
-To sponsor, ask on [X](https://x.com/claudeebum), [Discord](https://discord.gg/JEaPEtkHwh)
-(`#sponsors`), or jun@lidgeai.com, and read [SPONSORS.md](./SPONSORS.md) first.
 
 ## License
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -63,8 +63,8 @@ and the placements themselves:
 1. One Main banner (empty until a Main sponsor signs).
 2. The Standard table, one row per sponsor, in order of signing date.
 
-The tier summary and the contact channels live in a **Sponsorship** section at the bottom of the
-README, just above the license, and point here for the full rule set.
+The README says nothing else about sponsorship; tiers, pricing, and contact channels live only on
+this page.
 
 The translated READMEs under [`readme/`](./readme) carry one linking line right after their
 own quick-start block instead of duplicating the section, so a sponsor change is one edit in

--- a/devlog/_plan/260907_sponsor_branches/000_plan.md
+++ b/devlog/_plan/260907_sponsor_branches/000_plan.md
@@ -1,0 +1,41 @@
+# 260907 sponsor branches
+
+Goal: two sponsor branches from `origin/dev` (`8bc9e4ee2`, which carries SPONSORS.md and the README
+Sponsors section), each ending in an open PR against `dev`. Neither merges here.
+
+## Shared mechanism (010, applied identically on both branches)
+
+- `ProviderRegistryEntry.sponsor?: { tier: "main" | "standard"; url: string }`.
+- `DerivedProviderPreset.sponsor?: "main" | "standard"` via `entryToPreset`.
+- `deriveProviderPresets()` keeps registry order; sorting is the picker's job.
+- GUI catalog (`provider-presets.ts` + `ProviderCatalog.tsx`): sponsors first, alphabetical by label
+  among sponsors (Main before Standard), then the existing usage/label order. Sponsor rows get a
+  `Sponsor` chip (`badge-accent`) before the auth badge. i18n key `modal.badge.sponsor` in all
+  nine locales.
+- CLI `ocx provider presets` prints `(sponsor)` after the label for sponsor rows.
+- Tests: derive test for the field, catalog ordering test for pinning + chip.
+
+## OrcaRouter (020)
+
+- Registry: `sponsor: { tier: "standard", url: "https://www.orcarouter.ai/?utm_source=opencodex" }`
+  on the existing `orcarouter` entry. PKCE lands separately via #3908 (author akf66), untouched.
+- README: first Standard row, uncomment the table. Logo `assets/sponsors/orcarouter.png` (from
+  `gui/public/provider-icons/orcarouter.svg` rendered to PNG), blurb from the sponsor if delivered,
+  else a neutral maintainer-written 60-word blurb marked for replacement.
+- docs-site providers guide: OrcaRouter paragraph in section 3.
+- Screenshots: dashboard Providers tab picker with OrcaRouter pinned, README section render.
+
+## PackyCode (030)
+
+- Registry: new `packycode` entry, `openai-chat`, baseUrl `https://cf.api.fan/v1` (from
+  docs.packyapi.com Codex/Kimi guides; `/v1/models` answers 401 without a key so the host is live),
+  `dashboardUrl https://www.packyapi.com/register?aff=k5KT`, sponsor standard. Model list from
+  the docs token groups: Codex group (gpt-5.5, gpt-5.1-codex), CC group (claude), seeded conservatively.
+- Icon: `gui/public/provider-icons/packycode.svg` from packyapi.com favicon.
+- README: Standard row with the sponsor's EN blurb and the ZH blurb beneath.
+- docs-site providers guide paragraph; screenshots as above.
+
+## Order
+
+010 on `sponsors/orcarouter`, cherry-picked to `sponsors/packycode`, then 020 and 030 in
+parallel. Each branch: privacy:scan, typecheck, focused tests, push `--no-verify`, PR with template.

--- a/devlog/_plan/260907_sponsor_branches/010_phase1.md
+++ b/devlog/_plan/260907_sponsor_branches/010_phase1.md
@@ -1,0 +1,3 @@
+# 010 shared sponsor mechanism
+
+See 000_plan.md section Shared mechanism. Diff targets: src/types/provider.ts (registry entry type), src/providers/derive.ts, gui/src/components/provider-catalog/provider-presets.ts, ProviderCatalog.tsx, gui/src/i18n/*.ts, src/cli/provider-runtime.ts, tests.

--- a/devlog/_plan/260907_sponsor_branches/020_phase2.md
+++ b/devlog/_plan/260907_sponsor_branches/020_phase2.md
@@ -1,0 +1,3 @@
+# 020 OrcaRouter branch
+
+See 000_plan.md section OrcaRouter.

--- a/devlog/_plan/260907_sponsor_branches/030_phase3.md
+++ b/devlog/_plan/260907_sponsor_branches/030_phase3.md
@@ -1,0 +1,3 @@
+# 030 PackyCode branch
+
+See 000_plan.md section PackyCode.


### PR DESCRIPTION
## Summary

The README keeps a single sponsor line under Quick start ("Interested? See SPONSORS.md") plus the placement slots. The bottom Sponsorship section with tiers, pricing, and contact channels is removed; that information lives only in SPONSORS.md.

## Verification

- bun run privacy:scan — passed
- Docs-only change. Full suite NOT RUN locally; CI on this head is the gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to direct readers to the dedicated sponsorship page.
  - Moved sponsorship tiers, pricing, and contact information out of the README and into `SPONSORS.md`.
  - Clarified that `SPONSORS.md` is the sole location for sponsorship details.
  - Added planning documentation covering upcoming sponsor catalog support and provider-specific sponsorship branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->