### PR TITLE
fix(codex): fence late WebSocket quota by credential generation

### DIFF
--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -15,6 +15,7 @@ import { nativeContextLimits } from "../../codex/catalog";
 import { describeUpstreamConnectFailure } from "./upstream-error";
 import type { CodexWsQuotaObserver } from "./codex-ws-metadata";
 import { applyAccountQuotaFromUpstreamHeaders as applyCapturedCodexQuota } from "../../codex/quota";
+import { isCodexAccountGenerationLive } from "../../codex/account-store";
 import { isCodexWsQuotaObservedResponse } from "./ws-upstream";
 import {
   multiAgentGuidanceEnabled,
@@ -1004,8 +1005,12 @@ export function usesCodexForwardPoolAuth(
 function codexWsQuotaObserver(authCtx: CodexAuthContext, provider: OcxProviderConfig): CodexWsQuotaObserver | undefined {
   if (!isCanonicalOpenAiForwardProvider(provider) || !usesCodexForwardPoolAuth(authCtx, provider)) return undefined;
   const { accountId, writerGeneration } = authCtx;
+  const credentialGeneration = authCtx.kind === "pool" ? authCtx.generation : undefined;
   const mainWriter = authCtx.kind === "main-pool" ? authCtx.mainQuotaWriter : undefined;
-  return headers => applyCapturedCodexQuota(accountId, headers, writerGeneration, mainWriter);
+  return headers => {
+    if (credentialGeneration !== undefined && !isCodexAccountGenerationLive(accountId, credentialGeneration)) return;
+    applyCapturedCodexQuota(accountId, headers, writerGeneration, mainWriter);
+  };
 }
 
 export function preAuthUpstreamHostCircuitKey(

--- a/tests/responses/responses-account-label.test.ts
+++ b/tests/responses/responses-account-label.test.ts
@@ -190,6 +190,65 @@ describe("Responses account usage attribution", () => {
     }
   });
 
+  test("late WS quota from a replaced pool credential cannot repopulate cleared state", async () => {
+    const originalWebSocket = globalThis.WebSocket;
+    let releaseFinalQuota!: () => void;
+    const finalQuotaAllowed = new Promise<void>(resolve => { releaseFinalQuota = resolve; });
+    try {
+      await withPoolHome(async () => {
+        savePoolCredential("pool-ws-replaced");
+        class MetadataSocket {
+          listeners = new Map<string, Array<(event: unknown) => void>>();
+          constructor() { queueMicrotask(() => this.emit("open", {})); }
+          addEventListener(type: string, listener: (event: unknown) => void) {
+            this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+          }
+          removeEventListener(type: string, listener: (event: unknown) => void) {
+            this.listeners.set(type, (this.listeners.get(type) ?? []).filter(value => value !== listener));
+          }
+          emit(type: string, event: unknown) {
+            for (const listener of this.listeners.get(type) ?? []) listener(event);
+          }
+          send() {
+            const payload = (value: unknown) => this.emit("message", { data: JSON.stringify(value) });
+            queueMicrotask(() => {
+              payload({ type: "codex.rate_limits", rate_limits: {
+                primary: { used_percent: 10, window_minutes: 10080 },
+              } });
+              payload({ type: "response.created", response: { id: "quota-response" } });
+              void finalQuotaAllowed.then(() => {
+                payload({ type: "codex.rate_limits", rate_limits: {
+                  primary: { used_percent: 100, window_minutes: 10080 },
+                } });
+                payload({ type: "response.completed", response: { id: "quota-response", status: "completed", output: [] } });
+              });
+            });
+          }
+          close() { this.emit("close", {}); }
+        }
+        globalThis.WebSocket = MetadataSocket as unknown as typeof WebSocket;
+        globalThis.fetch = (async () => { throw new Error("unexpected HTTP request"); }) as typeof fetch;
+        const response = await handleResponses(new Request("http://localhost/v1/responses", {
+          method: "POST", headers: { "content-type": "application/json" },
+          body: JSON.stringify({ model: "gpt-5.5", input: "hello", stream: true }),
+        }), poolConfig(["pool-ws-replaced"]), { model: "", provider: "" }, {
+          codexWsRuntimeIdentity: "1.4.0",
+        });
+        expect(getAccountQuota("pool-ws-replaced")?.weeklyPercent).toBe(10);
+
+        savePoolCredential("pool-ws-replaced");
+        clearAccountQuota("pool-ws-replaced");
+        releaseFinalQuota();
+        await response.text();
+
+        expect(getAccountQuota("pool-ws-replaced")).toBeNull();
+      });
+    } finally {
+      releaseFinalQuota();
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
+
   test("main-pool and legacy added accounts carry their effective labels", async () => {
     await withPoolHome(async home => {
       writeFileSync(join(home, "auth.json"), JSON.stringify({


### PR DESCRIPTION
## Summary

A streaming Codex request can keep receiving WebSocket quota metadata after its pool credential is replaced under the same local account ID. Previously, a late frame could repopulate the quota cleared for that replacement and make the new credential appear exhausted.

Capture the selected pool credential generation when creating the response's quota observer and ignore subsequent observations once that generation is no longer live. Existing configuration-generation fencing and the main-pool writer remain unchanged. The regression delivers quota 10, replaces the credential, clears quota, and then delivers quota 100 from the old connection.

This carries only the source change and regression from `a40f419fe0e1cf29faeb77599cd61bf535be7e5d`, preserving its author. It restores the existing serving-account ownership invariant without adding configuration, logs, or a new user workflow.

## Verification

Head `e5c01f44e9736baba5b3a993c7f489f6b60d5ddd`, based on `dev` `2abf071e0a3e765195ea2997b962171c87151f06`.

- Bun 1.4.0 on Windows: `bun test tests/responses/responses-account-label.test.ts tests/lab/core-lab-boundary.test.ts --timeout 60000` passed 25 tests with 80 assertions. This includes existing pool/main-pool prelude and final quota behavior and the core import boundary.
- Removing only the generation check made the new regression fail: the cleared quota was repopulated with `weeklyPercent: 100`. The original source bytes and SHA-256 were restored afterwards.
- `bun run typecheck`, `bun run privacy:scan`, and `git diff HEAD^ HEAD --check` passed.
- Independent read-only code/security review found no blocking defect: generation 0, deletion/replacement, main-pool ownership, observer exception containment, and the final-header path were checked. No required additional regression was identified.
- `bun run test:changed --timeout 60000` reached the wrapper's 900-second suite deadline and exited 124. It produced no completed selection summary, so this run is not a passing result. The scoped tests above passed separately; [Full cross-platform CI](https://github.com/luvs01/opencodex/actions/runs/34147264836) initially finished with 24 successful jobs, a `macos 2/2` cancellation at its 20-minute job limit, and a failed aggregate. The specific timed-out job and its dependent aggregate then passed on the unchanged head: attempt 2 is complete with 26/26 jobs successful. CodeRabbit completed review of this head with no actionable findings and there are no unresolved review threads. Readiness is supported by this exact-head cross-platform CI; the separate local 900-second limit remains recorded above.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated WebSocket quota updates from restoring cleared quota information after account credentials are replaced.
  - Ensured quota state remains accurate when delayed usage reports arrive from inactive credentials.

- **Tests**
  - Added coverage for delayed quota reports following credential replacement and quota clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->