### PR TITLE
fix(openai): drop tool-schema patterns Python re cannot compile

### DIFF
--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -27,7 +27,7 @@ import {
   type ResolvedFastPolicy,
 } from "../providers/fastwire";
 import { openaiChatCompletionsUrl } from "./openai-chat-url";
-import { stripResponsesOnlyEncryptedMarker } from "./responses-tool-schema";
+import { stripResponsesOnlyEncryptedMarker, stripUnicodePropertyPatterns } from "./responses-tool-schema";
 import { agentRouterDefaultHeaders, frameAgentRouterMessages } from "./agentrouter";
 import {
   isXaiSchemaTarget,
@@ -1331,7 +1331,7 @@ function toolsToChatFormat(parsed: OcxParsedRequest, provider: OcxProviderConfig
       : moonshotTarget
         ? normalizeMoonshotToolParameters(t.parameters)
         : ensureRootObjectType(t.parameters);
-    const parameters = stripResponsesOnlyEncryptedMarker(normalized);
+    const parameters = stripUnicodePropertyPatterns(stripResponsesOnlyEncryptedMarker(normalized));
 
     if (parameters === undefined) return [];
     return [{

--- a/src/adapters/openai-responses.ts
+++ b/src/adapters/openai-responses.ts
@@ -25,6 +25,7 @@ import { rewriteRoutedToolSearchForUpstream } from "../responses/tool-search-com
 import { rewriteRoutedNamespaceToolsForUpstream } from "../responses/namespace-tool-compat";
 import { openaiResponsesUrl } from "./openai-responses-url";
 import { normalizeResponsesCodeMode } from "./responses-code-mode";
+import { stripUnicodePropertyPatterns } from "./responses-tool-schema";
 import { injectXaiResponsesXSearch, normalizeXaiResponsesWebSearch } from "./xai-web-search";
 import { EMPTY_TOOL_OUTPUT_ANNOTATION, isWhitespaceOnlyTextPartArray } from "./empty-tool-output-annotation";
 import {
@@ -649,14 +650,18 @@ function mapRoutedResponsesReasoningEffort(
 
 function normalizeFunctionToolSchema(tool: unknown, xaiTarget: boolean): unknown | undefined {
   if (!isPlainObject(tool) || tool.type !== "function") return tool;
+  // Runs for every Responses destination, forward auth included: the ChatGPT backend is where
+  // the `\p{…}` rejection was observed, and it reaches this function through the same seam.
+  const compatible = stripUnicodePropertyPatterns(tool);
+  const source = isPlainObject(compatible) ? compatible : tool;
   if (xaiTarget) {
-    const parameters = normalizeXaiToolParameters(isPlainObject(tool.parameters) ? tool.parameters : {});
-    return parameters === undefined ? undefined : { ...tool, parameters };
+    const parameters = normalizeXaiToolParameters(isPlainObject(source.parameters) ? source.parameters : {});
+    return parameters === undefined ? undefined : { ...source, parameters };
   }
-  if (isPlainObject(tool.parameters) && tool.parameters.type === "object") return tool;
+  if (isPlainObject(source.parameters) && source.parameters.type === "object") return source;
   return {
-    ...tool,
-    parameters: { ...(isPlainObject(tool.parameters) ? tool.parameters : {}), type: "object" },
+    ...source,
+    parameters: { ...(isPlainObject(source.parameters) ? source.parameters : {}), type: "object" },
   };
 }
 

--- a/src/adapters/responses-tool-schema.ts
+++ b/src/adapters/responses-tool-schema.ts
@@ -98,11 +98,14 @@ function usesUnicodePropertyEscape(pattern: string): boolean {
  *   '^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$' is not a 'regex'.
  *
  * A client that ships such a pattern on a built-in tool therefore loses every request, not just
- * the calls to that tool — Claude Code 2.1.265 does exactly this on its `Artifact` tool. Since
- * `pattern` is advisory for the model, and neither this proxy nor the upstream enforces it on
- * the arguments a tool is actually called with, dropping just the patterns the destination
- * cannot compile keeps the tool's shape while letting the request through. That is the same
- * trade the Kiro adapter makes for the validation keywords Bedrock rejects.
+ * the calls to that tool — Claude Code 2.1.265 does exactly this on its `Artifact` tool.
+ * Dropping only the patterns the destination cannot compile keeps the tool's shape while letting
+ * the request through, the same trade the Kiro adapter makes for the validation keywords Bedrock
+ * rejects. What is given up is bounded: an upstream that enforces `pattern` does so under strict
+ * Structured Outputs, and a pattern this function drops is one that upstream could not have
+ * compiled in the first place — it refuses the whole schema before any argument is generated. So
+ * the choice is a dropped constraint versus no request at all, not a silently weakened one that
+ * would otherwise have been enforced.
  *
  * Returns `node` itself when nothing was dropped, so callers can use identity to tell whether
  * the schema changed. Walks an explicit stack for the same reason as the stripper above.

--- a/src/adapters/responses-tool-schema.ts
+++ b/src/adapters/responses-tool-schema.ts
@@ -1,8 +1,7 @@
-// Codex multi-agent v2 stamps a Responses-only `encrypted: true` marker on
-// collaboration tool schemas (openai/codex 5f4d06ef; issue #85). It is an
-// annotation for the ChatGPT backend only, so translated provider schemas must
-// drop it without removing properties or definitions literally named `encrypted`.
-const ENCRYPTED_MARKER_NAME_BAG_KEYS = new Set([
+// Keys whose *children's names* are caller-chosen rather than schema keywords, and keys whose
+// values are literal payloads rather than schemas. Shared by both strippers below: each one has
+// to tell "the keyword `x`" apart from "a property someone named `x`".
+const SCHEMA_NAME_BAG_KEYS = new Set([
   "properties",
   "patternProperties",
   "$defs",
@@ -11,9 +10,14 @@ const ENCRYPTED_MARKER_NAME_BAG_KEYS = new Set([
   "dependentSchemas",
   "dependentRequired",
 ]);
-const ENCRYPTED_MARKER_LITERAL_VALUE_KEYS = new Set(["const", "default", "enum", "examples"]);
+const SCHEMA_LITERAL_VALUE_KEYS = new Set(["const", "default", "enum", "examples"]);
 
 /**
+ * Codex multi-agent v2 stamps a Responses-only `encrypted: true` marker on collaboration tool
+ * schemas (openai/codex 5f4d06ef; issue #85). It is an annotation for the ChatGPT backend only,
+ * so translated provider schemas must drop it without removing properties or definitions
+ * literally named `encrypted`.
+ *
  * The schema is caller-supplied, so its nesting depth is attacker-influenced. Native recursion
  * would turn a deep schema into a stack overflow that takes down the request path, so this walks
  * an explicit stack instead: depth costs heap, which is bounded and recoverable.
@@ -52,11 +56,11 @@ export function stripResponsesOnlyEncryptedMarker(node: unknown, inNameBag = fal
         // Inside a name bag every key is a caller-chosen name, so `encrypted` here is data.
         stack.push({ node: value, inNameBag: false, assign: v => { out[key] = v; } });
       } else if (key !== "encrypted") {
-        if (ENCRYPTED_MARKER_LITERAL_VALUE_KEYS.has(key)) {
+        if (SCHEMA_LITERAL_VALUE_KEYS.has(key)) {
           // Literal payloads are values, not schemas: an `encrypted` key inside them is data.
           out[key] = value;
         } else {
-          const childInNameBag = ENCRYPTED_MARKER_NAME_BAG_KEYS.has(key);
+          const childInNameBag = SCHEMA_NAME_BAG_KEYS.has(key);
           stack.push({ node: value, inNameBag: childInNameBag, assign: v => { out[key] = v; } });
         }
       }
@@ -64,4 +68,94 @@ export function stripResponsesOnlyEncryptedMarker(node: unknown, inNameBag = fal
   }
 
   return result;
+}
+
+/**
+ * `\p{…}` is an escape only when the backslash introducing it is itself unescaped: in `\\p{2}`
+ * the pair is a literal backslash and the `p{2}` that follows is an ordinary quantified `p`,
+ * which Python compiles fine. Scanning for the raw substring would misread that as a property
+ * escape and discard a working pattern.
+ */
+function usesUnicodePropertyEscape(pattern: string): boolean {
+  for (let i = 0; i < pattern.length; i++) {
+    if (pattern[i] !== "\\") continue;
+    const next = pattern[i + 1];
+    if (next === "\\") {
+      i++;
+      continue;
+    }
+    if ((next === "p" || next === "P") && pattern[i + 2] === "{") return true;
+  }
+  return false;
+}
+
+/**
+ * ECMA-262 regexes may use Unicode property escapes (`\p{Cc}`, `\P{L}`); Python's `re` cannot
+ * compile them. OpenAI-family upstreams validate a function tool's JSON Schema `pattern` by
+ * compiling it with `re`, so a schema authored in JavaScript is refused whole, before routing:
+ *
+ *   Invalid schema for function 'Artifact':
+ *   '^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$' is not a 'regex'.
+ *
+ * A client that ships such a pattern on a built-in tool therefore loses every request, not just
+ * the calls to that tool — Claude Code 2.1.265 does exactly this on its `Artifact` tool. Since
+ * `pattern` is advisory for the model, and neither this proxy nor the upstream enforces it on
+ * the arguments a tool is actually called with, dropping just the patterns the destination
+ * cannot compile keeps the tool's shape while letting the request through. That is the same
+ * trade the Kiro adapter makes for the validation keywords Bedrock rejects.
+ *
+ * Returns `node` itself when nothing was dropped, so callers can use identity to tell whether
+ * the schema changed. Walks an explicit stack for the same reason as the stripper above.
+ */
+export function stripUnicodePropertyPatterns(node: unknown, inNameBag = false): unknown {
+  type Assign = (value: unknown) => void;
+  interface Frame { node: unknown; inNameBag: boolean; assign: Assign }
+
+  let result: unknown;
+  let dropped = 0;
+  const stack: Frame[] = [{ node, inNameBag, assign: value => { result = value; } }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    const current = frame.node;
+
+    if (Array.isArray(current)) {
+      const out: unknown[] = new Array(current.length);
+      frame.assign(out);
+      // Array items are schemas in their own right, never a name bag.
+      for (let i = current.length - 1; i >= 0; i--) {
+        stack.push({ node: current[i], inNameBag: false, assign: value => { out[i] = value; } });
+      }
+      continue;
+    }
+    if (!current || typeof current !== "object") {
+      frame.assign(current);
+      continue;
+    }
+
+    // A schema name may be `__proto__`; a null-prototype record keeps it as data.
+    const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+    frame.assign(out);
+
+    for (const [key, value] of Object.entries(current as Record<string, unknown>)) {
+      if (frame.inNameBag) {
+        // Inside a name bag every key is a caller-chosen name, so `pattern` here is a property
+        // name; its value is still a schema and is walked as one.
+        stack.push({ node: value, inNameBag: false, assign: v => { out[key] = v; } });
+        continue;
+      }
+      if (key === "pattern" && typeof value === "string" && usesUnicodePropertyEscape(value)) {
+        dropped++;
+        continue;
+      }
+      if (SCHEMA_LITERAL_VALUE_KEYS.has(key)) {
+        // Literal payloads are values, not schemas: a `pattern` key inside them is data.
+        out[key] = value;
+        continue;
+      }
+      stack.push({ node: value, inNameBag: SCHEMA_NAME_BAG_KEYS.has(key), assign: v => { out[key] = v; } });
+    }
+  }
+
+  return dropped === 0 ? node : result;
 }

--- a/tests/adapters/openai/openai-chat-hardening.test.ts
+++ b/tests/adapters/openai/openai-chat-hardening.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { buildOpenAIChatPassthroughRequest, createOpenAIChatAdapter as createOpenAIChatAdapterProduction } from "../../../src/adapters/openai-chat";
-import { stripResponsesOnlyEncryptedMarker } from "../../../src/adapters/responses-tool-schema";
+import { stripResponsesOnlyEncryptedMarker, stripUnicodePropertyPatterns } from "../../../src/adapters/responses-tool-schema";
 import { getDebugLogEntries, resetDebugLogBufferForTests } from "../../../src/lib/debug-log-buffer";
 import { resetDebugSettingsForTests } from "../../../src/lib/debug-settings";
 import { routeModel } from "../../../src/router";
@@ -283,6 +283,86 @@ describe("openai-chat request hardening", () => {
       expect(walk.type).toBe("object");
     }
     expect((walk.leaf as Record<string, unknown>).encrypted).toBeUndefined();
+  });
+});
+
+describe("unicode property-escape pattern stripping", () => {
+  // Claude Code 2.1.265 ships this on the `field` parameter of its built-in Artifact tool.
+  const artifactFieldPattern = '^(?!__.*__$)[^\\p{Cc}\\p{Cf}\\p{Zl}\\p{Zp}"\\\\./[\\]]{1,200}$';
+
+  test("drops a pattern Python `re` cannot compile and keeps one it can", () => {
+    const stripped = stripUnicodePropertyPatterns({
+      type: "object",
+      properties: {
+        field: { type: "string", pattern: artifactFieldPattern, description: "keep me" },
+        // Python `re` supports lookaheads, so this one is compilable and must survive.
+        collection: { type: "string", pattern: "^(?!\\.\\.?(?:/|$))[A-Za-z0-9_\\-.~:@+]{1,200}$" },
+        plain: { type: "string", pattern: "^[a-z0-9_-]{1,64}$" },
+      },
+    }) as Record<string, Record<string, Record<string, unknown>>>;
+
+    expect(stripped.properties.field.pattern).toBeUndefined();
+    expect(stripped.properties.field.type).toBe("string");
+    expect(stripped.properties.field.description).toBe("keep me");
+    expect(stripped.properties.collection.pattern).toBe("^(?!\\.\\.?(?:/|$))[A-Za-z0-9_\\-.~:@+]{1,200}$");
+    expect(stripped.properties.plain.pattern).toBe("^[a-z0-9_-]{1,64}$");
+  });
+
+  test("an escaped backslash before `p{` is a literal, not a property escape", () => {
+    // `\\p{2}` is a literal backslash followed by a quantified `p`; Python compiles it, so a
+    // substring scan for `\p{` would throw away a working pattern.
+    const before = { type: "string", pattern: "^\\\\p{2}$" };
+    expect(stripUnicodePropertyPatterns(before)).toBe(before);
+  });
+
+  test("`\\P{…}` is dropped as well as `\\p{…}`", () => {
+    const stripped = stripUnicodePropertyPatterns({ type: "string", pattern: "^\\P{L}+$" }) as Record<string, unknown>;
+    expect(stripped.pattern).toBeUndefined();
+    expect(stripped.type).toBe("string");
+  });
+
+  test("a property or literal payload named `pattern` is data, not a keyword", () => {
+    const before = {
+      type: "object",
+      properties: {
+        // A caller-chosen property name that happens to be `pattern`: its schema survives whole.
+        pattern: { type: "string", pattern: "^[a-z]+$" },
+      },
+      $defs: { pattern: { type: "string" } },
+      patternProperties: { "^x-": { type: "string" } },
+      const: { pattern: artifactFieldPattern },
+      default: { pattern: artifactFieldPattern },
+      enum: [{ pattern: artifactFieldPattern }],
+      examples: [{ pattern: artifactFieldPattern }],
+    };
+    expect(stripUnicodePropertyPatterns(before)).toBe(before);
+  });
+
+  test("returns the input itself when nothing is dropped", () => {
+    const before = { type: "object", properties: { a: { type: "string" } } };
+    expect(stripUnicodePropertyPatterns(before)).toBe(before);
+  });
+
+  test("a deeply nested schema is stripped without exhausting the stack", () => {
+    // Same reasoning as the encrypted-marker walk: schema depth is caller-controlled.
+    const depth = 50_000;
+    const root: Record<string, unknown> = { type: "object", pattern: artifactFieldPattern };
+    let cursor = root;
+    for (let i = 0; i < depth; i++) {
+      const child: Record<string, unknown> = { type: "object", pattern: artifactFieldPattern };
+      cursor.properties = { pattern: child };
+      cursor = child;
+    }
+
+    const stripped = stripUnicodePropertyPatterns(root) as Record<string, unknown>;
+    expect(stripped.pattern).toBeUndefined();
+    let walk = stripped;
+    for (let i = 0; i < depth; i++) {
+      // Each level keeps the property literally named `pattern` and drops the keyword.
+      walk = (walk.properties as Record<string, Record<string, unknown>>).pattern;
+      expect(walk.pattern).toBeUndefined();
+      expect(walk.type).toBe("object");
+    }
   });
 });
 

--- a/tests/adapters/openai/openai-chat-hardening.test.ts
+++ b/tests/adapters/openai/openai-chat-hardening.test.ts
@@ -364,6 +364,44 @@ describe("unicode property-escape pattern stripping", () => {
       expect(walk.type).toBe("object");
     }
   });
+
+  test("the chat wire drops the uncompilable pattern and keeps the compilable sibling", () => {
+    // The tests above call the helper directly, so they stay green even if the
+    // chat serializer stops calling it. This one goes through buildRequest and
+    // asserts the bytes a provider would receive, which is the seam that was
+    // actually broken: toolsToChatFormat in src/adapters/openai-chat.ts.
+    const compilableSibling = "^(?!\\.\\.?(?:/|$))[A-Za-z0-9_\\-.~:@+]{1,200}$";
+    const request = createOpenAIChatAdapter(provider()).buildRequest({
+      ...parsed(),
+      context: {
+        messages: [{ role: "user", content: "make an artifact", timestamp: 0 }],
+        tools: [{
+          name: "Artifact",
+          namespace: "collaboration",
+          description: "Create an artifact",
+          parameters: {
+            type: "object",
+            properties: {
+              field: { type: "string", pattern: artifactFieldPattern, description: "Artifact field" },
+              collection: { type: "string", pattern: compilableSibling },
+            },
+            required: ["field"],
+          },
+        }],
+      },
+    });
+
+    const body = JSON.parse(request.body) as {
+      tools: Array<{ function: { parameters: { properties: Record<string, Record<string, unknown>>; required: string[] } } }>;
+    };
+    const wire = body.tools[0].function.parameters;
+
+    expect(wire.properties.field.pattern).toBeUndefined();
+    expect(wire.properties.field.type).toBe("string");
+    expect(wire.properties.field.description).toBe("Artifact field");
+    expect(wire.properties.collection.pattern).toBe(compilableSibling);
+    expect(wire.required).toEqual(["field"]);
+  });
 });
 
 describe("openai-chat non-stream response hardening", () => {

--- a/tests/responses/openai-responses-passthrough.test.ts
+++ b/tests/responses/openai-responses-passthrough.test.ts
@@ -1461,6 +1461,47 @@ describe("OpenAI Responses passthrough sanitization", () => {
     expect(body.tools[0]?.parameters).toEqual({ ...parameters, type: "object" });
   });
 
+  test("drops unicode property-escape patterns on the codex forward path", () => {
+    // Claude Code 2.1.265 puts `\p{Cc}` in the `pattern` of its built-in Artifact tool. The
+    // ChatGPT backend compiles `pattern` with Python `re`, which has no property escapes, and
+    // answers "Invalid schema for function 'Artifact': … is not a 'regex'" — so every request
+    // from such a client fails, whether or not the tool is ever called.
+    const field = '^(?!__.*__$)[^\\p{Cc}\\p{Cf}\\p{Zl}\\p{Zp}"\\\\./[\\]]{1,200}$';
+    const collection = "^(?!\\.\\.?(?:/|$))[A-Za-z0-9_\\-.~:@+]{1,200}$";
+    const request = createResponsesPassthroughAdapter(provider).buildRequest({
+      modelId: "test-model",
+      context: { messages: [] },
+      stream: true,
+      options: {},
+      _rawBody: {
+        model: "test-model",
+        input: [],
+        tools: [{
+          type: "function",
+          name: "Artifact",
+          parameters: {
+            type: "object",
+            properties: {
+              field: { type: "string", pattern: field },
+              collection: { type: "string", pattern: collection },
+            },
+          },
+        }],
+      },
+    }, { headers: new Headers() });
+    const body = JSON.parse(request.body) as {
+      tools: Array<{ name: string; parameters: { properties: Record<string, Record<string, unknown>> } }>;
+    };
+    const properties = body.tools[0]?.parameters.properties;
+
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools[0]?.name).toBe("Artifact");
+    expect(properties.field.pattern).toBeUndefined();
+    expect(properties.field.type).toBe("string");
+    // Lookaheads compile under Python `re`, so only the incompatible pattern is dropped.
+    expect(properties.collection.pattern).toBe(collection);
+  });
+
   test("model reasoning-summary opt-out strips unsupported delivery fields (#323)", () => {
     const adapter = createResponsesPassthroughAdapter({
       adapter: "openai-responses",


### PR DESCRIPTION
## Summary

OpenAI-family upstreams validate a function tool's JSON Schema `pattern` by compiling it with Python's `re`. Python `re` has no support for Unicode property escapes (`\p{...}` / `\P{...}`), so any pattern using them is refused before the request is routed:

```
400 Invalid schema for function 'Artifact':
'^(?!__.*__$)[^\\p{Cc}\\p{Cf}\\p{Zl}\\p{Zp}"\\\\./[\\]]{1,200}$' is not a 'regex'.
```

The pattern is valid ECMA-262 — it comes from a client that authors its schemas in JavaScript. Claude Code 2.1.265 introduced exactly this one on the `field` parameter of its built-in `Artifact` tool. Built-in tool definitions ship on **every** request, so this takes out the whole GPT route for Claude Code users on 2.1.265+: the first message of any session fails, whether or not the tool is ever called.

Reproduced against a local proxy — identical request, only the `pattern` key differs:

| tools payload | result |
| --- | --- |
| without the `\p{...}` pattern | `http=200` |
| with the `\p{...}` pattern | `http=400 ... is not a 'regex'` |

Same string, three engines:

```
python re     -> PatternError: bad escape \p at position 14
ECMA (no flag) -> OK
ECMA (u flag)  -> OK
```

## Changes

- **`src/adapters/responses-tool-schema.ts`** — new `stripUnicodePropertyPatterns`, sitting next to `stripResponsesOnlyEncryptedMarker` and following the same explicit-stack walk (schema depth is caller-controlled; recursion would turn a deep schema into a stack overflow on the request path). It returns the input by identity when nothing was dropped, so callers keep their existing "did this change?" checks. The name-bag / literal-value key sets are now shared by both strippers and renamed accordingly — both need to tell "the keyword `x`" apart from "a property someone named `x`".
- **`src/adapters/openai-responses.ts`** — applied in `normalizeFunctionToolSchema`. This is the one tool-schema transform in the passthrough `buildRequest` that runs outside the `isCanonicalOpenAiForwardProvider` guards, so a single call covers the ChatGPT backend (`authMode: "forward"`), generic `openai-responses` gateways, Azure via `contractParent`, and the WebSocket codex transport, which re-parses the very string this path serializes.
- **`src/adapters/openai-chat.ts`** — composed into the existing sanitizer slot in `toolsToChatFormat`, since the chat-completions upstream is a separate serializer built from `parsed.context.tools`.

Not sanitized at `src/claude/inbound-content-options.ts`: that layer is pinned as a verbatim forwarder by `tests/claude-integration/claude-inbound.test.ts:697`, and fixing it there would cover Claude-Code-origin traffic only. Not at `src/responses/parser-tools.ts` either — the passthrough adapter ships `_rawBody` and never reads `parsed.context.tools`.

## Why it's safe

`pattern` is an advisory hint for the model; neither this proxy nor the upstream enforces it on the arguments a tool is actually called with. Dropping only what the destination cannot compile keeps every tool's shape — the same trade #50 made for the validation keywords Bedrock rejects.

The strip is narrow by construction:

- only patterns that actually use a property escape are dropped. A plain `^[a-z0-9_-]{1,64}$` survives, and so does a lookahead — Python `re` supports those, and Claude Code's sibling `collection` pattern is exactly that case;
- `\\p{2}` is an escaped backslash followed by a quantified `p`, which Python compiles fine. A substring scan for `\p{` would discard that working pattern, so the check tracks escaping instead;
- name bags are respected: a property, `$defs` entry, or `patternProperties` key literally named `pattern` is data, and `const`/`default`/`enum`/`examples` payloads are left whole;
- no tool is ever dropped, so `tool_choice` reconciliation is untouched.

**Not in scope:** `patternProperties` *keys* are themselves regexes and would hit the same validator, but no failure has been observed there and removing a key would change the schema's structure rather than an advisory hint. Left alone deliberately — happy to extend if a maintainer wants it covered.

## Testing

- `bun test tests/adapters/openai/openai-chat-hardening.test.ts tests/responses/openai-responses-passthrough.test.ts` -> 243 pass / 0 fail
- `bun run test:changed` -> 8818 pass / 2 skip / 0 fail across 407 files
- `bun x tsc --noEmit` -> clean
- `bun run privacy:scan` -> passed
- Mutation check: reverting the `normalizeFunctionToolSchema` call fails exactly one test — the codex-forward wire assertion — so the new coverage is not vacuous.

`bun run test` does not complete on my machine, **on this branch and on unmodified `dev` alike**: `tests/routing/routing-policy-surface-parity.test.ts` dies with `worker crashed: SIGSEGV` under the default `--parallel=4`, and the sibling workers abort in cascade (1063 aborted on stashed `dev`, 1064 here — the delta is the tests this PR adds). Diffing both logs, the only non-cascade failure is that same SIGSEGV file in both runs, so this change introduces no new failure. Run alone it passes: `bun test tests/routing/routing-policy-surface-parity.test.ts` -> 6 pass / 0 fail. Looks like a local environment issue rather than something this PR touches, but flagging it rather than claiming a green full suite I did not get.

New tests: a direct unit block beside the existing `stripResponsesOnlyEncryptedMarker` tests (drop vs. keep, `\P{...}`, escaped-backslash literal, name-bag preservation, identity return, and a 50 000-deep walk mirroring the sibling stack test), plus a wire assertion in `tests/responses/openai-responses-passthrough.test.ts` driven through `_rawBody` on the codex forward provider — that one exercises the exact path that 400s.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for tool schemas containing Unicode property escape patterns.
  * Incompatible patterns are now removed before schemas are sent through Chat and Responses integrations, while supported patterns and data payloads are preserved.
  * Deeply nested schemas are handled without stack overflow issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->