### PR TITLE
test(codex): reuse the stored JWT in admission substitution assertion

### DIFF
--- a/tests/codex-integration/codex-auth-context.test.ts
+++ b/tests/codex-integration/codex-auth-context.test.ts
@@ -1447,8 +1447,9 @@ describe("Codex auth context", () => {
     // The caller proved admission with one of OUR secrets. That secret must never leave the
     // process, so the only acceptable outcome is the stored main credential in its place.
     const admissionSecret = "ocx_data_localsecret";
+    const storedCredential = liveJwt();
     writeFileSync(join(testDir, "auth.json"), JSON.stringify({
-      tokens: { access_token: liveJwt(), account_id: "stored_main_acc" },
+      tokens: { access_token: storedCredential, account_id: "stored_main_acc" },
     }));
 
     const headers = materializeCodexUpstreamAuth(
@@ -1458,7 +1459,7 @@ describe("Codex auth context", () => {
     );
 
     expect(headers.get("authorization")).not.toContain(admissionSecret);
-    expect(headers.get("authorization")).toBe(`Bearer ${liveJwt()}`);
+    expect(headers.get("authorization")).toBe(`Bearer ${storedCredential}`);
     expect(headers.get("chatgpt-account-id")).toBe("stored_main_acc");
     // Unrelated forwarded headers still ride along.
     expect(headers.get("openai-beta")).toBe("responses=experimental");


### PR DESCRIPTION
## Summary

An admission-substitution test generated its stored JWT and expected JWT in separate calls. Crossing a wall-clock second changed the expiry claim and made equal credentials appear different. Capture the fixture token once and use that same value for storage and comparison, preserving admission-secret exclusion, account identity and unrelated-header assertions.

Carries only JWT commit `9b9e4d28bebf58dcb07c161914b3b9e324c55713` from #3950. The timezone fixture is delivered separately by the C workstream. Keep #3950 open until both independent slices are on dev. No runtime behavior changes.

## Verification

- `git diff --check HEAD^ HEAD` passed; only `tests/codex-integration/codex-auth-context.test.ts` changes (+3/-2).
- Independent source-plan audit passed; independent final candidate source review passed on `aa44a5909bf425c1b419b35332eb76062308e898`, preserving all four assertions and exact original patch. Current-head PR CI is pending.
- Local product tests/suites NOT RUN per owner instruction. No local runtime validation is claimed. An earlier baseline-sync post-merge hook accidentally invoked installation/typecheck/build in this session; it was disclosed and excluded from evidence. All subsequent Git mutations disable hooks per invocation, and pushes use `--no-verify`.
- Static inspection establishes single-token reuse; no executed wall-clock-boundary control is claimed from an ordinary test pass.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; test-only correction needs no product guide change.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; fixture only, production auth is unchanged.

Co-authored-by: luvs01 <27862058+luvs01@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by consistently reusing the stored credential when validating authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->