### PR TITLE
fix(codex): attribute Spark quota headers

### DIFF
--- a/src/codex/quota-auto-refresh.ts
+++ b/src/codex/quota-auto-refresh.ts
@@ -169,7 +169,8 @@ async function warmAccount(config: OcxConfig, accountId: string): Promise<void |
     try {
       await warmCodexAccount({ ...token, onCompleted: headers => {
         if (isCodexAccountGenerationLive(accountId, token.generation)) {
-          applyAccountQuotaFromUpstreamHeaders(accountId, headers, writerGeneration);
+          // Warmup's default and fallback models both use the shared account quota.
+          applyAccountQuotaFromUpstreamHeaders(accountId, headers, writerGeneration, undefined, "shared");
         }
       } });
     } catch (error) {
@@ -206,7 +207,8 @@ async function warmAccount(config: OcxConfig, accountId: string): Promise<void |
       try {
         await warmCodexAccount({ ...token, onCompleted: headers => {
           if (writer && credentialStillLive()) {
-            applyAccountQuotaFromUpstreamHeaders(accountId, headers, writerGeneration, writer);
+            // Warmup's default and fallback models both use the shared account quota.
+            applyAccountQuotaFromUpstreamHeaders(accountId, headers, writerGeneration, writer, "shared");
           }
         } });
       } catch (error) {

--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -5,6 +5,7 @@ import { captureConfigGeneration, type GenerationContext } from "../lib/state-st
 import { isThirtyDayOnlyCodexPlan } from "./plan";
 import { MAIN_CODEX_ACCOUNT_ID } from "./account-id";
 import { getObservedMainQuotaIdentityKey, isMainQuotaWriterLive, type MainQuotaWriter } from "./main-account-cache";
+import type { CodexQuotaScope } from "./routing";
 
 import type { StoredAccountQuota, WhamUsageResponse, WhamUsageWindow } from "./quota-types";
 export type { StoredAccountQuota, WhamUsageResponse } from "./quota-types";
@@ -44,6 +45,8 @@ const MONTHLY_WINDOW_MIN_MINUTES = MONTHLY_WINDOW_MIN_SECONDS / 60;
 // Derived, never written as a literal: the header parser and the WHAM parser must not be able
 // to drift to different thresholds, which is the class of defect this pair exists to prevent.
 const WEEKLY_WINDOW_MIN_MINUTES = WEEKLY_WINDOW_MIN_SECONDS / 60;
+const CODEX_SPARK_SHORT_LABEL = "GPT-5.3-Codex-Spark 5h";
+const CODEX_SPARK_WEEKLY_LABEL = "GPT-5.3-Codex-Spark Weekly";
 
 const accountQuota = new Map<string, StoredAccountQuota>();
 let lastReconciledGeneration = 0;
@@ -480,12 +483,44 @@ export function applyAccountQuotaFromUpstreamHeaders(
   headers: Headers,
   writerGeneration = captureConfigGeneration(),
   mainWriter?: MainQuotaWriter,
+  quotaScope?: CodexQuotaScope,
 ): void {
-  const quota = parseUpstreamQuotaHeaders(headers);
-  if (!quota) return;
+  const parsed = parseUpstreamQuotaHeaders(headers);
+  if (!parsed) return;
+  let quota = parsed;
+  let policyInput = parsed;
+  if (quotaScope === "spark" && snapshotHasShort(parsed)) {
+    // Response headers do not label quota families. The caller's resolved model is the
+    // provenance: Spark's sub-day primary belongs in its custom window, while the secondary
+    // account window and any previously observed shared 5h window keep their existing meaning.
+    const {
+      shortPercent,
+      shortResetAt,
+      shortWindowSeconds: _shortWindowSeconds,
+      ...ordinaryQuota
+    } = parsed;
+    policyInput = ordinaryQuota;
+    quota = ordinaryQuota;
+    if (shortPercent !== undefined) {
+      const sparkShort = {
+        label: CODEX_SPARK_SHORT_LABEL,
+        percent: shortPercent,
+        ...(shortResetAt !== undefined ? { resetAt: shortResetAt } : {}),
+      };
+      const existing = getAccountQuota(accountId)?.customWindows ?? [];
+      let replaced = false;
+      const customWindows = existing.map(window => {
+        if (window.label !== CODEX_SPARK_SHORT_LABEL) return window;
+        replaced = true;
+        return sparkShort;
+      });
+      if (!replaced) customWindows.push(sparkShort);
+      quota = { ...ordinaryQuota, customWindows };
+    }
+  }
   const policyQuota = [
     "x-codex-primary-used-percent", "x-codex-secondary-used-percent", "x-codex-tertiary-used-percent",
-  ].some(name => isInvalidPolicyUsagePercent(headers.get(name))) ? null : filterMainPolicyMonthlyQuota(quota);
+  ].some(name => isInvalidPolicyUsagePercent(headers.get(name))) ? null : filterMainPolicyMonthlyQuota(policyInput);
   setAccountQuotaFromParsed(accountId, quota, writerGeneration, mainWriter, policyQuota);
 }
 
@@ -812,8 +847,8 @@ export function parseUsageQuota(data: WhamUsageResponse): Omit<StoredAccountQuot
   });
   const sparkCustomWindows: Array<{ label: string; percent: number; resetAt?: number }> = [];
   for (const [label, window] of [
-    ["GPT-5.3-Codex-Spark 5h", sparkShort],
-    ["GPT-5.3-Codex-Spark Weekly", sparkWeekly],
+    [CODEX_SPARK_SHORT_LABEL, sparkShort],
+    [CODEX_SPARK_WEEKLY_LABEL, sparkWeekly],
   ] as const) {
     const percent = normalizeUsagePercent(window?.used_percent);
     if (percent === undefined) continue;

--- a/src/server/responses/compact.ts
+++ b/src/server/responses/compact.ts
@@ -61,6 +61,7 @@ import {
   type NativeMainRefreshDependencies,
 } from "../../codex/main-account";
 import {
+  codexQuotaScopeForModel,
   formatCodexProviderForLog,
   handOffThreadAffinityGeneration,
   recordCodexUpstreamOutcome,
@@ -1015,6 +1016,7 @@ export async function handleResponsesCompact(
             upstream.headers,
             authCtx.writerGeneration,
             authCtx.kind === "main-pool" ? authCtx.mainQuotaWriter : undefined,
+            codexQuotaScopeForModel(selectedModelId),
           );
         }
         recordCompactPoolOutcome(authCtx, upstream.status, {

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -1012,14 +1012,18 @@ export function usesCodexForwardPoolAuth(
     && provider.authMode === "forward" && provider.adapter === "openai-responses";
 }
 
-function codexWsQuotaObserver(authCtx: CodexAuthContext, provider: OcxProviderConfig): CodexWsQuotaObserver | undefined {
+function codexWsQuotaObserver(
+  authCtx: CodexAuthContext,
+  provider: OcxProviderConfig,
+  modelId?: string,
+): CodexWsQuotaObserver | undefined {
   if (!isCanonicalOpenAiForwardProvider(provider) || !usesCodexForwardPoolAuth(authCtx, provider)) return undefined;
   const { accountId, writerGeneration } = authCtx;
   const credentialGeneration = authCtx.kind === "pool" ? authCtx.generation : undefined;
   const mainWriter = authCtx.kind === "main-pool" ? authCtx.mainQuotaWriter : undefined;
   return headers => {
     if (credentialGeneration !== undefined && !isCodexAccountGenerationLive(accountId, credentialGeneration)) return;
-    applyCapturedCodexQuota(accountId, headers, writerGeneration, mainWriter);
+    applyCapturedCodexQuota(accountId, headers, writerGeneration, mainWriter, codexQuotaScopeForModel(modelId));
   };
 }
 
@@ -1382,6 +1386,7 @@ async function retryCodexPoolOnAlternateAccount(
       firstResponse.headers,
       firstAuthCtx.writerGeneration,
       firstAuthCtx.kind === "main-pool" ? firstAuthCtx.mainQuotaWriter : undefined,
+      codexQuotaScopeForModel(route.modelId),
     );
   }
   const deferFirstOutcome = shouldDeferCodexResetDerivedCooldown(
@@ -1473,7 +1478,7 @@ async function retryCodexPoolOnAlternateAccount(
           providerFetch(route.provider, options.codexWsRuntimeIdentity, {
             providerName: route.providerName,
             modelId: route.modelId,
-            onCodexWsQuota: codexWsQuotaObserver(retryAuthCtx, route.provider),
+            onCodexWsQuota: codexWsQuotaObserver(retryAuthCtx, route.provider, route.modelId),
             beforeDispatch: isCanonicalOpenAiForwardProvider(route.provider)
               ? createCodexReserveDispatchGuard(retryAuthCtx, options.codexAuthPolicy ?? config, route.modelId, options.admission, options.visionDescribeTerminal === true) : undefined,
           }),
@@ -5050,7 +5055,7 @@ async function handleResponsesInner(
               dispatchOverride: oauthDispatch(request),
               providerName: route.providerName,
               modelId: route.modelId,
-              onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider),
+              onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider, route.modelId),
               beforeDispatch: isCanonicalOpenAiForwardProvider(route.provider)
                 ? createCodexReserveDispatchGuard(authCtx, options.codexAuthPolicy ?? config, route.modelId, options.admission, options.visionDescribeTerminal === true) : undefined,
             }),
@@ -5128,7 +5133,7 @@ async function handleResponsesInner(
               dispatchOverride: oauthDispatch(request),
                 providerName: route.providerName,
                 modelId: route.modelId,
-                onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider),
+                onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider, route.modelId),
                 beforeDispatch: isCanonicalOpenAiForwardProvider(route.provider)
                   ? createCodexReserveDispatchGuard(authCtx, options.codexAuthPolicy ?? config, route.modelId, options.admission, options.visionDescribeTerminal === true) : undefined,
               }),
