### PR TITLE
test: stabilize Windows fixture waits and case cleanup

### DIFF
--- a/tests/codex-integration/codex-retained-root-serialization.test.ts
+++ b/tests/codex-integration/codex-retained-root-serialization.test.ts
@@ -124,6 +124,21 @@ function sandboxChildEnv(sandbox: Sandbox): Record<string, string> {
   return { ...sandbox.env, ...sandbox.serviceManagerEnv };
 }
 
+interface ChildResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** One consumer per pipe; barrier diagnostics and final assertions share the result. */
+function captureChildResult(child: ReturnType<typeof Bun.spawn>): Promise<ChildResult> {
+  return Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]).then(([exitCode, stdout, stderr]) => ({ exitCode, stdout, stderr }));
+}
+
 /**
  * Wait for a child to reach its barrier, failing fast with its output if it exits
  * first. The exit branch is a REJECTING promise, so while the race is pending an
@@ -135,15 +150,29 @@ function sandboxChildEnv(sandbox: Sandbox): Record<string, string> {
  * no-op catch attached up front marks that late rejection handled without
  * changing what the race sees.
  */
-async function raceBarrier(child: ReturnType<typeof Bun.spawn>, barrier: Promise<void>): Promise<void> {
-  const exitedEarly = child.exited.then(async exitCode => {
-    const stdout = await new Response(child.stdout).text();
-    const stderr = await new Response(child.stderr).text();
+async function raceBarrier(result: Promise<ChildResult>, barrier: Promise<void>): Promise<void> {
+  const exitedEarly = result.then(({ exitCode, stdout, stderr }) => {
     throw new Error(`sync exited before provider barrier (${exitCode})\nstdout=${stdout}\nstderr=${stderr}`);
   });
   exitedEarly.catch(() => undefined);
   await Promise.race([barrier, exitedEarly]);
 }
+
+test("barrier diagnostics retain both pipes when the child exits first", async () => {
+  const sandbox = makeSandbox("ocx-retained-early-exit-");
+  const child = Bun.spawn([process.execPath, "--eval", `
+    process.stdout.write("fixture-stdout\\n");
+    process.stderr.write("fixture-stderr\\n");
+    process.exitCode = 7;
+  `], { cwd: repoRoot, env: sandboxChildEnv(sandbox), stdout: "pipe", stderr: "pipe" });
+  sandbox.children.add(child);
+  const result = captureChildResult(child);
+
+  await expect(raceBarrier(result, new Promise<void>(() => {}))).rejects.toThrow(
+    "sync exited before provider barrier (7)\nstdout=fixture-stdout\n\nstderr=fixture-stderr\n",
+  );
+  expect(await result).toEqual({ exitCode: 7, stdout: "fixture-stdout\n", stderr: "fixture-stderr\n" });
+}, SPAWN_BUDGET_MS);
 
 // A `bun --eval` child on a loaded windows-latest shard takes 8-11 s just to boot and
 // reach its marker (runs 33590540220 and 33605898170), so a 10 s wait was the coin flip,
@@ -370,8 +399,9 @@ for (const publisher of ["convergence", "retained"] as const) {
         console.log(JSON.stringify({ status: response.status, body: await response.json() }));
       `], sandbox.preloadPath)], { cwd: repoRoot, env: sandboxChildEnv(sandbox), stdout: "pipe", stderr: "pipe" });
       sandbox.children.add(sync);
+      const syncResult = captureChildResult(sync);
 
-      await raceBarrier(sync, waitForPath(requested, INTERNAL_DEADLINE_MS));
+      await raceBarrier(syncResult, waitForPath(requested, INTERNAL_DEADLINE_MS));
       const published = await runPublisher(sandbox, publisher, config);
       if (published.exitCode !== 0) {
         throw new Error(`${publisher} publisher failed\nstdout=${published.stdout}\nstderr=${published.stderr}`);
@@ -380,11 +410,9 @@ for (const publisher of ["convergence", "retained"] as const) {
       expect(newer).not.toBe(initial);
 
       writeFileSync(release, "release");
-      const [exitCode, stdout, stderr] = await Promise.all([
-        sync.exited,
-        new Response(sync.stdout).text(),
-        new Response(sync.stderr).text(),
-      ]);
+      // Exercise the losing exit branch before the successful caller reads output.
+      await sync.exited;
+      const { exitCode, stdout, stderr } = await syncResult;
       expect({ exitCode, stdout, stderr }).toMatchObject({ exitCode: 0 });
       expect(readFileSync(catalogPath, "utf8")).toBe(newer);
     } finally {
@@ -447,8 +475,9 @@ test("a persisted runtime selection moved by another process during the await bl
     console.log(JSON.stringify(await syncCatalogModels(config)));
   `], sandbox.preloadPath)], { cwd: repoRoot, env: sandboxChildEnv(sandbox), stdout: "pipe", stderr: "pipe" });
   sandbox.children.add(sync);
