### PR TITLE
test(clients): bound transaction fixture child completion

### DIFF
--- a/tests/clients/client-connect.test.ts
+++ b/tests/clients/client-connect.test.ts
@@ -14,7 +14,7 @@ import {
 import { handleConnectCommand } from "../../src/cli/connect";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 import { repoRoot as findRepoRoot } from "../helpers/repo-root";
-import { INTERNAL_DEADLINE_MS } from "../helpers/test-budget";
+import { INTERNAL_DEADLINE_MS, SPAWN_BUDGET_MS } from "../helpers/test-budget";
 
 const repoRoot = findRepoRoot();
 
@@ -316,7 +316,10 @@ describe("remote hub client boundary", () => {
 /** A catalog the user already had before ever connecting. */
 const PRIOR_CATALOG_BYTES = '{"models":[{"slug":"local/only-model"}]}';
 
-function runTransactionScenario(stage: "success" | "catalog" | "preflight" | "commit" | "prior-catalog" | "coordinator") {
+function runTransactionScenario(
+  stage: "success" | "catalog" | "preflight" | "commit" | "prior-catalog" | "coordinator",
+  options: { script?: string; timeoutMs?: number } = {},
+) {
   const opencodexHome = mkdtempSync(join(tmpdir(), "ocx-client-connect-home-"));
   const codexHome = mkdtempSync(join(tmpdir(), "ocx-client-connect-codex-"));
   const configPath = join(opencodexHome, "config.json");
@@ -335,7 +338,7 @@ function runTransactionScenario(stage: "success" | "catalog" | "preflight" | "co
     const { mkdirSync } = require("node:fs") as typeof import("node:fs");
     mkdirSync(join(opencodexHome, "config-mutation.sqlite"));
   }
-  const script = `
+  const script = options.script ?? `
     const { existsSync, readFileSync } = require("node:fs");
     const { createHash } = require("node:crypto");
     const { connectClient, disconnectClient } = require("./src/client/connect");
@@ -396,26 +399,110 @@ function runTransactionScenario(stage: "success" | "catalog" | "preflight" | "co
       console.log(JSON.stringify({ connected, error, beforeDisconnect, artifacts, disconnected, catalogAfter, after: readClientConnectionState(), calls, commitFaultTriggered }));
     })();
   `;
-  const result = spawnSync(process.execPath, ["--eval", script], {
-    cwd: repoRoot,
-    env: { ...process.env, OPENCODEX_HOME: opencodexHome, CODEX_HOME: codexHome, OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR: join(opencodexHome, "desktop") },
-    encoding: "utf8",
-  });
-  const output = result.stdout.trim().split("\n").at(-1) ?? "{}";
-  const parsed = JSON.parse(output) as Record<string, any>;
-  return {
-    status: result.status,
-    stderr: result.stderr,
-    parsed,
-    configBytes: readFileSync(configPath, "utf8"),
-    cleanup: () => {
-      removeTreeWithRetry(opencodexHome);
-      removeTreeWithRetry(codexHome);
-    },
+  const cleanup = () => {
+    const failures: unknown[] = [];
+    for (const home of [opencodexHome, codexHome]) {
+      try { removeTreeWithRetry(home); }
+      catch (error) { failures.push(error); }
+    }
+    if (failures.length) throw new AggregateError(failures, "Could not clean client transaction homes");
   };
+  try {
+    const result = spawnSync(process.execPath, ["--eval", script], {
+      cwd: repoRoot,
+      env: { ...process.env, OPENCODEX_HOME: opencodexHome, CODEX_HOME: codexHome, OPENCODEX_CLAUDE_DESKTOP_CONFIG_DIR: join(opencodexHome, "desktop") },
+      encoding: "utf8",
+      timeout: options.timeoutMs ?? INTERNAL_DEADLINE_MS,
+      killSignal: "SIGKILL",
+    });
+    if (result.error || result.status !== 0 || result.signal !== null) {
+      throw new ClientStateProbeError(result.pid, result.status, result.signal, (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT");
+    }
+    let parsed: Record<string, any>;
+    try { parsed = JSON.parse(result.stdout.trim().split("\n").at(-1) ?? "{}"); }
+    catch { throw new ClientStateProbeError(result.pid, result.status, result.signal, false); }
+    return { status: result.status, stderr: result.stderr, parsed, configBytes: readFileSync(configPath, "utf8"), cleanup };
+  } catch (error) {
+    try { cleanup(); }
+    catch (cleanupError) { throw new AggregateError([error, cleanupError], "Client transaction failed and fixture cleanup failed"); }
+    throw error;
+  }
 }
 
 describe("connect transaction and offline disconnect", () => {
+  test("transaction fixture stops a child retained after valid output", async () => {
+    const proofHome = mkdtempSync(join(tmpdir(), "ocx-transaction-child-proof-"));
+    const markerPath = join(proofHome, "child-started.json");
+    const naturalExitPath = join(proofHome, "natural-exit");
+    const script = `
+      const fs = require("node:fs");
+      fs.writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify({
+        pid: process.pid, home: process.env.OPENCODEX_HOME, codexHome: process.env.CODEX_HOME,
+      }));
+      fs.writeSync(1, '{"ok":true}\\n');
+      setTimeout(() => { fs.writeFileSync(${JSON.stringify(naturalExitPath)}, "exited"); }, 5_000);
+    `;
+    let run: Awaited<ReturnType<typeof runTransactionScenario>> | undefined;
+    try {
+      let failure: unknown;
+      const startedAt = performance.now();
+      try { run = await runTransactionScenario("coordinator", { script, timeoutMs: 2_000 }); }
+      catch (error) { failure = error; }
+      expect(performance.now() - startedAt).toBeLessThan(10_000);
+      expect(failure).toBeInstanceOf(ClientStateProbeError);
+      if (!(failure instanceof ClientStateProbeError)) throw new Error("Expected bounded transaction child failure");
+      expect(failure.timedOut).toBe(true);
+      expect(existsSync(naturalExitPath)).toBe(false);
+      const proof = JSON.parse(readFileSync(markerPath, "utf8")) as { pid: number; home: string; codexHome: string };
+      expect(proof.pid).toBe(failure.pid);
+      expect(existsSync(proof.home)).toBe(false);
+      expect(existsSync(proof.codexHome)).toBe(false);
+      let exitCode: string | undefined;
+      try { process.kill(proof.pid, 0); }
+      catch (error) { exitCode = (error as NodeJS.ErrnoException).code; }
+      expect(exitCode).toBe("ESRCH");
+    } finally {
+      run?.cleanup();
+      removeTreeWithRetry(proofHome);
+    }
+  }, SPAWN_BUDGET_MS);
+
+  for (const [mode, output, status] of [
+    ["nonzero exit", '{"ok":true}', 7],
+    ["invalid JSON", "private-child-output", 0],
+  ] as const) {
+    test(`transaction fixture cleans homes after ${mode}`, () => {
+      const proofHome = mkdtempSync(join(tmpdir(), "ocx-transaction-child-proof-"));
+      const markerPath = join(proofHome, "child-started.json");
+      const script = `
+        const fs = require("node:fs");
+        fs.writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify({
+          pid: process.pid, home: process.env.OPENCODEX_HOME, codexHome: process.env.CODEX_HOME,
+        }));
+        fs.writeSync(1, ${JSON.stringify(output)});
+        process.exit(${status});
+      `;
+      let run: ReturnType<typeof runTransactionScenario> | undefined;
+      try {
+        let failure: unknown;
+        try { run = runTransactionScenario("coordinator", { script }); }
+        catch (error) { failure = error; }
+        expect(failure).toBeInstanceOf(ClientStateProbeError);
+        if (!(failure instanceof ClientStateProbeError)) throw new Error("Expected transaction child failure");
+        expect(failure.status).toBe(status);
+        expect(failure.timedOut).toBe(false);
+        expect(failure.message).not.toContain(output);
+        const proof = JSON.parse(readFileSync(markerPath, "utf8")) as { pid: number; home: string; codexHome: string };
+        expect(failure.pid).toBe(proof.pid);
+        expect(existsSync(proof.home)).toBe(false);
+        expect(existsSync(proof.codexHome)).toBe(false);
+      } finally {
+        try { run?.cleanup(); }
+        finally { removeTreeWithRetry(proofHome); }
+      }
+    }, SPAWN_BUDGET_MS);
+  }
+
   test("an unavailable config coordinator refuses before issuing any hub key", () => {
     const run = runTransactionScenario("coordinator");
     try {


### PR DESCRIPTION
## Summary

Closes #4003.

The client transaction fixture can keep a worker blocked after its child prints valid JSON because its synchronous spawn has no deadline. Bound that child with the existing 15-second internal budget and `SIGKILL`; reject spawn errors, nonzero exits and signals before parsing output. Clean both temporary homes on process or parse failure, preserving the original failure if cleanup also fails.

Only `tests/clients/client-connect.test.ts` changes. Existing transaction, rollback and stderr assertions remain. This is a direct-child fixture bound, not a claim that this helper caused the earlier macOS CI cancellation or that all descendant-pipe lifecycle problems are resolved.

## Verification

Head `9809dc4d62ab78626674f05a2a428ec303ed43f3`, based on `dev` `402be7c1f88283eb8465c3aec8437ccecd2542ec`.

- Bun 1.4.0 on Windows: the new retained-child regression failed before the fix because the unbounded helper returned normally after 5.09 seconds.
- Three focused regressions pass with 22 assertions: valid JSON followed by a held child, nonzero exit, and invalid JSON. The timeout case checks the natural-exit marker remains absent, the exact PID is gone, and both homes are removed.
- The complete affected file passed: 49 tests / 257 assertions in 233.94 seconds. A subsequent type annotation correction and cleanup of unexpected-success returns in the new regressions were followed by a passing rerun of those three cases; they do not change the existing transaction path.
- `bun run typecheck`, `bun run privacy:scan`, and `git diff --check` pass.
- [Full contributor CI](https://github.com/luvs01/opencodex/actions/runs/34189808467) **passed all 26 jobs on this exact head, attempt 2**. The first attempt had 24 successful jobs; macOS 1/2 exceeded its 20-minute limit and the aggregate failed. All three new regressions and all seven existing transaction tests had passed in that original [macOS job](https://github.com/luvs01/opencodex/actions/runs/34189808467/job/101945431311), including the timeout regression in 2,006.78ms. Progress later stopped after a held-lock test in another file. After the workflow was terminal, one retry of the failed macOS job and aggregate passed. The initial incomplete run remains recorded; no source or timeout changes were made to obtain the successful retry.
- CodeRabbit completed its review of this head without actionable inline findings. Its summary's possible duplicate-declaration claim was disproved by lexical scope and actual module execution; [CodeRabbit explicitly withdrew it](https://github.com/lidge-jun/opencodex/pull/4004#issuecomment-5579740451). Docstring coverage is advisory. No user-facing runtime or documentation behavior changes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after client process timeouts, failures, and invalid output.
  * Ensured retained child processes are terminated and temporary homes are removed.
  * Consolidated cleanup failures so multiple issues are reported together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->