### PR TITLE
fix(openai-chat): normalize oversized inline images before they reach the wire

### DIFF
--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -916,6 +916,7 @@
     "openai-chat-dangling-toolcalls.test.ts": "adapters/openai",
     "openai-chat-eof.test.ts": "adapters/openai",
     "openai-chat-hardening.test.ts": "adapters/openai",
+    "openai-chat-image-normalization.test.ts": "adapters/openai",
     "openai-chat-invalid-tool-call-diagnostics.test.ts": "adapters/openai",
     "openai-chat-model-suffix.test.ts": "adapters/openai",
     "openai-chat-native-policy.test.ts": "adapters/openai",

--- a/src/adapters/anthropic-image-normalize.ts
+++ b/src/adapters/anthropic-image-normalize.ts
@@ -68,6 +68,14 @@ export interface NormalizeTarget {
   mediaType: string;
   replace(data: string, mediaType: string): void;
   drop(note: string): void;
+  /**
+   * True when `drop` leaves the original bytes on the wire instead of removing or
+   * textifying them (openai-chat, which has no downstream guard that could re-attach a
+   * dropped image). The core normally stops counting a dropped target, which is correct
+   * only when the bytes actually leave. Here they do not, so those bytes keep counting
+   * toward the budget and the demotion loop keeps shrinking the images it still can.
+   */
+  retainsBytesOnDrop?: boolean;
 }
 
 export interface NormalizeTargetsOptions extends NormalizeOptions {
@@ -127,11 +135,17 @@ export async function normalizeImageTargets(targets: NormalizeTarget[], options:
       if (newestFirstIndex >= processLimit) continue;
       if (b64.length > MAX_INPUT_BASE64_LENGTH) {
         target.drop(BOMB_TEXT);
+        if (target.retainsBytesOnDrop) {
+          entries[i] = { target, sourceB64: b64, sourceMedia: target.mediaType.toLowerCase(), pos: TERMINAL_POS, size: b64.length, done: true };
+        }
         continue;
       }
       const dims = sniffImageDimensions(b64);
       if (dims && dims.width * dims.height > MAX_INPUT_PIXELS) {
         target.drop(BOMB_TEXT);
+        if (target.retainsBytesOnDrop) {
+          entries[i] = { target, sourceB64: b64, sourceMedia: target.mediaType.toLowerCase(), pos: TERMINAL_POS, size: b64.length, done: true };
+        }
         continue;
       }
       const sourceMedia = target.mediaType.toLowerCase();
@@ -139,6 +153,9 @@ export async function normalizeImageTargets(targets: NormalizeTarget[], options:
       const result = await processAt(b64, pos, sourceMedia, encode, validate);
       if (result.kind === "failed") {
         target.drop(UNDECODABLE_TEXT);
+        if (target.retainsBytesOnDrop) {
+          entries[i] = { target, sourceB64: b64, sourceMedia, pos: TERMINAL_POS, size: b64.length, done: true };
+        }
         continue;
       }
       let size = b64.length;
@@ -178,8 +195,14 @@ export async function normalizeImageTargets(targets: NormalizeTarget[], options:
     const result = await processAt(entry.sourceB64, entry.pos + 1, entry.sourceMedia, encode, validate);
     if (result.kind === "failed") {
       entry.target.drop(UNDECODABLE_TEXT);
-      sum -= entry.size;
-      entries[entries.indexOf(entry)] = null;
+      if (entry.target.retainsBytesOnDrop) {
+        // Bytes stay on the wire, so they stay in the total; mark it terminal so the
+        // loop moves on to a target it can still shrink instead of retrying this one.
+        entry.done = true;
+      } else {
+        sum -= entry.size;
+        entries[entries.indexOf(entry)] = null;
+      }
       continue;
     }
     let newSize = entry.size;

--- a/src/adapters/anthropic-image-normalize.ts
+++ b/src/adapters/anthropic-image-normalize.ts
@@ -225,6 +225,11 @@ export async function normalizeImageTargets(targets: NormalizeTarget[], options:
       const e = entries[i];
       if (!e) continue;
       e.target.drop(OVERFLOW_DROP_TEXT);
+      if (e.target.retainsBytesOnDrop) {
+        // The drop left the bytes in place, so they still count and dropping another
+        // copy of this target would not help. Move on to one that can actually leave.
+        continue;
+      }
       sum -= e.size;
       entries[i] = null;
     }

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -15,8 +15,8 @@ export interface IncomingMeta {
   providerFetch?: typeof globalThis.fetch;
   /**
    * Image-normalization ladder bias for upstream-413 tightened retries: every image
-   * starts one tier lower (devlog/260714_image_normalization_pipeline/030). Only the
-   * anthropic adapter consumes it; others ignore it.
+   * starts one tier lower (devlog/260714_image_normalization_pipeline/030). Consumed by
+   * the anthropic and openai-chat adapters; others ignore it.
    */
   imageTierBias?: number;
 }

--- a/src/adapters/mimo-free.ts
+++ b/src/adapters/mimo-free.ts
@@ -225,7 +225,7 @@ export function createMimoFreeAdapter(provider: OcxProviderConfig): ProviderAdap
 
       // Let the base adapter build the wire body (handles reasoning, tools, etc.)
       // but override the URL and headers after.
-      const baseReq = base.buildRequest(parsed, incoming) as AdapterRequest;
+      const baseReq = await base.buildRequest(parsed, incoming);
       const baseBody = JSON.parse(baseReq.body as string) as unknown;
       const markedBody = injectMimoSystemMarker(baseBody);
 

--- a/src/adapters/openai-chat-images.ts
+++ b/src/adapters/openai-chat-images.ts
@@ -1,0 +1,96 @@
+import { parseDataUrl } from "./image";
+import {
+  normalizeImageTargets,
+  type NormalizeOptions,
+  type NormalizeTarget,
+} from "./anthropic-image-normalize";
+
+/**
+ * Keep inline image payloads under the chat-completions request ceiling that several
+ * OpenAI-compatible providers enforce as a raw byte limit on the serialized body.
+ * GitHub Copilot rejects at roughly 5.2MB with a bare 413 and no diagnostic body, and
+ * nothing downstream of this adapter can shrink a request once it has been built.
+ *
+ * Only data URLs are touched. Remote URLs carry no base64 weight here because request
+ * construction never fetches them.
+ */
+export const OPENAI_CHAT_IMAGE_BASE64_BUDGET = 3_670_016; // 3.5MiB
+
+export interface NormalizeOpenAIChatImagesOptions
+  extends Pick<NormalizeOptions, "encode" | "tierBias" | "validate"> {}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function forEachImagePart(
+  messages: unknown,
+  visit: (imageUrl: Record<string, unknown>, url: string) => boolean | void,
+): void {
+  if (!Array.isArray(messages)) return;
+  for (const message of messages) {
+    if (!isRecord(message) || !Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (!isRecord(part) || part.type !== "image_url" || !isRecord(part.image_url)) continue;
+      const imageUrl = part.image_url;
+      if (typeof imageUrl.url !== "string") continue;
+      if (visit(imageUrl, imageUrl.url) === false) return;
+    }
+  }
+}
+
+/**
+ * Whether this turn carries inline image bytes worth normalizing. The adapter uses this
+ * to stay synchronous for text-only turns, which is every turn on most providers.
+ */
+export function hasShrinkableOpenAIChatImages(messages: unknown): boolean {
+  let total = 0;
+  let found = false;
+  forEachImagePart(messages, (_imageUrl, url) => {
+    const source = parseDataUrl(url);
+    if (!source) return;
+    total += source.base64.length;
+    if (total > OPENAI_CHAT_IMAGE_BASE64_BUDGET) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+}
+
+/**
+ * Normalize image_url parts in already-built Chat Completions messages, in place.
+ *
+ * The drop callback deliberately keeps the original URL. The shared normalizer calls
+ * drop for corrupt or decode-bomb inputs, and this wire has no downstream guard that
+ * would re-attach a dropped image, so dropping here would silently lose a user's
+ * screenshot. Terminal-size overflow uses overflowAction "none" for the same reason:
+ * an image floored at 320px stays attached rather than being removed.
+ */
+export async function normalizeOpenAIChatImages(
+  messages: unknown,
+  options: NormalizeOpenAIChatImagesOptions = {},
+): Promise<void> {
+  const targets: NormalizeTarget[] = [];
+  forEachImagePart(messages, (imageUrl, url) => {
+    const source = parseDataUrl(url);
+    if (!source) return;
+    targets.push({
+      base64: source.base64,
+      mediaType: source.mediaType,
+      replace: (data: string, mediaType: string) => {
+        imageUrl.url = `data:${mediaType};base64,${data}`;
+      },
+      drop: () => {
+        // Preserve the original image URL when it cannot be normalized.
+      },
+    });
+  });
+  if (targets.length === 0) return;
+
+  await normalizeImageTargets(targets, {
+    budget: OPENAI_CHAT_IMAGE_BASE64_BUDGET,
+    overflowAction: "none",
+    ...options,
+  });
+}

--- a/src/adapters/openai-chat-images.ts
+++ b/src/adapters/openai-chat-images.ts
@@ -19,10 +19,15 @@ export const OPENAI_CHAT_IMAGE_BASE64_BUDGET = 3_670_016; // 3.5MiB
 export interface NormalizeOpenAIChatImagesOptions
   extends Pick<NormalizeOptions, "encode" | "tierBias" | "validate"> {}
 
+/** Whether `value` is a plain object, so message and part shapes can be walked safely. */
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * Walk every well-formed `image_url` part in a Chat Completions message array, ignoring
+ * malformed shapes rather than throwing on them. Returning false from `visit` stops the walk.
+ */
 function forEachImagePart(
   messages: unknown,
   visit: (imageUrl: Record<string, unknown>, url: string) => boolean | void,

--- a/src/adapters/openai-chat-images.ts
+++ b/src/adapters/openai-chat-images.ts
@@ -84,6 +84,10 @@ export async function normalizeOpenAIChatImages(
       drop: () => {
         // Preserve the original image URL when it cannot be normalized.
       },
+      // The drop above is a no-op, so these bytes are still on the wire and must keep
+      // counting against the budget. Without this the core would stop counting them and
+      // the demotion loop could stop early, shipping a body that is still oversized.
+      retainsBytesOnDrop: true,
     });
   });
   if (targets.length === 0) return;

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1456,6 +1456,11 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
       lastRequestedModelId = parsed.modelId;
       const { url, headers, hasCredential } = openAIChatTransport(provider);
       const messages = frameAgentRouterMessages(provider.baseUrl, messagesToChatFormat(parsed, provider));
+      /**
+       * Build the wire request from `messages` as they stand. Called directly for the
+       * synchronous path, or after image normalization has rewritten `messages` in place.
+       * Everything after message construction lives here so both paths share one body.
+       */
       const finish = (): AdapterRequest => {
         const tools = toolsToChatFormatForProvider(parsed, provider);
         const toolChoice = toolChoiceToChatFormat(parsed.options.toolChoice, parsed.context.tools, provider);

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1,4 +1,4 @@
-import type { AdapterRequest, ProviderAdapter } from "./base";
+import type { AdapterRequest, IncomingMeta, ProviderAdapter } from "./base";
 import type { AdapterEvent, OcxAssistantMessage, OcxContentPart, OcxMessage, OcxParsedRequest, OcxProviderConfig, OcxTextContent, OcxThinkingContent, OcxToolCall, OcxUsage } from "../types";
 import { isAllowedToolChoice, modelInList, namespacedToolName, resolveToolChoiceWireName, toolChoiceToolPredicate } from "../types";
 import { mapReasoningEffort, modelRecordValue } from "../reasoning-effort";
@@ -40,6 +40,7 @@ import {
   TRANSLATOR_MAX_SSE_EVENT_BYTES,
   type TranslatorBudget,
 } from "../lib/translator-budget";
+import { hasShrinkableOpenAIChatImages, normalizeOpenAIChatImages } from "./openai-chat-images";
 
 // Providers may opt into stripping one trailing "[...]" group from the wire model id.
 // Z.AI needs this because its OpenAI path rejects glm-5.2[1m] with 400 code 1211;
@@ -1445,202 +1446,216 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
 
     formatErrorBody: formatOpenAIChatErrorBody,
 
-    buildRequest(parsed: OcxParsedRequest) {
+    /**
+     * Synchronous unless the turn actually carries an inline image the provider would
+     * reject on size. base.ts already allows a promise return and every routed caller
+     * awaits it, but many direct callers depend on the synchronous shape, and turning
+     * every text-only turn into a promise would change their timing for no benefit.
+     */
+    buildRequest(parsed: OcxParsedRequest, incoming?: IncomingMeta) {
       lastRequestedModelId = parsed.modelId;
       const { url, headers, hasCredential } = openAIChatTransport(provider);
       const messages = frameAgentRouterMessages(provider.baseUrl, messagesToChatFormat(parsed, provider));
-      const tools = toolsToChatFormatForProvider(parsed, provider);
-      const toolChoice = toolChoiceToChatFormat(parsed.options.toolChoice, parsed.context.tools, provider);
+      const finish = (): AdapterRequest => {
+        const tools = toolsToChatFormatForProvider(parsed, provider);
+        const toolChoice = toolChoiceToChatFormat(parsed.options.toolChoice, parsed.context.tools, provider);
 
-      const body: Record<string, unknown> = {
-        model: provider.modelSuffixBracketStrip ? stripBracketedModelSuffix(parsed.modelId) : parsed.modelId,
-        messages,
-        stream: parsed.stream,
-      };
-      // A policy-produced canonical decision has already passed capability validation. Without
-      // that decision, a canonical caller value still requires an explicit true capability;
-      // unclassified Chat routes remain behind the caller-forwarding opt-in.
-      const serviceTier = parsed.options.serviceTier;
-      const tierDecision = parsed.options.tierDecision;
-      const canSerializeServiceTier = canSerializeOpenAIChatServiceTier(
-        provider,
-        parsed.modelId,
-        serviceTier,
-        tierDecision,
-      );
-      if (canSerializeServiceTier && serviceTier !== undefined) {
-        body.service_tier = serviceTier;
-      }
-      if (modelInList(provider.reasoningSplitModels, parsed.modelId)) body.reasoning_split = true;
-      const maxTokens = resolveMaxTokens(provider, parsed);
-      const openRouterRouting = resolveOpenRouterRouting(provider, parsed.modelId);
-      if (openRouterRouting) body.provider = openRouterProviderPayload(openRouterRouting);
-      const vercelRouting = resolveVercelGatewayRouting(provider, parsed.modelId);
-      if (vercelRouting) body.provider = vercelGatewayProviderPayload(vercelRouting);
-      if (tools) body.tools = tools;
-      if (tools && toolChoice !== undefined) {
-        body.tool_choice = modelInList(provider.autoToolChoiceOnlyModels, parsed.modelId)
-          ? (toolChoice === "none" ? "none" : "auto")
-          : toolChoice;
-      }
-      if (maxTokens !== undefined) body.max_tokens = maxTokens;
-      if (parsed.options.temperature !== undefined && !modelInList(provider.noTemperatureModels, parsed.modelId)) {
-        body.temperature = parsed.options.temperature;
-      }
-      if (parsed.options.topP !== undefined && !modelInList(provider.noTopPModels, parsed.modelId)) {
-        body.top_p = parsed.options.topP;
-      }
-      if (parsed.options.stopSequences !== undefined) body.stop = parsed.options.stopSequences;
-      const reasoningDisabled = modelInList(provider.noReasoningModels, parsed.modelId);
-      // Some gateways accept a reasoning-effort field on a plain turn but reject the
-      // effort + tools combination. `noReasoningModels` would fix that only by
-      // stripping reasoning everywhere, costing the model its whole picker. This keeps
-      // the ladder advertised and drops the wire field for tool-bearing requests only.
-      const omitReasoningEffortWithTools = !!tools
-        && modelInList(provider.omitReasoningEffortWithToolsModels, parsed.modelId);
-      const reasoningEffort = omitReasoningEffortWithTools
-        ? undefined
-        : mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning);
-      const nativeOpenAI = isNativeOpenAIChatTarget(provider);
-      let reasoningLog: AdapterRequest["reasoningLog"];
-      if (!reasoningDisabled && !omitReasoningEffortWithTools && provider.reasoningWireFormat === "gateway-object" && parsed.options.reasoning === "none") {
-        if (nativeOpenAI) {
-          body.reasoning_effort = "none";
-          reasoningLog = {
-            effectiveEffort: "none",
-            wireField: "reasoning_effort",
-            wireValue: "none",
-          };
-        } else {
-          body.reasoning = { enabled: false };
-          reasoningLog = {
-            effectiveEffort: "none",
-            wireField: "reasoning.enabled",
-            wireValue: false,
-          };
+        const body: Record<string, unknown> = {
+          model: provider.modelSuffixBracketStrip ? stripBracketedModelSuffix(parsed.modelId) : parsed.modelId,
+          messages,
+          stream: parsed.stream,
+        };
+        // A policy-produced canonical decision has already passed capability validation. Without
+        // that decision, a canonical caller value still requires an explicit true capability;
+        // unclassified Chat routes remain behind the caller-forwarding opt-in.
+        const serviceTier = parsed.options.serviceTier;
+        const tierDecision = parsed.options.tierDecision;
+        const canSerializeServiceTier = canSerializeOpenAIChatServiceTier(
+          provider,
+          parsed.modelId,
+          serviceTier,
+          tierDecision,
+        );
+        if (canSerializeServiceTier && serviceTier !== undefined) {
+          body.service_tier = serviceTier;
         }
-      } else if (reasoningEffort !== undefined) {
-        if (provider.reasoningWireFormat === "gateway-object") {
+        if (modelInList(provider.reasoningSplitModels, parsed.modelId)) body.reasoning_split = true;
+        const maxTokens = resolveMaxTokens(provider, parsed);
+        const openRouterRouting = resolveOpenRouterRouting(provider, parsed.modelId);
+        if (openRouterRouting) body.provider = openRouterProviderPayload(openRouterRouting);
+        const vercelRouting = resolveVercelGatewayRouting(provider, parsed.modelId);
+        if (vercelRouting) body.provider = vercelGatewayProviderPayload(vercelRouting);
+        if (tools) body.tools = tools;
+        if (tools && toolChoice !== undefined) {
+          body.tool_choice = modelInList(provider.autoToolChoiceOnlyModels, parsed.modelId)
+            ? (toolChoice === "none" ? "none" : "auto")
+            : toolChoice;
+        }
+        if (maxTokens !== undefined) body.max_tokens = maxTokens;
+        if (parsed.options.temperature !== undefined && !modelInList(provider.noTemperatureModels, parsed.modelId)) {
+          body.temperature = parsed.options.temperature;
+        }
+        if (parsed.options.topP !== undefined && !modelInList(provider.noTopPModels, parsed.modelId)) {
+          body.top_p = parsed.options.topP;
+        }
+        if (parsed.options.stopSequences !== undefined) body.stop = parsed.options.stopSequences;
+        const reasoningDisabled = modelInList(provider.noReasoningModels, parsed.modelId);
+        // Some gateways accept a reasoning-effort field on a plain turn but reject the
+        // effort + tools combination. `noReasoningModels` would fix that only by
+        // stripping reasoning everywhere, costing the model its whole picker. This keeps
+        // the ladder advertised and drops the wire field for tool-bearing requests only.
+        const omitReasoningEffortWithTools = !!tools
+          && modelInList(provider.omitReasoningEffortWithToolsModels, parsed.modelId);
+        const reasoningEffort = omitReasoningEffortWithTools
+          ? undefined
+          : mapReasoningEffort(provider, parsed.modelId, parsed.options.reasoning);
+        const nativeOpenAI = isNativeOpenAIChatTarget(provider);
+        let reasoningLog: AdapterRequest["reasoningLog"];
+        if (!reasoningDisabled && !omitReasoningEffortWithTools && provider.reasoningWireFormat === "gateway-object" && parsed.options.reasoning === "none") {
           if (nativeOpenAI) {
+            body.reasoning_effort = "none";
+            reasoningLog = {
+              effectiveEffort: "none",
+              wireField: "reasoning_effort",
+              wireValue: "none",
+            };
+          } else {
+            body.reasoning = { enabled: false };
+            reasoningLog = {
+              effectiveEffort: "none",
+              wireField: "reasoning.enabled",
+              wireValue: false,
+            };
+          }
+        } else if (reasoningEffort !== undefined) {
+          if (provider.reasoningWireFormat === "gateway-object") {
+            if (nativeOpenAI) {
+              body.reasoning_effort = reasoningEffort;
+              reasoningLog = {
+                effectiveEffort: reasoningEffort,
+                wireField: "reasoning_effort",
+                wireValue: reasoningEffort,
+              };
+            } else {
+              body.reasoning = { enabled: true, effort: reasoningEffort };
+              reasoningLog = {
+                effectiveEffort: reasoningEffort,
+                wireField: "reasoning.effort",
+                wireValue: reasoningEffort,
+              };
+            }
+          } else if (modelInList(provider.thinkingBudgetModels, parsed.modelId)) {
+            const budget = thinkingBudgetForEffort(parsed, reasoningEffort, maxTokens);
+            if (budget !== undefined) {
+              body.thinking_budget = budget;
+              reasoningLog = {
+                effectiveEffort: parsed.options.reasoning === "minimal" ? "minimal" : reasoningEffort,
+                wireField: "thinking_budget",
+                wireValue: budget,
+              };
+            }
+          } else if (modelInList(provider.thinkingToggleModels, parsed.modelId)) {
+            if (reasoningEffort === "enabled" || reasoningEffort === "disabled" || reasoningEffort === "adaptive") {
+              body.thinking = { type: reasoningEffort };
+              reasoningLog = {
+                effectiveEffort: reasoningEffort,
+                wireField: "thinking.type",
+                wireValue: reasoningEffort,
+              };
+            }
+          } else {
             body.reasoning_effort = reasoningEffort;
             reasoningLog = {
               effectiveEffort: reasoningEffort,
               wireField: "reasoning_effort",
               wireValue: reasoningEffort,
             };
-          } else {
-            body.reasoning = { enabled: true, effort: reasoningEffort };
-            reasoningLog = {
-              effectiveEffort: reasoningEffort,
-              wireField: "reasoning.effort",
-              wireValue: reasoningEffort,
+          }
+        }
+        if (parsed.options.presencePenalty !== undefined && !modelInList(provider.noPenaltyModels, parsed.modelId)) {
+          body.presence_penalty = parsed.options.presencePenalty;
+        }
+        if (parsed.options.frequencyPenalty !== undefined && !modelInList(provider.noPenaltyModels, parsed.modelId)) {
+          body.frequency_penalty = parsed.options.frequencyPenalty;
+        }
+        if (provider.promptCacheKey && parsed.options.promptCacheKey !== undefined) {
+          body.prompt_cache_key = parsed.options.promptCacheKey;
+        }
+        // Structured-output support varies by the physical upstream model even when one
+        // gateway exposes a uniform OpenAI-compatible endpoint. Keep the #1137 translation
+        // as the default, but let an exact model opt out instead of forcing a provider-wide
+        // rollback that would silently return prose for siblings that support JSON Schema.
+        if (!provider.noStructuredOutputModels?.includes(parsed.modelId)) {
+          const textFormat = parsed.options.textFormat;
+          if (textFormat?.type === "json_object") {
+            body.response_format = { type: "json_object" };
+          } else if (textFormat?.type === "json_schema") {
+            body.response_format = {
+              type: "json_schema",
+              json_schema: {
+                name: textFormat.name ?? "response",
+                ...(textFormat.description !== undefined ? { description: textFormat.description } : {}),
+                ...(textFormat.schema !== undefined ? { schema: textFormat.schema } : {}),
+                ...(textFormat.strict !== undefined ? { strict: textFormat.strict } : {}),
+              },
             };
           }
-        } else if (modelInList(provider.thinkingBudgetModels, parsed.modelId)) {
-          const budget = thinkingBudgetForEffort(parsed, reasoningEffort, maxTokens);
-          if (budget !== undefined) {
-            body.thinking_budget = budget;
-            reasoningLog = {
-              effectiveEffort: parsed.options.reasoning === "minimal" ? "minimal" : reasoningEffort,
-              wireField: "thinking_budget",
-              wireValue: budget,
-            };
-          }
-        } else if (modelInList(provider.thinkingToggleModels, parsed.modelId)) {
-          if (reasoningEffort === "enabled" || reasoningEffort === "disabled" || reasoningEffort === "adaptive") {
-            body.thinking = { type: reasoningEffort };
-            reasoningLog = {
-              effectiveEffort: reasoningEffort,
-              wireField: "thinking.type",
-              wireValue: reasoningEffort,
-            };
-          }
-        } else {
-          body.reasoning_effort = reasoningEffort;
-          reasoningLog = {
-            effectiveEffort: reasoningEffort,
-            wireField: "reasoning_effort",
-            wireValue: reasoningEffort,
-          };
         }
-      }
-      if (parsed.options.presencePenalty !== undefined && !modelInList(provider.noPenaltyModels, parsed.modelId)) {
-        body.presence_penalty = parsed.options.presencePenalty;
-      }
-      if (parsed.options.frequencyPenalty !== undefined && !modelInList(provider.noPenaltyModels, parsed.modelId)) {
-        body.frequency_penalty = parsed.options.frequencyPenalty;
-      }
-      if (provider.promptCacheKey && parsed.options.promptCacheKey !== undefined) {
-        body.prompt_cache_key = parsed.options.promptCacheKey;
-      }
-      // Structured-output support varies by the physical upstream model even when one
-      // gateway exposes a uniform OpenAI-compatible endpoint. Keep the #1137 translation
-      // as the default, but let an exact model opt out instead of forcing a provider-wide
-      // rollback that would silently return prose for siblings that support JSON Schema.
-      if (!provider.noStructuredOutputModels?.includes(parsed.modelId)) {
-        const textFormat = parsed.options.textFormat;
-        if (textFormat?.type === "json_object") {
-          body.response_format = { type: "json_object" };
-        } else if (textFormat?.type === "json_schema") {
-          body.response_format = {
-            type: "json_schema",
-            json_schema: {
-              name: textFormat.name ?? "response",
-              ...(textFormat.description !== undefined ? { description: textFormat.description } : {}),
-              ...(textFormat.schema !== undefined ? { schema: textFormat.schema } : {}),
-              ...(textFormat.strict !== undefined ? { strict: textFormat.strict } : {}),
-            },
-          };
-        }
-      }
 
-      if (tools) {
-        if (provider.parallelToolCalls === false) {
-          // NIM documents the Boolean defaulting to false and kimi rejects true; pin the
-          // wire bit so Codex cannot opt in via request.options. Other opted-out providers
-          // omit the field by default so strict OpenAI-compatible hosts never see an
-          // unsupported knob, but a self-hosted gateway that DOES honor the field and keeps
-          // emitting parallel calls without it can opt in via pinParallelToolCallsFalse.
-          if (provider.baseUrl === "https://integrate.api.nvidia.com/v1"
-              || provider.pinParallelToolCallsFalse === true) {
-            body.parallel_tool_calls = false;
+        if (tools) {
+          if (provider.parallelToolCalls === false) {
+            // NIM documents the Boolean defaulting to false and kimi rejects true; pin the
+            // wire bit so Codex cannot opt in via request.options. Other opted-out providers
+            // omit the field by default so strict OpenAI-compatible hosts never see an
+            // unsupported knob, but a self-hosted gateway that DOES honor the field and keeps
+            // emitting parallel calls without it can opt in via pinParallelToolCallsFalse.
+            if (provider.baseUrl === "https://integrate.api.nvidia.com/v1"
+                || provider.pinParallelToolCallsFalse === true) {
+              body.parallel_tool_calls = false;
+            }
+          } else if (provider.parallelToolCalls === true) {
+            body.parallel_tool_calls = parsed.options.parallelToolCalls !== false;
           }
-        } else if (provider.parallelToolCalls === true) {
-          body.parallel_tool_calls = parsed.options.parallelToolCalls !== false;
         }
-      }
-      if (parsed.stream) body.stream_options = { include_usage: true };
+        if (parsed.stream) body.stream_options = { include_usage: true };
 
-      const bodyJson = JSON.stringify(body);
-      const actualServiceTier = typeof body.service_tier === "string" ? body.service_tier : null;
-      const tierLog = createAdapterTierMetadata(
-        parsed.options.tierObservation,
-        parsed.options.tierDecision,
-        actualServiceTier === null ? null : "service-tier",
-        actualServiceTier,
-      );
-      if (isDebugEnabled()) {
-        let host = "upstream";
-        try { host = new URL(url).host; } catch { /* keep fallback */ }
-        debugProviderDiagnostic("openai-chat", "request", {
-          host,
-          model: body.model,
-          stream: parsed.stream,
-          messageCount: Array.isArray(messages) ? messages.length : 0,
-          toolCount: Array.isArray(tools) ? tools.length : 0,
-          hasCredential,
-          bodyBytes: new TextEncoder().encode(bodyJson).length,
-        });
-      }
+        const bodyJson = JSON.stringify(body);
+        const actualServiceTier = typeof body.service_tier === "string" ? body.service_tier : null;
+        const tierLog = createAdapterTierMetadata(
+          parsed.options.tierObservation,
+          parsed.options.tierDecision,
+          actualServiceTier === null ? null : "service-tier",
+          actualServiceTier,
+        );
+        if (isDebugEnabled()) {
+          let host = "upstream";
+          try { host = new URL(url).host; } catch { /* keep fallback */ }
+          debugProviderDiagnostic("openai-chat", "request", {
+            host,
+            model: body.model,
+            stream: parsed.stream,
+            messageCount: Array.isArray(messages) ? messages.length : 0,
+            toolCount: Array.isArray(tools) ? tools.length : 0,
+            hasCredential,
+            bodyBytes: new TextEncoder().encode(bodyJson).length,
+          });
+        }
 
-      return {
-        url,
-        method: "POST",
-        headers,
-        body: bodyJson,
-        ...(reasoningLog ? { reasoningLog } : {}),
-        ...(tierLog ? { tierLog } : {}),
+        return {
+          url,
+          method: "POST",
+          headers,
+          body: bodyJson,
+          ...(reasoningLog ? { reasoningLog } : {}),
+          ...(tierLog ? { tierLog } : {}),
+        };
       };
+      if (hasShrinkableOpenAIChatImages(messages)) {
+        return normalizeOpenAIChatImages(messages, {
+          ...(incoming?.imageTierBias !== undefined ? { tierBias: incoming.imageTierBias } : {}),
+        }).then(finish);
+      }
+      return finish();
     },
 
     async *parseStream(

--- a/src/adapters/openai-chat.ts
+++ b/src/adapters/openai-chat.ts
@@ -1651,9 +1651,12 @@ export function createOpenAIChatAdapter(provider: OcxProviderConfig): ProviderAd
         };
       };
       if (hasShrinkableOpenAIChatImages(messages)) {
+        // A normalizer failure must not fail the turn. The shared pipeline already leaves an
+        // image it cannot process untouched, so the worst case here is the request the caller
+        // would have sent anyway: oversized, and rejected upstream with a classifiable error.
         return normalizeOpenAIChatImages(messages, {
           ...(incoming?.imageTierBias !== undefined ? { tierBias: incoming.imageTierBias } : {}),
-        }).then(finish);
+        }).then(finish, finish);
       }
       return finish();
     },

--- a/structure/01_runtime.md
+++ b/structure/01_runtime.md
@@ -156,6 +156,7 @@ The server exposes `POST /api/stop` which restores native Codex config, stops an
 | `src/adapters/kiro.ts` and its `src/adapters/kiro-*.ts` helpers | Kiro event/tool/thinking/truncation/retry handling. |
 | `src/adapters/mimo-free.ts` | Mimo Free transport (client identity + JWT). |
 | `src/adapters/image.ts`, `src/adapters/anthropic-image-guard.ts`, `src/adapters/anthropic-image-normalize.ts` | Image conversion for adapter ingress and Anthropic-specific normalization/limits. |
+| `src/adapters/openai-chat-images.ts` | Inline `image_url` budget for every `openai-chat` provider. Lossy JPEG re-encode above a best-effort 3.5MiB image budget; never drops an image; bypassed by the native Chat fast path. |
 | `src/adapters/run-turn-queue.ts`, `src/adapters/tool-catalog-nudge.ts`, `src/adapters/identity.ts`, `src/adapters/upstream-http-error.ts` | Shared adapter execution support: turn queueing, tool-catalog nudging, client identity, upstream error normalization. |
 
 Adapter output must stay in internal `AdapterEvent` form until `bridge.ts` converts it back to

--- a/structure/04_transports-and-sidecars.md
+++ b/structure/04_transports-and-sidecars.md
@@ -859,6 +859,36 @@ prompts or images: it does not own the client's transcript, and deleting input w
 was never analyzed. The streaming error message is proxy-owned and bounded instead of relaying the
 upstream 413 body, which may echo request content.
 
+### openai-chat inline image budget
+
+Several OpenAI-compatible providers enforce a raw byte ceiling on the serialized Chat Completions
+body that is separate from any token limit. GitHub Copilot rejects at roughly 5.2MB with a bare 413
+and no diagnostic content, and nothing downstream of an adapter can shrink a request once it has
+been built. `src/adapters/openai-chat-images.ts` therefore runs the shared image ladder over
+`image_url` data-URL parts while the request is being built.
+
+The scope is every provider that reaches `createOpenAIChatAdapter`, not only Copilot, plus
+`mimo-free` through its `contractParent` delegation. It is a **default lossy transformation**:
+re-encoded images are emitted as JPEG, so a PNG alpha channel is flattened and detail is lost at
+lower tiers. This is the same trade the anthropic and kiro wires already make. Re-encoding is
+skipped entirely when an image already fits its tier's dimension and byte caps, so ordinary
+screenshots pass through byte-identical.
+
+`OPENAI_CHAT_IMAGE_BASE64_BUDGET` (3.5MiB) is a **best-effort image budget, not a request-size
+guarantee**. It bounds inline image bytes only; text, tool schemas and history are outside it, and a
+turn can still exceed a provider's ceiling on those alone. Images are never dropped on this wire
+(`overflowAction: "none"`, and `drop` restores the original URL), because unlike anthropic there is
+no downstream guard that would re-attach or textify a removed image. An image floored at the
+terminal 320px tier stays attached even when the total is still over budget.
+
+This runs in the adapter's `buildRequest`. The native Chat fast path
+(`src/server/chat-native.ts`, entered from `src/server/chat-completions.ts` when
+`isNativeChatRouteEligible` holds) builds its wire body through
+`buildOpenAIChatPassthroughRequest` and so **bypasses this normalization**. A Chat-inbound caller
+on an eligible native route keeps its original image bytes; only routed Responses traffic through
+the adapter is normalized. Widening the budget to that lane is a separate contract change, since the
+fast path is defined as a passthrough of the caller's body.
+
 [Decision Log]
 - 목적과 의도: Stop Codex from replaying a provider-rejected oversized turn and hand the failure
   to the client's existing context-compaction semantics.

--- a/tests/adapters/anthropic/anthropic-image-normalize.test.ts
+++ b/tests/adapters/anthropic/anthropic-image-normalize.test.ts
@@ -542,6 +542,30 @@ describe("bounded parallel first pass (WP170)", () => {
     expect(droppedForOverflow).toEqual([0]);
   });
 
+  test("terminal overflow keeps counting a target whose drop leaves the bytes on the wire", async () => {
+    // A wire whose drop cannot remove bytes (openai-chat) must not have them subtracted
+    // from the total here either. Subtracting would let the loop believe it reached the
+    // budget after a drop that changed nothing, and stop before a removable target.
+    const encode: EncodeFn = (_input, spec) => {
+      const px = fakePngBase64(Math.min(64, spec.maxEdge), Math.min(64, spec.maxEdge), 3 * 1024);
+      return Promise.resolve({ data: px.slice(0, 4 * 1024), mediaType: "image/webp" });
+    };
+    const images = distinctImages(4);
+    const droppedForOverflow: number[] = [];
+    const targets: NormalizeTarget[] = images.map((b64, i) => ({
+      base64: b64,
+      mediaType: "image/png",
+      replace: () => {},
+      drop: note => { if (note.includes("provider request budget")) droppedForOverflow.push(i); },
+      // Only the oldest target keeps its bytes when dropped.
+      retainsBytesOnDrop: i === 0,
+    }));
+    // Budget fits 3 of the 4 terminal outputs. Dropping the oldest frees nothing, so the
+    // loop must continue and drop the next one to actually get under budget.
+    await normalizeImageTargets(targets, { encode, budget: 3 * 4 * 1024, overflowAction: "drop" });
+    expect(droppedForOverflow).toEqual([0, 1]);
+  });
+
   test("skip paths free the worker slot: URL sources and over-limit images never reach the encoder", async () => {
     const g = gatedEncoder();
     const real = distinctImages(3);

--- a/tests/adapters/openai/openai-chat-image-normalization.test.ts
+++ b/tests/adapters/openai/openai-chat-image-normalization.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createOpenAIChatAdapter } from "../../../src/adapters/openai-chat";
+import {
+  hasShrinkableOpenAIChatImages,
+  normalizeOpenAIChatImages,
+  OPENAI_CHAT_IMAGE_BASE64_BUDGET,
+} from "../../../src/adapters/openai-chat-images";
+import { resetNormalizeStateForTests, TIER_SPECS, type EncodeFn } from "../../../src/adapters/anthropic-image-normalize";
+import type { OcxMessage, OcxParsedRequest, OcxProviderConfig } from "../../../src/types";
+
+// Issue #4112 follow-up: chat-completions providers such as GitHub Copilot reject a body
+// over roughly 5.2MB with a bare 413 and no diagnostic content. Nothing downstream of the
+// adapter can shrink a built request, so inline image bytes are normalized here. Images are
+// never dropped on this wire: there is no downstream guard that would re-attach them.
+
+const provider: OcxProviderConfig = {
+  adapter: "openai-chat",
+  baseUrl: "https://api.githubcopilot.com",
+  apiKey: "sk-test",
+  authMode: "key",
+};
+
+const ONE_PX_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+async function realPngB64(width: number, height: number): Promise<string> {
+  const buf = await new Bun.Image(Buffer.from(ONE_PX_PNG, "base64")).resize(width, height).png().toBuffer();
+  return Buffer.from(buf).toString("base64");
+}
+
+/**
+ * A flat-colour PNG compresses to almost nothing, so budget behaviour needs incompressible
+ * pixels. Deterministic noise is written as an uncompressed BMP and converted, which keeps
+ * the fixture in-repo and the encoded size realistic.
+ */
+async function noisyPngB64(width: number, height: number): Promise<string> {
+  const rowSize = width * 3 + ((4 - ((width * 3) % 4)) % 4);
+  const pixelBytes = rowSize * height;
+  const bmp = Buffer.alloc(54 + pixelBytes);
+  bmp.write("BM", 0);
+  bmp.writeUInt32LE(bmp.length, 2);
+  bmp.writeUInt32LE(54, 10);
+  bmp.writeUInt32LE(40, 14);
+  bmp.writeInt32LE(width, 18);
+  bmp.writeInt32LE(height, 22);
+  bmp.writeUInt16LE(1, 26);
+  bmp.writeUInt16LE(24, 28);
+  bmp.writeUInt32LE(pixelBytes, 34);
+  let seed = 0x2545f491;
+  for (let y = 0; y < height; y++) {
+    let offset = 54 + y * rowSize;
+    for (let x = 0; x < width; x++) {
+      seed ^= seed << 13; seed ^= seed >>> 17; seed ^= seed << 5; seed >>>= 0;
+      bmp[offset++] = seed & 0xff;
+      bmp[offset++] = (seed >>> 8) & 0xff;
+      bmp[offset++] = (seed >>> 16) & 0xff;
+    }
+  }
+  const png = await new Bun.Image(bmp).png().toBuffer();
+  return Buffer.from(png).toString("base64");
+}
+
+
+function dataUrl(b64: string, mediaType = "image/png"): string {
+  return `data:${mediaType};base64,${b64}`;
+}
+
+interface ChatPart {
+  type: string;
+  text?: string;
+  image_url?: { url: string };
+}
+
+interface ChatMsg {
+  role: string;
+  content?: string | ChatPart[];
+}
+
+function parsedWith(messages: OcxMessage[]): OcxParsedRequest {
+  return {
+    modelId: "claude-opus-5",
+    context: { messages },
+    stream: false,
+    options: {},
+  } as unknown as OcxParsedRequest;
+}
+
+function imageMessage(urls: string[], text = "what is this"): OcxMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text },
+      ...urls.map(url => ({ type: "image" as const, imageUrl: url })),
+    ],
+    timestamp: 0,
+  } as unknown as OcxMessage;
+}
+
+function wireMessages(body: string): ChatMsg[] {
+  return (JSON.parse(body) as { messages: ChatMsg[] }).messages;
+}
+
+function imageParts(messages: ChatMsg[]): ChatPart[] {
+  return messages.flatMap(m => (Array.isArray(m.content) ? m.content : [])).filter(p => p.type === "image_url");
+}
+
+/** Deterministic encoder: output size is a function of the tier's max edge. */
+const sizedEncoder = (sizeFor: (maxEdge: number) => number): EncodeFn =>
+  (_input, spec) => Promise.resolve({
+    data: "A".repeat(sizeFor(spec.maxEdge)),
+    mediaType: "image/jpeg",
+  });
+
+describe("openai-chat inline image normalization", () => {
+  beforeEach(() => resetNormalizeStateForTests());
+
+  test("a text-only turn builds synchronously and is unchanged", () => {
+    const request = createOpenAIChatAdapter(provider).buildRequest(
+      parsedWith([{ role: "user", content: "hello", timestamp: 0 } as unknown as OcxMessage]),
+    );
+    expect(request).not.toBeInstanceOf(Promise);
+    const messages = wireMessages((request as { body: string }).body);
+    expect(messages.at(-1)?.content).toBe("hello");
+  });
+
+  test("an image turn under the budget stays synchronous and keeps its exact bytes", async () => {
+    const small = await realPngB64(8, 8);
+    expect(hasShrinkableOpenAIChatImages([
+      { role: "user", content: [{ type: "image_url", image_url: { url: dataUrl(small) } }] },
+    ])).toBe(false);
+
+    const request = createOpenAIChatAdapter(provider).buildRequest(parsedWith([imageMessage([dataUrl(small)])]));
+    expect(request).not.toBeInstanceOf(Promise);
+    const parts = imageParts(wireMessages((request as { body: string }).body));
+    expect(parts).toHaveLength(1);
+    expect(parts[0]?.image_url?.url).toBe(dataUrl(small));
+  });
+
+  test("an oversized turn is re-encoded through the adapter and keeps every image", async () => {
+    const big = await noisyPngB64(1000, 1000);
+    const urls = Array.from({ length: 4 }, () => dataUrl(big));
+    expect(hasShrinkableOpenAIChatImages([
+      { role: "user", content: urls.map(url => ({ type: "image_url", image_url: { url } })) },
+    ])).toBe(true);
+
+    const built = createOpenAIChatAdapter(provider).buildRequest(parsedWith([imageMessage(urls)]));
+    expect(built).toBeInstanceOf(Promise);
+    const { body } = await (built as Promise<{ body: string }>);
+    const messages = wireMessages(body);
+    const parts = imageParts(messages);
+
+    expect(parts).toHaveLength(4);
+    const total = parts.reduce((sum, p) => sum + (p.image_url?.url.split(",")[1]?.length ?? 0), 0);
+    expect(total).toBeLessThanOrEqual(OPENAI_CHAT_IMAGE_BASE64_BUDGET);
+    for (const part of parts) expect(part.image_url?.url.startsWith("data:image/")).toBe(true);
+    // The caption survives alongside the images.
+    expect(JSON.stringify(messages)).toContain("what is this");
+  });
+
+  test("terminal overflow keeps images attached instead of dropping the oldest", async () => {
+    const terminalEdge = TIER_SPECS[TIER_SPECS.length - 1]!.maxEdge;
+    const small = await realPngB64(40, 40);
+    const messages = [{
+      role: "user",
+      content: Array.from({ length: 6 }, () => ({
+        type: "image_url",
+        image_url: { url: dataUrl(small) },
+      })),
+    }];
+    // Every tier, including the floor, still exceeds the budget on its own.
+    await normalizeOpenAIChatImages(messages, {
+      encode: sizedEncoder(() => OPENAI_CHAT_IMAGE_BASE64_BUDGET),
+      validate: () => Promise.resolve(),
+    });
+    const parts = imageParts(messages as ChatMsg[]);
+    expect(parts).toHaveLength(6);
+    expect(terminalEdge).toBeGreaterThan(0);
+    for (const part of parts) expect(part.image_url?.url).toContain("base64,");
+  });
+
+  test("a remote https image is left untouched", async () => {
+    const messages = [{
+      role: "user",
+      content: [{ type: "image_url", image_url: { url: "https://example.com/cat.png" } }],
+    }];
+    expect(hasShrinkableOpenAIChatImages(messages)).toBe(false);
+    await normalizeOpenAIChatImages(messages);
+    expect(imageParts(messages as ChatMsg[])[0]?.image_url?.url).toBe("https://example.com/cat.png");
+  });
+
+  test("an undecodable image keeps its original url rather than being dropped", async () => {
+    const corrupt = dataUrl("!!!!not-base64-image!!!!");
+    const messages = [{
+      role: "user",
+      content: [{ type: "image_url", image_url: { url: corrupt } }],
+    }];
+    await normalizeOpenAIChatImages(messages, {
+      encode: () => Promise.reject(new Error("undecodable")),
+      validate: () => Promise.reject(new Error("undecodable")),
+    });
+    expect(imageParts(messages as ChatMsg[])[0]?.image_url?.url).toBe(corrupt);
+  });
+
+  test("malformed message shapes neither throw nor lose parts", async () => {
+    const messages: unknown[] = [
+      null,
+      "not-a-message",
+      { role: "user" },
+      { role: "user", content: "plain text" },
+      { role: "user", content: [{ type: "image_url" }, { type: "image_url", image_url: {} }] },
+    ];
+    const before = JSON.stringify(messages);
+    expect(hasShrinkableOpenAIChatImages(messages)).toBe(false);
+    await normalizeOpenAIChatImages(messages);
+    expect(JSON.stringify(messages)).toBe(before);
+    await normalizeOpenAIChatImages(undefined);
+    await normalizeOpenAIChatImages("nonsense");
+  });
+
+  test("imageTierBias from incoming meta reaches the normalizer", async () => {
+    const big = await noisyPngB64(1000, 1000);
+    const urls = Array.from({ length: 4 }, () => dataUrl(big));
+    const adapter = createOpenAIChatAdapter(provider);
+
+    const build = async (imageTierBias?: number) => {
+      resetNormalizeStateForTests();
+      const built = adapter.buildRequest(parsedWith([imageMessage(urls)]), {
+        headers: new Headers(),
+        ...(imageTierBias !== undefined ? { imageTierBias } : {}),
+      });
+      const request = await (built as Promise<{ body: string }>);
+      return imageParts(wireMessages(request.body))
+        .reduce((sum, part) => sum + (part.image_url?.url.length ?? 0), 0);
+    };
+
+    expect(await build(3)).toBeLessThan(await build());
+  });
+});

--- a/tests/adapters/openai/openai-chat-image-normalization.test.ts
+++ b/tests/adapters/openai/openai-chat-image-normalization.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { createOpenAIChatAdapter } from "../../../src/adapters/openai-chat";
+import {
+  buildOpenAIChatPassthroughRequest,
+  createOpenAIChatAdapter,
+} from "../../../src/adapters/openai-chat";
 import { createMimoFreeAdapter } from "../../../src/adapters/mimo-free";
 import {
   hasShrinkableOpenAIChatImages,
   normalizeOpenAIChatImages,
   OPENAI_CHAT_IMAGE_BASE64_BUDGET,
 } from "../../../src/adapters/openai-chat-images";
-import { resetNormalizeStateForTests, type EncodeFn } from "../../../src/adapters/anthropic-image-normalize";
+import {
+  getNormalizeStatsForTests,
+  resetNormalizeStateForTests,
+  TIER_SPECS,
+  type EncodeFn,
+} from "../../../src/adapters/anthropic-image-normalize";
 import type { OcxMessage, OcxParsedRequest, OcxProviderConfig } from "../../../src/types";
 import { createTestTranslatorBudget } from "../../helpers/translator-budget";
 
@@ -160,35 +168,55 @@ describe("openai-chat inline image normalization", () => {
   });
 
   test("terminal overflow keeps images attached instead of dropping the oldest", async () => {
-    const small = await realPngB64(40, 40);
+    // The input has to miss every tier's dimension and byte caps, otherwise processAt
+    // passes it through before the injected encoder is ever consulted and the ladder is
+    // never walked. A 1000x1000 noise PNG misses them; a small one does not.
+    const big = await noisyPngB64(1000, 1000);
     const messages = [{
       role: "user",
       content: Array.from({ length: 6 }, () => ({
         type: "image_url",
-        image_url: { url: dataUrl(small) },
+        image_url: { url: dataUrl(big) },
       })),
     }];
+    const tiersReached: number[] = [];
     // Every tier, including the floor, still exceeds the budget on its own.
     await normalizeOpenAIChatImages(messages, {
-      encode: sizedEncoder(() => OPENAI_CHAT_IMAGE_BASE64_BUDGET),
+      encode: (input, spec, quality) => {
+        tiersReached.push(spec.maxEdge);
+        return sizedEncoder(() => OPENAI_CHAT_IMAGE_BASE64_BUDGET)(input, spec, quality);
+      },
       validate: () => Promise.resolve(),
     });
+
+    // The ladder actually ran and bottomed out at the terminal tier.
+    const terminalEdge = TIER_SPECS[TIER_SPECS.length - 1]?.maxEdge;
+    expect(getNormalizeStatsForTests().encodeCalls).toBeGreaterThan(0);
+    expect(tiersReached).toContain(terminalEdge);
+
     const parts = imageParts(messages as ChatMsg[]);
+    // Still over budget at the floor, and every image survives regardless.
+    const total = parts.reduce((sum, p) => sum + (p.image_url?.url.split(",")[1]?.length ?? 0), 0);
+    expect(total).toBeGreaterThan(OPENAI_CHAT_IMAGE_BASE64_BUDGET);
     expect(parts).toHaveLength(6);
     for (const part of parts) expect(part.image_url?.url).toContain("base64,");
   });
 
   test("a normalizer failure degrades to the unshrunk request instead of failing the turn", async () => {
     const big = await noisyPngB64(1000, 1000);
-    const parsed = parsedWith([imageMessage([dataUrl(big)])]);
+    const original = dataUrl(big);
+    const parsed = parsedWith([imageMessage([original])]);
     const built = createOpenAIChatAdapter(provider).buildRequest(parsed, {
       headers: new Headers(),
       translatorBudget: createTestTranslatorBudget(),
       imageTierBias: Number.NaN,
     });
     const request = await (built as Promise<{ body: string }>);
-    expect(typeof request.body).toBe("string");
-    expect(imageParts(wireMessages(request.body))).toHaveLength(1);
+    const parts = imageParts(wireMessages(request.body));
+    expect(parts).toHaveLength(1);
+    // The fallback is the unshrunk request: the exact original bytes, not a re-encode.
+    expect(parts[0]?.image_url?.url).toBe(original);
+    expect(getNormalizeStatsForTests().encodeCalls).toBe(0);
   });
 
   test("a remote https image is left untouched", async () => {
@@ -267,5 +295,36 @@ describe("openai-chat inline image normalization", () => {
     };
 
     expect(await build(3)).toBeLessThan(await build());
+  });
+
+  test("the native Chat fast path bypasses normalization and keeps the caller's bytes", async () => {
+    // Scope boundary, asserted so it cannot move silently: normalization lives in the
+    // adapter's buildRequest, but a native Chat route (chat-native.ts, entered when
+    // isNativeChatRouteEligible holds) builds its wire body through this passthrough
+    // builder instead, so a Chat-inbound caller on that lane keeps its original image
+    // bytes. Widening the budget to the fast path is a separate contract change, since
+    // that lane is defined as a passthrough of the caller's body. The eligibility
+    // predicate itself is not imported here: chat-native's transitive graph fails to
+    // load under this suite for reasons that predate this change.
+    const big = await noisyPngB64(1000, 1000);
+    const url = dataUrl(big);
+    const rawBody = {
+      model: "claude-opus-5",
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "what is this" },
+          ...Array.from({ length: 4 }, () => ({ type: "image_url", image_url: { url } })),
+        ],
+      }],
+    };
+
+    resetNormalizeStateForTests();
+    const request = buildOpenAIChatPassthroughRequest(provider, rawBody, "claude-opus-5", false);
+    const parts = imageParts(wireMessages(request.body));
+
+    expect(getNormalizeStatsForTests().encodeCalls).toBe(0);
+    expect(parts).toHaveLength(4);
+    for (const part of parts) expect(part.image_url?.url).toBe(url);
   });
 });