@@ -5234,7 +5239,7 @@ async function handleResponsesInner(
               dispatchOverride: oauthDispatch(request),
               providerName: route.providerName,
               modelId: route.modelId,
-              onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider),
+              onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider, route.modelId),
               beforeDispatch: isCanonicalOpenAiForwardProvider(route.provider)
                 ? createCodexReserveDispatchGuard(authCtx, options.codexAuthPolicy ?? config, route.modelId, options.admission, options.visionDescribeTerminal === true) : undefined,
             }),
@@ -5354,7 +5359,7 @@ async function handleResponsesInner(
               dispatchOverride: oauthDispatch(request),
                 providerName: route.providerName,
                 modelId: route.modelId,
-                onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider),
+                onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider, route.modelId),
                 beforeDispatch: isCanonicalOpenAiForwardProvider(route.provider)
                   ? createCodexReserveDispatchGuard(authCtx, options.codexAuthPolicy ?? config, route.modelId, options.admission, options.visionDescribeTerminal === true) : undefined,
               }),
@@ -5454,7 +5459,7 @@ async function handleResponsesInner(
               dispatchOverride: oauthDispatch(request),
                 providerName: route.providerName,
                 modelId: route.modelId,
-                onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider),
+                onCodexWsQuota: codexWsQuotaObserver(authCtx, route.provider, route.modelId),
                 beforeDispatch: isCanonicalOpenAiForwardProvider(route.provider)
                   ? createCodexReserveDispatchGuard(authCtx, options.codexAuthPolicy ?? config, route.modelId, options.admission, options.visionDescribeTerminal === true) : undefined,
               }),
