### PR TITLE
fix(readme): show the OrcaRouter sponsor logo on every branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [SPONSORS.md](./SPONSORS.md).
 <table>
 <tbody>
 <tr>
-<td width="180"><a href="https://www.orcarouter.ai/?utm_source=opencodex&utm_medium=readme"><img src="https://raw.githubusercontent.com/lidge-jun/opencodex/main/assets/sponsors/orcarouter.png" alt="OrcaRouter" width="150"></a></td>
+<td width="180"><a href="https://www.orcarouter.ai/?utm_source=opencodex&utm_medium=readme"><img src="assets/sponsors/orcarouter.png" alt="OrcaRouter" width="150"></a></td>
 <td>Thanks to <a href="https://www.orcarouter.ai/?utm_source=opencodex&utm_medium=readme">OrcaRouter</a> for sponsoring this project! OrcaRouter is one OpenAI-compatible AI gateway for production AI: adaptive routing that grades every prompt and sends it to the model that clears your bar, automatic failover, routing rules as code, zero-markup provider pricing with prompt caching, and guardrails, an agent firewall, and request logs on every call across 200+ models. Pick <code>OrcaRouter</code> in the Add provider picker or run <code>ocx provider add orcarouter</code>; <code>orcarouter/auto</code> is the adaptive router.</td>
 </tr>
 </tbody>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "assets/architecture.png",
     "assets/claude-code-models.gif",
     "assets/codex-app-picker.png",
+    "assets/sponsors/orcarouter.png",
     "README.md",
     "SPONSORS.md",
     "AGENTS_INSTALL.md",


### PR DESCRIPTION
## Summary

The OrcaRouter sponsor row loaded its logo from
`raw.githubusercontent.com/lidge-jun/opencodex/main/assets/sponsors/orcarouter.png`. The asset
landed on `dev` in #3914 and only reaches `main` at the next promotion, so anyone reading the
README on `dev` — which is where contributors read it — got a broken image where the sponsor
logo should be. The URL returns HTTP 404 today.

The demo GIF on line 27 already uses a repository-relative `src` for exactly this reason, so the
sponsor logo now does too. A relative path resolves against whichever ref the reader is on, so it
works on `dev`, on `main` after promotion, and in a fork.

`assets/sponsors/orcarouter.png` is also added to the npm `files` list, so the packaged README
carries the logo instead of pointing at a file the tarball does not contain.

## Verification

- `curl` on the old `main` URL returns 404; the same path on the `dev` tree returns 200.
- `bun run privacy:scan` — passed.
- `bun test tests/ci-workflows` — passed.
- Rendered check: the sponsor row on this branch shows the wordmark rather than a broken image.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README sponsor banner to reference the locally bundled image asset.

- **Chores**
  - Included the sponsor banner image in published package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->