### PR TITLE
fix(google): guard model-tail histories with user continue nudge across Gemini and CCA (carry #3988)

### DIFF
--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -906,17 +906,9 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
           // fills a first functionCall that replay could not sign. Outside the cache branch too,
           // because the turn still needs a signature when no session was ever recorded.
           applyAntigravityThoughtSignatureFallback(wireModelId, contents);
-          // Gemini and Claude-on-Antigravity reject assistant-tail (model-tail in Gemini terms)
-          // histories. Gemini fails upstream with "Requests ending with a model turn are not supported"
-          // (HTTP 400), while Claude fails with "This model does not support assistant message prefill.
-          // The conversation must end with a user message." Context compaction, previous_response_id
-          // expansion, subagent orchestration, and interrupted-turn replay can all produce a
-          // model-tail history. Append a user "(continue)" nudge, mirroring the anthropic adapter's
-          // tail guard (src/adapters/anthropic.ts).
-          const last = contents.length > 0 ? contents[contents.length - 1] as { role?: string } : undefined;
-          if (!last || last.role === "model") {
-            contents.push({ role: "user", parts: [{ text: "(continue)" }] });
-          }
+          // The model-tail "(continue)" guard runs once, in messagesToGeminiFormat, so CCA,
+          // Vertex and AI Studio share one decision. A second check here would append a
+          // duplicate nudge whenever signature sanitization reshapes the tail afterwards.
         }
         const envelope = {
           model: wireModelId,

--- a/src/adapters/google.ts
+++ b/src/adapters/google.ts
@@ -429,6 +429,18 @@ function messagesToGeminiFormat(
     }
   }
 
+  // Gemini API and Claude-on-Antigravity reject assistant-tail (model-tail in Gemini terms)
+  // histories. Gemini fails upstream with "Requests ending with a model turn are not supported"
+  // (HTTP 400), while Claude fails with "This model does not support assistant message prefill.
+  // The conversation must end with a user message." Context compaction, previous_response_id
+  // expansion, subagent orchestration, and interrupted-turn replay can all produce a
+  // model-tail history. Append a user "(continue)" nudge, mirroring the anthropic adapter's
+  // tail guard (src/adapters/anthropic.ts).
+  const lastTurn = contents.length > 0 ? (contents[contents.length - 1] as { role?: string }) : undefined;
+  if (!lastTurn || lastTurn.role === "model") {
+    contents.push({ role: "user", parts: [{ text: "(continue)" }] });
+  }
+
   return { systemInstruction, contents, replayedCallIds };
 }
 
@@ -894,16 +906,16 @@ export function createGoogleAdapter(provider: OcxProviderConfig): ProviderAdapte
           // fills a first functionCall that replay could not sign. Outside the cache branch too,
           // because the turn still needs a signature when no session was ever recorded.
           applyAntigravityThoughtSignatureFallback(wireModelId, contents);
