### PR TITLE
release: apply final roster correction to preview

### DIFF
--- a/gui/src/components/subagents-workspace/SubagentsWorkspace.tsx
+++ b/gui/src/components/subagents-workspace/SubagentsWorkspace.tsx
@@ -32,6 +32,7 @@ import type { DelegationPatch, DelegationModelOption, UltraModePatch, UltraModeS
 
 export interface SubagentsWorkspaceProps {
   available: string[];
+  fallbackAvailable?: string[];
   chosen: string[];
   busy?: boolean;
   onToggle: (m: string) => void;
@@ -64,6 +65,7 @@ export const FEATURED_MAX = 5;
 
 export default function SubagentsWorkspace({
   available,
+  fallbackAvailable,
   chosen,
   busy = false,
   onToggle,
@@ -247,7 +249,7 @@ export default function SubagentsWorkspace({
             fallback={fallback}
             fallbackPollMs={fallbackPollMs}
             fallbackBusy={fallbackBusy}
-            availableModels={available}
+            availableModels={fallbackAvailable ?? available}
             onFallbackChange={onFallbackChange}
             onFallbackPollMsChange={onFallbackPollMsChange}
             onFallbackSave={onFallbackSave}

--- a/gui/src/pages/Subagents.tsx
+++ b/gui/src/pages/Subagents.tsx
@@ -321,7 +321,7 @@ export default function Subagents({ apiBase }: { apiBase: string }) {
       )}
       <SubagentsWorkspace
         available={available}
-        fallbackAvailable={fallbackAvailable}
+        fallbackAvailable={fallbackAvailable ?? []}
         chosen={chosen}
         busy={busy}
         onToggle={toggle}

--- a/gui/src/pages/Subagents.tsx
+++ b/gui/src/pages/Subagents.tsx
@@ -320,9 +320,8 @@ export default function Subagents({ apiBase }: { apiBase: string }) {
         </Notice>
       )}
       <SubagentsWorkspace
-        // Discovery excludes disabled models; configured roster/fallback entries stay
-        // in their separate ordered lists so saving cannot silently discard them.
-        available={fallbackAvailable ?? available}
+        available={available}
+        fallbackAvailable={fallbackAvailable}
         chosen={chosen}
         busy={busy}
         onToggle={toggle}

--- a/gui/tests/subagents-fallback.test.tsx
+++ b/gui/tests/subagents-fallback.test.tsx
@@ -308,6 +308,52 @@ test("fallback discovery excludes roster-only stale choices without losing confi
   expect(putBodies()).toEqual([{ models: [UNAVAILABLE_MODEL, "a-2"], pollMs: 45_000 }]);
 });
 
+test.each([503, 200])("fresh roster choices stay independent of cached fallback discovery (HTTP %s)", async status => {
+  available = ["a-1", "a-2"];
+  fallbackAvailable = ["a-1"];
+  testWindow.sessionStorage.setItem(CACHE_KEY, JSON.stringify({
+    available: ["a-1"], chosen: ["a-1"], fallback: ["a-1"], pollMs: 90_000, fallbackAvailable: ["a-1"],
+  }));
+  if (status === 503) {
+    pendingFallbackResponse = Promise.resolve(Response.json({ error: "Fallback unavailable" }, { status: 503 }));
+  } else {
+    fallbackSettings.models = [];
+  }
+  await mount();
+
+  expect(pollInput().disabled).toBe(status === 503);
+  expect(saveButton().disabled).toBe(status === 503);
+  expect(labelledButton(editor(), en["sub.fallbackAdd"]).disabled).toBe(status === 503);
+  await click(labelledButton(container, en["sub.workspace.addToFeatured"].replace("{m}", "a-2")));
+  const rosterSaveRow = container.querySelector(".swi-save-row");
+  if (!rosterSaveRow) throw new Error("Roster Save row not found");
+  await click(saveButton(rosterSaveRow));
+  expect(putBodies(ROSTER_PATH)).toEqual([{ models: ["a-1", "a-2"] }]);
+  expect(cached()?.available).toEqual(["a-1", "a-2"]);
+  expect(cached()?.fallbackAvailable).toEqual(["a-1"]);
+
+  if (status === 503) {
+    expect(container.textContent).toContain("Fallback unavailable");
+    expectOrder(["a-1"]);
+    await act(async () => { saveButton().click(); });
+    expect(putBodies()).toEqual([]);
+  } else {
+    // Neither model is already in the chain: discovery alone must exclude a-2 from fallback choices.
+    expectOrder([]);
+    const trigger = labelledButton(editor(), en["sub.fallbackAdd"]);
+    await click(trigger);
+    const listbox = testWindow.document.getElementById(trigger.getAttribute("aria-controls") ?? "");
+    if (!listbox) throw new Error("Fallback model listbox not found");
+    const options = Array.from(listbox.querySelectorAll('[role="option"]'), option => option.textContent?.trim());
+    expect(options).toContain("a-1");
+    expect(options).not.toContain("a-2");
+    await click(trigger);
+    await addFallback("a-1");
+    await click(saveButton());
+    expect(putBodies()).toEqual([{ models: ["a-1"], pollMs: 45_000 }]);
+  }
+});
+
 test("cached fallback availability survives remount while discovery is pending", async () => {
   available.push(UNAVAILABLE_MODEL);
   chosen = [UNAVAILABLE_MODEL, "a-1"];

--- a/gui/tests/subagents-fallback.test.tsx
+++ b/gui/tests/subagents-fallback.test.tsx
@@ -650,14 +650,14 @@ test("a legacy cache keeps fallback disabled through GET failure, roster Save, a
 });
 
 test.each([false, true])("a captured old fallback GET cannot overwrite a newer draft or save (saved=%s)", async (saveNewer) => {
-  const committedA = { available, chosen: ["a-1"], fallback: ["a-2"], pollMs: 45_000 };
+  const committedA = { available, fallbackAvailable: available, chosen: ["a-1"], fallback: ["a-2"], pollMs: 45_000 };
   testWindow.sessionStorage.setItem(CACHE_KEY, JSON.stringify(committedA));
   // Serialize A before any edit or PUT. Reading mutable fallbackSettings after the gate
   // would accidentally return B and let the stale-response regression pass.
   const capturedOldResponse = Response.json({ models: ["a-2"], pollMs: 45_000, available });
   let releaseGet!: (response: Response) => void;
   pendingFallbackResponse = new Promise<Response>(resolve => { releaseGet = resolve; });
-  const committedB = { available, chosen: ["a-1"], fallback: ["a-3"], pollMs: 90_000 };
+  const committedB = { available, fallbackAvailable: available, chosen: ["a-1"], fallback: ["a-3"], pollMs: 90_000 };
 
   try {
     await mount();


### PR DESCRIPTION
## Summary

Bring the pre-publication roster cache correction from #3931 into preview. The main roster keeps its own fresh discovery list; fallback availability is used only for fallback controls. No version change and no sponsor placement.

The owner authorized these release promotions. Depends on #3931 landing in dev; the prepared tree matches its candidate except the channel version.

## Verification

- Three-file source correction with stale-cache/fallback-failure regression scenarios.
- Local suites/typechecks/builds/installs NOT RUN per owner; hosted CI only.
- Previous regression repairs passed independent Astra review; this follow-up receives independent source re-review and fresh hosted checks.
- Publication still requires this final promotion SHA's push CI, service lifecycle and all-lanes Windows/macOS control verification, then release dry-run.
- Expected enforce-target wrong-base is the previously declared owner-authorized release promotion exception; it is not reported as passing and no policies are disabled.

GUI layout unchanged; earlier mocked workspace failure-state evidence:
![Subagent workspace](https://raw.githubusercontent.com/lidge-jun/opencodex/codex/release-247-evidence/docs/pr-assets/release-247/01-subagents-503-roster-saved.png)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
