### PR TITLE
test(responses): keep stale-temp ENOENT fixture foreign to the runner

### DIFF
--- a/tests/responses/responses-state.test.ts
+++ b/tests/responses/responses-state.test.ts
@@ -3019,21 +3019,26 @@ describe("Responses previous_response_id state", () => {
     // Two proxies sharing one config dir race every tick. Reporting the loser's ENOENT as a
     // failure would tell an operator a file is "in use or locked" when nobody holds it.
     const old = new Date(Date.now() - 60 * 60 * 1_000);
-    const path = join(home, "responses-state.json.ocx.9104.1.tmp");
+    const deadPid = findDeadPid();
+    expect(deadPid).not.toBe(process.pid);
+    const path = join(home, `responses-state.json.ocx.${deadPid}.1.tmp`);
     writeFileSync(path, "private state");
     utimesSync(path, old, old);
 
+    const unlinked: string[] = [];
     const result = recoverStaleResponseStateTemps(home, {
       isProcessAlive: () => false,
       bootTime: () => 0,
-      unlink: () => {
+      unlink: target => {
+        unlinked.push(target);
         const error = new Error("gone") as NodeJS.ErrnoException;
         error.code = "ENOENT";
         throw error;
       },
     });
 
-    expect(result).toMatchObject({ matched: 1, removed: 1, failed: 0 });
+    expect(result).toMatchObject({ matched: 1, eligible: 1, removed: 1, failed: 0 });
+    expect(unlinked).toEqual([path]);
   });
 
   test("a dry run reports exactly what a reclaim then removes", () => {


### PR DESCRIPTION
## Summary

The stale-temp ENOENT fixture used a fixed PID of 9104. If that equals the test process, the production self-owner guard correctly skips the entry before the injected liveness or unlink callback. Use the existing verified-dead-PID helper and explicitly assert it is foreign to the runner.

Retain the reclaim counters and ENOENT behavior, and additionally require eligible=1 and exactly one unlink call for the expected path. The existing own-PID protection test and production recovery logic are unchanged.

## Verification

- `git diff --check` passed. One existing test changes (+8/-3).
- Independent source-plan review passed; final source review and exact-head PR CI pending.
- Prior Windows job101903254910 observed matched=1/eligible=0/removed=0, proving the ENOENT callback was not reached. The historical runner PID was not captured, so its equality to 9104 is not claimed.
- Local tests/typecheck/build/install NOT RUN; hooks disabled per Git command and push uses `--no-verify`. Final cumulative B Windows CI will include this fixture.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; test-only correction.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; production self-owner protection unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for temporary-file recovery scenarios.
  * Added validation that cleanup targets the correct stale files and reports the expected recovery result.
  * Updated test setup to use a reliably inactive process, reducing the risk of environment-dependent test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->