### PR TITLE
test(storage): synchronize cleanup ownership before policy admission

### DIFF
--- a/tests/storage/storage-mutation-race.test.ts
+++ b/tests/storage/storage-mutation-race.test.ts
@@ -265,27 +265,40 @@ describe("storage mutation coordinator", () => {
 
   test("policy run is rejected while manual cleanup holds the shared mutation slot", async () => {
     const home = isolatedCodexHome!.path;
-    setArchivedCleanupJobTestHooks({ blockMs: 1200 });
+    const cleanupReadyPath = join(testDir, "policy-cleanup-slot.ready");
+    const releaseCleanupPath = join(testDir, "policy-cleanup-release");
+    setArchivedCleanupJobTestHooks({
+      pauseAfterAcquire: {
+        kind: "cleanup",
+        readyPath: cleanupReadyPath,
+        releasePath: releaseCleanupPath,
+      },
+    });
     seedArchivedPair(home);
 
     const server = startServer(0);
+    let cleanupPromise: Promise<Response> | null = null;
     try {
       const preview = await previewDigest(server.url, 50);
-      const cleanupPromise = fetch(new URL("/api/storage/cleanup", server.url), {
+      cleanupPromise = fetch(new URL("/api/storage/cleanup", server.url), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ percent: 50, mode: "quarantine", digest: preview.digest }),
       });
-      await Bun.sleep(80);
+      await waitForCondition("cleanup slot before policy admission", () => existsSync(cleanupReadyPath));
+      expect(getActiveStorageMutation(home)?.kind).toBe("cleanup");
 
       const { startedAt } = await enablePolicyAndRun(server.url);
       const done = await waitForPolicyJob(server.url, startedAt);
       expect(done.job.lastOutcome?.ok).toBe(false);
       expect(done.job.lastOutcome?.error).toBe("storage_mutation_busy");
 
+      writeFileSync(releaseCleanupPath, "release\n");
       const cleanupRes = await cleanupPromise;
       expect(cleanupRes.status).toBe(200);
     } finally {
+      writeFileSync(releaseCleanupPath, "release\n");
+      if (cleanupPromise) await cleanupPromise.catch(() => undefined);
       await stopRaceServer(server);
     }
   }, { timeout: 30_000 });


### PR DESCRIPTION
## Summary

The policy-versus-manual-cleanup race test used a 1.2-second cleanup delay and an 80ms sleep, neither of which proved that policy admission happened while cleanup held the mutation slot. Use the existing pause-after-acquire ready/release handshake and assert the actual active cleanup slot before running policy.

Keep the startedAt-specific outcome wait, busy rejection assertions and successful cleanup response. Release and settle the cleanup request before server shutdown even when an assertion fails. Production storage code, timeouts and other tests are unchanged.

## Verification

- `git diff --check` passed. One existing fixture changes (+16/-3).
- Independent source-plan audit passed; final source review and hosted current-head execution pending.
- Prior Windows job101888425573 observed a successful policy instead of the expected busy result. The old timing assumption could miss overlap; exact historical timing is not claimed as captured.
- Local tests/typecheck/build/install NOT RUN. Git hooks disabled per invocation; push `--no-verify`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; test fixture only.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; real isolated test server, no production policy changes.
