### PR TITLE
fix(codex): settle reset-credit retry aliases with canonical identity

### DIFF
--- a/docs-site/src/content/docs/reference/management-api.md
+++ b/docs-site/src/content/docs/reference/management-api.md
@@ -427,6 +427,13 @@ manager. Its routes are:
 | `POST /api/codex-auth/login/cancel` | Cancel a Codex login flow | — |
 | `GET /api/codex-auth/login-status` | Poll a flow or account login state. A completed new-account flow includes `catalogRefreshPending: true` only when recovery is needed. | Unknown flows report `expired`; no active flow reports `idle` |
 
+For reset-credit consumption, a different `operationId` supplied while the same physical
+account has an unfinished operation joins that operation as an alias. Its retry uses the
+original upstream request ID and records the outcome under that same identity, so later
+requests with the original ID or a known alias replay the stored result without another
+consume request. A previously unseen ID supplied after settlement starts a new explicit
+redemption; clients retrying an existing action should keep its ID.
+
 If a new account config row is saved but credential setup cannot finish, OAuth `login-status` reports
 `status: "error"` with
 `code: "codex_credential_persistence_failed"`, `accountId`, `needsReauth: true`, and optional

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -2341,7 +2341,7 @@ export async function handleCodexAuthAPI(
       const operation = await withResetCreditAuth(getRuntimeConfig(config), accountId, async auth => {
         // The ledger keys manual operations by the *physical* ChatGPT account, which is
         // only known after the auth wrapper resolves credentials. Open here, not earlier.
-        const identity = requestedOperationId === undefined
+        let identity = requestedOperationId === undefined
           ? undefined
           : {
             accountId,
@@ -2377,6 +2377,7 @@ export async function handleCodexAuthAPI(
             return response;
           }
           // Canonical id, which an alias join may map to an earlier caller id.
+          identity = { ...identity, operationId: opened.operationId };
           idempotencyKey = opened.operationId;
         } else {
           idempotencyKey = crypto.randomUUID();

--- a/tests/codex-integration/codex-auth-api.test.ts
+++ b/tests/codex-integration/codex-auth-api.test.ts
@@ -3280,6 +3280,13 @@ describe("codex-auth API", () => {
           config,
         );
         expect(retried!.status).toBe(200);
+        const replayed = await handleCodexAuthAPI(
+          consumeRequest({ accountId: "pool-alias", operationId: OTHER_OP_ID }),
+          new URL("http://localhost/api/codex-auth/reset-credits/consume"),
+          config,
+        );
+        expect(replayed!.status).toBe(200);
+        expect(await replayed!.json()).toEqual({ code: "reset", replayed: true });
         expect(upstream.redeemRequestIds).toEqual([OP_ID, OP_ID]);
       } finally {
         globalThis.fetch = previousFetch;

--- a/tests/codex-integration/codex-auth-api.test.ts
+++ b/tests/codex-integration/codex-auth-api.test.ts
@@ -29,6 +29,7 @@ import {
 import * as accountStoreModule from "../../src/codex/account-store";
 import * as reserveAvailabilityModule from "../../src/codex/reserve-availability";
 import { getMainAccountInfoCache, observeMainQuotaCredential } from "../../src/codex/main-account-cache";
+import { openManualResetCreditOperation } from "../../src/codex/reset-credit-operation-ledger";
 import {
   clearCodexUpstreamHealth,
   clearThreadAccountMap,
@@ -3292,6 +3293,48 @@ describe("codex-auth API", () => {
         globalThis.fetch = previousFetch;
       }
     });
+
+    for (const failure of ["throw", "non-2xx", "unknown-code"] as const) {
+      test(`an alias marks a pending canonical operation ambiguous after ${failure}`, async () => {
+        const config = makeConfig();
+        const accountId = "pool-pending-alias";
+        const chatgptAccountId = "physical-pending-alias";
+        seedPoolAccount(config, { id: accountId, email: "pending@example.test", chatgptAccountId });
+        expect(openManualResetCreditOperation({ accountId, chatgptAccountId, operationId: OP_ID }))
+          .toMatchObject({ kind: "execute", operationId: OP_ID });
+        const readOperation = () => {
+          const database = new Database(join(TEST_DIR, "config-mutation.sqlite"), { readonly: true });
+          try {
+            return database.query<{ account_key: string; operation_id: string; state: string; code: string | null }, []>(
+              "SELECT account_key, operation_id, state, code FROM reset_credit_operations WHERE operation_kind = 'manual'",
+            ).get();
+          } finally {
+            database.close();
+          }
+        };
+        const pending = readOperation();
+        expect(pending).toMatchObject({ operation_id: OP_ID, state: "pending", code: null });
+        const upstream = stubUpstream(() => {
+          if (failure === "throw") throw new Error("fixture consume failure");
+          return failure === "non-2xx"
+            ? new Response("fixture unavailable", { status: 503 })
+            : Response.json({ code: "weird" });
+        });
+        try {
+          const response = await handleCodexAuthAPI(
+            consumeRequest({ accountId, operationId: OTHER_OP_ID }),
+            new URL("http://localhost/api/codex-auth/reset-credits/consume"),
+            config,
+          );
+          expect(response!.status).toBe(failure === "throw" ? 500 : failure === "non-2xx" ? 503 : 200);
+          expect(readOperation()).toEqual({ ...pending!, state: "ambiguous" });
+          expect(upstream.redeemRequestIds).toEqual([OP_ID]);
+          expect(getCodexAccountCredential(accountId)?.chatgptAccountId).toBe(chatgptAccountId);
+        } finally {
+          globalThis.fetch = previousFetch;
+        }
+      });
+    }
 
     test("an unknown upstream code stays ambiguous instead of settling the ledger", async () => {
       const config = makeConfig();


### PR DESCRIPTION
## Summary

A reset-credit retry may join an unfinished operation with a different caller ID. The request already uses the canonical upstream ID, but recording its settlement or ambiguous failure with the alias can be rejected by the ledger. Adopt the ledger-returned operation ID for both outcomes after existing authentication, ownership and execute admission.

Carries #3919 from `6f20c3d08cd202e43b8679de33674133bdc7f34c`, preserving the contributor's two production hunks and management API explanation. Added regressions start with a real pending canonical operation and exercise an alias fetch error, non-2xx response and unknown code; the durable row must become ambiguous without changing account key, canonical ID or terminal code. Existing settled-alias replay remains covered. No automatic-redemption worker or identity policy change.

## Verification

- `git diff --check` passed. Only the original three-file scope changes.
- Independent source-plan audit passed; final independent source/security review passed on `6c1477d19c7d1a77a1866cabfd2b4411f1a210d7` with no blocking findings. Hosted CI pending.
- Current-head PR CI and full `ci.yml` workflow dispatch with `lane=all` will be inspected before landing. Skipped or cancelled work is not passing evidence.
- Local product tests/suites NOT RUN per owner instruction. No local runtime validation is claimed. An initial baseline-sync post-merge hook accidentally ran install/typecheck/build earlier in this session; it was disclosed and excluded from evidence. Subsequent Git writes disable hooks per invocation, with `--no-verify` pushes.
- Fixtures use synthetic credentials and mocked upstream responses. No real account or reset credit is used. The fix prevents unnecessary consume requests; it does not claim an externally verified upstream exactly-once guarantee.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: luvs01 <27862058+luvs01@users.noreply.github.com>

Integration refresh: base `9c8f66b9df4cdf133a16c95a95ee07ff5171a46d`; both commits unchanged by range-diff. Independent interdiff/security review PASS, with no alias dependency impact from Go translation/release-note changes. New-head PR CI 34169890598 and full dispatch 34169887448 pending. Earlier-head CI is historical evidence only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reset-credit consumption retries when different operation IDs refer to the same in-progress action.
  - Retries now consistently use the original operation identity, preventing duplicate upstream consumption.
  - Improved handling and status reporting for upstream failures and uncertain outcomes.

- **Documentation**
  - Clarified reset-credit operation identity, retry behavior, and when a new operation begins in the Management API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->