### PR TITLE
fix: preserve Claude Go affinity across combo selection and failover

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -475,8 +475,9 @@ Chat, bridged Chat, and Responses derive the same result. Explicit provider-conf
 session headers are operator overrides and are sent unchanged. Clients must keep the
 identifier stable within a conversation and distinct across conversations; requests
 without a session identifier cannot receive automatic session affinity.
-For Claude Messages, valid conversation identity in `metadata.user_id` supplies
-the fallback when no usable explicit session identifier exists. This fallback is
+For Claude Messages, configured OpenCode Go session headers remain authoritative.
+Otherwise, valid explicit session or thread headers take precedence, and valid
+conversation identity in `metadata.user_id` supplies the fallback. This fallback is
 applied to the final Go destination, including random combo selections and fallback
 attempts, rather than the preliminary route. Shared system-prompt cache keys do
 not identify conversations, and Go-specific identity is not sent to non-Go targets.

--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -473,8 +473,10 @@ inbound value is treated as client input and
 hashed into Go affinity; the internal bridge carries the original value, so native
 Chat, bridged Chat, and Responses derive the same result. Explicit provider-config
 session headers are operator overrides and are sent unchanged. Clients must keep the
-identifier stable within a conversation and distinct across conversations; requests
-without a session identifier cannot receive automatic session affinity.
+identifier stable within a conversation and distinct across conversations. A request
+without any session identifier is not given an inferred cross-request identity; it is
+instead sent under a session allocated for that request alone, isolated from every
+other request (see the provider reference for how that value is carried).
 For Claude Messages, configured OpenCode Go session headers remain authoritative.
 Otherwise, valid explicit session or thread headers take precedence, and valid
 conversation identity in `metadata.user_id` supplies the fallback. This fallback is

--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -475,6 +475,11 @@ Chat, bridged Chat, and Responses derive the same result. Explicit provider-conf
 session headers are operator overrides and are sent unchanged. Clients must keep the
 identifier stable within a conversation and distinct across conversations; requests
 without a session identifier cannot receive automatic session affinity.
+For Claude Messages, valid conversation identity in `metadata.user_id` supplies
+the fallback when no usable explicit session identifier exists. This fallback is
+applied to the final Go destination, including random combo selections and fallback
+attempts, rather than the preliminary route. Shared system-prompt cache keys do
+not identify conversations, and Go-specific identity is not sent to non-Go targets.
 Generated Pi provider configurations enable `compat.sendSessionAffinityHeaders`
 so Pi sends its per-session identity to the proxy. Existing manually managed Pi
 configurations can set this option on their `opencodex` provider as well.

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -38,6 +38,7 @@ import { readJsonRequestBody, resolveInboundBodyLimitBytes } from "./request-dec
 import { addFinalRequestLog, httpStatusForRequestLogTerminal, recordFirstOutput, type RequestLogContext, type RequestLogEntry } from "./request-log";
 import {
   conversationIdFromClaudeMetadata,
+  getOrAllocateRequestSessionLane,
   linkRequestSessionLane,
   normalizeLogConversationId,
   sessionLaneIdFromRequest,
@@ -867,27 +868,31 @@ async function handleClaudeMessagesWithBudget(
       };
     }
   }
-  if (opencodeGoRoute) {
-    const session = req.headers.get("x-opencode-session");
-    if (session) headers.set("x-opencode-session", session);
-  }
-  const hasExplicitGoSession = opencodeGoRoute
-    && (sessionLaneIdFromRequest(headers) !== undefined
-      || normalizeLogConversationId(headers.get("x-opencode-session")) !== undefined);
-  const synthesizeGoSession = opencodeGoRoute && !hasExplicitGoSession
+  // Carry Go identity out of band: a combo's preflight target may differ from its
+  // actual dispatch/fallback target. Never add Go-only identity to replay headers.
+  const metadataGoLane = cacheKeySource === "metadata"
+    && typeof internalBody.prompt_cache_key === "string"
     && isRec(anthropicBody)
