### PR TITLE
chore(release): open dev at 2.49.0 before releasing 2.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitkyc08/opencodex",
-  "version": "2.48.0",
+  "version": "2.49.0",
   "description": "Universal provider proxy for OpenAI Codex & Claude Code — use any LLM with Codex CLI/App/SDK and Claude Code",
   "type": "module",
   "main": "./bin/package-main.mjs",


### PR DESCRIPTION
## Summary

Move `dev` to 2.49.0 so the 2.48.0 stable release can publish.

The release workflow's "Require dev to be ready for this release" gate refused the 2.48.0 stable dispatch because `origin/dev` still carried 2.48.0, which does not outrank the version being released. `tests/ci-workflows/release-version-line.test.ts` would go red on `dev` and on every pull request against it once 2.48.0 ships, which is inherited red a contributor cannot fix from their own diff.

The new version comes from `scripts/bump-dev-version.ts`, which decides it rather than having it hand-picked: a published stable `X.Y.Z` moves `dev` to `X.(Y+1).0`, so 2.48.0 gives 2.49.0.

## Verification

- `bun scripts/bump-dev-version.ts 2.48.0 ./package.json` returned `{"changed":true,"version":"2.49.0","reason":"2.48.0 is a stable release, so dev moves to the next minor 2.49.0"}`.
- The diff is one line in `package.json`.
- Local test suite and typecheck: **NOT RUN**, per the owner's instruction for this release train; this branch is pushed with `--no-verify` and verified by hosted CI on this head.
- 2.48.0-preview.20260908 is already published from `preview` `c71474e83`; the stable 2.48.0 publish from `main` `9a27e8699` follows once this lands.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; the release workflow generates channel release notes.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version from 2.48.0 to 2.49.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->