### PR TITLE
fix(web-search): stop inactivity timing after terminal events

### DIFF
--- a/src/web-search/progress-stream.ts
+++ b/src/web-search/progress-stream.ts
@@ -303,6 +303,10 @@ export async function* parseStreamWithProgress(
         }
         if (event.type === "done" || event.type === "incomplete") {
           heldTerminal = event;
+          // Response-byte inactivity ends once the adapter has produced a terminal event.
+          // From here the separate post-terminal drain guard owns the bounded wait for
+          // iterator cleanup, so leaving the inactivity timer armed creates a false timeout.
+          clearInactivity();
           continue;
         }
         await handoff.deliver(event);

--- a/tests/web-search/web-search-progress-stream.test.ts
+++ b/tests/web-search/web-search-progress-stream.test.ts
@@ -215,10 +215,13 @@ describe("web-search streamed-body progress collector", () => {
     let returned = false;
     const parser: ParseStream = async function* () {
       yield { type: "done", usage: { inputTokens: 1, outputTokens: 2 } };
-      await sleep(20);
+      await sleep(30);
       returned = true;
     };
-    const iterator = parseStreamWithProgress(new Response(chunkStream([])), parser, { inactivityTimeoutMs: 100 });
+    const iterator = parseStreamWithProgress(new Response(chunkStream([])), parser, {
+      inactivityTimeoutMs: 10,
+      postTerminalDrainTimeoutMs: 100,
+    });
     const next = await iterator.next();
     expect(returned).toBe(true);
     expect(next.value).toEqual({ type: "done", usage: { inputTokens: 1, outputTokens: 2 } });


### PR DESCRIPTION
## Summary

A valid done or incomplete event can be buffered while the downstream consumer pauses. Clear the upstream inactivity timer when that terminal arrives, so consuming the terminal later cannot incorrectly raise RoutedModelInactivityError.

No interface or configuration changes; existing documentation remains accurate.

## Verification

`bun run typecheck` passed. `bun test tests/web-search/web-search-progress-stream.test.ts`: 21 passed. Removing the terminal timer clear made the held-done regression fail, then the fix was restored.

All runtime checks used a fresh temporary OPENCODEX_HOME and alternate port; production config fingerprint and backup inventory remained unchanged. Full root-suite and review-readiness gates have not been completed for this head; this is intentionally a draft.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Added/updated regression coverage or verified existing coverage for the affected behavior.
- [x] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

### Review readiness

- [ ] Local CI green.
- [ ] Branch on the latest dev commit.
- [ ] All correct Codex and CodeRabbit findings fixed.
- [ ] Ready-for-review confirmation.

Co-authored-by: SB Yoon <44089734+yansigit@users.noreply.github.com>
Co-authored-by: Yumi <automation@sbyoon.com>

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
