### PR TITLE
fix(providers): raise Nous model discovery response cap

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1539,8 +1539,10 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     modelDiscovery: {
       // Resolves against effectiveBaseUrl (registry baseUrl .../v1) to the same
       // canonical endpoint https://inference-api.nousresearch.com/v1/models.
+      // Nous returns a mixed paid/free catalog whose JSON can exceed 256 KiB;
+      // keep the provider-specific limit below the process-wide 4 MiB ceiling.
       path: "models",
-      maxResponseBytes: 262_144,
+      maxResponseBytes: 1_048_576,
       maxModels: 512,
     },
     note: "Nous Research subscription gateway. OAuth device login with your own Portal account; mixed paid + :free models discovered live (fallback seed 2026-08-10: tencent/hy3:free, poolside/laguna-s-2.1:free, stepfun/step-3.7-flash:free, poolside/laguna-xs-2.1:free).",

--- a/tests/providers/provider-model-discovery-contract.test.ts
+++ b/tests/providers/provider-model-discovery-contract.test.ts
@@ -428,6 +428,27 @@ describe("registry-owned provider model discovery", () => {
     expect(cancelled).toBe(true);
   });
 
+  test("accepts the observed Nous mixed catalog within its provider-specific response cap", async () => {
+    const entry = PROVIDER_REGISTRY.find(row => row.id === "nous");
+    if (!entry) throw new Error("missing nous registry entry");
+    const discovery = resolveProviderModelDiscovery("nous", {
+      adapter: entry.adapter,
+      baseUrl: entry.baseUrl,
+      authMode: "oauth",
+    });
+    const payload = JSON.stringify({
+      data: Array.from({ length: 390 }, (_, index) => ({
+        id: index === 0 ? "tencent/hy3:free" : `vendor/model-${index}`,
+        metadata: { description: "x".repeat(1_400) },
+      })),
+    });
+
+    expect(new TextEncoder().encode(payload).byteLength).toBeGreaterThan(262_144);
+    expect(discovery.maxResponseBytes).toBe(1_048_576);
+    const result = await readBoundedDiscoveryJson(new Response(payload), discovery.maxResponseBytes);
+    expect(result.ok).toBe(true);
+  });
+
   test("rejects invalid UTF-8 before JSON parsing", async () => {
     const invalidUtf8Json = new Uint8Array([
       0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,


### PR DESCRIPTION
## Summary

Raise the Nous provider's live model-discovery response cap from 256 KiB to 1 MiB.

## Problem

Nous's authenticated `/v1/models` endpoint currently returns a mixed paid/free catalog whose JSON is larger than the provider-specific `262_144` byte limit. A representative response was HTTP 200 with 390 model rows and 566,054 bytes, but OpenCodex rejected it with:

```
Provider model discovery for "nous" exceeded the 262144-byte response limit
```

This prevents live catalog reconciliation and leaves the configured Nous model roster stale or incomplete.

## Fix

- Set the Nous provider-specific cap to `1_048_576` bytes.
- Keep the existing process-wide 4 MiB safety ceiling.
- Keep the existing `maxModels: 512` row limit.
- Add a deterministic regression test using a 390-row payload larger than 256 KiB and within the new 1 MiB cap.

## Verification

- The regression test fails on the base configuration with `Expected: 1048576 / Received: 262144`.
- The regression test passes after the change.
- The provider model-discovery contract test file passes.
- Typecheck, privacy scan, and `git diff --check` pass.
- On macOS with OpenCodex 2.46.0, the patched local service successfully discovers the live Nous catalog without the previous response-limit error.

The upstream 429/524 responses observed for some free inference models are separate upstream availability/quota issues and are outside this catalog-discovery fix.

Fixes #3938


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum response size for Nous model discovery, allowing larger mixed model catalogs to load successfully.
* **Tests**
  * Added coverage to verify that larger Nous discovery responses are accepted within the provider-specific limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