--- a/tests/adapters/openai/openai-chat-image-normalization.test.ts
+++ b/tests/adapters/openai/openai-chat-image-normalization.test.ts
@@ -241,7 +241,10 @@ describe("openai-chat inline image normalization", () => {
       adapter: "mimo-free",
       baseUrl: "https://api.xiaomimimo.com/api/free-ai/openai/chat",
     });
-    const built = await adapter.buildRequest(parsed, { headers: new Headers() });
+    const built = await adapter.buildRequest(parsed, {
+      headers: new Headers(),
+      translatorBudget: createTestTranslatorBudget(),
+    });
     expect(typeof built.body).toBe("string");
     expect(imageParts(wireMessages(built.body as string))).toHaveLength(1);
   });

--- a/tests/adapters/openai/openai-chat-image-normalization.test.ts
+++ b/tests/adapters/openai/openai-chat-image-normalization.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { createOpenAIChatAdapter } from "../../../src/adapters/openai-chat";
+import { createMimoFreeAdapter } from "../../../src/adapters/mimo-free";
 import {
   hasShrinkableOpenAIChatImages,
   normalizeOpenAIChatImages,
   OPENAI_CHAT_IMAGE_BASE64_BUDGET,
 } from "../../../src/adapters/openai-chat-images";
-import { resetNormalizeStateForTests, TIER_SPECS, type EncodeFn } from "../../../src/adapters/anthropic-image-normalize";
+import { resetNormalizeStateForTests, type EncodeFn } from "../../../src/adapters/anthropic-image-normalize";
 import type { OcxMessage, OcxParsedRequest, OcxProviderConfig } from "../../../src/types";
