### PR TITLE
devlog: name the language on the design-dial fence

### DIFF
--- a/devlog/_plan/260909_usage_custom_range_disclosure/000_plan.md
+++ b/devlog/_plan/260909_usage_custom_range_disclosure/000_plan.md
@@ -10,7 +10,7 @@ Reading this as: a dense local analytics page for a single operator who reads th
 every time and reaches for an explicit interval rarely, in the quiet utilitarian language the rest
 of the dashboard already speaks. Tokens come from `gui/src/styles.css`; nothing new is invented.
 
-```
+```text
 DESIGN_VARIANCE: 3
 MOTION_INTENSITY: 1
 Product density profile: D5


### PR DESCRIPTION
## Summary

- CodeRabbit flagged MD040 on the design-dial fence in `devlog/_plan/260909_usage_custom_range_disclosure/000_plan.md`, added in #4093. The block is plain configuration-style text, so the fence now says `text`.
- Documentation only. No source, test, workflow or locale file is touched.

## Verification

- One-character-class docs change with no code path: no test covers a devlog fence, and the repository gates (`hygiene`, `enforce-target`, `gates`) run on this head.
- Local suite runs are disallowed for this task by the maintainer, so `bun run test` is **NOT RUN** locally; remote CI on this head is the evidence.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved syntax highlighting for a Design read section code block by identifying it as plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->