@@ -5658,7 +5663,8 @@ async function handleResponsesInner(
       const { applyAccountQuotaFromUpstreamHeaders } = await import("../../codex/auth-api");
       if (!isCodexWsQuotaObservedResponse(upstreamResponse)) {
         applyAccountQuotaFromUpstreamHeaders(authCtx.accountId, upstreamResponse.headers,
-          authCtx.writerGeneration, authCtx.kind === "main-pool" ? authCtx.mainQuotaWriter : undefined);
+          authCtx.writerGeneration, authCtx.kind === "main-pool" ? authCtx.mainQuotaWriter : undefined,
+          codexQuotaScopeForModel(route.modelId));
       }
       if (terminalBodyWillRecord) {
         options.setTerminalOutcomeRecorder?.((status, httpStatusOverride) => {

--- a/tests/codex-integration/codex-quota-parser-parity.test.ts
+++ b/tests/codex-integration/codex-quota-parser-parity.test.ts
@@ -49,6 +49,83 @@ describe("Spark quota survives partial header updates", () => {
     setAccountQuotaFromParsed("spark-clear", { weeklyPercent: 21 });
     expect(getAccountQuota("spark-clear")?.customWindows).toBeUndefined();
   });
+
+  it("attributes a Spark response's short primary window without creating a generic 5h quota", () => {
+    clearAccountQuota();
+    setAccountQuotaFromParsed("spark-attributed", parseUsageQuota({
+      plan_type: "pro",
+      rate_limit: {
+        primary_window: { used_percent: 53, reset_at: 2_000_000_000, limit_window_seconds: 604_800 },
+      },
+      additional_rate_limits: [{
+        limit_name: "GPT-5.3-Codex-Spark",
+        metered_feature: "codex_bengalfox",
+        rate_limit: {
+          primary_window: { used_percent: 6, reset_at: 1_900_000_000, limit_window_seconds: 18_000 },
+          secondary_window: { used_percent: 7, reset_at: 2_100_000_000, limit_window_seconds: 604_800 },
+        },
+      }],
+    }));
+
+    applyAccountQuotaFromUpstreamHeaders("spark-attributed", new Headers({
+      "x-codex-primary-used-percent": "8",
+      "x-codex-primary-reset-at": "1900000100",
+      "x-codex-primary-window-minutes": "300",
+      "x-codex-secondary-used-percent": "54",
+      "x-codex-secondary-reset-at": "2000000100",
+      "x-codex-secondary-window-minutes": "10080",
+    }), undefined, undefined, "spark");
+
+    expect(getAccountQuota("spark-attributed")).toMatchObject({
+      weeklyPercent: 54,
+      weeklyResetAt: 2_000_000_100,
+      customWindows: [
+        { label: "GPT-5.3-Codex-Spark 5h", percent: 8, resetAt: 1_900_000_100 },
+        { label: "GPT-5.3-Codex-Spark Weekly", percent: 7, resetAt: 2_100_000_000 },
+      ],
+    });
+    expect(getAccountQuota("spark-attributed")).not.toHaveProperty("shortPercent");
+    expect(getAccountQuota("spark-attributed")).not.toHaveProperty("shortResetAt");
+    expect(getAccountQuota("spark-attributed")).not.toHaveProperty("shortWindowSeconds");
+  });
+
+  it("keeps a genuine generic 5h quota while updating the Spark 5h window", () => {
+    clearAccountQuota();
+    setAccountQuotaFromParsed("spark-and-shared", {
+      shortPercent: 12,
+      shortResetAt: 2_200_000_000,
+      shortWindowSeconds: 18_000,
+    });
+
+    applyAccountQuotaFromUpstreamHeaders("spark-and-shared", new Headers({
+      "x-codex-primary-used-percent": "9",
+      "x-codex-primary-reset-at": "1900000200",
+      "x-codex-primary-window-minutes": "300",
+    }), undefined, undefined, "spark");
+
+    expect(getAccountQuota("spark-and-shared")).toMatchObject({
+      shortPercent: 12,
+      shortResetAt: 2_200_000_000,
+      shortWindowSeconds: 18_000,
+      customWindows: [{ label: "GPT-5.3-Codex-Spark 5h", percent: 9, resetAt: 1_900_000_200 }],
+    });
+  });
+
+  it("continues to store a shared model's short primary window as generic 5h quota", () => {
+    clearAccountQuota();
+    applyAccountQuotaFromUpstreamHeaders("shared-attributed", new Headers({
+      "x-codex-primary-used-percent": "10",
+      "x-codex-primary-reset-at": "1900000300",
+      "x-codex-primary-window-minutes": "300",
+    }), undefined, undefined, "shared");
+
+    expect(getAccountQuota("shared-attributed")).toMatchObject({
+      shortPercent: 10,
+      shortResetAt: 1_900_000_300,
+      shortWindowSeconds: 18_000,
+    });
+    expect(getAccountQuota("shared-attributed")?.customWindows).toBeUndefined();
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

- carry the resolved Codex quota scope through HTTP, WebSocket, compact-retry, and warmup header writers
- attribute a Spark response's sub-day primary window to `GPT-5.3-Codex-Spark 5h` instead of the account-level `short*` fields
- preserve the ordinary secondary weekly window, genuine shared 5-hour windows, other custom windows, and existing generation/main-writer fences
- avoid plan checks or percent/reset equality heuristics; attribution comes from the model that produced the headers

Closes #4122.

## Verification

- `bun test tests/codex-integration/codex-quota-parser-parity.test.ts` (14 pass)
- `bun test tests/codex-integration/codex-quota-auto-refresh.test.ts --timeout 10000` (20 pass)
- `bun test tests/codex-integration/main-quota-provenance.test.ts tests/codex-integration/main-quota-window-observation.test.ts` (all assertions passed)
- `bun test tests/responses/responses-account-label.test.ts --timeout 10000` (8 pass)
- `bun test tests/responses/responses-compaction-routing.test.ts --timeout 10000` (121 pass)
- `bun run typecheck`
- `bun run lint:gui:if-changed` (correctly skipped; no GUI changes)
- `bun run privacy:scan`
- `git diff --check`

Windows note: the existing `successive idle windows` auto-refresh test took about 5-6.5 seconds locally and crossed Bun's default 5-second per-test timeout; it passed with the explicit 10-second timeout above. No assertion failed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
