### PR TITLE
fix(provider): enable service_tier priority on the xAI OAuth Responses lane

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1265,9 +1265,14 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     baseUrl: "https://api.x.ai/v1",
     authKind: "oauth",
     allowKeyAuthOverride: true,
-    // Priority Processing is documented for xAI's public API-key Chat Completions and
-    // Responses endpoints. OAuth is a separate Grok CLI subscription gateway and remains
-    // unclassified; do not turn this into a provider-wide supportsServiceTier declaration.
+    // Priority Processing is offered on both xAI endpoints — the public api.x.ai key-auth
+    // lane and the Grok CLI OAuth gateway cli-chat-proxy.grok.com. A 2026-09-09 live probe
+    // against the OAuth gateway carrying service_tier "priority" completed with
+    // response.service_tier "priority" while the same request without the field completed
+    // with "default". Declare Fast support auth-agnostically so OAuth callers (grok-4.6,
+    // grok-4.5, grok-4.20-*, grok-composer-2.5-fast) can pass a caller/pinned tier through;
+    // keyAuthServiceTier stays as the chat-encoding carrier for the key lane.
+    supportsServiceTier: true,
     keyAuthServiceTier: {
       supportsServiceTier: true,
       chatServiceTier: true,
@@ -1312,20 +1317,21 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // Grok 4.6/4.5 subscription Responses callers use the native wire with the existing
     // namespace/web-search/replay normalization. Chat remains an explicit modelAdapters
     // opt-in. Multi-agent has no Chat wire and uses Responses under both auth modes.
-    // Caller-owned service tiers stay off the unclassified OAuth subscription route; key-auth
-    // Fast remains proxy-owned and is still selected through keyAuthServiceTier above.
+    // The unclassified-subscription comment above is retired: the OAuth Responses gateway
+    // demonstrably honors service_tier "priority". Caller-owned tiers therefore pass on
+    // the routes below; no wire default stays drop-for-tiers.
     modelWireDefaults: {
       "grok-4.6": {
         wire: "openai-responses",
         inbound: ["responses"],
         authModes: ["oauth"],
-        forwardCallerServiceTier: false,
+        forwardCallerServiceTier: true,
       },
       "grok-4.5": {
         wire: "openai-responses",
         inbound: ["responses"],
         authModes: ["oauth"],
-        forwardCallerServiceTier: false,
+        forwardCallerServiceTier: true,
       },
       "grok-4.20-multi-agent-0309": {
         // Even at high effort it emits no reasoning-summary deltas or encrypted replay
@@ -1338,7 +1344,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
         // openai-chat adapter and sent this model to the wire it 400s on.
         wire: "openai-responses",
         inbound: ["responses", "chat", "anthropic"],
-        forwardCallerServiceTier: false,
+        forwardCallerServiceTier: true,
       },
     },
     // Vision lineup per docs.x.ai model-capabilities/images/understanding: the grok-4.x chat

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1277,7 +1277,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
       supportsServiceTier: true,
       chatServiceTier: true,
     },
-    fastTierDescription: "Priority processing, 2x token price",
+    fastTierDescription: "Priority processing; tier pricing applies on key auth only",
     featured: true,
     oauthId: "xai",
     jawcodeBundle: "xai",