+import { createTestTranslatorBudget } from "../../helpers/translator-budget";
 
 // Issue #4112 follow-up: chat-completions providers such as GitHub Copilot reject a body
 // over roughly 5.2MB with a bare 413 and no diagnostic content. Nothing downstream of the
@@ -158,7 +160,6 @@ describe("openai-chat inline image normalization", () => {
   });
 
   test("terminal overflow keeps images attached instead of dropping the oldest", async () => {
-    const terminalEdge = TIER_SPECS[TIER_SPECS.length - 1]!.maxEdge;
     const small = await realPngB64(40, 40);
     const messages = [{
       role: "user",
@@ -174,8 +175,20 @@ describe("openai-chat inline image normalization", () => {
     });
     const parts = imageParts(messages as ChatMsg[]);
     expect(parts).toHaveLength(6);
-    expect(terminalEdge).toBeGreaterThan(0);
     for (const part of parts) expect(part.image_url?.url).toContain("base64,");
+  });
+
+  test("a normalizer failure degrades to the unshrunk request instead of failing the turn", async () => {
+    const big = await noisyPngB64(1000, 1000);
+    const parsed = parsedWith([imageMessage([dataUrl(big)])]);
+    const built = createOpenAIChatAdapter(provider).buildRequest(parsed, {
+      headers: new Headers(),
+      translatorBudget: createTestTranslatorBudget(),
+      imageTierBias: Number.NaN,
+    });
+    const request = await (built as Promise<{ body: string }>);
+    expect(typeof request.body).toBe("string");
+    expect(imageParts(wireMessages(request.body))).toHaveLength(1);
   });
 
   test("a remote https image is left untouched", async () => {
@@ -217,6 +230,22 @@ describe("openai-chat inline image normalization", () => {
     await normalizeOpenAIChatImages("nonsense");
   });
 
+  test("a delegating adapter awaits the built request instead of reading an undefined body", async () => {
+    // mimo-free wraps this adapter and reads baseReq.body. When an image turn makes
+    // buildRequest return a promise, a synchronous cast there yields undefined and the
+    // JSON.parse of the delegated body throws.
+    const big = await noisyPngB64(1000, 1000);
+    const parsed = parsedWith([imageMessage([dataUrl(big)])]);
+    const adapter = createMimoFreeAdapter({
+      ...provider,
+      adapter: "mimo-free",
+      baseUrl: "https://api.xiaomimimo.com/api/free-ai/openai/chat",
+    });
+    const built = await adapter.buildRequest(parsed, { headers: new Headers() });
+    expect(typeof built.body).toBe("string");
+    expect(imageParts(wireMessages(built.body as string))).toHaveLength(1);
+  });
+
   test("imageTierBias from incoming meta reaches the normalizer", async () => {
     const big = await noisyPngB64(1000, 1000);
     const urls = Array.from({ length: 4 }, () => dataUrl(big));
@@ -226,6 +255,7 @@ describe("openai-chat inline image normalization", () => {
       resetNormalizeStateForTests();
       const built = adapter.buildRequest(parsedWith([imageMessage(urls)]), {
         headers: new Headers(),
+        translatorBudget: createTestTranslatorBudget(),
         ...(imageTierBias !== undefined ? { imageTierBias } : {}),
       });
       const request = await (built as Promise<{ body: string }>);

--- a/tests/adapters/openai/openai-chat-image-normalization.test.ts
+++ b/tests/adapters/openai/openai-chat-image-normalization.test.ts
@@ -30,6 +30,7 @@ const provider: OcxProviderConfig = {
 const ONE_PX_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
+/** A real, decodable PNG of the requested size, upscaled from a 1px source. */
 async function realPngB64(width: number, height: number): Promise<string> {
   const buf = await new Bun.Image(Buffer.from(ONE_PX_PNG, "base64")).resize(width, height).png().toBuffer();
   return Buffer.from(buf).toString("base64");
@@ -68,6 +69,7 @@ async function noisyPngB64(width: number, height: number): Promise<string> {
 }
 
 
+/** Wrap raw base64 as a data URL, the only image form this wire normalizes. */
 function dataUrl(b64: string, mediaType = "image/png"): string {
   return `data:${mediaType};base64,${b64}`;
 }
@@ -83,6 +85,7 @@ interface ChatMsg {
   content?: string | ChatPart[];
 }
 
+/** Minimal parsed request carrying just the messages an adapter build needs. */
 function parsedWith(messages: OcxMessage[]): OcxParsedRequest {
   return {
     modelId: "claude-opus-5",
@@ -92,6 +95,7 @@ function parsedWith(messages: OcxMessage[]): OcxParsedRequest {
   } as unknown as OcxParsedRequest;
 }
 
+/** A user turn holding `text` plus one image per URL, in canonical (pre-wire) form. */
 function imageMessage(urls: string[], text = "what is this"): OcxMessage {
   return {
     role: "user",
@@ -103,10 +107,12 @@ function imageMessage(urls: string[], text = "what is this"): OcxMessage {
   } as unknown as OcxMessage;
 }
 
+/** Read the messages back out of a built request body. */
 function wireMessages(body: string): ChatMsg[] {
   return (JSON.parse(body) as { messages: ChatMsg[] }).messages;
 }
 
+/** Every image part across the given messages, flattened. */
 function imageParts(messages: ChatMsg[]): ChatPart[] {
   return messages.flatMap(m => (Array.isArray(m.content) ? m.content : [])).filter(p => p.type === "image_url");
 }

--- a/tests/adapters/openai/openai-chat-image-normalization.test.ts
+++ b/tests/adapters/openai/openai-chat-image-normalization.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import {
-  buildOpenAIChatPassthroughRequest,
-  createOpenAIChatAdapter,
-} from "../../../src/adapters/openai-chat";
-import { createMimoFreeAdapter } from "../../../src/adapters/mimo-free";
+import { createOpenAIChatAdapter } from "../../../src/adapters/openai-chat";
+import { createMimoFreeAdapter, resetMimoJwtCache } from "../../../src/adapters/mimo-free";
 import {
   hasShrinkableOpenAIChatImages,
   normalizeOpenAIChatImages,
@@ -229,6 +226,35 @@ describe("openai-chat inline image normalization", () => {
     expect(imageParts(messages as ChatMsg[])[0]?.image_url?.url).toBe("https://example.com/cat.png");
   });
 
+  test("an image this wire cannot drop keeps counting toward the budget", async () => {
+    // The drop callback here is a no-op, so an undecodable image stays on the wire. The
+    // shared core normally stops counting a dropped target, which is only correct when
+    // the bytes actually leave. If those bytes stopped counting, the demotion loop would
+    // stop early and still ship an oversized body — the exact failure this file exists
+    // to prevent.
+    const big = await noisyPngB64(1000, 1000);
+    // Truncated PNG: sniffs as an image, so it reaches the ladder, but cannot decode.
+    const corrupt = big.slice(0, 3_000_000);
+    const messages = [{
+      role: "user",
+      content: [
+        { type: "image_url", image_url: { url: dataUrl(corrupt) } },
+        ...Array.from({ length: 3 }, () => ({ type: "image_url", image_url: { url: dataUrl(big) } })),
+      ],
+    }];
+
+    resetNormalizeStateForTests();
+    await normalizeOpenAIChatImages(messages);
+
+    const parts = imageParts(messages as ChatMsg[]);
+    const total = parts.reduce((sum, p) => sum + (p.image_url?.url.split(",")[1]?.length ?? 0), 0);
+    expect(parts).toHaveLength(4);
+    // The undecodable image is retained, unchanged.
+    expect(parts[0]?.image_url?.url).toBe(dataUrl(corrupt));
+    // And the turn as a whole still lands under budget.
+    expect(total).toBeLessThanOrEqual(OPENAI_CHAT_IMAGE_BASE64_BUDGET);
+  });
+
   test("an undecodable image keeps its original url rather than being dropped", async () => {
     const corrupt = dataUrl("!!!!not-base64-image!!!!");
     const messages = [{
@@ -262,19 +288,39 @@ describe("openai-chat inline image normalization", () => {
     // mimo-free wraps this adapter and reads baseReq.body. When an image turn makes
     // buildRequest return a promise, a synchronous cast there yields undefined and the
     // JSON.parse of the delegated body throws.
-    const big = await noisyPngB64(1000, 1000);
-    const parsed = parsedWith([imageMessage([dataUrl(big)])]);
-    const adapter = createMimoFreeAdapter({
-      ...provider,
-      adapter: "mimo-free",
-      baseUrl: "https://api.xiaomimimo.com/api/free-ai/openai/chat",
-    });
-    const built = await adapter.buildRequest(parsed, {
-      headers: new Headers(),
-      translatorBudget: createTestTranslatorBudget(),
-    });
-    expect(typeof built.body).toBe("string");
-    expect(imageParts(wireMessages(built.body as string))).toHaveLength(1);
+    // mimo-free's buildRequest bootstraps a JWT over the network, so the stub below is
+    // what keeps this suite hermetic. Both cache resets matter: the first stops a JWT
+    // cached by an earlier test from bypassing the stub, the second stops this test's
+    // synthetic token from escaping into a later one.
+    const originalFetch = globalThis.fetch;
+    const bootstrapUrl = "https://api.xiaomimimo.com/api/free-ai/bootstrap";
+    const fetched: string[] = [];
+    resetMimoJwtCache();
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      fetched.push(url);
+      if (url !== bootstrapUrl) throw new Error(`unexpected external request: ${url}`);
+      return Response.json({ jwt: "test-jwt" });
+    }) as typeof fetch;
+    try {
+      const big = await noisyPngB64(1000, 1000);
+      const parsed = parsedWith([imageMessage([dataUrl(big)])]);
+      const adapter = createMimoFreeAdapter({
+        ...provider,
+        adapter: "mimo-free",
+        baseUrl: "https://api.xiaomimimo.com/api/free-ai/openai/chat",
+      });
+      const built = await adapter.buildRequest(parsed, {
+        headers: new Headers(),
+        translatorBudget: createTestTranslatorBudget(),
+      });
+      expect(fetched).toEqual([bootstrapUrl]);
+      expect(typeof built.body).toBe("string");
+      expect(imageParts(wireMessages(built.body as string))).toHaveLength(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      resetMimoJwtCache();
+    }
   });
 
   test("imageTierBias from incoming meta reaches the normalizer", async () => {
@@ -297,34 +343,4 @@ describe("openai-chat inline image normalization", () => {
     expect(await build(3)).toBeLessThan(await build());
   });
 
-  test("the native Chat fast path bypasses normalization and keeps the caller's bytes", async () => {
-    // Scope boundary, asserted so it cannot move silently: normalization lives in the
-    // adapter's buildRequest, but a native Chat route (chat-native.ts, entered when
-    // isNativeChatRouteEligible holds) builds its wire body through this passthrough
-    // builder instead, so a Chat-inbound caller on that lane keeps its original image
-    // bytes. Widening the budget to the fast path is a separate contract change, since
-    // that lane is defined as a passthrough of the caller's body. The eligibility
-    // predicate itself is not imported here: chat-native's transitive graph fails to
-    // load under this suite for reasons that predate this change.
-    const big = await noisyPngB64(1000, 1000);
-    const url = dataUrl(big);
-    const rawBody = {
-      model: "claude-opus-5",
-      messages: [{
-        role: "user",
-        content: [
-          { type: "text", text: "what is this" },
-          ...Array.from({ length: 4 }, () => ({ type: "image_url", image_url: { url } })),
-        ],
-      }],
-    };
-
-    resetNormalizeStateForTests();
-    const request = buildOpenAIChatPassthroughRequest(provider, rawBody, "claude-opus-5", false);
-    const parts = imageParts(wireMessages(request.body));
-
-    expect(getNormalizeStatsForTests().encodeCalls).toBe(0);
-    expect(parts).toHaveLength(4);
-    for (const part of parts) expect(part.image_url?.url).toBe(url);
-  });
 });

--- a/tests/adapters/openai/openai-chat-native-policy.test.ts
+++ b/tests/adapters/openai/openai-chat-native-policy.test.ts
@@ -397,4 +397,54 @@ describe("main and native Chat tier authorization parity", () => {
       expect(native.service_tier).toBe(main.service_tier);
     }
   });
+
+  test("the native lane keeps caller image bytes instead of normalizing them", async () => {
+    // Scope boundary for the openai-chat inline image budget (see
+    // tests/adapters/openai/openai-chat-image-normalization.test.ts). That budget lives in
+    // the adapter's buildRequest, but an eligible Chat-inbound request is dispatched down
+    // this native lane, which builds through buildOpenAIChatPassthroughRequest and never
+    // reaches the normalizer. Asserted through the real handler rather than the builder,
+    // so it proves the dispatcher selects that lane. Widening the budget to cover the
+    // fast path is a separate contract change.
+    const url = `data:image/png;base64,${"A".repeat(4_000_000)}`;
+    const captured: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      captured.push(String(init?.body ?? ""));
+      return Response.json({
+        id: "chatcmpl_native_image",
+        object: "chat.completion",
+        choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+      });
+    }) as typeof fetch;
+
+    const target = provider();
+    const response = await handleChatCompletions(
+      new Request("http://localhost/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: `${PROVIDER_NAME}/${MODEL_ID}`,
+          messages: [{
+            role: "user",
+            content: [
+              { type: "text", text: "what is this" },
+              ...Array.from({ length: 4 }, () => ({ type: "image_url", image_url: { url } })),
+            ],
+          }],
+        }),
+      }),
+      { port: 0, defaultProvider: PROVIDER_NAME, providers: { [PROVIDER_NAME]: target } } as OcxConfig,
+      { model: "", provider: "" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    const parts = (JSON.parse(captured[0]!) as { messages: Array<{ content: unknown }> })
+      .messages.flatMap(m => (Array.isArray(m.content) ? m.content : []))
+      .filter((p): p is { type: string; image_url: { url: string } } =>
+        typeof p === "object" && p !== null && (p as { type?: unknown }).type === "image_url");
+    // Well over the 3.5MiB image budget, and still byte-identical on the wire.
+    expect(parts).toHaveLength(4);
+    for (const part of parts) expect(part.image_url.url).toBe(url);
+  });
 });

--- a/tests/fixtures/test-layout-expected.json
+++ b/tests/fixtures/test-layout-expected.json
@@ -751,6 +751,7 @@
   "openai-chat-dangling-toolcalls.test.ts": "adapters/openai",
   "openai-chat-eof.test.ts": "adapters/openai",
   "openai-chat-hardening.test.ts": "adapters/openai",
+  "openai-chat-image-normalization.test.ts": "adapters/openai",
   "openai-chat-invalid-tool-call-diagnostics.test.ts": "adapters/openai",
   "openai-chat-model-suffix.test.ts": "adapters/openai",
   "openai-chat-native-policy.test.ts": "adapters/openai",


### PR DESCRIPTION
Follow-up to #4112, and the payload-reduction half of what #2511 tracks.

### Problem

Several OpenAI-compatible providers enforce a raw byte ceiling on the serialized chat-completions body that is separate from any token limit. GitHub Copilot rejects at roughly 5.2MB with a bare `HTTP 413` and an empty diagnostic body. Measured on `github-copilot/claude-opus-5`: four screenshots at 4.44MB went through, five at 5.47MB did not, and plain text crosses at about the same point, so it is a byte limit rather than a token or image-count one. The token limit produces a clean 400 with a useful message and is unaffected by this change.

On that route a turn over the ceiling cannot recover on its own, because compaction has to send the same history in order to summarize it and gets the same rejection. In one local session, 105 successful turns climbed to roughly 74k tokens and were then followed by eighteen consecutive 413s over eight minutes as compaction repeatedly tried and failed.

Nothing downstream of the adapter can shrink a request once it has been built. The one-tier image retry in `src/server/image-retry.ts` is gated to `adapterName === "anthropic"`, and these providers route through `openai-chat`.

### Change

The image ladder that already solves this for the anthropic and kiro wires operates on generic `NormalizeTarget` handles, and `kiro-images.ts` already reuses it for the CodeWhisperer format. This adds the equivalent wrapper for `image_url` parts in Chat Completions messages, with a 3.5MiB base64 budget that leaves headroom for text and tools under the observed ceiling.

Measured with six 4000x4000 PNGs of real screenshot content in one turn: 6.14MB before, 0.90MB after, all six images still attached and the accompanying text unchanged.

Two deliberate choices are worth review attention:

**Images are never dropped on this wire.** `overflowAction` is `"none"` and the `drop` callback keeps the original URL. Unlike anthropic, this wire has no downstream guard that would re-attach or textify a removed image, so a drop here is silent data loss from the user's point of view. An image floored at the terminal 320px tier stays attached, and a corrupt or decode-bomb input rides through unchanged rather than disappearing.

**`buildRequest` stays synchronous unless a turn actually carries inline image bytes over the budget.** `base.ts` already permits a promise return and every routed caller awaits it, but a large number of direct callers depend on the synchronous shape. Making every text-only turn async changed 85 existing tests and would alter their timing for no benefit, so the async path is entered only via `hasShrinkableOpenAIChatImages`.

### Behaviour notes

Re-encoding only happens when an image exceeds its tier's dimension and size caps; anything already within them passes through byte-identical, which covers ordinary screenshots. Re-encoded images are emitted as JPEG, so a large PNG with an alpha channel is flattened, the same trade the anthropic and kiro paths already make. Normalization is wire-only, so stored response state keeps the originals and each turn re-shrinks from source, absorbed by the existing encode cache.

This does not address text-driven overflow. A conversation that crosses the ceiling on text alone still fails, and classifying that failure is what #4112 and #4127 cover.

### Budget accounting for images this wire cannot drop

The shared core stops counting a target once it calls `drop`. That is correct for anthropic and kiro, whose `drop` removes or textifies the image, but this wire's `drop` is a deliberate no-op leaving the original URL in place. Those bytes stayed on the wire while the accounting forgot them, so the demotion loop could stop early believing it was under budget and still ship an oversized body.

Measured with one truncated-PNG data URL alongside three 1000x1000 noise PNGs: the normalized turn came out at 5,680,788 base64 characters against the 3,670,016 budget. With the fix it lands at 3,179,572 and still retains the undecodable image. `NormalizeTarget` gains an opt-in `retainsBytesOnDrop` flag set only by `openai-chat-images.ts`, so anthropic and kiro accounting is unchanged.

The terminal-overflow branch needed the same treatment for the flag to be coherent. It subtracted a dropped target's bytes unconditionally, which on a retaining wire would credit space that never came free and could stop the loop before reaching a target that can actually leave. That branch is unreachable from `openai-chat` because it passes `overflowAction: "none"`, but the two drop paths should agree; a regression in the shared suite covers it.

### Scope and tradeoffs

`structure/04_transports-and-sidecars.md` documents this as a default lossy transformation for every provider that reaches `createOpenAIChatAdapter`, not only Copilot, plus `mimo-free` through its `contractParent`. It records the JPEG/alpha flattening tradeoff, the pass-through behaviour for images already within their tier caps, and that 3.5MiB bounds inline image base64 only. It is not a serialized request-size guarantee: a turn can still exceed a provider's ceiling on text and tool schemas alone. `structure/01_runtime.md` carries the adapter-table entry.

The native Chat fast path in `src/server/chat-native.ts` builds through `buildOpenAIChatPassthroughRequest` and bypasses this normalization. That boundary is pinned at dispatch level in `openai-chat-native-policy.test.ts`, which drives `handleChatCompletions` against a fake upstream and asserts a 4MB inline image arrives byte-identical, so it exercises the route selection rather than only the builder.

### Validation

```
bun test tests/adapters/openai/openai-chat-image-normalization.test.ts   11 pass, 0 fail
bun test tests/adapters/openai/openai-chat-native-policy.test.ts         22 pass, 0 fail
bun test tests/adapters/anthropic tests/providers/kiro                  823 pass, 0 fail
bun test tests/test-layout.test.ts tests/test-layout-tooling.test.ts      17 pass, 0 fail
bun run typecheck                                                         pass
bun scripts/privacy-scan.ts                                               pass
```

Broader run over `tests/adapters`, `tests/providers/kiro`, `tests/images` and `tests/providers/mimo-free-provider.test.ts`: **1003 pass / 106 fail / 55 errors** on this branch against **991 pass / 106 fail / 55 errors** on unmodified `dev` at `6d3ad12e3`, run with the same command in a clean worktree. That is a baseline delta, not a green suite. The two sorted failure lists diff to zero lines and the error count is identical; the difference is the 12 new passing tests. The pre-existing failures are network-pinned transport, GCP ADC, and provider-option spine tests.

One caveat on that broad run: `openai-chat-native-policy.test.ts` aborts inside the whole-directory batch with `SyntaxError: Export named 'pinnedHttpPost' not found`. That is order-dependent `mock.module` pollution from `tests/images/download-cap-default.test.ts`, it occurs identically on unmodified `dev` in the same batch, and the file passes 22/22 on its own. It is not caused by this branch, and I have not tried to fix it here.

Both focused suites were re-run with a preload that throws on any un-stubbed `fetch`, and both still pass, so neither reaches the network.

CodeRabbit's Docstring Coverage pre-merge check was failing at 35.71% on this diff. The last commit documents the three functions it flagged: the `finish` closure in `openai-chat.ts` and the two message-walking helpers in `openai-chat-images.ts`.

New coverage: terminal overflow keeps counting a target whose drop leaves the bytes on the wire; an image this wire cannot drop keeps counting toward the budget; a delegating adapter awaits the built request instead of reading an undefined body; a normalizer rejection degrades to the unshrunk request; text-only turns stay synchronous and unchanged; under-budget image turns stay synchronous and byte-identical; an oversized turn is re-encoded through the real adapter wiring and keeps every image; terminal overflow keeps images attached instead of dropping the oldest; remote `https://` URLs are untouched; undecodable images keep their original URL; malformed message shapes neither throw nor lose parts; and `imageTierBias` from `IncomingMeta` reaches the normalizer.

### Review follow-up

`mimo-free` wraps this adapter and read `baseReq.body` from a synchronous cast. Once an image-bearing turn made `buildRequest` return a promise, that read produced `undefined` and `JSON.parse` threw, so image turns on that provider failed outright. Confirmed against the built adapter: `body` was `undefined` before the fix and is a string after. It now awaits the delegated call, with a regression test.

A normalizer rejection no longer fails the turn. The shared pipeline already leaves an image it cannot process untouched, so falling back to the unshrunk request means the worst case is the oversized request the caller would have sent anyway.

The terminal-overflow test was vacuous: its 40x40 PNG fits every tier's caps, so `processAt` passed it through before the injected encoder was reached and the ladder never ran. It now uses a 1000x1000 noise PNG, asserts the encoder reaches the terminal 320px tier, and asserts the total is still over budget while every image is retained.

The mimo regression called the real adapter, whose `buildRequest` bootstraps a JWT over the network. It passed locally and failed CI with `ECONNRESET` against `api.xiaomimimo.com`. It now stubs `fetch` and resets the JWT cache on both sides, following `tests/providers/mimo-free-provider.test.ts`.

The stale `imageTierBias` doc in `base.ts` now names `openai-chat` as a second consumer.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI Chat requests now automatically resize oversized inline images to stay within a 3.5 MiB image budget.
  * Images are preserved when resizing fails or inputs cannot be decoded; no images are dropped.
  * Image quality and tier preferences are respected during normalization.
  * Native Chat passthrough requests retain their original image bytes.

* **Documentation**
  * Added documentation describing inline image limits, resizing behavior, and native passthrough handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->