### PR TITLE
fix(auth): retain stored sidecar auth for caller-auth Chat

### DIFF
--- a/src/server/chat-completions.ts
+++ b/src/server/chat-completions.ts
@@ -258,9 +258,9 @@ async function handleChatCompletionsWithBudget(
     const value = req.headers.get(name);
     if (value) headers.set(name, value);
   }
-  // Never enrich a caller-auth transport with a credential from another domain.
-  // Later shadow/thread rewrites strip credentials at the actual Responses boundary.
-  if (!callerAuthorizationRoute) {
+  // A noncanonical caller-auth route can use stored main auth only through a sidecar snapshot.
+  // Later shadow/thread rewrites strip primary credentials at the actual Responses boundary.
+  if (!callerAuthorizationRoute || (settledRoute && !isCanonicalOpenAiForwardProvider(settledRoute.provider))) {
     // This enrichment is optional for routed/non-main providers. If native main
     // is fenced, omit it and let auth-context reject only a final physical-main
     // selection while healthy pool/provider routes continue.
@@ -271,7 +271,7 @@ async function handleChatCompletionsWithBudget(
         if (token) {
           const mainHeaders = new Headers({ authorization: `Bearer ${token.accessToken}`, "chatgpt-account-id": token.chatgptAccountId });
           openAiSidecarAuth ??= captureExplicitOpenAiCallerAuth(mainHeaders, config);
-          if (!routeMayChangeCredentialDomain) {
+          if (!callerAuthorizationRoute && !routeMayChangeCredentialDomain) {
             headers.set("authorization", `Bearer ${token.accessToken}`);
             headers.set("chatgpt-account-id", token.chatgptAccountId);
           }

--- a/tests/codex-integration/bearer-admission-routed-provider.test.ts
+++ b/tests/codex-integration/bearer-admission-routed-provider.test.ts
@@ -440,7 +440,8 @@ describe("bearer admission is not reused as a Cursor upstream credential", () =>
         adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex",
         authMode: "forward", codexAccountMode: "direct",
       };
-      config.visionSidecar = { enabled: true, backend: "openai", model: "gpt-5.4-mini" };
+      // Keep this auth fixture independent of the legacy sidecar model migration.
+      config.visionSidecar = { enabled: true, backend: "openai", model: "gpt-5.6-luna" };
       saveConfig(config);
       const stored = fakeChatGptJwt({ chatgpt_account_id: "stored_main_acc", exp: Math.floor(Date.now() / 1000) + 3600 });
       writeFileSync(join(codexHome, "auth.json"), JSON.stringify({

--- a/tests/codex-integration/bearer-admission-routed-provider.test.ts
+++ b/tests/codex-integration/bearer-admission-routed-provider.test.ts
@@ -19,6 +19,7 @@ import type { OcxConfig } from "../../src/types";
 import { ownedServiceHomeInspection } from "../helpers/owned-service-home-inspection";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 import { fakeChatGptJwt } from "../helpers/fake-chatgpt-jwt";
+import { resetVisionDescriptionCache } from "../../src/vision";
 
 /**
  * Issue #2132: bearer admission must not require a stored ChatGPT credential.
@@ -151,6 +152,7 @@ async function withCursorCaptureServer<T>(
 }
 
 beforeEach(() => {
+  resetVisionDescriptionCache();
   clearComboTargetCooldowns();
   resetSubagentModelFallbackStateForTests();
   delete process.env.OPENCODEX_CURSOR_TEST_TOKEN;
@@ -186,6 +188,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  resetVisionDescriptionCache();
   closeRequestHistoryIndex();
   clearComboTargetCooldowns();
   resetSubagentModelFallbackStateForTests();
@@ -426,6 +429,60 @@ describe("bearer admission is not reused as a Cursor upstream credential", () =>
       } finally {
         await server.stop(true);
       }
+    });
+  });
+
+  test.each(["owned", "fenced"])("Chat Cursor keeps stored vision auth off its primary wire (%s)", async ownership => {
+    await withCursorCaptureServer(async (baseUrl, capturedAuth) => {
+      const config = cursorForwardConfig(baseUrl);
+      config.providers.cursorcustom!.noVisionModels = ["auto"];
+      config.providers.openai = {
+        adapter: "openai-responses", baseUrl: "https://chatgpt.com/backend-api/codex",
+        authMode: "forward", codexAccountMode: "direct",
+      };
+      config.visionSidecar = { enabled: true, backend: "openai", model: "gpt-5.4-mini" };
+      saveConfig(config);
+      const stored = fakeChatGptJwt({ chatgpt_account_id: "stored_main_acc", exp: Math.floor(Date.now() / 1000) + 3600 });
+      writeFileSync(join(codexHome, "auth.json"), JSON.stringify({
+        tokens: { access_token: stored, account_id: "stored_main_acc" },
+      }));
+      const sidecar: Array<{ authorization: string | null; account: string | null; claimed: boolean }> = [];
+      globalThis.fetch = (async (input, init) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        if (url.hostname === "chatgpt.com") {
+          const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
+          sidecar.push({ authorization: headers.get("authorization"), account: headers.get("chatgpt-account-id"),
+            claimed: getNativeMainProfileRequestCount() > 0 });
+          return new Response(`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "A red square." })}\n\ndata: [DONE]\n\n`, {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+      const server = ownership === "owned" ? await startOwnedServer() : startServer(0, {
+        inspectNativeCodexOwnership: () => ({ ownership: "foreign", reason: "fixture owned by another service" }),
+      });
+      try {
+        if (ownership === "fenced") expect(await waitForNativeMainStartupGate()).toMatchObject({ status: "blocked" });
+        const response = await originalFetch(new URL("/v1/chat/completions", server.url), {
+          method: "POST",
+          headers: { "content-type": "application/json", "x-opencodex-api-key": ADMISSION_SECRET,
+            authorization: "Bearer cursor-upstream-token" },
+          body: JSON.stringify({ model: "cursorcustom/auto", stream: false, messages: [{ role: "user", content: [
+            { type: "text", text: "Describe this image" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,aGVsbG8taW1hZ2UtYnl0ZXM=" } },
+          ] }] }),
+        });
+        await response.text();
+        // The capture-only Cursor fixture ends without a completion frame.
+        expect(response.status).toBe(502);
+        expect(sidecar).toEqual(ownership === "owned"
+          ? [{ authorization: `Bearer ${stored}`, account: "stored_main_acc", claimed: true }] : []);
+        expect(capturedAuth).toEqual(["Bearer cursor-upstream-token"]);
+      } finally {
+        await server.stop(true);
+      }
+      expect(getNativeMainProfileRequestCount()).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

Restore stored OpenAI sidecar authentication for an unchanged keyless, non-OAuth Cursor Chat route. A request using its own Cursor bearer skipped the entire optional native-main claim, leaving a Direct OpenAI vision/search sidecar without the stored login.

Claim and capture the stored main credential into the existing sidecar-only snapshot for this route. Primary headers keep the independent Cursor bearer, and the caller Direct snapshot remains caller-owned. A native-main ownership fence still suppresses the sidecar while allowing the Cursor request.

This is a two-file child of #4102 and targets its carry branch so the maintainer can review or integrate the delta directly. It addresses the stored-sidecar finding linked from #4081. The parent's explicit 401 behavior for duplicated proxy credentials is unchanged. Existing authentication documentation already requires a turn claim for optional stored-main sidecar enrichment; this correction restores that documented behavior.

## Verification

- Current parent: `3af5402bcc471a4b9f7a8ba9b6dc67b36464eab0`; child head: `4a201df671bf69c83be1c8da736dd33ec245e214`; Bun 1.4.2. The parent added three-state ChatGPT-domain classification and malformed-marker/payload guards after the first child validation. Rebases were conflict-free and `git range-diff` confirmed both child commits retained identical patches. The fixture pins the model already selected by startup migration, avoiding that unrelated config write.
- Regression baseline: the owned-main case failed because no sidecar request occurred; the ownership-fenced case passed.
- The new wire regression checks the stored JWT/account and active main claim at the vision sidecar, the independent caller bearer at the real HTTP/2 Cursor capture server, and claim release after completion. The capture fixture intentionally ends without a completion frame; its expected endpoint result is HTTP 502, while the assertions verify both credential destinations.
- On parent `bf8f36f7`, the complete bearer-admission and Chat endpoint suites passed **147 tests / 452 assertions** in 185.82s. After the fixture correction, both owned/fenced cases passed again (**2 tests / 9 assertions**). On parent `7939ff3e`, the complete bearer suite passed **47 tests / 163 assertions** in 133.55s, including all added malformed-marker cases.
- On final parent `3af5402b`, the affected unmarked-JWT, Direct-restore matrix, and stored-sidecar cases passed **18 tests / 60 assertions** in 40.08s. A direct inspector probe also verified that number, boolean, string, null, and array payloads do not throw, while a malformed reserved namespace remains invalid. Typecheck, privacy scan, and diff check passed on this head. [Full current-head cross-platform CI](https://github.com/luvs01/opencodex/actions/runs/34339651388) passed **26/26 jobs** on `4a201df671bf69c83be1c8da736dd33ec245e214`, including all Windows shards and macOS control; earlier runs remain tied to their previous heads.
- The previous child `135df7396e95b4984bc85708ebd209fa6aae689b` on parent `545a8e46` passed 143 tests / 434 assertions and [26/26 full CI jobs](https://github.com/luvs01/opencodex/actions/runs/34333608665). Those results are previous-parent evidence, not a claim that the new-head CI has passed.
- Typecheck, privacy scan and diff checks passed. Independent source review found no blocking issue in the two-file delta.
- CodeRabbit completed the `d5cf0474` review and identified the fixture's legacy model migration. [That finding is fixed and resolved](https://github.com/lidge-jun/opencodex/pull/4103#discussion_r3967065705); there are no unresolved child review threads. [CodeRabbit completed the current-head review](https://github.com/lidge-jun/opencodex/pull/4103#issuecomment-5599426542) with no actionable comments. The child is ready for maintainer review and integration into #4102; the original #4081 finding remains open until integration is verified.
- All credentials and servers are synthetic and isolated.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed; the existing documented claim/snapshot contract is restored.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults; maintainer review remains required.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authorization handling for routed chat requests, preventing stored credentials from being sent directly when caller-provided authorization is in use.
  - Ensured caller authorization remains isolated to the primary request while permitted vision processing uses the appropriate stored credentials.
  - Prevented vision processing requests for profiles that are not authorized to use them.
  - Preserved correct request accounting after routed chat and vision processing completes.
  - Added coverage for routed requests using separate caller and stored credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
