### PR TITLE
test(lib): make idle deadline reset timing deterministic

### DIFF
--- a/tests/lib/abort-idle-deadline.test.ts
+++ b/tests/lib/abort-idle-deadline.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { idleDeadline } from "../../src/lib/abort";
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -17,18 +17,59 @@ test("idleDeadline fires once after the idle window with no reset", async () => 
   expect(fired).toBe(1);
 });
 
-test("idleDeadline reset() re-arms and postpones firing", async () => {
+test("idleDeadline reset() re-arms and postpones firing", () => {
+  // Keep this boundary check synchronous: real sleeps can resume after the idle window.
+  // The other cases below still exercise Bun's real timers.
+  type TimerHandle = ReturnType<typeof setTimeout>;
+  let now = 0;
+  let nextHandle = 0;
+  const timers = new Map<TimerHandle, { at: number; fire: () => void }>();
+  const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
+    callback: (...args: unknown[]) => void, delay = 0, ...args: unknown[]
+  ) => {
+    const handle = ++nextHandle as unknown as TimerHandle;
+    timers.set(handle, { at: now + delay, fire: () => callback(...args) });
+    return handle;
+  }) as typeof setTimeout);
+  const clearSpy = spyOn(globalThis, "clearTimeout").mockImplementation(handle => {
+    timers.delete(handle as TimerHandle);
+  });
+  const advanceBy = (ms: number) => {
+    const target = now + ms;
+    for (;;) {
+      const due = [...timers].filter(([, timer]) => timer.at <= target)
+        .sort((a, b) => a[1].at - b[1].at)[0];
+      if (!due) break;
+      timers.delete(due[0]);
+      now = due[1].at;
+      due[1].fire();
+    }
+    now = target;
+  };
   let fired = 0;
-  const idle = idleDeadline(120, () => { fired += 1; });
-  idle.reset();
-  for (let i = 0; i < 4; i++) {
-    await sleep(40);
-    idle.reset(); // keep-alive: total elapsed (160ms) exceeds 120ms but silence never does
+  let idle: ReturnType<typeof idleDeadline> | undefined;
+  try {
+    idle = idleDeadline(120, () => { fired += 1; });
+    idle.reset();
+    for (let i = 0; i < 4; i++) {
+      advanceBy(40);
+      idle.reset(); // total elapsed exceeds 120 ms, but each silent interval does not
+    }
+    expect(fired).toBe(0);
+    advanceBy(119);
+    expect(fired).toBe(0);
+    advanceBy(1);
+    expect(fired).toBe(1);
+    advanceBy(240);
+    expect(fired).toBe(1);
+  } finally {
+    try {
+      idle?.cancel();
+    } finally {
+      clearSpy.mockRestore();
+      timeoutSpy.mockRestore();
+    }
   }
-  expect(fired).toBe(0);
-  await sleep(220);
-  expect(fired).toBe(1);
-  idle.cancel();
 });
 
 test("idleDeadline pause() disarms without retiring; reset() re-arms after pause", async () => {


### PR DESCRIPTION
## Summary

The `idleDeadline` reset/postpone test assumes each requested 40 ms sleep resumes before a 120 ms idle deadline. Under scheduling delay, the production timer can correctly fire before the next reset, making the test fail even though the primitive's contract is satisfied. This occurred in the [macOS control for #4036](https://github.com/luvs01/opencodex/actions/runs/34235799731/job/102093155231): the test reported 432.21 ms and observed one firing where it expected zero. The primitive and this test were unchanged by that PR; individual callback timings were not logged, so the exact delayed interval is unknown.

Make only this boundary case synchronous with a scoped timer fixture. The fixture models generic timer scheduling/cancellation, while the real `idleDeadline` implementation handles resets and terminal state. Advance 40 ms and reset four times, verify no firing through another 119 ms, then verify exactly one firing at the next millisecond and no later repeat. Individual spies are restored in nested `finally` blocks. The five other cases still exercise Bun's real timers. Runtime code and user behavior are unchanged, so no documentation update is needed.

## Verification

- Head `9aa3e9204c12c1bbd9068e77115501e16203bb60`, based on `dev` `7dc7dc99e65268bc8764e19840952256b030bce9`; Bun 1.4.0 on Windows. Only `tests/lib/abort-idle-deadline.test.ts` changes.
- A controlled copy of the original reset test that resumes requested 40 ms waits after 160 ms failed with **expected 0 / received 1** (644.95 ms). This demonstrates the scheduling assumption; it does not claim to reproduce the exact hosted-CI scheduling event.
- `bun run test -- --timeout 60000 --parallel=1 tests/lib/abort-idle-deadline.test.ts`: **6 tests / 12 assertions passed**, 678 ms, including all five unchanged real-timer cases. Cases following the modified test run after spy restoration.
- Two isolated source ablations were rejected by the new fixture: removing cancellation before rearming, and making repeated resets no-ops while a timer exists. Each produced the expected **0 / 1** assertion failure. The selected real-timer pause/rearm control still passed after the failed assertion, checking that the spies were restored on the failure path. Canonical runtime source was not modified; temporary ablation/reproduction files were removed after verification.
- `bun run typecheck`, `bun run privacy:scan`, and `git diff --check` passed. Independent read-only review found no required corrections in mock lifetime, timer handles, or assertion coverage.
- [CodeRabbit reviewed the current patch](https://github.com/lidge-jun/opencodex/pull/4041#issuecomment-5587160380) and found no blocking issue after checking spy lifetime, deadline boundaries, and regression sensitivity. No inline findings are outstanding at this update. [Full contributor CI](https://github.com/luvs01/opencodex/actions/runs/34241379683) passed **26/26 jobs** on exact head `9aa3e9204`, including all Windows shards and the macOS control. Current `dev` remains `7dc7dc99e`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
