### PR TITLE
fix(providers): admit larger Nous catalogs within native limits

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1539,8 +1539,10 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     modelDiscovery: {
       // Resolves against effectiveBaseUrl (registry baseUrl .../v1) to the same
       // canonical endpoint https://inference-api.nousresearch.com/v1/models.
+      // Nous returns a mixed paid/free catalog whose JSON can exceed 256 KiB;
+      // keep the provider-specific limit below the process-wide 4 MiB ceiling.
       path: "models",
-      maxResponseBytes: 262_144,
+      maxResponseBytes: 1_048_576,
       maxModels: 512,
     },
     note: "Nous Research subscription gateway. OAuth device login with your own Portal account; mixed paid + :free models discovered live (fallback seed 2026-08-10: tencent/hy3:free, poolside/laguna-s-2.1:free, stepfun/step-3.7-flash:free, poolside/laguna-xs-2.1:free).",

--- a/tests/providers/provider-connection-test.test.ts
+++ b/tests/providers/provider-connection-test.test.ts
@@ -331,11 +331,11 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
       fetches += 1;
       expect(String(input)).toBe("https://inference-api.nousresearch.com/v1/models");
       expect(init?.method ?? "GET").toBe("GET");
-      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer nous-probe-fixture-access");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer access-token-nous-probe-fixture");
       return new Response(payload, { headers: { "content-type": "application/json" } });
     }) as typeof fetch;
     await saveCredential("nous", {
-      access: "nous-probe-fixture-access",
+      access: "access-token-nous-probe-fixture",
       refresh: "nous-probe-fixture-refresh",
       expires: Date.now() + 3_600_000,
     });

--- a/tests/providers/provider-connection-test.test.ts
+++ b/tests/providers/provider-connection-test.test.ts
@@ -316,6 +316,40 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
     });
   });
 