-          // Claude-on-Antigravity rejects assistant-tail (model-tail in Gemini terms) histories
-          // as prefill: "This model does not support assistant message prefill. The conversation
-          // must end with a user message." Context compaction, previous_response_id expansion,
-          // and interrupted-turn replay can all produce a model-tail history. Append a user
-          // "(continue)" nudge, mirroring the anthropic adapter's tail guard (src/adapters/anthropic.ts).
-          if (/claude/i.test(wireModelId)) {
-            const last = contents.length > 0 ? contents[contents.length - 1] as { role?: string } : undefined;
-            if (!last || last.role === "model") {
-              contents.push({ role: "user", parts: [{ text: "(continue)" }] });
-            }
+          // Gemini and Claude-on-Antigravity reject assistant-tail (model-tail in Gemini terms)
+          // histories. Gemini fails upstream with "Requests ending with a model turn are not supported"
+          // (HTTP 400), while Claude fails with "This model does not support assistant message prefill.
+          // The conversation must end with a user message." Context compaction, previous_response_id
+          // expansion, subagent orchestration, and interrupted-turn replay can all produce a
+          // model-tail history. Append a user "(continue)" nudge, mirroring the anthropic adapter's
+          // tail guard (src/adapters/anthropic.ts).
+          const last = contents.length > 0 ? contents[contents.length - 1] as { role?: string } : undefined;
+          if (!last || last.role === "model") {
+            contents.push({ role: "user", parts: [{ text: "(continue)" }] });
           }
         }
         const envelope = {

--- a/tests/adapters/google/google-claude-prefill-guard.test.ts
+++ b/tests/adapters/google/google-claude-prefill-guard.test.ts
@@ -78,14 +78,39 @@ describe("google claude prefill guard", () => {
     expect(JSON.stringify(contents.at(-1))).not.toContain("(continue)");
   });
 
-  test("does not append nudge for non-Claude models on Antigravity", async () => {
+  test("appends a user continue nudge when Gemini context ends with model turn", async () => {
     const contents = await envelopeContents(parsed([
       { role: "user", content: "start", timestamp: 0 },
       { role: "assistant", content: [{ type: "text", text: "answer" }], model: "gemini", timestamp: 0 },
     ], "gemini-3.7-flash"));
 
-    // Gemini natively accepts model-tail; no nudge
-    expect(contents.at(-1)!.role).toBe("model");
-    expect(JSON.stringify(contents)).not.toContain("(continue)");
+    // Google Gemini strictly rejects requests ending with a model turn with HTTP 400
+    // "Requests ending with a model turn are not supported." A user continue nudge is required.
+    expect(contents.at(-1)).toEqual({ role: "user", parts: [{ text: "(continue)" }] });
+  });
+
+  test("appends a user continue nudge for Gemini 3.8 Flash on Antigravity", async () => {
+    const contents = await envelopeContents(parsed([
+      { role: "user", content: "start", timestamp: 0 },
+      { role: "assistant", content: [{ type: "text", text: "answer" }], model: "gemini", timestamp: 0 },
+    ], "gemini-3.8-flash"));
+
+    expect(contents.at(-1)).toEqual({ role: "user", parts: [{ text: "(continue)" }] });
+  });
+
+  test("appends a user continue nudge in AI Studio mode", async () => {
+    const aiStudioProvider = {
+      adapter: "google",
+      baseUrl: "https://generativelanguage.googleapis.com",
+      apiKey: "key-123",
+    } as OcxProviderConfig;
+
+    const { body } = await createGoogleAdapter(aiStudioProvider).buildRequest(parsed([
+      { role: "user", content: "hello", timestamp: 0 },
+      { role: "assistant", content: [{ type: "text", text: "assistant reply" }], model: "gemini", timestamp: 0 },
+    ], "gemini-2.5-flash"));
+
+    const payload = JSON.parse(body);
+    expect(payload.contents.at(-1)).toEqual({ role: "user", parts: [{ text: "(continue)" }] });
   });
 });


### PR DESCRIPTION
## Summary

Carries #3988 by @rrmlima (`cherry-pick -x`): Gemini via Cloud Code Assist, Vertex AI and AI Studio reject histories that end on a model turn with HTTP 400 "Requests ending with a model turn are not supported". The `(continue)` user nudge that previously applied only to Claude-on-Antigravity now applies in `messagesToGeminiFormat` for every Google mode.

Maintainer commit folded from audit: the carried change also widened the post-replay Antigravity check to all models, leaving two injection sites on one request; the second is a no-op only while nothing reshapes the tail in between, and the signature sanitizer can. The post-replay copy is removed so the formatter is the single owner of the invariant.

This is the top of the stack: its head is the CI gate for L1–L6.

Supersedes #3988.

**Stack** (merge bottom-up, ordinary dependent bases):

| # | Branch | Layer |
|---|--------|-------|
| 6 | `codex/prs-l6-gemini-tail` | Gemini/CCA model-tail continue nudge (carry #3988, rrmlima) ← you are here |
| 5 | `codex/prs-l5-hermes-yaml` | Hermes source-preserving YAML (carry #3990, rrmlima) |
| 4 | `codex/prs-l4-marks-docs` | Qoder mark, display names, docs-site Qoder section |
| 3 | `codex/prs-l3-qoder-cn` | Qoder CN PAT provider (carry #3350) |
| 2 | `codex/prs-l2-qoder-global` | Qoder Global PAT provider (carry #3349) |
| 1 | `codex/prs-l1-codebuddy` | CodeBuddy Global/CN CLI providers (carry #3340) |

CI is run once on the top-of-stack head (L6) with `lane=all`; lower PRs exist for review navigation and merge order. Review this PR's diff only.

## Verification

- Hosted CI on the top-of-stack head `codex/prs-l6-gemini-tail` (`ci.yml`, `lane=all`) is the gate for the whole stack; run link recorded in the L6 PR before merge.
- Local `bun run test`, `bun run typecheck`, `bun run build:gui`, `bun install`: **NOT RUN** by maintainer instruction (hosted-only proof).
- Read-only adversarial audits (two rounds) with findings folded into the layers; see `devlog/_plan/260908_provider_runtime_stack/` (lands with the delivery record).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: Flowershangfromthebranches <152056395+Flowershangfromthebranches@users.noreply.github.com>
Co-authored-by: rrmlima <rrmlima@users.noreply.github.com>
Co-authored-by: Liang-Psych <wolfxuliang@gmail.com>
