### PR TITLE
test: stabilize clock-dependent auth and usage fixtures

### DIFF
--- a/gui/tests/usage-custom-range.test.tsx
+++ b/gui/tests/usage-custom-range.test.tsx
@@ -154,31 +154,45 @@ for (const connected of [false, true]) {
 }
 
 test("America/Santiago midnight DST retains final-day activity and tooltip", async () => {
-  const previous = process.env.TZ;
-  process.env.TZ = "America/Santiago";
-  try {
-    expect(new Date(2026, 8, 6, 0).getHours()).toBe(1);
-    await mount();
-    await respond(0, "preset-marker");
-    await enter("2026-09-05T00:00", "2026-09-07T23:59");
-    await apply();
-    const gate = requests.at(-1)!;
-    const data = report(gate, "santiago-marker", "2026-09-07");
-    data.days = ["2026-09-05", "2026-09-06", "2026-09-07"].map(date => ({
-      date, requests: date === "2026-09-07" ? 7 : 0, measuredRequests: 0, reportedRequests: 0,
-      totalTokens: date === "2026-09-07" ? 700 : 0, models: [],
-    }));
-    await act(async () => gate.resolve(Response.json(data)));
-    const active = container.querySelector<HTMLElement>('.heatmap-grid .heatmap-cell:not(.heatmap-cell-0)');
-    expect(active).not.toBeNull();
-    await act(async () => active!.dispatchEvent(new testWindow.MouseEvent("mouseover", { bubbles: true })));
-    expect(container.querySelector(".heatmap-tip-date")?.textContent).toBe("2026-09-07");
-    expect(container.querySelector(".heatmap-tip")?.textContent).toContain("700");
-  } finally {
-    if (previous === undefined) delete process.env.TZ;
-    else process.env.TZ = previous;
+  if (process.env.TZ !== "America/Santiago") {
+    // Restoring an absent TZ can change Bun's effective timezone on Windows.
+    // Start the DST case in its timezone without mutating this suite's clock.
+    const timezone = { present: Object.hasOwn(process.env, "TZ"), value: process.env.TZ };
+    const localTime = new Date(2020, 8, 15, 10, 20).getTime();
+    const child = Bun.spawnSync([
+      process.execPath, "test", import.meta.path,
+      "-t", "^America/Santiago midnight DST retains final-day activity and tooltip$",
+      "--timeout", "10000",
+    ], {
+      env: { ...process.env, TZ: "America/Santiago" },
+      stdout: "pipe", stderr: "pipe", timeout: 12000, killSignal: "SIGKILL",
+    });
+    const diagnostics = `${child.stdout.toString()}\n${child.stderr.toString()}`;
+    expect(child.exitedDueToTimeout, diagnostics).not.toBe(true);
+    expect(child.signalCode, diagnostics).toBeUndefined();
+    expect(child.exitCode, diagnostics).toBe(0);
+    expect({ present: Object.hasOwn(process.env, "TZ"), value: process.env.TZ }).toEqual(timezone);
+    expect(new Date(2020, 8, 15, 10, 20).getTime()).toBe(localTime);
+    return;
   }
-});
+  expect(new Date(2026, 8, 6, 0).getHours()).toBe(1);
+  await mount();
+  await respond(0, "preset-marker");
+  await enter("2026-09-05T00:00", "2026-09-07T23:59");
+  await apply();
+  const gate = requests.at(-1)!;
+  const data = report(gate, "santiago-marker", "2026-09-07");
+  data.days = ["2026-09-05", "2026-09-06", "2026-09-07"].map(date => ({
+    date, requests: date === "2026-09-07" ? 7 : 0, measuredRequests: 0, reportedRequests: 0,
+    totalTokens: date === "2026-09-07" ? 700 : 0, models: [],
+  }));
+  await act(async () => gate.resolve(Response.json(data)));
+  const active = container.querySelector<HTMLElement>('.heatmap-grid .heatmap-cell:not(.heatmap-cell-0)');
+  expect(active).not.toBeNull();
+  await act(async () => active!.dispatchEvent(new testWindow.MouseEvent("mouseover", { bubbles: true })));
+  expect(container.querySelector(".heatmap-tip-date")?.textContent).toBe("2026-09-07");
+  expect(container.querySelector(".heatmap-tip")?.textContent).toContain("700");
+}, 15000);
 
 test("Apply submits inclusive bounds once; Clear restores the held preset without custom cache entries", async () => {
   await mount();

--- a/tests/codex-integration/codex-auth-context.test.ts
+++ b/tests/codex-integration/codex-auth-context.test.ts
@@ -1447,8 +1447,9 @@ describe("Codex auth context", () => {
     // The caller proved admission with one of OUR secrets. That secret must never leave the
     // process, so the only acceptable outcome is the stored main credential in its place.
     const admissionSecret = "ocx_data_localsecret";
+    const storedCredential = liveJwt();
     writeFileSync(join(testDir, "auth.json"), JSON.stringify({
-      tokens: { access_token: liveJwt(), account_id: "stored_main_acc" },
+      tokens: { access_token: storedCredential, account_id: "stored_main_acc" },
     }));
 
     const headers = materializeCodexUpstreamAuth(
@@ -1458,7 +1459,7 @@ describe("Codex auth context", () => {
     );
 
     expect(headers.get("authorization")).not.toContain(admissionSecret);
-    expect(headers.get("authorization")).toBe(`Bearer ${liveJwt()}`);
+    expect(headers.get("authorization")).toBe(`Bearer ${storedCredential}`);
     expect(headers.get("chatgpt-account-id")).toBe("stored_main_acc");
     // Unrelated forwarded headers still ride along.
     expect(headers.get("openai-beta")).toBe("responses=experimental");


### PR DESCRIPTION
## Summary

Two clock-dependent fixtures can fail without a product regression.

The Santiago DST case in `usage-custom-range.test.tsx` changes `process.env.TZ` inside the shared test process. On Windows with Bun 1.4.0, restoring an initially absent variable can change the effective timezone from the one used to calculate the module's date-bound expectations. Four later URL assertions then differ by nine hours, even when this file runs alone.

Run the unchanged Santiago UI assertions in a child Bun process started with `TZ=America/Santiago`. The parent retains the presence and value of `TZ` and its local Date epoch. The child is limited to this exact test name, has a 12-second process deadline, and reports timeout, signal and nonzero-exit failures with captured diagnostics. The admission-substitution test also generated its expected JWT a second time after storing the original. Crossing a wall-clock second changes its expiry claim and therefore its bytes. Capture one token for both storage and comparison.

No product code or date interpretation changes.

## Verification

Current standalone head `9b9e4d28bebf58dcb07c161914b3b9e324c55713`.

- Bun 1.4.0 on Windows: unchanged baseline reproduced 20 pass / 4 fail; the fixed file passed 24 tests with 331 assertions.
- Parent timezone presence/value and local epoch are asserted unchanged after the child returns. The original skipped-midnight, final-day activity and tooltip assertions remain in the child.
- Full dashboard validation passed 1,933 tests across 242 files with 15,655 assertions in the dependent proactive-preset validation tree. That tree includes this exact fixture change plus an unrelated Subagents change; this is not a claim of a separate full-suite run on the test-only tree.
- Dashboard lint, i18n lint and production build, root typecheck, privacy scan and diff checks passed in that validation tree. Rebasing onto `dev` `514350e6f79ed4539378388bc39d3fc79ff2c70c` changed only devlog files; test and build inputs remained identical.
- Independent read-only review checked subprocess bounds and preservation of the parent's timezone.
- The authentication failure occurred in [a macOS CI job](https://github.com/luvs01/opencodex/actions/runs/34156843536/job/101850393135) across a logged second boundary. A deterministic advancing-expiry control failed on the old assertion and passed with the captured token; the normal focused test also passed (4 assertions). Exact source bytes and SHA-256 were restored after the control, and typecheck/privacy/diff checks passed.
- [Cross-platform CI on the updated standalone head](https://github.com/luvs01/opencodex/actions/runs/34159054386) passed 24 jobs but failed Windows 4/6 on an unchanged storage-scanner test exceeding its explicit 15-second deadline. The same test, scanner and cleanup/watchdog inputs passed in the dependent preset run. Attempt 2 reran only the failed jobs and completed successfully; the precise I/O delay cause remains unestablished. All cross-platform jobs are now green on this head. The current CodeRabbit review has no actionable comments. The test-only screenshot waiver remains pending before undrafting.

This changes two test files and has no visible UI change to capture. Please apply the documented maintainer screenshot waiver for this test-only change if the path-based gate requests an image.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed (no product behavior change).
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
