### PR TITLE
wp7: report the actual reason a proxy refused to stop

### DIFF
--- a/src/lib/process-control.ts
+++ b/src/lib/process-control.ts
@@ -71,7 +71,25 @@ export function gracefulStopHost(hostname: string | undefined): string {
  */
 export type GracefulStopResult = boolean | "refused";
 
-/** A proxy declined shutdown because a service under another home owns it (HTTP 409). */
+/**
+ * The server's own explanation for the most recent 409, captured so `stopProxy` can report
+ * the real reason. There is more than one: a scheduler wrapper under another home, or the
+ * proxy being the installed service itself (#4023). Module-scoped because
+ * `GracefulStopResult` is a public contract with several callers, and widening it to carry
+ * the text would change every one of them for a message only this file reports.
+ */
+let lastRefusalMessage: string | null = null;
+
+/** The server's explanation for the most recent 409, or `null` when it sent none. */
+export function lastStopRefusalMessage(): string | null {
+  return lastRefusalMessage;
+}
+
+/**
+ * A proxy declined shutdown (HTTP 409). There is more than one reason it can say no — a
+ * scheduler wrapper under another home, or the proxy being the installed service itself
+ * (#4023) — so the server's own message is carried through rather than guessed at.
+ */
 export class ProxyOwnershipRefusedError extends Error {}
 
 /**
@@ -111,7 +129,15 @@ export async function stopProxyGracefully(pid: number, io: GracefulStopIo = {}):
     // would respawn it anyway). That is a policy answer, not a dead endpoint — escalating to
     // SIGTERM here would run the daemon's cleanup and strip shared config out from under the
     // still-running service. Report the refusal instead of forcing.
-    if (res.status === 409) return "refused";
+    if (res.status === 409) {
+      lastRefusalMessage = await res.json()
+        .then(body => {
+          const message = (body as { message?: unknown } | null)?.message;
+          return typeof message === "string" && message.trim() ? message.trim() : null;
+        })
+        .catch(() => null);
+      return "refused";
+    }
     if (!res.ok) return false;
   } catch {
     return false;
@@ -140,8 +166,9 @@ export async function stopProxy(pid: number, io: GracefulStopIo = {}): Promise<b
     // The proxy refused on purpose (foreign service owns it). Forcing would strip shared
     // config while that service keeps the proxy alive.
     throw new ProxyOwnershipRefusedError(
-      "The running proxy refused to stop: a service installed under a different "
-      + "CODEX_HOME/OPENCODEX_HOME owns it. Run the stop from that home.",
+      lastRefusalMessage
+      ?? "The running proxy refused to stop: a service installed under a different "
+        + "CODEX_HOME/OPENCODEX_HOME owns it. Run the stop from that home.",
     );
   }
   if (graceful) {

--- a/tests/lib/process-control-graceful.test.ts
+++ b/tests/lib/process-control-graceful.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { gracefulStopHost, stopProxyGracefully } from "../../src/lib/process-control";
+import { gracefulStopHost, lastStopRefusalMessage, stopProxyGracefully } from "../../src/lib/process-control";
 
 function okResponse(): Response {
   return new Response(JSON.stringify({ success: true }), { status: 200 });
@@ -105,5 +105,40 @@ describe("stopProxyGracefully", () => {
       env: {},
     });
     expect(noExit).toBe(false);
+  });
+});
+
+describe("409 refusal reporting", () => {
+  test("a refusal carries the server's own reason, not the ownership guess", async () => {
+    // /api/stop answers 409 for more than one reason: a scheduler wrapper under another
+    // home, and (since #4023) the proxy being the installed launchd/systemd job itself.
+    // stopProxy used to report the first of those unconditionally, sending an operator
+    // whose proxy is simply the service to a CODEX_HOME that does not exist.
+    const selfUnload = "This proxy is running as the installed service, so stopping the manager"
+      + " from inside it would end this process before native Codex is restored."
+      + " Run `ocx stop`, which stops the service from outside and completes the restore."
+      + " Nothing was changed.";
+    const result = await stopProxyGracefully(7, {
+      readRuntime: () => ({ port: 10100 }),
+      fetchFn: (async () => new Response(
+        JSON.stringify({ success: false, code: "self_unload_service", message: selfUnload }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      )) as typeof fetch,
+      waitExit: () => true,
+      env: {},
+    });
+    expect(result).toBe("refused");
+    expect(lastStopRefusalMessage()).toBe(selfUnload);
+  });
+
+  test("a 409 with no readable body falls back rather than reporting a stale reason", async () => {
+    const result = await stopProxyGracefully(7, {
+      readRuntime: () => ({ port: 10100 }),
+      fetchFn: (async () => new Response("not json", { status: 409 })) as typeof fetch,
+      waitExit: () => true,
+      env: {},
+    });
+    expect(result).toBe("refused");
+    expect(lastStopRefusalMessage()).toBeNull();
   });
 });

--- a/tests/providers/xai/grok-lifecycle.test.ts
+++ b/tests/providers/xai/grok-lifecycle.test.ts
@@ -509,7 +509,18 @@ describe("POST /api/stop teardown", () => {
   test("a 409 does not escalate to a forced kill", () => {
     // Escalating would run the daemon's cleanup and strip shared config while the foreign
     // service keeps the proxy alive — the exact hole the ownership gate exists to close.
-    expect(PROCESS_CONTROL_SOURCE).toContain('if (res.status === 409) return "refused"');
+    // The 409 branch may capture the server's reason first (#4023 added a second refusal
+    // cause), but it must still return "refused" without falling through to !res.ok.
+    const stopGracefully = sliceFn(
+      PROCESS_CONTROL_SOURCE,
+      "export async function stopProxyGracefully(",
+      "export async function stopProxy(",
+    );
+    const four09At = stopGracefully.indexOf("res.status === 409");
+    expect(four09At).toBeGreaterThan(-1);
+    expect(stopGracefully.slice(four09At)).toContain('return "refused"');
+    expect(stopGracefully.indexOf('return "refused"', four09At))
+      .toBeLessThan(stopGracefully.indexOf("if (!res.ok) return false;", four09At));
 
     const stopProxyFn = sliceFn(PROCESS_CONTROL_SOURCE, "export async function stopProxy(", "export function killProxy(");
     const refusedAt = stopProxyFn.indexOf('graceful === "refused"');


### PR DESCRIPTION
## Summary

Fixes a misleading error message found by the `main` → `dev` regression review for the 2.49.0 promotion.

`POST /api/stop` answers 409 for two different reasons. The original one is a Task Scheduler wrapper under another `CODEX_HOME` that would respawn the proxy anyway; #4023 added a second, the proxy being the installed launchd or systemd job itself. `stopProxy` reported the first unconditionally, so an operator whose proxy is simply the service was told *"a service installed under a different CODEX_HOME/OPENCODEX_HOME owns it. Run the stop from that home"* — and sent to a home that does not exist.

The server already sends a precise message for each case (`respawnable_service` and `self_unload_service`). It is now carried through to the thrown error, with the previous text kept as the fallback for an unreadable body.

Reaching it needs a receipt-write failure plus a surviving managed proxy: `ocx stop` normally passes a teardown nonce that exempts it from the risk check, and `claimTeardown` deliberately swallows a receipt-write failure so a lost deferral does not lose the stop. That degradation was benign before #4023 and is not any more. Nothing is force-killed and no config is stripped either way — the path is fail-closed, so this is about telling the operator the truth rather than about behavior.

The refusal message is captured module-locally rather than by widening `GracefulStopResult`, which is a public contract with several callers, for text only this file reports.

## Verification

- `bun x tsc --noEmit` — exit 0.
- `bun test tests/lib/process-control-graceful.test.ts` — **9 pass / 0 fail**.
- The added case is non-vacuous: with the message capture removed it reports 8 pass / 1 fail.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful proxy stop refusals now display the server-provided explanation when available.
  * Refusals without a readable explanation now show the standard fallback message.
  * Refusal details are cleared when the response body cannot be read, preventing stale messages from being shown.
  * HTTP 409 refusals continue to be reported as refusals without escalating to a forced stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->