+  const syncResult = captureChildResult(sync);
 
-  await raceBarrier(sync, waitForPath(requested, INTERNAL_DEADLINE_MS));
+  await raceBarrier(syncResult, waitForPath(requested, INTERNAL_DEADLINE_MS));
 
   // Another process selects a different Codex runtime. No catalog byte changes.
   writeFileSync(runtimeStatePath, `${JSON.stringify({
@@ -460,11 +489,8 @@ test("a persisted runtime selection moved by another process during the await bl
   }, null, 2)}\n`);
 
   writeFileSync(release, "release");
-  const [exitCode, stdout, stderr] = await Promise.all([
-    sync.exited,
-    new Response(sync.stdout).text(),
-    new Response(sync.stderr).text(),
-  ]);
+  await sync.exited;
+  const { exitCode, stdout, stderr } = await syncResult;
   expect({ exitCode, stderr }).toMatchObject({ exitCode: 0 });
   expect(JSON.parse(stdout.trim())).toMatchObject({ catalogWritten: false });
   expect(readFileSync(catalogPath, "utf8")).toBe(initial);

--- a/tests/codex-integration/codex-retained-root-serialization.test.ts
+++ b/tests/codex-integration/codex-retained-root-serialization.test.ts
@@ -21,6 +21,7 @@ import { removeTreeWithRetry } from "../helpers/remove-tree";
 import { repoRoot as resolveRepoRoot } from "../helpers/repo-root";
 import { SPAWN_BUDGET_MS } from "../helpers/test-budget";
 import { INTERNAL_DEADLINE_MS } from "../helpers/test-budget";
+import { watchdogMs } from "../helpers/ci-watchdog";
 
 const repoRoot = resolveRepoRoot();
 const sandboxes: Sandbox[] = [];
