### PR TITLE
fix(catalog): sidecar-covered combo members keep image advertising

### DIFF
--- a/src/codex/catalog/provider-fetch.ts
+++ b/src/codex/catalog/provider-fetch.ts
@@ -1016,7 +1016,19 @@ export function resolveComboCatalogMember(
       && fallback?.inputModalities !== undefined;
     const addReasoning = member.reasoningEfforts === undefined
       && fallback?.reasoningEfforts !== undefined;
-    if (!addMaxInput && !addMaxOutput && !adjustAutoCompact && !addModalities && !addReasoning) return member;
+    // A sidecar-covered member is advertised image-capable on its own provider row
+    // (applyProviderConfigHints), but complete discovery rows reach this resolver
+    // un-hinted, so the combo intersection saw the raw text-only declaration and one
+    // blind member collapsed the whole combo to text-only — the Codex app then blocks
+    // attachments client-side before the sidecar can run. Mirror the direct-row
+    // advertisement here so derivation intersects the modalities the runtime serves.
+    const modalitiesAfterFallback = addModalities
+      ? [...fallback!.inputModalities!]
+      : member.inputModalities;
+    const addSidecarImage = prov !== undefined
+      && isModelVisionSidecarConsumer(prov, member.id)
+      && !(modalitiesAfterFallback ?? ["text"]).includes("image");
+    if (!addMaxInput && !addMaxOutput && !adjustAutoCompact && !addModalities && !addReasoning && !addSidecarImage) return member;
     return {
       ...member,
       // Never claim a larger input budget than the window, and prefer the model's own
@@ -1026,6 +1038,7 @@ export function resolveComboCatalogMember(
       ...(adjustAutoCompact && autoCompactTokenLimit !== undefined ? { autoCompactTokenLimit } : {}),
       ...(addModalities ? { inputModalities: [...fallback!.inputModalities!] } : {}),
       ...(addReasoning ? { reasoningEfforts: [...fallback!.reasoningEfforts!] } : {}),
+      ...(addSidecarImage ? { inputModalities: [...(modalitiesAfterFallback ?? ["text"]), "image"] } : {}),
     };
   };
 

--- a/tests/codex-integration/catalog-vision-sidecar-modalities.test.ts
+++ b/tests/codex-integration/catalog-vision-sidecar-modalities.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { applyProviderConfigHints, gatherRoutedModels } from "../../src/codex/catalog";
+import { applyProviderConfigHints, gatherRoutedModels, resolveComboCatalogMember } from "../../src/codex/catalog";
 import { clearModelCache } from "../../src/codex/model-cache";
 import type { OcxProviderConfig } from "../../src/types";
 import { deriveComboCatalogModel } from "../../src/codex/catalog";
@@ -389,6 +389,71 @@ describe("vision-capable provider models feed combo modalities", () => {
       [memberA, memberB],
     );
     expect(derived?.inputModalities).toEqual(["text", "image"]);
+  });
+
+  test("a sidecar-covered discovery row no longer collapses combo image advertising", () => {
+    // The real call site resolves members through resolveComboCatalogMember, and complete
+    // discovery rows arrive WITHOUT the config hint that rewrites direct provider rows.
+    // The /planners combo hit exactly this: sidecar-covered DeepSeek rows kept their raw
+    // text-only modalities at derivation, so combo/planners advertised text-only and the
+    // Codex app blocked pasted images before the sidecar could run.
+    const blind = {
+      provider: "azu-lab1",
+      id: "DeepSeek-V4-Pro",
+      contextWindow: 128_000,
+      inputModalities: ["text"],
+    } as CatalogModel;
+    const covered = new Map([
+      ["azu-lab1", {
+        adapter: "openai-chat",
+        baseUrl: "https://azu-lab1.example/v1",
+        noVisionModels: ["DeepSeek-V4-Pro"],
+      } as OcxProviderConfig],
+    ]);
+    const resolved = resolveComboCatalogMember(
+      { provider: "azu-lab1", model: "DeepSeek-V4-Pro" },
+      new Map([["azu-lab1/DeepSeek-V4-Pro", blind]]),
+      covered,
+    );
+    expect(resolved?.inputModalities).toEqual(["text", "image"]);
+
+    const targets = [
+      { provider: "azu-lab1", model: "DeepSeek-V4-Pro" },
+      { provider: "azu-lab2", model: "gpt-5.6-terra" },
+    ];
+    const members = [
+      resolved!,
+      {
+        provider: "azu-lab2",
+        id: "gpt-5.6-terra",
+        contextWindow: 200_000,
+        inputModalities: ["text", "image"],
+      } as CatalogModel,
+    ];
+    const derived = deriveComboCatalogModel(
+      "planners",
+      { targets, defaultEffort: "high" } as never,
+      members,
+    );
+    expect(derived?.inputModalities).toEqual(["text", "image"]);
+
+    // combo.imageInput: "disabled" still strips image from the advertised modalities.
+    const disabled = deriveComboCatalogModel(
+      "planners",
+      { targets, defaultEffort: "high", imageInput: "disabled" } as never,
+      members,
+    );
+    expect(disabled?.inputModalities).toEqual(["text"]);
+
+    // Providers without sidecar coverage stay untouched (identity preserved).
+    expect(resolveComboCatalogMember(
+      { provider: "azu-lab1", model: "DeepSeek-V4-Pro" },
+      new Map([["azu-lab1/DeepSeek-V4-Pro", blind]]),
+      new Map([["azu-lab1", {
+        adapter: "openai-chat",
+        baseUrl: "https://azu-lab1.example/v1",
+      } as OcxProviderConfig]]),
+    )).toBe(blind);
   });
 });
 


### PR DESCRIPTION
## Summary

- Combo models whose members are text-only but covered by the vision sidecar (for example a planners combo over no-vision DeepSeek members) collapsed to `["text"]` in the Codex catalog, so Codex blocked pasting images client-side with "This model does not support image inputs" before the proxy could translate them.
- Root cause: complete discovery rows reach `resolveComboCatalogMember` through the `withFallbackMetadata` identity fast path un-hinted, so the sidecar `image` advertising that #3105 added for direct provider rows never reached derived combo members.
- Fix: `withFallbackMetadata` now appends `"image"` to a member's modalities when the provider's vision sidecar covers that model — the same rule direct rows already get — so derived combo rows keep image support. `imageInput: "disabled"` still strips it, and providers without sidecar coverage keep byte-identical rows.

## Verification

- New regression test in `tests/codex-integration/catalog-vision-sidecar-modalities.test.ts`: a sidecar-covered discovery member gains `["text","image"]`, the derived combo keeps `image`, `imageInput: "disabled"` strips it, and an uncovered provider's row is identity-equal.
- Focused consumer batches around the touched module: catalog/vision files 58+68 pass / 0 fail; provider/oauth/google batch 468 pass / 0 fail; serial e2e batch 193 pass / 1 pre-existing fail; `bun run typecheck` green.
- Full local suite not completed on this host: the per-lane watchdog fired twice with the production proxy and Codex app running, and several unrelated failures (retained-root catalog lock wait, OrcaRouter real-callback, Kiro image buildRequest, OpenAI provider-option spine) reproduce identically on clean `dev` without this patch. The three-OS CI run is the gate for those lanes.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vision-sidecar catalog entries now correctly advertise image input when their effective modalities do not include it.
  * Catalog-derived model metadata now preserves image-input settings and provider identity for covered and uncovered providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->