### PR TITLE
test(codex): isolate routing scratch homes and drain hardening

### DIFF
--- a/tests/codex-integration/codex-routing.test.ts
+++ b/tests/codex-integration/codex-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { STORE_BUDGET_MS } from "../helpers/test-budget";
 import {
@@ -54,9 +55,75 @@ import { consumeForInspection } from "../../src/server/relay";
 import type { OcxConfig } from "../../src/types";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 
-const TEST_DIR = join(import.meta.dir, ".tmp-codex-routing-test");
+import { flushConfigDirHardeningForTests, hardenConfigDir } from "../../src/config/paths";
+import { setAsyncIcaclsRunnerForTests, setIcaclsRunnerForTests } from "../../src/lib/windows-secret-acl";
+
+let TEST_DIR = "";
 let previousOpencodexHome: string | undefined;
 let previousCodexHome: string | undefined;
+
+const ICACLS_OK = { success: true, exitCode: 0, timedOut: false, stdout: "" };
+
+function installRoutingScratchHome(): void {
+  previousOpencodexHome = process.env.OPENCODEX_HOME;
+  previousCodexHome = process.env.CODEX_HOME;
+  TEST_DIR = mkdtempSync(join(tmpdir(), "ocx-routing-"));
+  // Routing cases exercise account state, not the operating system ACL implementation.
+  setIcaclsRunnerForTests(() => ICACLS_OK);
+  setAsyncIcaclsRunnerForTests(async () => ICACLS_OK);
+  process.env.OPENCODEX_HOME = TEST_DIR;
+  process.env.CODEX_HOME = TEST_DIR;
+}
+
+async function removeRoutingScratchHome(): Promise<void> {
+  const ownedDirectory = TEST_DIR;
+  TEST_DIR = "";
+  try {
+    await flushConfigDirHardeningForTests();
+  } finally {
+    setIcaclsRunnerForTests(null);
+    setAsyncIcaclsRunnerForTests(null);
+    if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
+    else process.env.OPENCODEX_HOME = previousOpencodexHome;
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    if (ownedDirectory) removeTreeWithRetry(ownedDirectory);
+  }
+}
+
+test.skipIf(process.platform !== "win32")("routing scratch cleanup waits for its outstanding hardening flight", async () => {
+  installRoutingScratchHome();
+  const ownedDirectory = TEST_DIR;
+  let entered!: () => void;
+  let release!: () => void;
+  const started = new Promise<void>(resolve => { entered = resolve; });
+  const gate = new Promise<void>(resolve => { release = resolve; });
+  let cleanup: Promise<void> | undefined;
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  try {
+    setAsyncIcaclsRunnerForTests(async () => { entered(); await gate; return ICACLS_OK; });
+    hardenConfigDir();
+    await Promise.race([
+      started,
+      new Promise<never>((_, reject) => { deadline = setTimeout(() => reject(new Error("hardening fixture did not start")), 5_000); }),
+    ]);
+    let cleaned = false;
+    cleanup = removeRoutingScratchHome().then(() => { cleaned = true; });
+    await Promise.resolve();
+    expect(cleaned).toBe(false);
+    expect(existsSync(ownedDirectory)).toBe(true);
+    release();
+    await cleanup;
+    expect(cleaned).toBe(true);
+    expect(existsSync(ownedDirectory)).toBe(false);
+  } finally {
+    if (deadline !== undefined) clearTimeout(deadline);
+    release();
+    if (cleanup) await cleanup;
+    else await removeRoutingScratchHome();
+  }
+}, STORE_BUDGET_MS);
+
 
 function makeConfig(overrides: Partial<OcxConfig> = {}): OcxConfig {
   return {
@@ -89,14 +156,7 @@ function pendingInspectionStream(): ReadableStream<Uint8Array> {
 
 describe("codex routing", () => {
   beforeEach(() => {
-    previousOpencodexHome = process.env.OPENCODEX_HOME;
-    if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
-    mkdirSync(TEST_DIR, { recursive: true });
-    process.env.OPENCODEX_HOME = TEST_DIR;
-    // Isolate the main-account credential source: TEST_DIR has no auth.json, so the main
-    // account is deterministically absent (these cases test the pool-only scenario).
-    previousCodexHome = process.env.CODEX_HOME;
-    process.env.CODEX_HOME = TEST_DIR;
+    installRoutingScratchHome();
     clearThreadAccountMap();
     clearCodexUpstreamHealth();
     clearAccountQuota();
@@ -107,18 +167,17 @@ describe("codex routing", () => {
     saveTestCredential("b");
   });
 
-  afterEach(() => {
-    clearAccountQuota();
-    clearCodexUpstreamHealth();
-    clearThreadAccountMap();
-    clearAccountNeedsReauth("a");
-    clearAccountNeedsReauth("b");
-    clearAccountNeedsReauth("c");
-    if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
-    else process.env.OPENCODEX_HOME = previousOpencodexHome;
-    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = previousCodexHome;
-    if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
+  afterEach(async () => {
+    try {
+      clearAccountQuota();
+      clearCodexUpstreamHealth();
+      clearThreadAccountMap();
+      clearAccountNeedsReauth("a");
+      clearAccountNeedsReauth("b");
+      clearAccountNeedsReauth("c");
+    } finally {
+      await removeRoutingScratchHome();
+    }
   });
 
   test("usage score uses the hottest known quota window", () => {
@@ -2175,12 +2234,7 @@ describe("codex routing", () => {
 
 describe("codex account selection order", () => {
   beforeEach(() => {
-    previousOpencodexHome = process.env.OPENCODEX_HOME;
-    if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
-    mkdirSync(TEST_DIR, { recursive: true });
-    process.env.OPENCODEX_HOME = TEST_DIR;
-    previousCodexHome = process.env.CODEX_HOME;
-    process.env.CODEX_HOME = TEST_DIR;
+    installRoutingScratchHome();
     clearThreadAccountMap();
     clearCodexUpstreamHealth();
     clearAccountQuota();
@@ -2191,18 +2245,17 @@ describe("codex account selection order", () => {
     saveTestCredential("b");
   });
 
-  afterEach(() => {
-    clearAccountQuota();
-    clearCodexUpstreamHealth();
-    clearThreadAccountMap();
-    clearPoolRotationState();
-    clearAccountNeedsReauth("a");
-    clearAccountNeedsReauth("b");
-    if (previousOpencodexHome === undefined) delete process.env.OPENCODEX_HOME;
-    else process.env.OPENCODEX_HOME = previousOpencodexHome;
-    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = previousCodexHome;
-    if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
+  afterEach(async () => {
+    try {
+      clearAccountQuota();
+      clearCodexUpstreamHealth();
+      clearThreadAccountMap();
+      clearPoolRotationState();
+      clearAccountNeedsReauth("a");
+      clearAccountNeedsReauth("b");
+    } finally {
+      await removeRoutingScratchHome();
+    }
   });
 
   /** `a` is ordered above `b`; the persisted operator selection is the lower tier. */


### PR DESCRIPTION
## Summary

Routing tests reused one repository-local configuration directory and removed it while optional Windows directory hardening could still be running. One failed setup/removal then poisoned later routing and account-selection tests on the same path.

Give each test its own scratch home, stub both OS ACL runners for these routing-only scenarios, and drain pending hardening before restoring the runners/environment and deleting that owned directory. Both describe blocks retain their original routing resets and assertions. A Windows regression holds a synthetic hardening flight and proves cleanup cannot remove the directory until it is released.

## Verification

- `git diff --check` passed. Changes are limited to `tests/codex-integration/codex-routing.test.ts`; no production behavior changes.
- Independent source-plan review passed; final source/test review and exact-head hosted CI pending.
- Original failing Windows job 101879068479 remains recorded: setup lock error followed by cleanup failures against a reused directory. This fixes demonstrable fixture ownership defects; the hidden initial SQLite error is not retroactively attributed as proven.
- Local tests, suites, typecheck, builds and installs NOT RUN. Git hooks disabled per command; push uses `--no-verify`. No live account or service operations.
- Windows runtime regression must execute in `ci.yml` workflow_dispatch lane=all; ordinary PR Windows skips are not passing platform evidence.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; test fixture only.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; synthetic test inputs, unchanged production ACL handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test isolation by using a fresh temporary directory for each run.
  * Added cleanup handling to restore environment settings and remove temporary test data.
  * Added Windows-specific coverage to verify cleanup waits for outstanding security hardening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->