### PR TITLE
test: isolate Santiago timezone state and prove child completion

### DIFF
--- a/gui/tests/usage-custom-range.test.tsx
+++ b/gui/tests/usage-custom-range.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { Window } from "happy-dom";
+import { resolve } from "node:path";
 import { act } from "react";
 import type { Root } from "react-dom/client";
 import { LanguageProvider } from "../src/i18n/provider";
@@ -154,7 +155,7 @@ for (const connected of [false, true]) {
 }
 
 test("America/Santiago midnight DST retains final-day activity and tooltip", async () => {
-  if (process.env.TZ !== "America/Santiago") {
+  if (process.env.OCX_USAGE_SANTIAGO_CHILD !== "1" && process.env.TZ !== "America/Santiago") {
     // Restoring an absent TZ can change Bun's effective timezone on Windows.
     // Start the DST case in its timezone without mutating this suite's clock.
     const timezone = { present: Object.hasOwn(process.env, "TZ"), value: process.env.TZ };
@@ -164,17 +165,20 @@ test("America/Santiago midnight DST retains final-day activity and tooltip", asy
       "-t", "^America/Santiago midnight DST retains final-day activity and tooltip$",
       "--timeout", "10000",
     ], {
-      env: { ...process.env, TZ: "America/Santiago" },
+      cwd: resolve(import.meta.dir, ".."),
+      env: { ...process.env, TZ: "America/Santiago", OCX_USAGE_SANTIAGO_CHILD: "1" },
       stdout: "pipe", stderr: "pipe", timeout: 12000, killSignal: "SIGKILL",
     });
     const diagnostics = `${child.stdout.toString()}\n${child.stderr.toString()}`;
     expect(child.exitedDueToTimeout, diagnostics).not.toBe(true);
     expect(child.signalCode, diagnostics).toBeUndefined();
     expect(child.exitCode, diagnostics).toBe(0);
+    expect(child.stdout.toString().split(/\r?\n/), diagnostics).toContain("OCX_SANTIAGO_CASE_COMPLETED");
     expect({ present: Object.hasOwn(process.env, "TZ"), value: process.env.TZ }).toEqual(timezone);
     expect(new Date(2020, 8, 15, 10, 20).getTime()).toBe(localTime);
     return;
   }
+  expect(process.env.TZ).toBe("America/Santiago");
   expect(new Date(2026, 8, 6, 0).getHours()).toBe(1);
   await mount();
   await respond(0, "preset-marker");
@@ -192,7 +196,8 @@ test("America/Santiago midnight DST retains final-day activity and tooltip", asy
   await act(async () => active!.dispatchEvent(new testWindow.MouseEvent("mouseover", { bubbles: true })));
   expect(container.querySelector(".heatmap-tip-date")?.textContent).toBe("2026-09-07");
   expect(container.querySelector(".heatmap-tip")?.textContent).toContain("700");
-}, 15000);
+  if (process.env.OCX_USAGE_SANTIAGO_CHILD === "1") console.log("OCX_SANTIAGO_CASE_COMPLETED");
+}, process.env.OCX_USAGE_SANTIAGO_CHILD === "1" ? 10000 : 15000);
 
 test("Apply submits inclusive bounds once; Clear restores the held preset without custom cache entries", async () => {
   await mount();

--- a/gui/tests/usage-custom-range.test.tsx
+++ b/gui/tests/usage-custom-range.test.tsx
@@ -154,31 +154,45 @@ for (const connected of [false, true]) {
 }
 
 test("America/Santiago midnight DST retains final-day activity and tooltip", async () => {
-  const previous = process.env.TZ;
-  process.env.TZ = "America/Santiago";
-  try {
-    expect(new Date(2026, 8, 6, 0).getHours()).toBe(1);
-    await mount();
-    await respond(0, "preset-marker");
-    await enter("2026-09-05T00:00", "2026-09-07T23:59");
-    await apply();
-    const gate = requests.at(-1)!;
-    const data = report(gate, "santiago-marker", "2026-09-07");
-    data.days = ["2026-09-05", "2026-09-06", "2026-09-07"].map(date => ({
-      date, requests: date === "2026-09-07" ? 7 : 0, measuredRequests: 0, reportedRequests: 0,
-      totalTokens: date === "2026-09-07" ? 700 : 0, models: [],
-    }));
-    await act(async () => gate.resolve(Response.json(data)));
-    const active = container.querySelector<HTMLElement>('.heatmap-grid .heatmap-cell:not(.heatmap-cell-0)');
-    expect(active).not.toBeNull();
-    await act(async () => active!.dispatchEvent(new testWindow.MouseEvent("mouseover", { bubbles: true })));
-    expect(container.querySelector(".heatmap-tip-date")?.textContent).toBe("2026-09-07");
-    expect(container.querySelector(".heatmap-tip")?.textContent).toContain("700");
-  } finally {
-    if (previous === undefined) delete process.env.TZ;
-    else process.env.TZ = previous;
+  if (process.env.TZ !== "America/Santiago") {
+    // Restoring an absent TZ can change Bun's effective timezone on Windows.
+    // Start the DST case in its timezone without mutating this suite's clock.
+    const timezone = { present: Object.hasOwn(process.env, "TZ"), value: process.env.TZ };
+    const localTime = new Date(2020, 8, 15, 10, 20).getTime();
+    const child = Bun.spawnSync([
+      process.execPath, "test", import.meta.path,
+      "-t", "^America/Santiago midnight DST retains final-day activity and tooltip$",
+      "--timeout", "10000",
+    ], {
+      env: { ...process.env, TZ: "America/Santiago" },
+      stdout: "pipe", stderr: "pipe", timeout: 12000, killSignal: "SIGKILL",
+    });
+    const diagnostics = `${child.stdout.toString()}\n${child.stderr.toString()}`;
+    expect(child.exitedDueToTimeout, diagnostics).not.toBe(true);
+    expect(child.signalCode, diagnostics).toBeUndefined();
+    expect(child.exitCode, diagnostics).toBe(0);
+    expect({ present: Object.hasOwn(process.env, "TZ"), value: process.env.TZ }).toEqual(timezone);
+    expect(new Date(2020, 8, 15, 10, 20).getTime()).toBe(localTime);
+    return;
   }
-});
+  expect(new Date(2026, 8, 6, 0).getHours()).toBe(1);
+  await mount();
+  await respond(0, "preset-marker");
+  await enter("2026-09-05T00:00", "2026-09-07T23:59");
+  await apply();
+  const gate = requests.at(-1)!;
+  const data = report(gate, "santiago-marker", "2026-09-07");
+  data.days = ["2026-09-05", "2026-09-06", "2026-09-07"].map(date => ({
+    date, requests: date === "2026-09-07" ? 7 : 0, measuredRequests: 0, reportedRequests: 0,
+    totalTokens: date === "2026-09-07" ? 700 : 0, models: [],
+  }));
+  await act(async () => gate.resolve(Response.json(data)));
+  const active = container.querySelector<HTMLElement>('.heatmap-grid .heatmap-cell:not(.heatmap-cell-0)');
+  expect(active).not.toBeNull();
+  await act(async () => active!.dispatchEvent(new testWindow.MouseEvent("mouseover", { bubbles: true })));
+  expect(container.querySelector(".heatmap-tip-date")?.textContent).toBe("2026-09-07");
+  expect(container.querySelector(".heatmap-tip")?.textContent).toContain("700");
+}, 15000);
 
 test("Apply submits inclusive bounds once; Clear restores the held preset without custom cache entries", async () => {
   await mount();

--- a/gui/tests/usage-custom-range.test.tsx
+++ b/gui/tests/usage-custom-range.test.tsx
@@ -155,7 +155,7 @@ for (const connected of [false, true]) {
 }
 
 test("America/Santiago midnight DST retains final-day activity and tooltip", async () => {
-  if (process.env.OCX_USAGE_SANTIAGO_CHILD !== "1" && process.env.TZ !== "America/Santiago") {
+  if (process.env.OCX_USAGE_SANTIAGO_CHILD !== "1") {
     // Restoring an absent TZ can change Bun's effective timezone on Windows.
     // Start the DST case in its timezone without mutating this suite's clock.
     const timezone = { present: Object.hasOwn(process.env, "TZ"), value: process.env.TZ };


### PR DESCRIPTION
## Summary

Extract only the Santiago timezone fixture from #3950. Run its existing skipped-midnight, final-day activity and tooltip assertions in a bounded child process instead of mutating the shared test process timezone.

The parent preserves both TZ presence/value and its effective local timestamp. The child uses an explicit dashboard working directory and marker, validates its timezone, and emits a completion marker after the last assertion. The parent requires that marker plus successful exit/signal/deadline checks. Child test, child process and parent test deadlines are 10, 12 and 15 seconds respectively.

Source commit 1d8f6ff7e8d48f33c3ce7a1b7118068754bbbe83 by @luvs01, with a focused test-integrity follow-up. Only the existing test file changes; no rendered UI, date interpretation, JWT, dependency or workflow change. B's JWT correction is separately landed in #3962; #3950 stays open until this independent part is also verified and landed.

## Verification

- Independent planning/source audit confirmed the isolated scope and preserved original assertions. Final source review is recorded separately.
- Local product tests, builds, typechecks and installations: NOT RUN per owner instruction. Git diff checks passed.
- Existing current-head hosted PR CI is required. Supplementary evidence runs the exact candidate on Linux, macOS and Windows with the pinned Bun version, explicit TZ variants, child failure/marker/deadline controls and byte restoration. The verification-only workflow is excluded from this PR and will not be merged.
- Test-only change: no product screen changed and no fabricated UI screenshot is supplied.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; product behavior is unchanged.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: luvs01 <27862058+luvs01@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved daylight-saving-time coverage for the America/Santiago timezone.
  - Isolated timezone-specific checks in a separate test process, preventing changes to the main test environment.
  - Added verification that the child test completes successfully and reports its expected result.
  - Confirmed the parent test environment’s timezone and system clock remain unchanged after the checks complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->