### PR TITLE
fix(claude): preserve OpenCode Go session affinity

### DIFF
--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -30,12 +30,13 @@ import {
 import { clearableDeadline, idleDeadline } from "../lib/abort";
 import { estimateTokens } from "../lib/token-estimate";
 import { NoEligiblePolicyCandidateError, UnknownRoutingPolicyError, routeModel } from "../router";
+import { registryEntryForProviderDestination } from "../providers/registry";
 import { evidenceFromBody } from "../routing/request-evidence";
 import { resolveWireProtocolOverride } from "./adapter-resolve";
 import type { OcxConfig } from "../types";
 import { readJsonRequestBody } from "./request-decompress";
 import { addFinalRequestLog, httpStatusForRequestLogTerminal, recordFirstOutput, type RequestLogContext, type RequestLogEntry } from "./request-log";
-import { conversationIdFromClaudeMetadata } from "./request-log-conversation";
+import { conversationIdFromClaudeMetadata, sessionLaneIdFromRequest } from "./request-log-conversation";
 import { responseWithDeferredRequestLog } from "./relay";
 import { handleResponses } from "./responses";
 import {
@@ -786,8 +787,12 @@ async function handleClaudeMessagesWithBudget(
   // bodies: it 400s on sampling params ("Unsupported parameter: max_output_tokens",
   // verified live 2026-07-11). Strip them for that route; routed providers keep them.
   let nativeRoute = false;
+  let opencodeGoRoute = false;
   try {
     const route = routeModel(config, internalBody.model as string, evidenceFromBody(internalBody));
+    // Match the fixed key-auth destination before per-model wire overrides, including
+    // renamed Go providers without treating custom or lookalike URLs as Go.
+    opencodeGoRoute = registryEntryForProviderDestination(route.provider)?.id === "opencode-go";
     // Settle the wire once so the sampling decision below reads the effective
     // adapter rather than the provider-wide default (#404).
     route.provider = resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, "anthropic");
@@ -851,11 +856,18 @@ async function handleClaudeMessagesWithBudget(
       headers.set("chatgpt-account-id", token.chatgptAccountId);
     }
   }
-  if (nativeRoute) {
+  if (opencodeGoRoute) {
+    const session = req.headers.get("x-opencode-session");
+    if (session) headers.set("x-opencode-session", session);
+  }
+  const hasExplicitGoSession = opencodeGoRoute
+    && (sessionLaneIdFromRequest(headers) !== undefined || headers.has("x-opencode-session"));
+  if ((nativeRoute || opencodeGoRoute) && !hasExplicitGoSession) {
     // ChatGPT-backend prompt-cache affinity rides the session_id HEADER (codex
     // clients always send their session uuid; devlog 090 follow-up: body-level
     // prompt_cache_key alone still yielded cached_tokens:0). Claude Code never sends
-    // the header, so synthesize a stable per-session uuid from the same cache key —
+    // the header, so synthesize a stable per-session uuid from the same cache key.
+    // Routed Go requests need this lane too for their x-opencode-session affinity —
     // but ONLY for a real per-session key (metadata.user_id). The system-hash fallback
     // key is shared across Desktop conversations, and a shared session_id's backend
     // semantics are unproven (audit 133 R2#3): body prompt_cache_key only there.

--- a/tests/providers/opencode-go-session-header.test.ts
+++ b/tests/providers/opencode-go-session-header.test.ts
@@ -4,6 +4,7 @@ import { resolveOpenCodeGoTransport } from "../../src/providers/opencode-go-tran
 import { getProviderRegistryEntry } from "../../src/providers/registry";
 import { handleResponses } from "../../src/server/responses/core";
 import { handleChatCompletions } from "../../src/server/chat-completions";
+import { handleClaudeMessages } from "../../src/server/claude-messages";
 import type { OcxConfig, OcxProviderConfig } from "../../src/types";
 
 const MUSE_MODEL = "muse-spark-1.3-contributor";
@@ -25,7 +26,14 @@ function codexHeaders(child = "child-thread-a"): Record<string, string> {
   };
 }
 
-function upstreamResponse(url: string): Response {
+function upstreamResponse(url: string, stream = false): Response {
+  if (stream && url.endsWith("/chat/completions")) {
+    return new Response([
+      `data: ${JSON.stringify({ choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1 } })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join(""), { headers: { "content-type": "text/event-stream" } });
+  }
   if (url.endsWith("/responses")) {
     return Response.json({
       id: "resp_opencode_go_session",
@@ -54,6 +62,8 @@ async function captureRequest(input: {
   child?: string;
   provider?: OcxProviderConfig;
   nativeChat?: boolean;
+  claude?: boolean;
+  metadataUserId?: string;
   headers?: Record<string, string>;
 } = {}): Promise<{ url: string; headers: Headers }> {
   const providerName = input.providerName ?? "opencode-go";
@@ -62,13 +72,26 @@ async function captureRequest(input: {
   globalThis.fetch = (async (requestInput: RequestInfo | URL, init?: RequestInit) => {
     const url = String(requestInput);
     requests.push({ url, headers: new Headers(init?.headers) });
-    return upstreamResponse(url);
+    return upstreamResponse(url, input.claude);
   }) as typeof fetch;
 
   const config = {
     providers: { [providerName]: input.provider ?? opencodeGo() },
   } as unknown as OcxConfig;
-  const response = input.nativeChat ? await handleChatCompletions(
+  const response = input.claude ? await handleClaudeMessages(
+    new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: input.headers ?? { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: `${providerName}/${model}`, max_tokens: 64, stream: false,
+        system: "A shared system prompt is not a conversation identifier.",
+        messages: [{ role: "user", content: "ping" }],
+        ...(input.metadataUserId ? { metadata: { user_id: input.metadataUserId } } : {}),
+      }),
+    }),
+    config,
+    { model: "", provider: "" },
+  ) : input.nativeChat ? await handleChatCompletions(
     new Request("http://localhost/v1/chat/completions", {
       method: "POST",
       headers: input.headers ?? codexHeaders(input.child),
@@ -96,6 +119,70 @@ async function captureRequest(input: {
 describe("OpenCode Go session affinity (#3344)", () => {
   const originalFetch = globalThis.fetch;
   afterEach(() => { globalThis.fetch = originalFetch; });
+
+  test("Claude metadata gives stable Go affinity across turns and distinct conversations", async () => {
+    const input = { claude: true, model: CHAT_MODEL, metadataUserId: "user_test_account__session_conversation-a" };
+    const first = await captureRequest(input);
+    const continued = await captureRequest(input);
+    const next = await captureRequest({ ...input, metadataUserId: "user_test_account__session_conversation-b" });
+    expect(first.url).toBe("https://opencode.ai/zen/go/v1/chat/completions");
+    expect(first.headers.get(SESSION_HEADER)).toMatch(/^ocx_[0-9a-f]{32}$/);
+    expect(continued.headers.get(SESSION_HEADER)).toBe(first.headers.get(SESSION_HEADER));
+    expect(next.headers.get(SESSION_HEADER)).not.toBe(first.headers.get(SESSION_HEADER));
+    expect(first.headers.get(SESSION_HEADER)).not.toContain("conversation-a");
+  });
+
+  test("Claude recognizes renamed canonical Go destinations and omits shared system affinity", async () => {
+    const input = { claude: true, model: CHAT_MODEL, providerName: "renamed-go" };
+    const metadata = await captureRequest({ ...input, metadataUserId: "user_test_account__session_conversation-a" });
+    const desktop = await captureRequest(input);
+    expect(metadata.headers.get(SESSION_HEADER)).toMatch(/^ocx_[0-9a-f]{32}$/);
+    expect(desktop.headers.has(SESSION_HEADER)).toBe(false);
+  });
+
+  test("Claude explicit Go header precedes metadata and matches native Chat affinity", async () => {
+    const headers = { "content-type": "application/json", [SESSION_HEADER]: "client-session-a" };
+    const claude = await captureRequest({ claude: true, model: CHAT_MODEL, headers, metadataUserId: "different-metadata-session" });
+    const chat = await captureRequest({ nativeChat: true, model: CHAT_MODEL, headers });
+    expect(claude.headers.get(SESSION_HEADER)).toBe("ocx_516d593899f34b7baca2db37c7b0c8c5");
+    expect(claude.headers.get(SESSION_HEADER)).toBe(chat.headers.get(SESSION_HEADER));
+  });
+
+  test("Claude affinity survives per-model Responses wire selection", async () => {
+    const input = { claude: true, metadataUserId: "user_test_account__session_conversation-a" };
+    const chat = await captureRequest({ ...input, model: CHAT_MODEL });
+    const responses = await captureRequest({ ...input, model: MUSE_MODEL });
+    expect(responses.url).toBe("https://opencode.ai/zen/go/v1/responses");
+    expect(responses.headers.get(SESSION_HEADER)).toBe(chat.headers.get(SESSION_HEADER));
+    const explicit = await captureRequest({
+      ...input, model: MUSE_MODEL,
+      headers: { "content-type": "application/json", [SESSION_HEADER]: "client-session-a" },
+    });
+    expect(explicit.headers.get(SESSION_HEADER)).toBe("ocx_516d593899f34b7baca2db37c7b0c8c5");
+  });
+
+  test("Claude preserves explicit session lanes and operator header precedence", async () => {
+    for (const laneHeader of ["session_id", "session-id", "thread-id"]) {
+      const headers = { "content-type": "application/json", [laneHeader]: "native-client-session", [SESSION_HEADER]: "different-fallback" };
+      const input = { claude: true, model: CHAT_MODEL, headers, metadataUserId: "different-metadata-session" };
+      const claude = await captureRequest(input);
+      const native = await captureRequest({ model: CHAT_MODEL, headers });
+      expect(claude.headers.get(SESSION_HEADER)).toBe(native.headers.get(SESSION_HEADER));
+      const operator = await captureRequest({ ...input, provider: opencodeGo({ headers: { "X-OpenCode-Session": "operator-session" } }) });
+      expect(operator.headers.get(SESSION_HEADER)).toBe("operator-session");
+    }
+  });
+
+  test("Claude does not add Go affinity to custom or lookalike destinations", async () => {
+    for (const baseUrl of ["https://custom.example/v1", "https://opencode.ai.evil.test/zen/go/v1"]) {
+      const captured = await captureRequest({
+        claude: true, model: CHAT_MODEL, providerName: "custom-go",
+        provider: opencodeGo({ baseUrl }), metadataUserId: "user_test_account__session_conversation-a",
+        headers: { "content-type": "application/json", [SESSION_HEADER]: "client-session-a" },
+      });
+      expect(captured.headers.has(SESSION_HEADER)).toBe(false);
+    }
+  });
 
   test("native Chat ingress preserves stable Go affinity and separates conversations", async () => {
     const provider = opencodeGo();


### PR DESCRIPTION
## Summary

Closes #3945

- Fix Claude Messages replay losing Go conversation affinity and failing with `MissingSessionID`. Forward `x-opencode-session` itself and use the existing metadata-derived UUID fallback only when no explicit session lane exists.
- Match registry destinations before wire overrides, including renamed canonical Go providers. Preserve operator-header precedence, unrelated destinations, and native Anthropic passthrough. Shared system text never becomes a session ID; Desktop requests without metadata still need explicit identity.
- Add full-handler fake-fetch regressions to the existing Go affinity test file. Target: `dev`. Prior ingress work: #3344, #3378, #3405, #3857, #3880.

## Verification

- Current-head follow-up: rebased the unchanged patch onto `dev` at `514350e6f79ed4539378388bc39d3fc79ff2c70c`; pushed head `a2909be453db7636da8ed4c13ad63b9ce5be6572`. The complete installed pre-push hook passed again on this exact head, including standard typecheck, full tests, and privacy scan; no bypass. The earlier run details below remain historical evidence.
- CodeRabbit completed review of the identical patch with no actionable comments; no unresolved review threads remain. Its docstring-coverage warning is advisory, not a failed CI job. The streamed test fixture is intentional: the Claude handler sets the internal replay's `stream` to `true` even for a non-streaming caller.

- `bun test tests/providers/opencode-go-session-header.test.ts`: 19 pass, 0 fail, including six new Claude cases and mixed Chat/Responses wires.
- `bun test tests/claude-integration/claude-messages-endpoint.test.ts -t 'native openai-responses route carries|native generated-agent passthrough preserves'`: two existing native compatibility tests passed.
- Rebased without changing the patch onto `origin/dev` at `6188458ae`; verified commit: `82fe10651ca8e56f1d3d616795f2a581967c12f8`.
- `bun run setup:hooks` installed the repository hooks. The installed `.git/hooks/pre-push` ran the complete standard `bun run prepush` gate successfully, exit 0, with Bun 1.4.0: typecheck passed; full tests total 21,519 passed, 19 skipped, 0 failed; privacy scan passed. Conditional frontend checks correctly skipped because no frontend files changed. No hooks or checks were bypassed. The checkout-local bundled Bun postinstall stub was initialized using its audited official installer and already-installed platform binary before this run.
- Independent Claude Fable review previously reproduced four image-guard failures (P1/P2/P2b/P4) on both this change and pristine `origin/dev` under Bun 1.3.8. Those failures did not recur in the complete required Bun 1.4.0 gate on the rebased commit. Local gate success is not a claim of remote CI or maintainer approval.
- `python3 -m unittest discover -s opencodex/upstream -p 'test_reproduce*.py'`: eight offline tests passed across both reproducer variants.
- Installed 2.46.0 workaround: real Claude Code 2.1.263 changed from a missing-session failure to `GO_OK`; standalone `python3 reproduce.py --base-url http://127.0.0.1:10101` returned HTTP 200 / GO_OK. Native subscription probes and Go tool calls through Messages and Responses passed. These results do not imply live acceptance of the refined branch.

- Direct-client acceptance on the patched local 2.46.0 workaround: `python3 reproduce-claude.py` invoked `ocx-claude` and printed `Client exit status: 0` followed by `GO_OK`; script exit status was 0. Only this direct-client variant was tested against the patched workaround; it was not run against pristine 2.46.0.

- Pristine standalone reproduction: one `python3 reproduce.py --base-url http://127.0.0.1:10102` request against an isolated, unmodified npm 2.46.0 tarball with verified integrity returned HTTP 400 and the script-normalized `Error: MissingSessionID / missing x-opencode-session`, exit 1. The server used fresh homes with no native subscription credentials or passthrough, was stopped afterwards, and left existing proxies untouched. This establishes the standalone prepatch failure, not live acceptance of the refined `dev` branch.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs/release notes updated or not required (internal compatibility fix; restores existing Go behavior without changing the public API or configuration).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. Independent Claude Fable review confirmed the credential surface is unchanged, native passthrough is preserved, and destination/header boundaries are covered.

Co-authored-by: GPT-6 Astra <noreply@openai.com>
Co-authored-by: Claude Fable 5.1 <noreply@anthropic.com>

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session continuity for Claude Messages requests routed through OpenCode Go.
  - Preserved caller-provided session headers and respected explicit session or lane selections.
  - Added stable session affinity when no explicit session information is provided.
  - Ensured session routing remains consistent across renamed providers and supported request formats.
  - Prevented session affinity from being applied to custom or lookalike destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
