### PR TITLE
fix(codex): retain Spark quota on partial header updates

### DIFF
--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -336,6 +336,9 @@ function mergeAccountQuota(
   }
 
   if (snapshotHasCustom(quota)) next.customWindows = quota.customWindows;
+  // Ordinary response headers omit model-specific windows reported by WHAM.
+  // Absence is a partial update; an explicit list (including []) still replaces it.
+  else if (existing?.customWindows !== undefined) next.customWindows = existing.customWindows;
 
   if (quota.resetCredits !== undefined) next.resetCredits = quota.resetCredits;
   else if (existing?.resetCredits !== undefined) next.resetCredits = existing.resetCredits;

--- a/tests/codex-integration/codex-quota-parser-parity.test.ts
+++ b/tests/codex-integration/codex-quota-parser-parity.test.ts
@@ -1,11 +1,55 @@
 import { describe, expect, it } from "bun:test";
 import {
   clearAccountQuota,
+  applyAccountQuotaFromUpstreamHeaders,
+  getAccountQuota,
   parseUpstreamQuotaHeaders,
   parseUsageQuota,
   setAccountQuotaFromParsed,
 } from "../../src/codex/quota";
 import { codexPoolQuotaEvidence } from "../../src/routing/quota";
+
+describe("Spark quota survives partial header updates", () => {
+  it("keeps the WHAM Spark window when an ordinary response updates standard quota", () => {
+    clearAccountQuota();
+    const refreshed = parseUsageQuota({
+      rate_limit: { primary_window: { used_percent: 20, limit_window_seconds: 604_800 } },
+      additional_rate_limits: [{
+        limit_name: "GPT-5.3-Codex-Spark",
+        rate_limit: { primary_window: { used_percent: 30, reset_at: 2_000_000_000, limit_window_seconds: 604_800 } },
+      }],
+    });
+    setAccountQuotaFromParsed("spark-partial", refreshed);
+    applyAccountQuotaFromUpstreamHeaders("spark-partial", new Headers({
+      "x-codex-primary-used-percent": "21",
+      "x-codex-primary-window-minutes": "10080",
+    }));
+    expect(getAccountQuota("spark-partial")?.weeklyPercent).toBe(21);
+    expect(getAccountQuota("spark-partial")?.customWindows).toEqual(refreshed?.customWindows);
+  });
+
+  it("replaces custom windows when supplied, including an explicit empty list", () => {
+    clearAccountQuota();
+    setAccountQuotaFromParsed("spark-replace", {
+      customWindows: [{ label: "GPT-5.3-Codex-Spark Weekly", percent: 30 }],
+    });
+    const replacement = [{ label: "GPT-5.3-Codex-Spark Weekly", percent: 0, resetAt: 2_000_000_000 }];
+    setAccountQuotaFromParsed("spark-replace", { customWindows: replacement });
+    expect(getAccountQuota("spark-replace")?.customWindows).toEqual(replacement);
+    setAccountQuotaFromParsed("spark-replace", { weeklyPercent: 21, customWindows: [] });
+    expect(getAccountQuota("spark-replace")?.customWindows).toEqual([]);
+  });
+
+  it("does not carry custom windows across an account cache clear", () => {
+    clearAccountQuota();
+    setAccountQuotaFromParsed("spark-clear", {
+      customWindows: [{ label: "GPT-5.3-Codex-Spark Weekly", percent: 30 }],
+    });
+    clearAccountQuota("spark-clear");
+    setAccountQuotaFromParsed("spark-clear", { weeklyPercent: 21 });
+    expect(getAccountQuota("spark-clear")?.customWindows).toBeUndefined();
+  });
+});
 
 /**
  * The two quota parsers, pinned against each other.
@@ -109,4 +153,3 @@ describe("routing headroom accounts for the burst window", () => {
     expect(evidence.headroom).toBeLessThanOrEqual(0.05);
   });
 });
-


### PR DESCRIPTION
## Summary

Closes #4007.

After refreshing Spark quota, an ordinary Codex response-header update drops the stored Spark weekly window because those headers omit `customWindows`. Retain the previous custom windows when the update omits them. Explicit replacements (including an empty array) and account-cache clearing keep their existing behavior.

The runtime change is limited to the partial-snapshot merge; it does not change quota parsing, account selection, authentication, or display settings. Regression coverage exercises the actual WHAM parse -> store -> response-header update sequence, replacement with zero usage, explicit clearing, and account-cache clearing.

## Verification

- Reproduced before the fix: the new WHAM/header regression failed because `customWindows` became `undefined`.
- After the fix: 184 tests passed across `codex-quota-parser-parity`, `codex-spark-visibility`, `main-quota-evidence-validation`, and `main-quota-provenance`.
- `bun run typecheck`: passed.
- `bun run privacy:scan`: passed.
- `git diff --check`: passed.
- `bun run test:changed`: selected 821 of 1,145 files and exceeded the runner's 900-second limit (exit 124). The run also reported individual test timeouts, including API-key management tests. Those failures have not been attributed or compared against an unmodified base; this is not an all-green result. The explicitly invoked repository-wide suite has not been run, and this PR remains draft.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. This restores existing partial-update behavior without changing configuration or workflows.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No credentials or real account data are included.

## Review readiness checklist

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.
- [ ] My PR is ready for review.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
