### PR TITLE
test(cursor): stabilize stream-health watchdog timing

### DIFF
--- a/tests/providers/cursor/cursor-stream-health.test.ts
+++ b/tests/providers/cursor/cursor-stream-health.test.ts
@@ -12,6 +12,7 @@ import {
 import { encodeConnectFrame } from "../../../src/adapters/cursor/framing";
 import { createLiveCursorTransport } from "../../../src/adapters/cursor/live-transport";
 import { createTestTranslatorBudget } from "../../helpers/translator-budget";
+import { isolationBudgetMs, watchdogMs } from "../../helpers/ci-watchdog";
 import type { CursorRunRequest, CursorServerMessage } from "../../../src/adapters/cursor/types";
 
 /**
@@ -99,7 +100,11 @@ function runRequest(): CursorRunRequest {
   } as CursorRunRequest;
 }
 
-async function drain(baseUrl: string, knobs: { streamSilenceFailMs?: number; streamHeartbeatOnlyFailMs?: number }): Promise<{
+async function drain(
+  baseUrl: string,
+  knobs: { streamSilenceFailMs?: number; streamHeartbeatOnlyFailMs?: number },
+  onFirstText?: () => void,
+): Promise<{
   messages: CursorServerMessage[];
   failure?: Error;
 }> {
@@ -112,7 +117,14 @@ async function drain(baseUrl: string, knobs: { streamSilenceFailMs?: number; str
   const messages: CursorServerMessage[] = [];
   let failure: Error | undefined;
   try {
-    for await (const message of transport.run(runRequest())) messages.push(message);
+    for await (const message of transport.run(runRequest())) {
+      messages.push(message);
+      if (message.type === "text" && onFirstText) {
+        const notify = onFirstText;
+        onFirstText = undefined;
+        notify();
+      }
+    }
   } catch (err) {
     failure = err instanceof Error ? err : new Error(String(err));
   } finally {
@@ -122,6 +134,15 @@ async function drain(baseUrl: string, knobs: { streamSilenceFailMs?: number; str
 }
 
 describe("Cursor inbound stream-health watchdog (T04)", () => {
+  // Scale once: the load helper applies a floor, so scaling each deadline separately
+  // would collapse the two clocks to the same value in CI.
+  const silenceMs = isolationBudgetMs(1_000);
+  const heartbeatOnlyMs = 2 * silenceMs;
+  const progressDurationMs = 3 * silenceMs;
+  // Include the existing two-second first-frame allowance and leave time for cleanup.
+  const fixtureLimitMs = 4 * silenceMs + 2_000;
+  const timeoutMs = Math.max(watchdogMs(15_000), fixtureLimitMs + silenceMs);
+
   test("silence after the first frame fails the turn with the stall error", async () => {
     await withH2Server(stream => {
       stream.on("error", () => {});
@@ -140,27 +161,24 @@ describe("Cursor inbound stream-health watchdog (T04)", () => {
       stream.on("error", () => {});
       stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
       stream.write(Buffer.from(textDeltaFrame("hi")));
-      // 40ms, not 100ms.
-      //
-      // The silence clock below is 400ms, so a 100ms ping left a margin of four
-      // ticks: miss three in a row and the SILENCE watchdog fires first, which
-      // is a different error and a green-looking bug report. That is exactly what
-      // happened on the v2.41.0 macOS runner -- the assertion wanted
-      // "heartbeat-only" and got "no inbound frames for 1s before turnEnded".
-      //
-      // Nothing about the behaviour under test needs a slow ping: the point is
-      // that heartbeats reset the silence clock and do NOT reset the
-      // heartbeat-only clock. A tighter interval tests the same two clocks with
-      // ten ticks of margin instead of four.
+      // Frequent heartbeats/checkpoints keep the silence clock fresh while the
+      // longer heartbeat-only clock must still expire under a loaded test runner.
       const ping = setInterval(() => {
         try {
           stream.write(Buffer.from(heartbeatFrame()));
           stream.write(Buffer.from(checkpointFrame()));
         } catch { clearInterval(ping); }
       }, 40);
-      stream.on("close", () => clearInterval(ping));
+      const limit = setTimeout(() => stream.close(), fixtureLimitMs);
+      stream.on("close", () => {
+        clearInterval(ping);
+        clearTimeout(limit);
+      });
     }, async baseUrl => {
-      const { failure } = await drain(baseUrl, { streamSilenceFailMs: 400, streamHeartbeatOnlyFailMs: 900 });
+      const { failure } = await drain(baseUrl, {
+        streamSilenceFailMs: silenceMs,
+        streamHeartbeatOnlyFailMs: heartbeatOnlyMs,
+      });
       expect(failure).toBeDefined();
       // Assert on the message, and say which watchdog won when the wrong one does.
       // A bare toContain here reported only the expected substring, which reads as
@@ -168,35 +186,50 @@ describe("Cursor inbound stream-health watchdog (T04)", () => {
       // silence watchdog fired first on a loaded runner.
       expect(failure!.message).toContain("heartbeat-only");
     });
-  }, 15_000);
+  }, timeoutMs);
 
   test("meaningful frames keep resetting both clocks; turnEnded finishes cleanly", async () => {
+    let firstTextReceivedAt: number | undefined;
+    let completedProgressSpan = false;
     await withH2Server(stream => {
       stream.on("error", () => {});
       stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+      stream.write(Buffer.from(textDeltaFrame("part-0")));
+      const latestEndAt = performance.now() + fixtureLimitMs;
       let count = 0;
       const tick = setInterval(() => {
         count += 1;
         try {
-          if (count < 6) {
-            stream.write(Buffer.from(textDeltaFrame(`part-${count}`)));
-          } else {
+          const now = performance.now();
+          const progressComplete = firstTextReceivedAt !== undefined
+            && now - firstTextReceivedAt >= progressDurationMs;
+          if (progressComplete || now >= latestEndAt) {
+            completedProgressSpan = progressComplete;
             stream.write(Buffer.from(turnEndedFrame()));
             stream.end();
             clearInterval(tick);
+          } else {
+            stream.write(Buffer.from(textDeltaFrame(`part-${count}`)));
           }
-        } catch { clearInterval(tick); }
-      }, 150);
+        } catch {
+          clearInterval(tick);
+          stream.destroy();
+        }
+      }, 100);
       stream.on("close", () => clearInterval(tick));
     }, async baseUrl => {
-      // Each 150ms text delta must reset the 400ms silence clock: six ticks ≈ 900ms total,
-      // far past a NON-resetting 400ms deadline.
-      const { messages, failure } = await drain(baseUrl, { streamSilenceFailMs: 400, streamHeartbeatOnlyFailMs: 10_000 });
+      // Observe progress for 3S after receipt: both non-resetting deadlines (S and 2S)
+      // would expire before turnEnded, even when the first text reaches us late.
+      const { messages, failure } = await drain(baseUrl, {
+        streamSilenceFailMs: silenceMs,
+        streamHeartbeatOnlyFailMs: heartbeatOnlyMs,
+      }, () => { firstTextReceivedAt = performance.now(); });
       expect(failure).toBeUndefined();
+      expect(completedProgressSpan).toBe(true);
       expect(messages.some(message => message.type === "text")).toBe(true);
       expect(messages.some(message => message.type === "done")).toBe(true);
     });
-  }, 15_000);
+  }, timeoutMs);
 
   test("turnEnded disarms the watchdog even when the server holds the stream open", async () => {
     await withH2Server(stream => {


### PR DESCRIPTION
## Summary

The [macOS control](https://github.com/luvs01/opencodex/actions/runs/34136111607/job/101787449639) hit the 400ms silence watchdog in two Cursor stream-health fixtures, while both cases passed in another macOS lane on the same head. The positive progress fixture also ended after about 900ms against a 10-second heartbeat-only limit, so it could not detect a missing progress-clock refresh.

Use one load-adjusted scale `S` for the silence deadline, `2S` for heartbeat-only failure, and at least `3S` of meaningful progress after the client receives its first text. Scaling once preserves the ordering when the existing helper applies its CI floor. Keep frequent heartbeat traffic and give each producer a bounded completion path, including write failure cleanup.

The change is confined to one existing test file and its private drain helper.

## Verification

Current head `141077f7270e2f2a0564fb036d091f0cf793b784`, rebased onto `dev` `2abf071e0a3e765195ea2997b962171c87151f06`. Tree: `cedc011fa2e59476077219022b97f5bd7b6f0831`. The local results below were obtained on `4b24e3c228bd56c0ababf2bdc3e0884654e0d7e3`; the rebase leaves the fixture, production transport, package manifest and lockfile unchanged.

- `bun run test:changed --timeout 60000`: 5 passed across the selected test file with Bun 1.4.0 on Windows. Its full-suite profile exercised 16-second heartbeat-only and 24-second progress intervals; the selection completed in 43.8 seconds.
- The original positive fixture still passed when progress-clock refresh was removed. The revised fixture failed when inbound refresh was removed (silence at about 1 second) and when progress refresh was removed (heartbeat-only at about 2 seconds).
- Making heartbeat traffic count as meaningful progress also failed the heartbeat-only fixture, which ended at its bounded fixture limit instead of leaving the producer running.
- Each ablation restored the production transport and verified its SHA-256. The final diff contains only the test file.
- `bun run typecheck`, `bun run privacy:scan`, and `git diff --check`: passed.
- Independent read-only review checked deadline ordering, first-text receipt, and producer cleanup; its cleanup finding was addressed and re-reviewed.

[Original-head full CI](https://github.com/luvs01/opencodex/actions/runs/34145520999) completed successfully with 26/26 jobs. [Full CI on the rebased head](https://github.com/luvs01/opencodex/actions/runs/34147173756) also completed successfully with 26/26 jobs. CodeRabbit reported no actionable findings on the original head; the PR file is unchanged by the rebase and there are no unresolved review threads. This does not claim a second completed CodeRabbit run on the new commit.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for stream health and heartbeat behavior.
  * Added progress tracking after the first text response.
  * Added safeguards for streams that exceed configured fixture limits.
  * Updated timing checks to adapt reliably across continuous integration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->