@@ -367,11 +368,13 @@ for (const publisher of ["convergence", "retained"] as const) {
       port: 0,
       fetch: async request => {
         if (!new URL(request.url).pathname.endsWith("/models")) return new Response("not found", { status: 404 });
-        if (requests++ === 0) {
+        const first = requests++ === 0;
+        if (first) {
           writeFileSync(requested, "requested");
           while (!existsSync(release)) await Bun.sleep(5);
         }
-        return Response.json({ data: [{ id: "race-model" }] });
+        // Distinct snapshots make a stale publish observable in the final catalog.
+        return Response.json({ data: [{ id: first ? "race-model" : "newer-race-model" }] });
       },
     });
     const config = {
@@ -401,24 +404,30 @@ for (const publisher of ["convergence", "retained"] as const) {
       sandbox.children.add(sync);
       const syncResult = captureChildResult(sync);
 
-      await raceBarrier(syncResult, waitForPath(requested, INTERNAL_DEADLINE_MS));
+      // This real child imports the management route before reaching /models.
+      // Keep the CI startup floor, then leave room for the second publisher process.
+      await raceBarrier(syncResult, waitForPath(requested, watchdogMs(INTERNAL_DEADLINE_MS)));
       const published = await runPublisher(sandbox, publisher, config);
       if (published.exitCode !== 0) {
         throw new Error(`${publisher} publisher failed\nstdout=${published.stdout}\nstderr=${published.stderr}`);
       }
       const newer = readFileSync(catalogPath, "utf8");
       expect(newer).not.toBe(initial);
+      const newerSlugs = JSON.parse(newer).models.map((model: { slug: string }) => model.slug);
+      expect(newerSlugs).toContain("fixture/newer-race-model");
+      expect(newerSlugs).not.toContain("fixture/race-model");
 
       writeFileSync(release, "release");
       // Exercise the losing exit branch before the successful caller reads output.
       await sync.exited;
       const { exitCode, stdout, stderr } = await syncResult;
       expect({ exitCode, stdout, stderr }).toMatchObject({ exitCode: 0 });
+      expect(JSON.parse(stdout).status).toBe(200);
       expect(readFileSync(catalogPath, "utf8")).toBe(newer);
     } finally {
       provider.stop(true);
     }
-  }, SPAWN_BUDGET_MS);
+  }, SPAWN_BUDGET_MS * 2);
 }
 
 /**

--- a/tests/server/server-xai-responses-streaming.test.ts
+++ b/tests/server/server-xai-responses-streaming.test.ts
@@ -12,6 +12,7 @@ import { startServer } from "../../src/server";
 import type { OcxConfig } from "../../src/types";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "../helpers/isolated-codex-home";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
+import { SERVER_BUDGET_MS } from "../helpers/test-budget";
 
 const RESPONSES_ENDPOINT = `${XAI_GROK_CLI_BASE_URL}/responses`;
 const encoder = new TextEncoder();
@@ -20,8 +21,34 @@ let testDir = "";
 let previousHome: string | undefined;
 let isolatedCodexHome: IsolatedCodexHome | null = null;
 let originalFetch: typeof fetch;
+let activeRoutedCase: { controller: AbortController; settled: Promise<void> } | null = null;
+
+function runRoutedCase(body: (signal: AbortSignal) => Promise<void>): Promise<void> {
+  const controller = new AbortController();
+  const result = body(controller.signal);
+  // Observe the entire body, including its server-stop finally, even after a test timeout.
+  activeRoutedCase = { controller, settled: result.then(() => {}, () => {}) };
+  return result;
+}
+
+async function drainRoutedCase(): Promise<void> {
+  const active = activeRoutedCase;
+  if (!active) return;
+  active.controller.abort(new DOMException("xAI fixture cleanup", "AbortError"));
+  await active.settled;
+  if (activeRoutedCase === active) activeRoutedCase = null;
+}
+
+function startXaiTestServer() {
+  return startServer(0, {
+    // This wire fixture does not exercise native Codex service ownership. Avoid
+    // unrelated Windows service queries and native-main recovery during setup.
+    inspectNativeCodexOwnership: () => ({ ownership: "foreign", reason: "xAI wire fixture" }),
+  });
+}
 
 beforeEach(async () => {
+  if (activeRoutedCase) throw new Error("previous routed-parent fixture has not finished cleanup");
   originalFetch = globalThis.fetch;
   previousHome = process.env.OPENCODEX_HOME;
   isolatedCodexHome = installIsolatedCodexHome("ocx-xai-responses-codex-");
@@ -36,14 +63,15 @@ beforeEach(async () => {
   });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await drainRoutedCase();
   globalThis.fetch = originalFetch;
   if (previousHome === undefined) delete process.env.OPENCODEX_HOME;
   else process.env.OPENCODEX_HOME = previousHome;
   isolatedCodexHome?.restore();
   isolatedCodexHome = null;
   if (testDir) removeTreeWithRetry(testDir);
-});
+}, SERVER_BUDGET_MS);
 
 function config(): OcxConfig {
   return {
@@ -72,7 +100,43 @@ function sse(payload: unknown): Uint8Array {
 }
 
 describe("xAI OAuth Responses streaming opt-in", () => {
-  test.each([true, false])("continues a routed parent after a string child result (stream=%s)", async stream => {
+  test("routed-case cleanup waits for the entire aborted body finally", async () => {
+    let markFinally!: () => void;
+    const enteredFinally = new Promise<void>(resolve => { markFinally = resolve; });
+    let releaseFinally!: () => void;
+    const finallyGate = new Promise<void>(resolve => { releaseFinally = resolve; });
+    let finallyFinished = false;
+    const running = runRoutedCase(async signal => {
+      try {
+        await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      } finally {
+        markFinally();
+        await finallyGate;
+        finallyFinished = true;
+      }
+    });
+    const outcome = running.then(() => null, (error: unknown) => error);
+    let drained = false;
+    const draining = drainRoutedCase().then(() => { drained = true; });
+    try {
+      await enteredFinally;
+      await Promise.resolve();
+      // Awaiting outcome first would hide a drain helper that returned too early.
+      expect(drained).toBe(false);
+      expect(finallyFinished).toBe(false);
+    } finally {
+      releaseFinally();
+      await draining;
+      await outcome;
+    }
+    expect(await outcome).toMatchObject({ name: "AbortError" });
+    expect(finallyFinished).toBe(true);
+    expect(activeRoutedCase).toBeNull();
+  }, SERVER_BUDGET_MS);
+
+  test.each([true, false])("continues a routed parent after a string child result (stream=%s)", stream => runRoutedCase(async signal => {
     const captured: Array<Record<string, unknown>> = [];
     let privateItemRejections = 0;
     const childText = "  Synthetic worker result\nAll requested observations returned.\n ";
@@ -112,9 +176,11 @@ describe("xAI OAuth Responses streaming opt-in", () => {
     }) as typeof fetch;
 
     saveConfig({ ...config(), multiAgentMode: "v2" });
-    const server = startServer(0);
+    const server = startXaiTestServer();
     const send = async (session: string, input: unknown[], parentSession?: string) => {
+      signal.throwIfAborted();
       const response = await originalFetch(new URL("/v1/responses", server.url), {
+        signal,
         method: "POST", headers: { "content-type": "application/json", "session-id": session,
           ...(parentSession ? { "x-codex-parent-thread-id": parentSession } : {}),
         },
@@ -163,7 +229,7 @@ describe("xAI OAuth Responses streaming opt-in", () => {
     } finally {
       await server.stop(true);
     }
-  }, 10_000);
+  }), 10_000);
 
   test("uses the native Responses wire and relays the first delta before completion", async () => {
     let releaseCompletion!: () => void;
@@ -258,7 +324,7 @@ describe("xAI OAuth Responses streaming opt-in", () => {
     }) as typeof fetch;
 
     saveConfig(config());
-    const server = startServer(0);
+    const server = startXaiTestServer();
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
     try {
       const response = await originalFetch(new URL("/v1/responses", server.url), {
@@ -373,7 +439,7 @@ describe("xAI OAuth Responses streaming opt-in", () => {
     }) as typeof fetch;
 
     saveConfig(config());
-    const server = startServer(0);
+    const server = startXaiTestServer();
     try {
       const response = await originalFetch(new URL("/v1/responses", server.url), {
         method: "POST",
@@ -468,7 +534,7 @@ describe("xAI OAuth Responses streaming opt-in", () => {
     }) as typeof fetch;
 
     saveConfig(config());
-    const server = startServer(0);
+    const server = startXaiTestServer();
     try {
       const response = await originalFetch(new URL("/v1/responses", server.url), {
         method: "POST",


### PR DESCRIPTION
## Summary

Windows shards exposed two fixture lifetime problems: retained-sync barrier and success paths competed for the same child output streams, and an xAI test body could continue after its timeout into the next test's fetch mock. A separate retained-sync failure timed out during the management child's startup before it reached the provider barrier.

- Capture each child output stream once and share its exit/output result. Preserve early-exit diagnostics, late-rejection handling, and child cleanup. Use the existing CI watchdog for the two publisher startup waits, with an outer budget for both real child processes. Give the first and newer publishers distinct provider snapshots, then verify the newer model, successful HTTP response, and unchanged final catalog.
- Abort and drain the entire routed xAI test body, including server-stop `finally`, before restoring fetch/home globals. Use the existing native-ownership test seam to avoid incidental Windows service queries. Preserve the routed test's 10-second timeout, the first-delta 1.5-second assertion, and all wire assertions.

Only two test files change; runtime behavior is unchanged.

## Verification

- Bun 1.4.0 on Windows; head `4141281b14cc7dad3e3a8b06b727ae4b2ec42ac0`, based on `dev` `7797586a8899c673eab48886a490e85b480c6d72`. Current `dev` `29bb221c3cfad89e4920ac411c9681073929c152` is four commits ahead, changing only the package version and release records; neither test file overlaps.
- `CI=true bun run test -- --timeout 60000 --parallel=1 tests/codex-integration/codex-retained-root-serialization.test.ts tests/server/server-xai-responses-streaming.test.ts`: 13 tests / 101 assertions passed in 61.37 seconds. Typecheck, privacy scan and `git diff --check` passed.
- [Original output failure](https://github.com/luvs01/opencodex/actions/runs/34208728445/job/102004410138): the second pipe consumer threw before the catalog assertion. Waiting for `sync.exited` before the original final read reproduced it deterministically; shared capture passed, including an exit-code-7 diagnostic control.
- [Startup failure on the previous PR head](https://github.com/luvs01/opencodex/actions/runs/34213292833/job/102019125559): the management child missed the fixed 15-second provider marker wait. Its sibling publisher case took 23 seconds. The new wait uses the repository's existing CI floor; these processes are intrinsic to the serialization assertion.
- Catalog negative control under the new CI budgets: removing only the production pre-await evidence comparison makes the convergence case fail because the old `fixture/race-model` replaces `fixture/newer-race-model`. The former identical-response fixture passed that ablation. The production guard was restored byte-for-byte; the retained publisher variant retains other fences and did not fail this partial ablation.
- [xAI failure](https://github.com/luvs01/opencodex/actions/runs/34208728445/job/102018008418): the timed-out first case continued after the next case began and consumed the next fetch mock response. A gated `finally` control verifies that drain cannot return early; removing its await fails the control. This is a body-lifetime control, not a simulated end-to-end HTTP timeout.
- Independent read-only review found no required corrections. [CodeRabbit reviewed this head](https://github.com/lidge-jun/opencodex/pull/4015#issuecomment-5584094686) with no blocking findings. [Full contributor CI](https://github.com/luvs01/opencodex/actions/runs/34218151305) passed all 26 jobs on `4141281b14cc7dad3e3a8b06b727ae4b2ec42ac0`, attempt 2. The first attempt passed the changed fixtures in Windows shard 6/6 but failed two unchanged shim cases in shard 1/6 at their 15-second child readiness limits. One job-only rerun passed. Missing child error/exit diagnostics prevent a definitive cause attribution for those original failures; this PR does not claim to fix those shim fixtures.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for synchronization scenarios, including model updates and diagnostic output when processes finish unexpectedly.
  * Strengthened streaming test cleanup and timeout handling to reduce flaky results.
  * Added validation for interrupted requests and complete server shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->