### PR TITLE
docs(security): document the private follow-up path for pending reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ Maintainer source-of-truth notes live under [`structure/`](./structure), contrib
 Report undisclosed vulnerabilities privately through
 [GitHub private vulnerability reporting](https://github.com/lidge-jun/opencodex/security/advisories/new),
 not a public issue.
+That form is the only technical channel — there is no security email. Follow-ups stay in the
+private report itself; a public issue may carry coordination only, never vulnerability details.
+Acknowledging a report is not the same as triaging it, and no first-response target is promised.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,32 @@ Include affected versions, reproduction steps, impact, and any required configur
 If the form is ever unreachable for you, open a minimal public issue that asks maintainers for a
 safe coordination path. Do not include exploit details, secrets, or live targets in that issue.
 
+### Public or private
+
+The test is whether a public diff already reveals the weakness. If the fix has shipped, or the
+defect is plainly visible in code that is already published, an ordinary public issue or pull
+request is the right route and normal review applies. If it has not, the report is
+pre-disclosure material and belongs in the private advisory form, whatever its severity looks
+like to you. When you are unsure, file privately; maintainers can move a report to public review,
+and the reverse is not possible.
+
+## Following Up on a Report You Already Filed
+
+Keep follow-up inside the private report. The advisory thread you opened stays open for
+comments, and that is where new evidence, corrected impact, and questions about status belong.
+There is no second private route: GitHub private vulnerability reporting is the only technical
+channel this project offers, and there is no security email to escalate to.
+
+If the private thread itself is stalled or unreachable, a public issue may carry **coordination
+only** — a request for a safe follow-up path, or a note that a filed report is still awaiting a
+response. Keep it free of the vulnerability: no reproduction steps, no exploit reasoning, no
+logs or attachments, no narrowing of affected versions, and no advisory identifiers or links.
+You do not need to say which report you mean; maintainers can match it privately, and naming it
+in public is itself a signal.
+
+A maintainer may answer such an issue in public. Read that answer narrowly — it confirms the
+route, not the content of anything you reported.
+
 ## Response Expectations
 
 Maintainers will review reports on a best-effort basis. Triage usually starts with:
@@ -39,6 +65,19 @@ Maintainers will review reports on a best-effort basis. Triage usually starts wi
 - reproducing the issue locally,
 - evaluating impact and safe remediation scope,
 - coordinating disclosure timing if a fix is needed.
+
+Receipt is not triage. An acknowledgment — including a maintainer confirming they can reach the
+private reporting queue — means the message arrived. It does not mean the report has been
+reproduced, assessed for impact, assigned an owner, or accepted. The private thread is the only
+place the technical outcome is recorded.
+
+Public review of a published patch does not close the corresponding private report, and it does
+not settle disclosure for anything else you filed. Landing a fix resolves the handling route for
+that fix; the private report closes when maintainers close it.
+
+There is no response deadline. Review is best-effort, as stated above, and this project does not
+publish a first-response target — please do not read one into an acknowledgment or into the
+triage steps listed here.
 
 ## Operational Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,12 +33,18 @@ safe coordination path. Do not include exploit details, secrets, or live targets
 
 ### Public or private
 
-The test is whether a public diff already reveals the weakness. If the fix has shipped, or the
-defect is plainly visible in code that is already published, an ordinary public issue or pull
-request is the right route and normal review applies. If it has not, the report is
-pre-disclosure material and belongs in the private advisory form, whatever its severity looks
-like to you. When you are unsure, file privately; maintainers can move a report to public review,
-and the reverse is not possible.
+Being findable in the source is not disclosure. opencodex is source-available, so nearly every
+defect here is in principle "visible in the code" — that is not the test, and it is not a reason
+to open a public issue.
+
+The test is whether the weakness is already public: the fix has shipped, or the defect is
+already described in a published advisory, issue, or pull request. When that is true, ordinary
+public review applies and a normal issue or pull request is the right route. When it is not, the
+report is pre-disclosure material and belongs in the private advisory form, whatever its
+severity looks like to you.
+
+If you are unsure, file privately. Maintainers can move a report to public review once it is
+safe to do so; the reverse is not possible.
 
 ## Following Up on a Report You Already Filed
 


### PR DESCRIPTION
## Summary

`SECURITY.md` explained how to file a report but stopped there. A reporter whose private
advisory had gone quiet had no stated follow-up route, no statement of what a public issue may
contain in that situation, and no way to tell an acknowledgment apart from completed triage —
which is the gap #4073 was opened to close.

Three additions, all wording only:

- **Public or private.** The test is whether the weakness is *already public* — the fix has
  shipped, or it is already described in a published advisory, issue, or pull request. Being
  findable in the source is explicitly called out as not disclosure, since opencodex is
  source-available and the opposite reading would route nearly every finding into the open. When
  unsure, file privately: a report can be moved to public review, not back.
- **Following up on a report you already filed.** Follow-up stays inside the private advisory
  thread. GitHub private vulnerability reporting is stated plainly as the only technical channel;
  there is no security email. If that thread itself is stalled, a public issue may carry
  **coordination only** — no reproduction, no exploit reasoning, no logs or attachments, no
  affected-version narrowing, and no advisory identifiers or links, since naming the report in
  public is itself a signal. A public maintainer reply confirms the route, not the content.
- **Response expectations.** Receipt is not triage: an acknowledgment, including a maintainer
  confirming they can reach the private queue, means the message arrived and nothing more. A
  landed public patch does not close the corresponding private report or settle disclosure for
  anything else. And there is **no response deadline** — stated explicitly so it is not read
  into the acknowledgment or into the triage-step list.

`README.md` carries the same three facts next to its existing security pointer.

**No response-time target or SLA is introduced.** Per @Ingwannu on #4073, a first-response target
needs @lidge-jun's agreement before it becomes a project commitment, so this PR states the
absence of one rather than proposing a number. No new reporting channel or email address is
invented either.

Closes #4073

## Verification

- `git diff origin/dev` — two files, documentation only. No `src/`, `gui/`, `scripts/`, workflow,
  or test file is touched, and nothing in the build, typecheck, or test path reads `SECURITY.md`
  or `README.md` prose (`rg 'SECURITY\.md' tests/ scripts/ .github/` finds only
  `.github/ISSUE_TEMPLATE/config.yml` and `.github/CODEOWNERS`, neither of which asserts on text).
- Independent audit of the diff and both full files by a separate agent, checking for an implied
  SLA, an invented channel, contradictions with the existing text, any wording that would push
  vulnerability detail into a public place, and Markdown/heading breakage. It returned FAIL on
  the first draft of the public-or-private test — "visible in published code" contradicted lines
  18, 26-27 and 85-86 of the same file — which is what `cf967c3d0` rewrites; a re-audit of the
  corrected text passed.
- **Local checks were NOT RUN** — no `bun run typecheck`, no `bun run test`, no build, no lint,
  no `bun install` — per explicit maintainer instruction for this lane. Exact-head remote CI on
  this PR is the gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Nothing here changes behavior, and no secret, identifier, or unreleased finding appears in the
diff — the policy text is written so that following it keeps such material out of public view.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that private vulnerability reporting is handled through GitHub’s private reporting form, with no security email channel.
  - Added guidance on follow-ups, stalled reports, and the limited coordination role of public issues.
  - Explained the distinction between acknowledging and triaging a report.
  - Clarified that public patch reviews do not close private reports and that response timing is best-effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->