-    && conversationIdFromClaudeMetadata(isRec(anthropicBody.metadata) ? anthropicBody.metadata : undefined) !== undefined;
-  // Go can also use the Responses adapter; its eligibility gate must win on both wires.
-  if (opencodeGoRoute ? synthesizeGoSession : nativeRoute) {
+    && conversationIdFromClaudeMetadata(isRec(anthropicBody.metadata) ? anthropicBody.metadata : undefined) !== undefined
+    ? normalizeLogConversationId(uuidFromHex(internalBody.prompt_cache_key))
+    : undefined;
+  // Without any valid conversation identity, fall back to the request-scoped lane
+  // allocated on the admitted client request (#4172): stable across retries and
+  // route reconstruction, distinct per request, and never derived from a shared
+  // system-prompt cache key or from a later synthesized native session_id header.
+  const claudeGoSessionLane = sessionLaneIdFromRequest(headers)
+    ?? normalizeLogConversationId(req.headers.get("x-opencode-session"))
+    ?? metadataGoLane
+    ?? getOrAllocateRequestSessionLane(req);
+  if (nativeRoute && !opencodeGoRoute) {
     // ChatGPT-backend prompt-cache affinity rides the session_id HEADER (codex
     // clients always send their session uuid; devlog 090 follow-up: body-level
     // prompt_cache_key alone still yielded cached_tokens:0). Claude Code never sends
     // the header, so synthesize a stable per-session uuid from the same cache key.
-    // Routed Go requests need this lane too for their x-opencode-session affinity —
-    // but ONLY for a real per-session key (metadata.user_id). The system-hash fallback
+    // Use ONLY a real per-session key (metadata.user_id). The system-hash fallback
     // key is shared across Desktop conversations, and a shared session_id's backend
     // semantics are unproven (audit 133 R2#3): body prompt_cache_key only there.
-    if (cacheKeySource === "metadata" && (synthesizeGoSession || !headers.has("session_id")) && typeof internalBody.prompt_cache_key === "string") {
+    if (cacheKeySource === "metadata" && !headers.has("session_id") && typeof internalBody.prompt_cache_key === "string") {
       headers.set("session_id", uuidFromHex(internalBody.prompt_cache_key));
     }
   }
@@ -934,6 +939,7 @@ async function handleClaudeMessagesWithBudget(
     // Without this the replay would look native and a Responses-scoped wire default
     // would fire, disagreeing with the pre-flight decision above.
     inboundWire: "anthropic",
+    claudeGoAffinity: { sessionLane: claudeGoSessionLane },
     stripClaudeMainAuthForNoncanonicalForward: true,
     ...(trustedClaudeMainAuth ? { trustedClaudeMainAuth } : {}),
     // Claude's internal stored-main enrichment is not an original caller credential.

--- a/src/server/claude-messages.ts
+++ b/src/server/claude-messages.ts
@@ -638,6 +638,12 @@ export async function handleClaudeMessages(
   }
 }
 
+/**
+ * Translate a Claude Messages request, route it through the Responses pipeline,
+ * and translate the reply back. Runs under a translator budget owned by the
+ * caller; Go session affinity is derived here and handed to the final Go
+ * transport out of band rather than through replay headers.
+ */
 async function handleClaudeMessagesWithBudget(
   req: Request,
   config: OcxConfig,

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1673,6 +1673,8 @@ export interface ConsumedComboFailure {
 
 
 export interface HandleResponsesOptions {
+  /** Internal Claude replay identity; consumed only by the final canonical Go transport. */
+  claudeGoAffinity?: { sessionLane?: string };
   /** Original live policy owner; separate from caller-specific routing/sidecar snapshots. */
   codexAuthPolicy?: CodexAuthPolicyConfig;
   turnAdmissionLease?: AdmissionLease;
@@ -2474,6 +2476,7 @@ async function applyFinalRouteRequestNormalization(args: {
   logCtx: RequestLogContext;
   inboundWire: InboundWire;
   inboundTransport?: "websocket";
+  claudeGoAffinity?: HandleResponsesOptions["claudeGoAffinity"];
 }): Promise<void> {
   const { parsed, route, config, req, logCtx, inboundWire, inboundTransport } = args;
   const effortSelector = prepareEffortNormalization(parsed, route);
@@ -2501,7 +2504,8 @@ async function applyFinalRouteRequestNormalization(args: {
 
   // Settle the wire once so logging, fast-mode, auth, and sidecars read the adapter
   // this request will actually use (#404).
-  route.provider = resolveOpenCodeGoTransport(route.provider, getOrAllocateRequestSessionLane(req));
+  route.provider = resolveOpenCodeGoTransport(route.provider,
+    args.claudeGoAffinity ? args.claudeGoAffinity.sessionLane : getOrAllocateRequestSessionLane(req));
   route.provider = resolveWireProtocolOverride(route.providerName, route.modelId, route.provider, inboundWire);
   if (preserveAnthropicResponseModel) parsed._responseModelId = responseModelId;
   logCtx.model = route.modelId;
@@ -3907,6 +3911,7 @@ async function handleResponsesInner(
     logCtx,
     inboundWire,
     inboundTransport: options.inboundTransport,
+    claudeGoAffinity: options.claudeGoAffinity,
   });
   // Attribute local auth/cooldown failures to the public selector too; exact auth may fail before
   // the normal post-resolution provider label is assigned.

--- a/tests/providers/opencode-go-session-header.test.ts
+++ b/tests/providers/opencode-go-session-header.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { clearComboSelectionState, clearComboTargetCooldowns } from "../../src/combos";
 import { providerConfigSeed } from "../../src/providers/derive";
 import { resolveOpenCodeGoTransport } from "../../src/providers/opencode-go-transport";
 import { getProviderRegistryEntry } from "../../src/providers/registry";
@@ -121,6 +122,127 @@ async function captureRequest(input: {
 describe("OpenCode Go session affinity (#3344)", () => {
   const originalFetch = globalThis.fetch;
   afterEach(() => { globalThis.fetch = originalFetch; });
+
+  for (const model of [CHAT_MODEL, MUSE_MODEL]) {
+    for (const preliminaryAdapter of ["openai-chat", "openai-responses"] as const) {
+    for (const strategy of ["random", "failover"] as const) {
+      for (const identity of [
+        { name: "metadata", headers: {}, metadata: "user_test_account__session_conversation-a", expected: "ocx_a89540229ef781fd5f7adf92a711b436" },
+        { name: "explicit Go header", headers: { [SESSION_HEADER]: "client-session-a" }, metadata: "other-session", expected: "ocx_516d593899f34b7baca2db37c7b0c8c5" },
+        { name: "explicit lane", headers: { session_id: "native-client-session", [SESSION_HEADER]: "client-session-a" }, metadata: "other-session", expected: "ocx_a197dbb87311c29a5fbe51140e3845ce" },
+        { name: "operator override", headers: {}, metadata: "user_test_account__session_conversation-a", operator: true, expected: "operator-session" },
+        { name: "invalid explicit lane", headers: { session_id: "invalid\tidentity", [SESSION_HEADER]: "invalid\tidentity" }, metadata: "user_test_account__session_conversation-a", expected: "ocx_a89540229ef781fd5f7adf92a711b436" },
+        { name: "invalid metadata", headers: {}, metadata: "invalid\u0000identity", expected: "isolated" },
+        { name: "shared system only", headers: {}, metadata: undefined, expected: "isolated" },
+      ]) {
+      test(`Claude ${strategy} ${preliminaryAdapter} to Go uses ${identity.name} on ${model}`, async () => {
+        // Without valid identity the final Go destination still receives a
+        // request-scoped lane (#4172): well-formed, never the shared-system or
+        // metadata-derived value, and distinct across independent requests.
+        const observed: string[] = [];
+        for (const round of [1, 2]) {
+        clearComboSelectionState();
+        clearComboTargetCooldowns();
+        const requests: Array<{ url: string; headers: Headers }> = [];
+        globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          requests.push({ url, headers: new Headers(init?.headers) });
+          if (url.startsWith("https://other.example")) {
+            return Response.json({ error: { message: "model retired", code: "model_not_found" } }, { status: 404 });
+          }
+          return upstreamResponse(url, true);
+        }) as typeof fetch;
+        const config = {
+          providers: {
+            other: { adapter: preliminaryAdapter, authMode: "key", baseUrl: "https://other.example/v1", apiKey: "test-key", models: ["other"] },
+            "renamed-go": opencodeGo(identity.operator ? { headers: { "X-OpenCode-Session": "operator-session" } } : {}),
+          },
+          combos: { affinity: { strategy, targets: [
+            { provider: "other", model: "other" }, { provider: "renamed-go", model },
+          ] } },
+        } as unknown as OcxConfig;
+        const entropy = spyOn(Math, "random").mockReturnValue(0.9);
+        // Preliminary route checks the first target; dispatch independently picks Go.
+        entropy.mockReturnValueOnce(0);
+        try {
+          const response = await handleClaudeMessages(new Request("http://localhost/v1/messages", {
+            method: "POST", headers: { "content-type": "application/json", ...identity.headers } as Record<string, string>,
+            body: JSON.stringify({ model: "combo/affinity", max_tokens: 64, stream: false,
+              messages: [{ role: "user", content: "ping" }],
+              system: "Shared system prompt is not a session.",
+              metadata: { user_id: identity.metadata } }),
+          }), config, { model: "", provider: "" });
+          await response.text();
+          expect(response.status).toBe(200);
+          expect(requests.at(-1)?.url).toStartWith("https://opencode.ai/zen/go/v1/");
+          const lane = requests.at(-1)?.headers.get(SESSION_HEADER);
+          if (identity.expected === "isolated") {
+            expect(lane).toMatch(/^ocx_[0-9a-f]{32}$/);
+            expect(lane).not.toBe("ocx_a89540229ef781fd5f7adf92a711b436");
+            observed.push(lane!);
+          } else {
+            expect(lane).toBe(identity.expected);
+          }
+          if (strategy === "failover") {
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.headers.has(SESSION_HEADER)).toBe(false);
+          } else {
+            expect(requests).toHaveLength(1);
+          }
+        } finally {
+          entropy.mockRestore();
+          clearComboSelectionState();
+          clearComboTargetCooldowns();
+        }
+        if (identity.expected !== "isolated" && round === 1) break;
+        }
+        if (identity.expected === "isolated") {
+          expect(observed).toHaveLength(2);
+          expect(observed[0]).not.toBe(observed[1]);
+        }
+      });
+      }
+    }
+    }
+
+    test(`Claude random Go preflight does not leak affinity to a final non-Go Responses target (${model})`, async () => {
+      clearComboSelectionState();
+      clearComboTargetCooldowns();
+      const requests: Headers[] = [];
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe("https://other.example/v1/responses");
+        requests.push(new Headers(init?.headers));
+        return upstreamResponse(String(input));
+      }) as typeof fetch;
+      const config = {
+        providers: {
+          other: { adapter: "openai-responses", authMode: "key", baseUrl: "https://other.example/v1", apiKey: "test-key", models: ["other"] },
+          "renamed-go": opencodeGo(),
+        },
+        combos: { affinity: { strategy: "random", targets: [
+          { provider: "renamed-go", model }, { provider: "other", model: "other" },
+        ] } },
+      } as unknown as OcxConfig;
+      const entropy = spyOn(Math, "random").mockReturnValue(0.9).mockReturnValueOnce(0);
+      try {
+        const response = await handleClaudeMessages(new Request("http://localhost/v1/messages", {
+          method: "POST", headers: { "content-type": "application/json", [SESSION_HEADER]: "client-session-a" },
+          body: JSON.stringify({ model: "combo/affinity", max_tokens: 64, stream: false,
+            messages: [{ role: "user", content: "ping" }],
+            metadata: { user_id: "user_test_account__session_conversation-a" } }),
+        }), config, { model: "", provider: "" });
+        await response.text();
+        expect(response.status).toBe(200);
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.has(SESSION_HEADER)).toBe(false);
+        expect(requests[0]?.has("session_id")).toBe(false);
+      } finally {
+        entropy.mockRestore();
+        clearComboSelectionState();
+        clearComboTargetCooldowns();
+      }
+    });
+  }
 
   test("Claude metadata gives stable Go affinity across turns and distinct conversations", async () => {
     const input = { claude: true, model: CHAT_MODEL, metadataUserId: "user_test_account__session_conversation-a" };


### PR DESCRIPTION
## Summary

- Follow-up to the late review on #3961: https://github.com/lidge-jun/opencodex/pull/3961#discussion_r3953074647.
- Claude preflight and combo dispatch independently select targets. Carry validated conversation affinity privately through replay and apply it only after the final canonical Go destination is selected, including failover.
- Preserve explicit session-lane > client Go header > validated metadata precedence, with configured operator headers still winning. Do not send Go-only identity to non-Go destinations or derive it from shared system cache keys.
- No changes to credentials, subscription routing, configuration schema, or dependencies.

## Verification

Head `e5c2411f7` (three commits: the fix `9e0783495`, the CodeRabbit docs/JSDoc follow-up, and a docs commit that states the sessionless per-request isolation precisely, as requested in review), rebased onto exact `dev` tip `16f18d654`. Range-diff against the previous head `5cb63c09c` shows all three commits unchanged; the intervening `dev` commits do not touch the files this PR changes. `dev` includes the request-scoped isolated session lane from #4184 (merged as `9e75542ff` via #4226). That merge conflicted with this PR at the final-route call in `src/server/responses/core.ts`; the resolution is the one previewed on `integ/4050-with-4184`: the final Go destination uses the Claude-derived affinity when present and otherwise the request-scoped lane, and Claude Messages falls back to that same request-scoped lane when no explicit or metadata identity is valid. The two matrix cases without valid identity now expect a well-formed isolated lane (distinct across requests, never the shared-system or metadata hash) instead of no header. All results below are from this head with the pinned Bun 1.4.2 (Linux); `bun run test:changed` additionally passed 4,991 tests across 182 import-connected files with 0 failures.

- `bun run typecheck`: passed.
- Focused Go affinity suite `tests/providers/opencode-go-session-header.test.ts`: **87 pass, 0 fail, 767 assertions**.
- Hosted-CI equivalent general suite via `scripts/ci/run-bun-test-batches.sh` for all four shards: **every shard exited 0, 0 assertion failures, 23,076 tests run**. Bun 1.4.2 batch-process crashes (exit 139, the #1302 class) were recovered by the runner's one-file-per-process isolation.
- Dedicated storage-policy job (`bun test --isolate`, six files): **18 pass, 0 fail**.
- Dedicated api-usage job: **33 pass, 0 fail**.
- `bun run privacy:scan`: passed. `git diff --check`: clean.
- `cd docs-site && bun run build`: passed (425 pages).
- Note for reproducers: running the batch runner with a PATH Bun older than the pinned 1.4.2 produces unrelated assertion failures (for example the `Bun.Image` tests); set `OPENCODEX_BUN_PATH` to the bundled binary.

### Deterministic reproduction (no API key)

Requires Git, Node.js, and Bun. All upstream fetches in the selected tests are mocked. The script creates a disposable checkout and keeps its logs; it does not start a proxy or call Go. It runs exactly the same new regression tests against the unpatched base and the fixed production files.

```bash
#!/usr/bin/env bash
set -euo pipefail
# Requires git, Node.js and Bun. No API key or running proxy is used.
repo="${REPRO_REPO:-https://github.com/david-wang-0/opencodex.git}"
base=16f18d654
fixed=e5c2411f7
export NO_COLOR=1
scratch=$(mktemp -d)
git init -q "$scratch/checkout"
cd "$scratch/checkout"
git remote add origin "$repo"
git fetch --depth=4 origin "$fixed"
git checkout --detach "$fixed"
bun install --frozen-lockfile --ignore-scripts
node node_modules/bun/install.js
test_file=tests/providers/opencode-go-session-header.test.ts
selector='Claude random openai-chat to Go uses metadata'

# Keep the new regression tests but restore only the two production files.
git restore --source="$base" --worktree -- \
  src/server/claude-messages.ts src/server/responses/core.ts
set +e
bun run test "$test_file" -t "$selector" > "$scratch/before.log" 2>&1
before_status=$?
set -e
cat "$scratch/before.log"
if [ "$before_status" -eq 0 ]; then
  echo 'ERROR: expected the unpatched implementation to fail' >&2
  exit 1
fi
grep -Eq '(^|[[:space:]])2 fail' "$scratch/before.log"
# On this base the unpatched final route already carries an isolated per-request lane,
# so the failure is a wrong lane rather than a missing header.
grep -Eq 'Received: "ocx_[0-9a-f]{32}"' "$scratch/before.log"
! grep -Fq 'Received: "ocx_a89540229ef781fd5f7adf92a711b436"' "$scratch/before.log"
grep -Fq 'Expected: "ocx_a89540229ef781fd5f7adf92a711b436"' "$scratch/before.log"

git restore --source="$fixed" --worktree -- \
  src/server/claude-messages.ts src/server/responses/core.ts
bun run test "$test_file" -t "$selector" > "$scratch/after.log" 2>&1
cat "$scratch/after.log"
echo "Unpatched exit: $before_status; patched exit: 0"
echo "Checkout and logs retained in: $scratch"
```

The selected cases force the preliminary route to a non-Go Chat provider and actual random dispatch to Go, on both Go wire protocols. Recorded standalone output (setup and stack traces omitted):

```text
Unpatched, both cases (the received lane is the isolated per-request value, different each run):
Expected: "ocx_a89540229ef781fd5f7adf92a711b436"
Received: "ocx_9a17584daa3bd0bfe661b1b25f1ef464"
 0 pass
 2 fail

Patched:
 2 pass
 0 fail
Unpatched exit: 1; patched exit: 0
```

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: GPT-6 Astra <noreply@openai.com>
Co-authored-by: Claude Fable 5.1 <noreply@anthropic.com>

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved OpenCode Go session affinity for Claude Messages and Responses across fallback and randomly selected destinations.
  - Added request-level isolation when no session identifier is available.
  - Supports configured, explicit, operator-provided, and metadata-based session identifiers.
  - Go session information remains isolated from non-Go destinations.

- **Documentation**
  - Expanded guidance on session-affinity precedence, fallback behavior, final destination selection, and the distinction between conversation identity and prompt-cache keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->












