### PR TITLE
test(codex): verify timeout termination without racing child timers

### DIFF
--- a/tests/codex-integration/native-profile-processes.test.ts
+++ b/tests/codex-integration/native-profile-processes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -157,27 +157,19 @@ describe("native profile process probe", () => {
   });
 
   test("kills and settles a timed-out child", async () => {
-    const directory = mkdtempSync(join(tmpdir(), "ocx-native-probe-"));
-    const survived = join(directory, "survived");
-    const script = [
-      `setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(survived)}, 'alive'), 300);`,
-      "setInterval(() => {}, 1_000);",
-    ].join(" ");
-    try {
-      await expect(executeNativeProcess(process.execPath, ["-e", script], {
-        encoding: "utf8",
-        timeout: 100,
-        maxBuffer: 1024,
-        windowsHide: true,
-        shell: false,
-        killSignal: "SIGKILL",
-      })).rejects.toThrow();
-      await Bun.sleep(600);
-      expect(existsSync(survived)).toBe(false);
-    } finally {
-      removeTreeWithRetry(directory);
-    }
-  });
+    // A child marker races the parent's timeout when its event loop is busy.
+    // Check the observed exit signal instead. Normal exit is a finite fuse, so
+    // disabling the executor timeout fails this assertion without orphaning a child.
+    const script = "setTimeout(() => process.exit(0), 10_000);";
+    await expect(executeNativeProcess(process.execPath, ["-e", script], {
+      encoding: "utf8",
+      timeout: 100,
+      maxBuffer: 1024,
+      windowsHide: true,
+      shell: false,
+      killSignal: "SIGKILL",
+    })).rejects.toMatchObject({ killed: true, signal: "SIGKILL" });
+  }, 15_000);
 
   test("rejects output above the configured byte cap", async () => {
     await expect(executeNativeProcess(process.execPath, [


### PR DESCRIPTION
## Summary

The native process probe timeout test races a child's 300 ms file marker against the parent's 100 ms timeout. A busy parent event loop can deliver the timeout after the marker is written even though the subprocess is terminated before the executor promise rejects. The marker then reports a false survival failure.

Assert the termination error's `SIGKILL` signal and `killed` flag instead of a wall-clock marker. Give the child a finite, successful exit so disabling the executor timeout fails the assertion without leaving an indefinitely running fixture. Only this test file changes; process probing and runtime execution are unchanged.

## Verification

- Bun 1.4.0 on Windows; head `59a390c7406e7910cb81ce4fbd1a5a436c16f41f`, based on `dev` `7797586a8899c673eab48886a490e85b480c6d72`.
- `bun run test -- --timeout 60000 --parallel=1 tests/codex-integration/native-profile-processes.test.ts`: 9 tests / 24 assertions passed.
- An isolated reproduction using the unchanged executor blocked only its parent event loop for 750 ms. The old child marker existed, but the callback reported `SIGKILL`, `killed: true`, and the recorded child PID was no longer alive. The unblocked control had no marker and the same termination result. This establishes the timer-race failure mode, not the exact cause of every hosted failure.
- Negative control: run the updated test with only `timeout: 100` replaced by `timeout: 0`. It failed as expected after the child's 10-second normal-exit fuse: the promise resolved rather than rejecting with `SIGKILL`.
- Typecheck, privacy scan and `git diff --check` passed. Independent read-only review found no required corrections.
- The motivating [macOS control job](https://github.com/luvs01/opencodex/actions/runs/34199076801/job/101973650838) had 21,750 passing tests and this one marker assertion failure. Its rerun passed; this change removes the test's timer race rather than treating a retry as a fix.
- [Full contributor CI](https://github.com/luvs01/opencodex/actions/runs/34206879552) passed all 26 jobs on current head `59a390c74`, including all six Windows shards and the unsharded macOS control.
- CodeRabbit reviewed the same head. Its Windows signal concern was [re-evaluated and withdrawn](https://github.com/lidge-jun/opencodex/pull/4012#discussion_r3956346914) after checking pinned Bun 1.4.0 source and same-head Windows CI; the review thread is resolved. Both termination assertions are retained on every platform.
- The callback signal verifies process termination; this test does not separately observe a stdio `close` event or assert an exact 100 ms dispatch time.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
