### PR TITLE
test(cli): make stale-port status fixture deterministic

### DIFF
--- a/tests/cli/cli-status-json.test.ts
+++ b/tests/cli/cli-status-json.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
@@ -711,13 +711,15 @@ describe("status reports stale process records end to end", () => {
    * discard port 9 is conventionally unused but not guaranteed, and if anything answers
    * on it the probe is accepted rather than refused and these fixtures invert.
    */
-  let freePort = 9;
-  beforeAll(async () => {
+  async function allocateFreePort(): Promise<number> {
     const probe = createServer();
     await new Promise<void>(resolve => { probe.listen(0, "127.0.0.1", () => resolve()); });
-    freePort = (probe.address() as AddressInfo).port;
+    const port = (probe.address() as AddressInfo).port;
     await new Promise<void>(resolve => { probe.close(() => resolve()); });
-  });
+    return port;
+  }
+  let freePort: number;
+  beforeEach(async () => { freePort = await allocateFreePort(); });
 
   test("a dead owner record surfaces in --json and in human output", () => {
     const home = mkdtempSync(join(tmpdir(), "ocx-stale-json-"));
@@ -787,10 +789,14 @@ describe("status reports stale process records end to end", () => {
     await new Promise<void>(resolve => { occupied.listen(0, "127.0.0.1", () => resolve()); });
     const occupiedPort = (occupied.address() as AddressInfo).port;
     try {
+      // Allocate after the listener is bound: it can reuse the port released by
+      // beforeEach, so that earlier number no longer proves a refused endpoint.
+      const recordedPort = await allocateFreePort();
+      expect(recordedPort).not.toBe(occupiedPort);
       const pid = findDeadPid();
       writeFileSync(join(home, "config.json"), JSON.stringify({ port: occupiedPort, codexAutoStart: false }), "utf8");
       writeFileSync(join(home, "ocx.pid"), String(pid), "utf8");
-      writeFileSync(join(home, "runtime-port.json"), JSON.stringify({ pid, port: freePort, hostname: "127.0.0.1" }), "utf8");
+      writeFileSync(join(home, "runtime-port.json"), JSON.stringify({ pid, port: recordedPort, hostname: "127.0.0.1" }), "utf8");
 
       const parsed = JSON.parse(runStatusJson(home).stdout) as { proxy?: { staleProcessState?: unknown } };
       expect(parsed.proxy?.staleProcessState).toBe(true);


### PR DESCRIPTION
## Summary

Allocate the refused runtime-record port after binding the deliberately occupied configured-port listener, and assert the two ports differ. Reallocate per test so the occupied listener cannot reuse a previously released shared port and silently invert the fixture.

Test fixture only; no user documentation change needed.

## Verification

`bun test tests/cli/cli-status-json.test.ts`: 47 passed.

All runtime checks used a fresh temporary OPENCODEX_HOME and alternate port; production config fingerprint and backup inventory remained unchanged. Full root-suite and review-readiness gates have not been completed for this head; this is intentionally a draft.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Added/updated regression coverage or verified existing coverage for the affected behavior.
- [x] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

### Review readiness

- [ ] Local CI green.
- [ ] Branch on the latest dev commit.
- [ ] All correct Codex and CodeRabbit findings fixed.
- [ ] Ready-for-review confirmation.

Co-authored-by: SB Yoon <44089734+yansigit@users.noreply.github.com>
Co-authored-by: Yumi <automation@sbyoon.com>

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
