### PR TITLE
fix(server): close expired dashboard selection streams quietly when no frames are queued

### DIFF
--- a/src/server/management/account-selection-stream.ts
+++ b/src/server/management/account-selection-stream.ts
@@ -3,6 +3,7 @@ import { registerOptionalShutdownHook } from "../../lib/optional-shutdown-hooks"
 
 const MAX_SELECTION_STREAMS = 64;
 const HEARTBEAT_MS = 15_000;
+const STREAM_QUEUE_HIGH_WATER_MARK = 16;
 const encoder = new TextEncoder();
 const connections = new Set<() => void>();
 
@@ -36,9 +37,17 @@ export function accountSelectionStream(request: Request, validate: () => boolean
       const send = (frame: string) => {
         if (closed) return;
         if (!authorized()) {
-          // Error clears queued frames as well, so a revoked consumer cannot drain them.
-          try { controller.error(new DOMException("Management session is no longer authorized", "NotAllowedError")); }
-          finally { close(); }
+          // A revoked consumer must not drain frames queued before revocation: error() is
+          // what discards a non-empty queue. When nothing is queued — the common expired-session
+          // path, including the heartbeat — close() alone terminates quietly, so an expired
+          // dashboard session does not dump an expected DOMException into the server console.
+          // desiredSize equals the high water mark exactly when the queue is empty.
+          if (controller.desiredSize !== null && controller.desiredSize < STREAM_QUEUE_HIGH_WATER_MARK) {
+            try { controller.error(new DOMException("Management session is no longer authorized", "NotAllowedError")); }
+            finally { close(); }
+          } else {
+            close();
+          }
           return;
         }
         // Reconnection sends a ready event, so a slow reader can reconcile without an
@@ -61,7 +70,7 @@ export function accountSelectionStream(request: Request, validate: () => boolean
       heartbeat.unref?.();
     },
     cancel() { cleanup(); },
-  }, { highWaterMark: 16 });
+  }, { highWaterMark: STREAM_QUEUE_HIGH_WATER_MARK });
   return new Response(body, { headers: {
     "Content-Type": "text/event-stream; charset=utf-8",
     "Cache-Control": "no-cache, no-transform",

--- a/tests/oauth/oauth-accounts-api.test.ts
+++ b/tests/oauth/oauth-accounts-api.test.ts
@@ -156,7 +156,9 @@ describe("multiauth accounts API", () => {
       expect(requireManagementAuth(ctx.req, state, ctx.config)).toBeNull(); // Deliberately memoized.
       const pending = reader.read();
       publishAccountSelection("private-provider", "oauth");
-      await expect(pending).rejects.toMatchObject({ name: "NotAllowedError" });
+      // Nothing was queued before revocation, so the stream closes quietly instead of
+      // erroring; the pending read resolves done and the post-revocation frame is never sent.
+      await expect(pending).resolves.toMatchObject({ done: true });
     } finally { await reader.cancel().catch(() => undefined); }
   });
 
@@ -179,7 +181,31 @@ describe("multiauth accounts API", () => {
       session.expiresAt = Date.now() - 1;
       const pending = reader.read();
       tick();
-      await expect(pending).rejects.toMatchObject({ name: "NotAllowedError" });
+      await expect(pending).resolves.toMatchObject({ done: true });
+    } finally {
+      await reader?.cancel().catch(() => undefined);
+      interval.mockRestore();
+    }
+  });
+
+  test("selection stream discards frames queued before revocation instead of draining them", async () => {
+    const { ctx, state, token } = selectionSessionFixture();
+    const interval = spyOn(globalThis, "setInterval");
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    try {
+      const response = await handleOauthAccountRoutes(ctx);
+      expect(response?.status).toBe(200);
+      reader = response!.body!.getReader();
+      expect(new TextDecoder().decode((await reader.read()).value)).toContain("event: ready");
+      // No pending read: this event stays queued in the controller when the session expires.
+      publishAccountSelection("queued-provider", "oauth");
+      state.sessions.get(token)!.expiresAt = Date.now() - 1;
+      const tick = interval.mock.calls.find(call => call[1] === 15_000)?.[0];
+      if (typeof tick !== "function") throw new Error("selection heartbeat not registered");
+      tick();
+      // A non-empty queue still takes the error path: the queued frame is discarded and the
+      // revoked consumer rejects instead of ever draining it.
+      await expect(reader.read()).rejects.toMatchObject({ name: "NotAllowedError" });
     } finally {
       await reader?.cancel().catch(() => undefined);
       interval.mockRestore();


### PR DESCRIPTION
## Summary

Closes #4069.

Since v2.47.0, an expired dashboard session left the account-selection event stream erroring with a `NotAllowedError` DOMException on its next send — including the 15-second heartbeat — and Bun prints every errored response stream to the server console, so the console filled with repeated DOMException dumps.

`controller.error()` is not incidental: it is the mechanism that discards frames already queued before revocation, so a revoked consumer cannot drain them. That contract is preserved. The stream now discriminates on queue state: with a non-empty queue it still errors and discards; with an empty queue — the common expired-session path, including every post-expiry heartbeat — it closes quietly, pending reads resolve `done`, and there is no error for Bun to dump.

The dashboard consumer treats a clean EOF and a stream error identically (same retry-with-backoff path, then quiet 401 on re-admission), so reconnect behavior is unchanged. Admission 401 and per-frame revalidation are unchanged.

The queue watermark is a named constant shared by the stream options and the check, so a future watermark change cannot mis-classify a non-empty queue.

**Security review:** this touches the management-session revocation path (src/server/management/). The revocation discard contract is preserved and now directly test-covered; per MAINTAINERS.md this still warrants explicit security review before merge.

## Verification

- Head: 589daec52b5ec7992678e8e9ef642218db65d8af, based on `dev` 8026405d9a527085b3c972dc8630abf8fe3b0441.
- Remote GitHub Actions on the exact head: 25 checks pass, 0 fail, 2 dispatch-only skips: main run https://github.com/lidge-jun/opencodex/actions/runs/34323955157 (Linux shards, macOS, gates incl. typecheck + privacy scan, keyring, npm-global, storage policy, api usage, docker smoke); enforce-target/hygiene/label all pass.
- Regression coverage (runs in CI): the logout/expiry and heartbeat liveness tests now assert the quiet close; a new negative test queues a frame before revocation and proves it is discarded (reader rejects, payload never delivered).
- Independent read-only design audit (Grok): queue-empty ⟺ desiredSize equals the watermark (verified including the pending-read case); both branches preserve no-drain-after-revocation; only the two updated tests depended on the old rejection; the dashboard treats EOF and error the same. Verdict: GO-WITH-FIXES, one blocker folded (named watermark constant).
- Local suite, typecheck, and privacy scan: NOT RUN (local execution restricted in the preparing environment); the remote jobs provide this evidence.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
