### PR TITLE
fix(codex): invalidate app-server observations at catalog boundaries

### DIFF
--- a/docs-site/src/content/docs/guides/codex-app-models.md
+++ b/docs-site/src/content/docs/guides/codex-app-models.md
@@ -319,3 +319,5 @@ ocx sync
 
 opencodex rewrites `models_cache.json` with a deliberately stale cache wrapper whenever catalog
 visibility, priority, or metadata changes, so the next Codex model refresh reads the new catalog.
+
+After a catalog or model-cache write, OpenCodex invalidates its cached app-server observation so the next request checks process freshness again. A configuration sync also invalidates the observation when catalog contents are unchanged. This refresh does not restart Codex processes.

--- a/src/codex/internal/catalog-writer.ts
+++ b/src/codex/internal/catalog-writer.ts
@@ -16,6 +16,7 @@ import {
   forgetEphemeralSecretPath,
   hardenSecretPath,
 } from "../../lib/windows-secret-acl";
+import { resetCodexAppServerCatalogStateCache } from "../app-server-processes";
 
 export interface PreparedCatalogFileWrite {
   readonly path: string;
@@ -167,6 +168,7 @@ export function replaceActiveCodexCatalog(
 ): void {
   assertCatalogWritePermit(permit, owningCodexHome);
   atomicWriteFile(prepared.path, prepared.content, io);
+  resetCodexAppServerCatalogStateCache();
 }
 
 /** Atomically publish the catalog-path-keyed immutable backup without clobbering. */
@@ -200,4 +202,5 @@ export function replaceCodexModelsCache(
 ): void {
   assertCatalogWritePermit(permit, owningCodexHome);
   atomicWriteFile(prepared.path, prepared.content, io);
+  resetCodexAppServerCatalogStateCache();
 }

--- a/src/codex/sync.ts
+++ b/src/codex/sync.ts
@@ -8,6 +8,7 @@ import { summarizeComboCatalogOmissions, type ComboCatalogOmission } from "./cat
 import { shouldSyncCodexOnStart } from "./desired-state";
 import { admitCodexWrite, type CodexAdmission } from "./admission";
 import type { CodexCatalogSyncOptions } from "./catalog/sync";
+import { resetCodexAppServerCatalogStateCache } from "./app-server-processes";
 
 export interface CodexSyncResult {
   /**
@@ -116,6 +117,10 @@ export async function syncModelsToCodex(
       message: admission.message,
     };
   }
+  // Config injection is a relevant Codex write even when the catalog bytes are unchanged.
+  // Drop cached process evidence before async discovery so a process that appeared since the
+  // last read cannot make native-default guidance report active after this sync.
+  resetCodexAppServerCatalogStateCache();
   const p = port ?? config.port ?? 10100;
   const externalProvider = (deps.currentExternalCodexModelProvider ?? currentExternalCodexModelProvider)();
 

--- a/tests/codex-integration/codex-models-cache-invalidate.test.ts
+++ b/tests/codex-integration/codex-models-cache-invalidate.test.ts
@@ -5,9 +5,14 @@ import { join } from "node:path";
 import { invalidateCodexModelsCache } from "../../src/codex/catalog";
 import { invalidateCodexModelsCacheWithPermit } from "../../src/codex/catalog/sync";
 import { withCatalogWriteSerialization } from "../../src/codex/catalog-write-serialization";
-import { afterCatalogWriteHandleAppServers } from "../../src/codex/app-server-processes";
+import {
+  collectCodexAppServerCatalogStateForRequest,
+  resetCodexAppServerCatalogStateCache,
+  afterCatalogWriteHandleAppServers,
+} from "../../src/codex/app-server-processes";
 import { refreshCodexModelCatalog } from "../../src/codex/refresh";
 import { syncModelsToCodex } from "../../src/codex/sync";
+import { flushConfigDirHardening } from "../../src/config/paths";
 import type { OcxConfig } from "../../src/types";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 
@@ -32,7 +37,9 @@ describe("invalidateCodexModelsCache write gate (#476 / #518)", () => {
     process.env.OPENCODEX_HOME = opencodexHome;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await flushConfigDirHardening(opencodexHome);
+    resetCodexAppServerCatalogStateCache();
     if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = previousCodexHome;
     if (previousOpenCodexHome === undefined) delete process.env.OPENCODEX_HOME;
@@ -297,5 +304,56 @@ describe("invalidateCodexModelsCache write gate (#476 / #518)", () => {
     expect(listed).toBe(0);
     expect(errors).toEqual([]);
     expect(logs).toEqual([]);
+  });
+  test("sync invalidates a cached not-running observation before a catalog write", async () => {
+    let snapshots: Array<{ pid: number; commandLine: string }> = [];
+    const io = {
+      platform: "win32" as const,
+      now: () => 3_000,
+      listSnapshotsAsync: async () => snapshots,
+      readStartMsBatchAsync: async (pids: readonly number[]) => new Map(pids.map(pid => [pid, 1_000])),
+      catalogMtimeMs: () => 2_000,
+    };
+    resetCodexAppServerCatalogStateCache();
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("not_running");
+    snapshots = [{ pid: 42, commandLine: "codex app-server" }];
+    // Prove the real request cache is warm; injected synchronous IO bypasses it.
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("not_running");
+
+    writeFileSync(join(codexHome, "opencodex-catalog.json"), JSON.stringify({ models: [{ slug: "gpt-5.5" }] }));
+    expect(invalidateCodexModelsCache({ allowWhenDesiredDisabled: true })).toBe(true);
+
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("stale");
+  });
+
+  test("sync invalidates cached process state even when catalog refresh is a no-op", async () => {
+    let snapshots: Array<{ pid: number; commandLine: string }> = [];
+    const io = {
+      platform: "win32" as const,
+      now: () => 3_000,
+      listSnapshotsAsync: async () => snapshots,
+      readStartMsBatchAsync: async (pids: readonly number[]) => new Map(pids.map(pid => [pid, 1_000])),
+      catalogMtimeMs: () => 2_000,
+    };
+    resetCodexAppServerCatalogStateCache();
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("not_running");
+    snapshots = [{ pid: 42, commandLine: "codex app-server" }];
+    // Prove the real request cache is warm; injected synchronous IO bypasses it.
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("not_running");
+
+    await syncModelsToCodex(19107, emptyConfig, null, {
+      refreshCodexModelCatalog: async () => ({
+        added: 0,
+        path: join(codexHome, "opencodex-catalog.json"),
+        catalogExists: false,
+        catalogWritten: false,
+        cacheSynced: false,
+        comboOmissions: [],
+      }),
+      injectCodexConfig: async () => ({ success: true, message: "injected" }),
+      currentExternalCodexModelProvider: () => null,
+    });
+
+    expect((await collectCodexAppServerCatalogStateForRequest(io)).state).toBe("stale");
   });
 });


### PR DESCRIPTION
## Summary

Reset cached app-server observations after catalog/cache publication and before model sync, including no-op refreshes. A recent not-running observation must not mask a newly visible process after these boundaries. The new tests exercise the upstream asynchronous cached API; injected synchronous process IO bypasses its cache.

Updated the Codex App models guide. This observes process state without adding a restart.

## Verification

`bun run typecheck` passed. `bun test tests/codex-integration/codex-models-cache-invalidate.test.ts`: 11 passed. Both new cache regressions fail when the reset calls are removed. Documentation frozen install and build passed.

All runtime checks used a fresh temporary OPENCODEX_HOME and alternate port; production config fingerprint and backup inventory remained unchanged. Full root-suite and review-readiness gates have not been completed for this head; this is intentionally a draft.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Added/updated regression coverage or verified existing coverage for the affected behavior.
- [x] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

### Review readiness

- [ ] Local CI green.
- [ ] Branch on the latest dev commit.
- [ ] All correct Codex and CodeRabbit findings fixed.
- [ ] Ready-for-review confirmation.

Co-authored-by: SB Yoon <44089734+yansigit@users.noreply.github.com>
Co-authored-by: Yumi <automation@sbyoon.com>

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
