### PR TITLE
fix(codex): report operator-owned root routing truthfully

### DIFF
--- a/src/codex/inject.ts
+++ b/src/codex/inject.ts
@@ -1430,7 +1430,7 @@ export async function injectCodexConfig(
   const historyMessage =
     keepRootOverrideAlongsideTable
       ? (keptUserBaseUrl
-        ? `  Codex resume history: left unchanged; threads already tagged openai follow your own root openai_base_url, not the proxy.\n`
+        ? `  Codex resume history: left unchanged; threads already tagged openai follow your configured root openai_base_url.\n`
         : `  Codex resume history: left unchanged; existing threads keep reaching the proxy through the retained openai_base_url override.\n`)
       : config?.syncResumeHistory === false
       ? `  Codex resume history: left unchanged (syncResumeHistory=false).\n`
@@ -1447,6 +1447,7 @@ export async function injectCodexConfig(
   // The client-compaction form writes a provider table as well, so "nothing was injected" would
   // misdescribe the file it just produced: new threads do use the injected table. Report that
   // mixed result on its own terms, and never tell the operator to delete a setting of theirs.
+  // Ownership alone says nothing about destination: their line may already target this proxy.
   if (keptUserBaseUrl && keepRootOverrideAlongsideTable) {
     return {
       success: true,
@@ -1459,7 +1460,7 @@ export async function injectCodexConfig(
         managedDefaultsMessage +
         `  New threads use the injected opencodex provider and route through the proxy.\n` +
         `  Threads already tagged openai resolve through Codex's built-in provider, which your root openai_base_url points at.\n` +
-        `  Remove that line and rerun 'ocx start' only if you want those threads on the proxy too.\n` +
+        `  No root URL change is required to enable client-side compaction for new threads.\n` +
         `  Fallback: codex --profile opencodex (same behavior)`,
     };
   }

--- a/structure/02_config-and-codex-home.md
+++ b/structure/02_config-and-codex-home.md
@@ -360,6 +360,12 @@ explicitly runs legacy OpenAI recovery. A user-owned root `openai_base_url` is p
 overwritten, and that case also blocks managed sub-agent defaults rather than fighting the user for
 ownership.
 
+Client-compaction mode can retain that user-owned root URL alongside an injected provider table.
+Its status must distinguish ownership from destination: an unmarked user-owned line may already
+point to this proxy. Report that existing `openai` threads follow the configured root URL and new
+threads use the injected table, without inferring a foreign endpoint or prescribing URL removal.
+This diagnostic distinction does not change URL ownership, journal entries, or session history.
+
 **API auth header (non-loopback).** The built-in `openai` provider cannot carry the
 `x-opencodex-api-key` env header, so this form re-tags the root provider and appends the table:
 

--- a/tests/codex-integration/codex-inject-integration.test.ts
+++ b/tests/codex-integration/codex-inject-integration.test.ts
@@ -934,7 +934,33 @@ describe("injectCodexConfig integration (Design B)", () => {
     expect(message).not.toContain("Codex routing NOT injected");
     expect(message).not.toContain("remove your openai_base_url line");
     expect(message).toContain("left exactly as you set it");
-    expect(message).toContain("follow your own root openai_base_url, not the proxy");
+    expect(message).toContain("follow your configured root openai_base_url");
+    expect(message).not.toContain("not the proxy");
+    expect(message).not.toContain("Remove that line");
+  });
+
+  test("client compaction does not mistake a user-owned proxy URL for a foreign destination (#4110)", () => {
+    // The URL equals the target but lacks our marker: keep ownership separate from destination.
+    const rootLine = 'openai_base_url = "http://127.0.0.1:10100/v1"';
+    writeFileSync(join(codexHome, "config.toml"), `${rootLine}\nmodel = "gpt-5.5"\n`, "utf8");
+
+    const enabled = runInject(codexHome, ocxHome, JSON.stringify({ codexClientCompaction: true }));
+    expect(enabled.status).toBe(0);
+    const config = readFileSync(join(codexHome, "config.toml"), "utf8");
+    expect(config).toContain(rootLine);
+    expect(config.match(/openai_base_url/g)?.length).toBe(1);
+    expect(config).toContain('model_provider = "opencodex"');
+    expect(config).toContain("[model_providers.opencodex]");
+    const journal = JSON.parse(readFileSync(join(codexHome, "opencodex-journal.json"), "utf8"));
+    expect(journal.injectedOpenaiBaseUrl).toBeNull();
+
+    const message = String(JSON.parse(enabled.stdout).message);
+    expect(message).toContain("Injected opencodex as default provider");
+    expect(message).toContain("left exactly as you set it");
+    expect(message).toContain("follow your configured root openai_base_url");
+    expect(message).not.toContain("not the proxy");
+    expect(message).not.toContain("Remove that line");
+    expect(message).not.toContain("Codex routing NOT injected");
   });
 
   test("the managed override keeps reporting proxy routing for existing threads", () => {


### PR DESCRIPTION
## Summary

Closes #4110.

An operator-owned, unmarked root `openai_base_url` can already point at the OCX proxy. The client-compaction status output incorrectly asserted that existing threads were "not the proxy" and advised removing that line. Ownership is not destination.

- Describe existing threads as following the configured root URL without guessing its destination.
- Keep the new-thread compaction guidance accurate without advising deletion of operator configuration.
- Add matching-target regression assertions and update the config/home structure contract.

This changes status text only: URL ownership, configuration writes, journal ownership, history handling, routing, and the managed-root positive control remain unchanged.

## Verification

- Base: `b5c98333ff9a01c54172efd105516a34743bd9f3`.
- Head: `9c9207c11041d2c9ae1aeab45821ce7890e65d3e`.
- `git diff --check`: passed.
- Source inspection: both differing and matching operator URLs are covered by assertions; matching-target test retains exactly one root line and null journal ownership.
- Product tests, typecheck, and build: **NOT RUN**. The available local Bun is 1.3.14 versus the repository's 1.4.2; an attempted credential-free sandbox setup failed before Bun execution. No product test code ran, and no installed runtime or protected configuration was changed.
- Exact-head hosted Cross-platform CI completed successfully: https://github.com/lidge-jun/opencodex/actions/runs/34347952320 at `9c9207c11041d2c9ae1aeab45821ce7890e65d3e`. Enabled Linux/macOS product shards and gates passed; conditional skipped Windows shards are not claimed as passed tests. Local product tests remain NOT RUN as disclosed above.
- Ready for independent review; @lidge-jun approval remains outstanding. No merge or release action has been performed.

@lidge-jun please independently review this narrow factual status correction. No merge or release action is requested before those checks.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No authentication, destination selection, or persistence behavior is changed.
- [x] Exact-head hosted product verification is complete for the enabled CI lanes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved client-compaction status messages to accurately distinguish user-owned root URLs from provider destinations.
  - No longer suggests removing a user-configured root URL when client-side compaction is enabled.
  - Correctly handles user-owned URLs that match the proxy URL without misidentifying them as externally configured destinations.

- **Documentation**
  - Clarified client-compaction behavior and URL ownership in the configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->