--- a/tests/routing/fastwire-policy.test.ts
+++ b/tests/routing/fastwire-policy.test.ts
@@ -259,6 +259,9 @@ describe("resolveFastPolicy matrix", () => {
   test("locks the five-row xAI and DeepSeek wire/tier regression matrix", () => {
     const rows = [
       {
+        // 2026-09-09 live probe: the OAuth Responses gateway honors service_tier "priority"
+        // (returns service_tier "priority", matches "default" without the field), so the
+        // previously drop-by-default OAuth route now forwards caller tiers like key auth.
         name: "xAI OAuth default",
         providerName: "xai",
         modelIds: ["grok-4.6", "grok-4.5"],
@@ -268,9 +271,9 @@ describe("resolveFastPolicy matrix", () => {
           authMode: "oauth" as const,
         },
         adapter: "openai-responses",
-        forwardCallerTier: false,
+        forwardCallerTier: true,
         callerTier: "flex",
-        settledCallerTier: undefined,
+        settledCallerTier: "flex",
       },
       {
         name: "xAI OAuth Responses override",
@@ -283,9 +286,9 @@ describe("resolveFastPolicy matrix", () => {
           modelAdapters: { "grok-4.6": "openai-responses", "grok-4.5": "openai-responses" },
         },
         adapter: "openai-responses",
-        forwardCallerTier: false,
+        forwardCallerTier: true,
         callerTier: "flex",
-        settledCallerTier: undefined,
+        settledCallerTier: "flex",
       },
       {
         // B2: key-auth Chat Completions is a documented Priority Processing transport.

--- a/tests/service/service-tier-capability.test.ts
+++ b/tests/service/service-tier-capability.test.ts
@@ -110,8 +110,9 @@ describe("xAI Fast capability follows the captured authentication transport", ()
       supportsServiceTier: true,
       chatServiceTier: true,
     });
-    expect(entry.supportsServiceTier).toBeUndefined();
-    expect(entry.chatServiceTier).toBeUndefined();
+    // Provider-level: after a 2026-09-09 live probe showed the OAuth Responses gateway
+    // honors service_tier "priority", support is declared auth-agnostically.
+    expect(entry.supportsServiceTier).toBe(true);
 
     const keyPolicy = fastPolicyForModel(xaiProvider("key"), "grok-4.6", "xai");
     expect(keyPolicy).toMatchObject({
@@ -122,9 +123,9 @@ describe("xAI Fast capability follows the captured authentication transport", ()
     });
 
     const oauthPolicy = fastPolicyForModel(xaiProvider("oauth"), "grok-4.6", "xai");
-    expect(oauthPolicy.capability).toBeUndefined();
-    expect(oauthPolicy.eligibility).toBe("unclassified");
-    expect(oauthPolicy.forwardCallerTier).toBe(false);
+    expect(oauthPolicy.capability).toBe(true);
+    expect(oauthPolicy.eligibility).toBe("eligible");
+    expect(oauthPolicy.forwardCallerTier).toBe(true);
   });
 
   test("catalog and runtime publish the same key/OAuth conclusion", async () => {
@@ -143,10 +144,16 @@ describe("xAI Fast capability follows the captured authentication transport", ()
     const oauthProvider = xaiProvider("oauth");
     const oauthPolicy = fastPolicyForModel(oauthProvider, "grok-4.6", "xai");
     const oauthCatalog = await catalogEntry(oauthProvider);
-    expect(serviceTierSupportFromPolicy(oauthPolicy)).toBe(false);
-    expect(oauthCatalog).not.toHaveProperty("service_tiers");
-    expect(oauthCatalog).not.toHaveProperty("additional_speed_tiers");
-    expect(decideTier(oauthPolicy, true, undefined)).toEqual({ kind: "drop" });
+    // With auth-agnostic supportsServiceTier the OAuth row now publishes the same Fast
+    // capability as key auth, and a caller tier is forwarded rather than dropped.
+    expect(serviceTierSupportFromPolicy(oauthPolicy)).toBe(true);
+    expect(oauthCatalog?.service_tiers).toEqual([{
+      id: "priority",
+      name: "Fast",
+      description: "Priority processing, 2x token price",
+    }]);
+    expect(oauthCatalog?.additional_speed_tiers).toEqual(["fast"]);
+    expect(decideTier(oauthPolicy, true, undefined)).toEqual({ kind: "set", value: "priority" });
   });
 
   test("explicit supportsServiceTier=false wins in policy and catalog for both transports", async () => {

--- a/tests/service/service-tier-capability.test.ts
+++ b/tests/service/service-tier-capability.test.ts
@@ -119,7 +119,7 @@ describe("xAI Fast capability follows the captured authentication transport", ()
       capability: true,
       eligibility: "eligible",
       forwardCallerTier: true,
-      fastTierDescription: "Priority processing, 2x token price",
+      fastTierDescription: "Priority processing; tier pricing applies on key auth only",
     });
 
     const oauthPolicy = fastPolicyForModel(xaiProvider("oauth"), "grok-4.6", "xai");
@@ -136,7 +136,7 @@ describe("xAI Fast capability follows the captured authentication transport", ()
     expect(keyCatalog?.service_tiers).toEqual([{
       id: "priority",
       name: "Fast",
-      description: "Priority processing, 2x token price",
+      description: "Priority processing; tier pricing applies on key auth only",
     }]);
     expect(keyCatalog?.additional_speed_tiers).toEqual(["fast"]);
     expect(decideTier(keyPolicy, true, undefined)).toEqual({ kind: "set", value: "priority" });
@@ -150,7 +150,7 @@ describe("xAI Fast capability follows the captured authentication transport", ()
     expect(oauthCatalog?.service_tiers).toEqual([{
       id: "priority",
       name: "Fast",
-      description: "Priority processing, 2x token price",
+      description: "Priority processing; tier pricing applies on key auth only",
     }]);
     expect(oauthCatalog?.additional_speed_tiers).toEqual(["fast"]);
     expect(decideTier(oauthPolicy, true, undefined)).toEqual({ kind: "set", value: "priority" });


### PR DESCRIPTION
## Summary

- xAI Grok의 OAuth(Responses) 레인도 호출자/고정 `service_tier`(Fast = `priority`)를 통과시킨다. 그동안 레지스트리가 Priority Processing을 키 인증 전용으로 잠그고 OAuth `modelWireDefaults` 행을 `forwardCallerServiceTier: false`로 두어, OAuth 사용자는 같은 티어를 요청해도 wire에 실리지 않고 조용히 버려졌다.
- 유지보수 관점: registry.xai에 `supportsServiceTier: true`를 선언하고(편차를 key lane의 채팅 인코딩에만 남김 `keyAuthServiceTier`), `grok-4.6/4.5/4.20-multi-agent-0309` 세 행의 `forwardCallerServiceTier`를 `false → true`로 뒤집고, OAuth subscription이 Fast를 안 한다는 옛 주석을 실측 일자(2026-09-09)로 대체한다. provider 레벨 선언 덕에 `grok-composer-2.5-fast` 같은 기본 라우트도 별도 엔트리 없이 동일하게 패스스루된다.
- 카탈로그 문구 정정: `fastTierDescription`을 `"2x token price"`에서 `"Priority processing; tier pricing applies on key auth only"`로 바꾼다. 구독 OAuth 레인에는 토큰당 가격이 없어, 이 PR이 연 OAuth 행에선 종전 문구가 틀렸다.

## Verification

- 라이브 프로브 (2026-09-09): mac mini의 OCX OAuth 자격으로 `https://cli-chat-proxy.grok.com/v1/responses`에 `xai/grok-composer-2.5-fast`를 `service_tier: "priority"`로 호출 → 응답에 `service_tier: "priority"`; 동일 요청에서 필드를 빼면 `"default"`. 즉 게이트웨이가 OAuth에서도 티어를 받는다는 증거.
- 패치 적용 로그 (오라클 OCX dev-built → Mac 호스트에 동일 적용): `xai/grok-composer-2.5-fast`와 `xai/grok-4.6` 요청에서 `callerServiceTier: "priority", modelSupportsServiceTier: True, tierOutcome: { wireKind: "service-tier", wireValue: "priority", fastOutcome: "applied" }`; 필드 없는 요청은 `wireValue: null, responseServiceTier: "default"`.
- 자동 테스트: `bun test tests/routing/fastwire-policy.test.ts tests/service/service-tier-capability.test.ts tests/providers/fast-row-ingress.test.ts` → 280/280 pass (봇-체크리스트 충족 후 동일 명령으로 재확인).
- 이 PR이 다루지 않은 속도 효과는 나중 문서화를 요한다. 이 변경은 wire를 열 뿐 최고 속도를 약속하지 않는다.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.
- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * xAI OAuth routes now support caller-selected service tiers, including priority and flex tiers.
  * Service-tier availability is now consistent across xAI authentication methods.
  * Fast-tier pricing information now clarifies that pricing applies to key-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->