+  test("Nous probe accepts 390 synthetic paid/free rows above 256 KiB (#3939)", async () => {
+    const payload = JSON.stringify({
+      data: Array.from({ length: 390 }, (_, index) => ({
+        id: index === 0 ? "tencent/hy3:free" : `vendor/model-${index}`,
+        metadata: { description: "x".repeat(1_400) },
+      })),
+    });
+    const bytes = new TextEncoder().encode(payload).byteLength;
+    expect(bytes).toBeGreaterThan(262_144);
+    expect(bytes).toBeLessThan(1_048_576);
+    let fetches = 0;
+    globalThis.fetch = (async (input, init) => {
+      fetches += 1;
+      expect(String(input)).toBe("https://inference-api.nousresearch.com/v1/models");
+      expect(init?.method ?? "GET").toBe("GET");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer nous-probe-fixture-access");
+      return new Response(payload, { headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    await saveCredential("nous", {
+      access: "nous-probe-fixture-access",
+      refresh: "nous-probe-fixture-refresh",
+      expires: Date.now() + 3_600_000,
+    });
+    const config = baseConfig({
+      nous: { ...structuredClone(OAUTH_PROVIDERS.nous!.providerConfig) },
+    });
+
+    const { status, body } = await probe(config, "nous");
+
+    expect(status).toBe(200);
+    expect(fetches).toBe(1);
+    expect(body).toMatchObject({ ok: true, models: 390 });
+  });
+
   test("Google's models-array response shape is accepted (x-goog-api-key path)", async () => {
     let requestedUrl = "";
     globalThis.fetch = (async (input: RequestInfo | URL) => {

--- a/tests/providers/provider-model-discovery-contract.test.ts
+++ b/tests/providers/provider-model-discovery-contract.test.ts
@@ -441,7 +441,7 @@ describe("registry-owned provider model discovery", () => {
       process.env.OPENCODEX_HOME = credentialHome;
       clearModelCache("nous");
       await saveCredential("nous", {
-        access: "nous-discovery-fixture-access",
+        access: "access-token-nous-discovery-fixture",
         refresh: "nous-discovery-fixture-refresh",
         expires: Date.now() + 3_600_000,
       });
@@ -472,7 +472,7 @@ describe("registry-owned provider model discovery", () => {
         fetches += 1;
         expect(String(input)).toBe("https://inference-api.nousresearch.com/v1/models");
         expect(init?.method ?? "GET").toBe("GET");
-        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer nous-discovery-fixture-access");
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer access-token-nous-discovery-fixture");
         return new Response(payload, { headers: { "content-type": "application/json" } });
       }) as typeof fetch;
       const config = withStubbedProviderFetch<OcxConfig>({

--- a/tests/providers/provider-model-discovery-contract.test.ts
+++ b/tests/providers/provider-model-discovery-contract.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gatherRoutedModels } from "../../src/codex/catalog";
 import { catalogHintsFromModelsApiItem } from "../../src/codex/catalog/provider-fetch";
-import { clearModelCache, getFreshCached, setCached } from "../../src/codex/model-cache";
+import { clearModelCache, getFreshCached, getProviderDiscoveryStatus, getProviderLiveModelCount, setCached } from "../../src/codex/model-cache";
 import { buildModelsRequest } from "../../src/oauth";
+import { saveCredential } from "../../src/oauth/store";
 import { KEY_LOGIN_PROVIDERS, validateApiKey } from "../../src/oauth/key-providers";
 import { deriveKeyLoginMap, providerConfigSeed } from "../../src/providers/derive";
 import {
@@ -25,6 +27,7 @@ import type { OcxConfig, OcxProviderConfig } from "../../src/types";
 import { withStubbedProviderFetch } from "../helpers/catalog-provider-fetch";
 import { withRegistryDiscovery } from "../helpers/provider-registry-discovery";
 import { fixturePath } from "../helpers/repo-root";
+import { removeTreeWithRetry } from "../helpers/remove-tree";
 
 const FIXTURE = readFileSync(fixturePath("provider-model-discovery.json"), "utf8");
 const originalFetch = globalThis.fetch;
@@ -426,6 +429,79 @@ describe("registry-owned provider model discovery", () => {
     const result = await readBoundedDiscoveryJson(response, 64);
     expect(result).toEqual({ ok: false, reason: "response_too_large" });
     expect(cancelled).toBe(true);
+  });
+
+  describe("Nous native catalog response cap (#3939)", () => {
+    let previousHome: string | undefined;
+    let credentialHome: string;
+
+    beforeEach(async () => {
+      previousHome = process.env.OPENCODEX_HOME;
+      credentialHome = mkdtempSync(join(tmpdir(), "ocx-nous-discovery-"));
+      process.env.OPENCODEX_HOME = credentialHome;
+      clearModelCache("nous");
+      await saveCredential("nous", {
+        access: "nous-discovery-fixture-access",
+        refresh: "nous-discovery-fixture-refresh",
+        expires: Date.now() + 3_600_000,
+      });
+    });
+
+    afterEach(() => {
+      clearModelCache("nous");
+      if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
+      else process.env.OPENCODEX_HOME = previousHome;
+      removeTreeWithRetry(credentialHome);
+    });
+
+    test("gathers and caches 390 synthetic paid/free rows above 256 KiB", async () => {
+      const entry = PROVIDER_REGISTRY.find(row => row.id === "nous");
+      if (!entry) throw new Error("missing nous registry entry");
+      const payload = JSON.stringify({
+        data: Array.from({ length: 390 }, (_, index) => ({
+          id: index === 0 ? "tencent/hy3:free" : `vendor/model-${index}`,
+          metadata: { description: "x".repeat(1_400) },
+        })),
+      });
+      const bytes = new TextEncoder().encode(payload).byteLength;
+      expect(bytes).toBeGreaterThan(262_144);
+      expect(bytes).toBeLessThan(1_048_576);
+
+      let fetches = 0;
+      globalThis.fetch = (async (input, init) => {
+        fetches += 1;
+        expect(String(input)).toBe("https://inference-api.nousresearch.com/v1/models");
+        expect(init?.method ?? "GET").toBe("GET");
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer nous-discovery-fixture-access");
+        return new Response(payload, { headers: { "content-type": "application/json" } });
+      }) as typeof fetch;
+      const config = withStubbedProviderFetch<OcxConfig>({
+        defaultProvider: "nous",
+        providers: { nous: { ...providerConfigSeed(entry), models: ["safe-fallback"] } },
+      });
+      const discovery = resolveProviderModelDiscovery("nous", config.providers.nous!);
+      expect(discovery.maxResponseBytes).toBe(1_048_576);
+      expect(discovery.maxModels).toBe(512);
+      const warning = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const models = (await gatherRoutedModels(config)).filter(model => model.provider === "nous");
+        expect(fetches).toBe(1);
+        expect(models).toHaveLength(390);
+        const ids = models.map(model => model.id);
+        expect(ids).toContain("tencent/hy3:free");
+        expect(ids).toContain("vendor/model-1");
+        expect(ids).toContain("vendor/model-389");
+        expect(ids).not.toContain("safe-fallback");
+        // Gather sorts its published rows; the cache retains upstream order.
+        expect(getFreshCached("nous", 60_000)?.map(model => model.id).sort()).toEqual([...ids].sort());
+        expect(getProviderLiveModelCount("nous")).toBe(390);
+        expect(getProviderDiscoveryStatus("nous")).toEqual({ status: "ok" });
+        expect((await gatherRoutedModels(config)).filter(model => model.provider === "nous")).toEqual(models);
+        expect(fetches).toBe(1);
+      } finally {
+        warning.mockRestore();
+      }
+    });
   });
 
   test("rejects invalid UTF-8 before JSON parsing", async () => {


### PR DESCRIPTION
## Summary

Nous model discovery can reject a valid paid/free catalog above its old 256 KiB response cap. Raise only the Nous cap to 1 MiB while retaining its 512-row limit and the shared 4 MiB ceiling.

Carry #3939 from `e31f5be74af6eb31ad871b22ab09cbace345fdd1`, preserving Vocllum. Add isolated synthetic regressions through the real catalog gather and management connection probe: 390 rows above the former cap, expected paid/free IDs, model count, cache publication and reuse. Existing shared overflow/cancellation and raw-row limit tests remain authoritative. No new provider or credential destination is introduced.

## Verification

- Local product tests, typecheck, builds and dependency installs: **NOT RUN**, explicitly prohibited by the owner.
- Main inspected the three-file diff, source registry equivalence, fixture home/credential isolation and injected outbound transport; Git diff checks passed.
- Independent source/security audit PASS, followed by interdiff re-review PASS on `711a3f65c5b5c8398b4309955cc20d8002c4c31c`.
- [Current-head Cross-platform CI](https://github.com/lidge-jun/opencodex/actions/runs/34166962088) completed successfully. Linux and macOS logs explicitly show the new 390-row gather/cache and probe regressions passing. The privacy gate passed. Windows runtime shards and macOS unsharded control were skipped; they are not counted as passes.
- Initial head `d5778ac8d7` failed because the synthetic bearer literals did not match the repository fixture allowance. Four fixture strings were corrected without changing scanner policy; the superseded failing run was cancelled and is not green evidence.
- CI checked synthetic merge `caeaf45` of this head into `514350e6f`. Later `dev` change `9c54000c9` removes historical account captures/notes only; runtime, tests, manifests, lockfiles and build inputs are identical. Whole final-tree identity will be checked against the merge calculation; that is distinct from claiming the final docs combination executed in CI.
- Owner-authorized maintainer integration into `dev`, subject to current-head review/CI and no outstanding maintainer objections. Original author credit must remain in the squash commit.
- The commit retains only this single bug. No release or deployment is included.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; this restores existing discovery behavior without a new user setting.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; tests use isolated synthetic credentials and intercepted transport.

Co-authored-by: Vocllum <149675937+Vocllum@users.noreply.github.com>

Pre-merge refresh: current dev `01c23aedcdfcb913151a2ac8f7acebda58d91eee` includes another C documentation/capture cleanup only. `git diff --quiet 514350e6f origin/dev -- src tests gui scripts package.json bun.lock tsconfig.json .github` exits 0. No runtime/test/build-input drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nous model discovery for larger catalogs, supporting responses up to 1 MiB.
  * Ensured mixed paid and free model catalogs exceeding 256 KiB are discovered successfully.
  * Improved connectivity checks so larger Nous catalogs can be validated and counted correctly.

* **Performance**
  * Confirmed that successfully discovered Nous model catalogs are reused from cache, avoiding unnecessary repeat requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->