### PR TITLE
fix(google): restore AI Studio model discovery

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -77,6 +77,7 @@ import {
   type ProviderModelsApiItem,
   type ResolvedProviderModelDiscovery,
 } from "../../providers/model-discovery";
+import { extractGoogleAiStudioModelItems } from "../../providers/google-ai-studio-model-discovery";
 import { applyConfiguredHeadersLast, fetchOllamaShowEnrichment, ollamaShowEnrichable } from "../../providers/ollama-show";
 import upstreamModelsSnapshot from "../data/upstream-models.json";
 import { createAdmissionGate, ResourceAdmissionError, type AdmissionMetrics } from "../../lib/admission";
@@ -1807,7 +1808,9 @@ async function fetchProviderModelsWithAuth(
       markProviderDiscoveryOk(name, live.length);
       return observed(withConfiguredRetention(forCache, { warnDrops: true }), "authoritative");
     }
-    const extracted = extractProviderModelItems(bounded.value, discovery);
+    const extracted = effectiveGoogleMode(name, prov) === "ai-studio"
+      ? extractGoogleAiStudioModelItems(bounded.value, discovery.maxModels)
+      : extractProviderModelItems(bounded.value, discovery);
     if (!extracted.ok) {
       const { models, fallback, shouldLog } = failedDiscoveryFallback({ reason: "invalid_response" });
       const diagnostic: Record<ModelDiscoveryResponseFailure, string> = {

--- a/src/providers/google-ai-studio-model-discovery.ts
+++ b/src/providers/google-ai-studio-model-discovery.ts
@@ -1,0 +1,64 @@
+import {
+  extractModelEnvelopeRows,
+  isValidModelDiscoveryModelId,
+  type ProviderModelItemsResult,
+  type ProviderModelsApiItem,
+} from "./model-discovery";
+
+const GOOGLE_MODEL_PREFIX = "models/";
+const MAX_GENERATION_METHODS = 32;
+const MAX_GENERATION_METHOD_LENGTH = 64;
+
+function positiveSafeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+export function extractGoogleAiStudioModelItems(
+  value: unknown,
+  maxModels: number,
+): ProviderModelItemsResult {
+  const envelope = extractModelEnvelopeRows(value, maxModels, ["models"]);
+  if (!envelope.ok) return envelope;
+
+  const items: ProviderModelsApiItem[] = [];
+  const seen = new Set<string>();
+  for (const raw of envelope.rows) {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      return { ok: false, reason: "invalid_shape" };
+    }
+    const name = Reflect.get(raw, "name");
+    const generationMethods = Reflect.get(raw, "supportedGenerationMethods");
+    if (!isValidModelDiscoveryModelId(name)) {
+      return { ok: false, reason: "invalid_shape" };
+    }
+    if (generationMethods === undefined) continue;
+    if (
+      !Array.isArray(generationMethods)
+      || generationMethods.length > MAX_GENERATION_METHODS
+      || generationMethods.some(method => typeof method !== "string" || method.length > MAX_GENERATION_METHOD_LENGTH)
+    ) {
+      return { ok: false, reason: "invalid_shape" };
+    }
+    if (!generationMethods.includes("generateContent")) continue;
+
+    const id = name.startsWith(GOOGLE_MODEL_PREFIX)
+      ? name.slice(GOOGLE_MODEL_PREFIX.length)
+      : name;
+    if (!isValidModelDiscoveryModelId(id) || seen.has(id)) continue;
+    seen.add(id);
+
+    const inputTokenLimit = positiveSafeInteger(Reflect.get(raw, "inputTokenLimit"));
+    const outputTokenLimit = positiveSafeInteger(Reflect.get(raw, "outputTokenLimit"));
+    items.push({
+      id,
+      owned_by: "google",
+      ...(inputTokenLimit !== undefined
+        ? { context_length: inputTokenLimit, max_input_tokens: inputTokenLimit }
+        : {}),
+      ...(outputTokenLimit !== undefined ? { max_output_tokens: outputTokenLimit } : {}),
+    });
+  }
+  return { ok: true, items, rawCount: envelope.rows.length };
+}

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -46,12 +46,12 @@ import { deriveProviderPresets, providerConfigSeed } from "../../providers/deriv
 import { initializeProviderModelSelection } from "../../providers/initial-model-selection";
 import { effectiveGoogleMode, providerCodexAccountMode, providerMatchesRegistryTransport } from "../../providers/registry";
 import {
-  extractModelEnvelopeRows,
   extractProviderModelItems,
   isRegistryModelDiscoveryUrl,
   readBoundedDiscoveryJson,
   resolveProviderModelDiscovery,
 } from "../../providers/model-discovery";
+import { extractGoogleAiStudioModelItems } from "../../providers/google-ai-studio-model-discovery";
 import { routedSlug, slugEquals } from "../../providers/slug-codec";
 import { clearAccountQuotaCache, clearProviderQuotaCache, fetchProviderQuotaReports } from "../../providers/quota";
 import { clearKeyCooldowns } from "../../providers/key-failover";
@@ -1403,17 +1403,11 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
       if (antigravity && !ccaModels) {
         return jsonResponse({ ok: false, latencyMs, error: "upstream CCA model discovery returned an unexpected shape" });
       }
-      // OpenAI-style lists (and Together top-level arrays) use the same validation/dedupe/filter
-      // as catalog discovery. Google's /v1beta/models uses `models[].name` and remains a
-      // connectivity-only count because it is not an authoritative catalog source.
-      const record = bounded.value !== null && typeof bounded.value === "object" && !Array.isArray(bounded.value)
-        ? bounded.value as Record<string, unknown>
-        : undefined;
       const extracted = ccaModels
         ? undefined
-        : Array.isArray(bounded.value) || Array.isArray(record?.data)
-        ? extractProviderModelItems(bounded.value, discovery)
-        : extractModelEnvelopeRows(bounded.value, discovery.maxModels, ["models"]);
+        : effectiveGoogleMode(name, prov) === "ai-studio"
+          ? extractGoogleAiStudioModelItems(bounded.value, discovery.maxModels)
+          : extractProviderModelItems(bounded.value, discovery);
       if (extracted && !extracted.ok) {
         return jsonResponse({
           ok: false,
@@ -1423,7 +1417,7 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
             : "upstream /models returned an unexpected shape",
         });
       }
-      const models = ccaModels?.length ?? ("items" in extracted! ? extracted!.items.length : extracted!.rows.length);
+      const models = ccaModels?.length ?? extracted?.items.length ?? 0;
       return jsonResponse({
         ok: true,
         latencyMs,

--- a/tests/adapters/google/google-models-listing.test.ts
+++ b/tests/adapters/google/google-models-listing.test.ts
@@ -330,7 +330,7 @@ describe("buildModelsRequest anthropic routing", () => {
 });
 
 describe("google models listing via catalog", () => {
-  test("treats a { models } 2xx shape as malformed and degrades to the static seed", async () => {
+  test("publishes generateContent models from the native models envelope", async () => {
     clearModelCache("google");
     const warning = spyOn(console, "warn").mockImplementation(() => {});
     const seen: { url: string; headers: Record<string, string> }[] = [];
@@ -338,8 +338,9 @@ describe("google models listing via catalog", () => {
       seen.push({ url: String(input), headers: (init?.headers ?? {}) as Record<string, string> });
       return new Response(JSON.stringify({
         models: [
-          { name: "models/gemini-3-pro", inputTokenLimit: 1048576, supportedGenerationMethods: ["generateContent", "countTokens"] },
+          { name: "models/gemini-3-pro", inputTokenLimit: 1048576, outputTokenLimit: 65536, supportedGenerationMethods: ["generateContent", "countTokens"] },
           { name: "models/text-embedding-004", supportedGenerationMethods: ["embedContent"] },
+          { name: "models/gemini-missing-methods" },
           { name: "models/gemini-3-flash", inputTokenLimit: 1048576, supportedGenerationMethods: ["generateContent"] },
         ],
       }), { status: 200, headers: { "content-type": "application/json" } });
@@ -356,12 +357,13 @@ describe("google models listing via catalog", () => {
       expect(seen).toHaveLength(1);
       expect(seen[0].url).toBe("https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000");
       expect(seen[0].headers["x-goog-api-key"]).toBe("gk-123");
-      const ids = models.filter(m => m.provider === "google").map(m => m.id);
-      expect(ids).toEqual(["gemini-3.1-pro-preview", "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.6-flash", "gemini-3.7-flash", "gemini-3.8-flash"]);
-      expect(ids).not.toContain("gemini-3-pro");
-      expect(ids).not.toContain("gemini-3-flash");
-      expect(getStaleCached("google")).toBeNull();
-      expect(warning.mock.calls.flat().join(" ")).toContain("google");
+      const live = models.filter(m => m.provider === "google");
+      expect(live.map(m => m.id)).toEqual(["gemini-3-flash", "gemini-3-pro"]);
+      expect(live.find(m => m.id === "gemini-3-pro")).toMatchObject({
+        contextWindow: 1_048_576,
+        maxInputTokens: 1_048_576,
+        maxOutputTokens: 65_536,
+      });
     } finally {
       warning.mockRestore();
     }

--- a/tests/providers/provider-connection-test.test.ts
+++ b/tests/providers/provider-connection-test.test.ts
@@ -350,11 +350,11 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
     expect(body).toMatchObject({ ok: true, models: 390 });
   });
 
-  test("Google's models-array response shape is accepted (x-goog-api-key path)", async () => {
+  test("Google's models-array response counts only generateContent models", async () => {
     let requestedUrl = "";
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       requestedUrl = String(input);
-      return new Response(JSON.stringify({ models: [{ name: "models/gemini-3-pro" }, { name: "models/gemini-3-flash" }, { name: "models/gemini-3-lite" }] }), {
+      return new Response(JSON.stringify({ models: [{ name: "models/gemini-3-pro", supportedGenerationMethods: ["generateContent"] }, { name: "models/gemini-3-flash", supportedGenerationMethods: ["generateContent", "countTokens"] }, { name: "models/text-embedding-004", supportedGenerationMethods: ["embedContent"] }, { name: "models/gemini-missing-methods" }] }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
@@ -365,7 +365,7 @@ describe("POST /api/providers/test (WP040 connectivity probe)", () => {
     const { body } = await probe(config, "google");
     expect(requestedUrl).toContain("/v1beta/models");
     expect(body.ok).toBe(true);
-    expect(body.models).toBe(3);
+    expect(body.models).toBe(2);
   });
 
   test("Together-style top-level /models array is accepted (#617)", async () => {


### PR DESCRIPTION
## Summary

- Restore Google AI Studio live model discovery for the native `models[]` response envelope.
- Normalize `models/` IDs, publish token limits, and admit only models that explicitly support `generateContent`.
- Reuse the same bounded parser for management connection counts while preserving Vertex, Antigravity, and generic OpenAI discovery behavior.

Closes #3926

## Verification

- `bun test tests/adapters/google/google-models-listing.test.ts tests/providers/provider-connection-test.test.ts` (34 pass, 0 fail)
- `bun run typecheck`
- `bun run privacy:scan`
- `bun run test` (21,467 pass, 16 skip, 0 fail across 1,139 files; all serial suites passed)
- Runtime parser audit confirmed native-envelope acceptance, generic-envelope rejection, missing-capability filtering, ID normalization, metadata projection, and provider-mode isolation.
- Goal, code-quality, security, context, and manual-QA reviews passed at exact head `1672707e310804cfdb514fd135db790d93e21a05`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Google AI Studio model discovery and catalog updates.
  - Live model listings now recognize supported models and exclude models without content-generation support.
  - Available models now include more accurate context-window and input/output token limits.

- **Bug Fixes**
  - Google AI Studio model listings are handled correctly during provider connection tests, improving model counts and availability reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->