### PR TITLE
feat(oauth): report an explicit account plan field for OAuth providers

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -803,6 +803,24 @@ Codex, OAuth, and API-key pools without opening the dashboard. See the
 [CLI reference](/reference/cli/#ocx-account-subcommand) for commands, JSON output, and
 new-session behavior.
 
+#### Subscription tier in account listings
+
+`ocx account list <provider> --json` and `GET /api/oauth/accounts` report a `plan` field on every
+OAuth account, using the same name and placement as the OpenAI/Codex provider so a consumer can
+read one shape across providers.
+
+The field is always present. It is `null` when the tier is unknown, which is deliberate: an
+**absent** key means the proxy predates this field, while `null` means this version looked and the
+provider did not report a tier. Collapsing the two would let a consumer quietly assume a tier.
+
+For Anthropic the value is `null` today. Its usage endpoint returns quota buckets only — the
+five-hour and seven-day windows, the model-scoped weekly windows, and a `limits` array — and no
+subscription or tier field; the OAuth token response carries only the account id and email. There
+is nothing to map, so nothing is mapped. The tier is also not derivable from the quota it does
+return, because percentages are normalized per account: a Max ×5 seat at 50% is indistinguishable
+from a Max ×20 seat at 50%. If you need weighted pool capacity across mixed Anthropic tiers, keep
+that mapping outside OpenCodex until upstream reports the tier itself.
+
 ### GPT-5.6 preview paths
 
 GPT-5.6 Sol/Terra/Luna are seeded in provider fallback lists so `ocx sync` can keep the models

--- a/src/cli/account-api.ts
+++ b/src/cli/account-api.ts
@@ -18,7 +18,11 @@ export interface AccountRow {
   id: string;
   label?: string;
   email?: string;
-  plan?: string;
+  /**
+   * Subscription tier. `null` means this version looked and the provider did not report one;
+   * an absent key means the row's surface does not carry a tier at all (#3777).
+   */
+  plan?: string | null;
   masked?: string;
   active: boolean;
   needsReauth?: boolean;
@@ -316,6 +320,8 @@ interface OAuthAccountDto {
   email?: string;
   active?: boolean;
   needsReauth?: boolean;
+  /** Always sent by the management route; explicitly `null` when the tier is unknown. */
+  plan?: string | null;
   quota?: CodexQuotaDto | null;
   quotaUnavailable?: boolean;
 }
@@ -346,6 +352,9 @@ async function fetchOAuthRows(
     email: a.email,
     active: a.active ?? a.id === activeId,
     needsReauth: a.needsReauth,
+    // Forward the server's answer verbatim, including `null`. Collapsing null to "absent" here
+    // would destroy the one distinction this field exists to make.
+    plan: a.plan ?? null,
     ...(a.quota !== undefined ? { quota: a.quota } : {}),
     ...(a.quotaUnavailable !== undefined ? { quotaUnavailable: a.quotaUnavailable } : {}),
   }));

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1781,7 +1781,29 @@ export function submitManualLoginCode(provider: string, input: string): { ok: tr
   return { ok: true };
 }
 
-export interface OAuthAccountSummary { id: string; alias?: string; email?: string; active: boolean; needsReauth?: boolean; expiresAt?: number }
+export interface OAuthAccountSummary {
+  id: string;
+  alias?: string;
+  email?: string;
+  active: boolean;
+  needsReauth?: boolean;
+  expiresAt?: number;
+  /**
+   * Subscription tier, mirroring the field the OpenAI/Codex provider reports, so a consumer
+   * weighting a multi-account pool by seat size needs no per-provider branching (#3777).
+   *
+   * Always present and explicitly `null` when the tier is unknown. The distinction matters:
+   * an ABSENT key means the proxy is too old to report a tier at all, while `null` means this
+   * version looked and upstream did not say. Omitting it would make those indistinguishable and
+   * invite a consumer to assume a tier.
+   *
+   * Every OAuth provider reports `null` today. Anthropic's `/api/oauth/usage` returns quota
+   * buckets only — `five_hour`, `seven_day`, the model-scoped weekly windows and `limits[]` —
+   * and carries no subscription/tier field, and its token response carries none either. See
+   * `fetchAnthropicUsageQuota` in `src/providers/quota.ts`.
+   */
+  plan: string | null;
+}
 
 export function getLoginStatus(provider: string): { loggedIn: boolean; email?: string; source?: OAuthCredentials["source"]; error?: string; done: boolean; activeAccountId?: string; accounts?: OAuthAccountSummary[] } {
   const cred = getCredential(provider);
@@ -1794,6 +1816,11 @@ export function getLoginStatus(provider: string): { loggedIn: boolean; email?: s
     active: a.id === set.activeAccountId,
     ...(a.needsReauth ? { needsReauth: true } : {}),
     expiresAt: a.credential.expires,
+    // Explicitly null rather than omitted — see OAuthAccountSummary.plan. No OAuth provider
+    // exposes a subscription tier today, so there is nothing truthful to put here; deriving one
+    // from quota percentages is not possible, because they are normalized per account and a
+    // half-consumed small seat is indistinguishable from a half-consumed large one.
+    plan: null,
   }));
 
   // A stored credential counts as "logged in" when it exists and is not marked for

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -1398,6 +1398,21 @@ function parseClaudeLimit(value: unknown): { label: string; percent: number; res
 /** Claude's OAuth usage endpoint, probed with ONE account's own bearer token. */
 const anthropicUsageInflight = new Map<string, Promise<ProviderQuota | null>>();
 
+/**
+ * Anthropic per-credential usage.
+ *
+ * This endpoint reports quota only. Its body carries `five_hour`, `seven_day`, the
+ * model-scoped weekly buckets (`seven_day_fable`/`_opus`/`_sonnet`) and a `limits` array,
+ * and **no subscription or tier field** — nor does the OAuth token response, which yields only
+ * `account.uuid` and `account.email_address` (`src/oauth/anthropic.ts`). That is why
+ * `OAuthAccountSummary.plan` is `null` for Anthropic rather than populated here (#3777); it is
+ * a missing upstream field, not an unfinished mapping.
+ *
+ * A tier must not be inferred from what is here. Percentages are normalized per account, so a
+ * Max x5 seat at 50% is byte-identical to a Max x20 seat at 50%, and the presence of a
+ * model-scoped window tracks entitlement rather than seat size. Populate `plan` only when
+ * upstream returns the tier itself.
+ */
 async function fetchAnthropicUsageQuota(accessToken: string): Promise<ProviderQuota | null> {
   const joinable = anthropicUsageInflight.get(accessToken);
   if (joinable) return joinable;

--- a/tests/oauth/oauth-accounts-api.test.ts
+++ b/tests/oauth/oauth-accounts-api.test.ts
@@ -352,6 +352,44 @@ describe("multiauth accounts API", () => {
     }
   });
 
+  test("GET reports an explicit null plan for an Anthropic account", async () => {
+    writeFileSync(join(testDir, "auth.json"), JSON.stringify({
+      anthropic: {
+        activeAccountId: "aaaa1111",
+        accounts: [
+          {
+            id: "aaaa1111",
+            credential: {
+              access: "t1",
+              refresh: "r1",
+              expires: 9999999999999,
+              email: "first@example.com",
+              accountId: "acct-1",
+            },
+          },
+        ],
+      },
+    }), { mode: 0o600 });
+
+    const server = startServer(0);
+    try {
+      const res = await fetch(new URL("/api/oauth/accounts?provider=anthropic", server.url));
+      expect(res.status).toBe(200);
+      const body = await res.json() as { accounts: Array<{ id: string; plan?: string | null }> };
+      const account = body.accounts[0]!;
+
+      // The key must be PRESENT and null, not omitted. A consumer weighting a pool by seat size
+      // has to tell "this version looked and upstream did not say" apart from "this proxy is too
+      // old to report a tier"; omitting the key collapses those and invites assuming a tier
+      // (#3777). Anthropic's usage endpoint carries no subscription field, so null is the only
+      // truthful answer available today.
+      expect("plan" in account).toBe(true);
+      expect(account.plan).toBeNull();
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test("PUT active switches; unknown account 404; unknown provider 400", async () => {
     const server = startServer(0);
     try {


### PR DESCRIPTION
## Summary

Closes #3777.

The OpenAI/Codex provider reports a per-account `plan` string, so a consumer can weight each account's remaining quota by its seat size. The OAuth providers reported no such field at all, so a multi-account Anthropic pool had no meaningful aggregate capacity number and every account looked identical in tier terms. The reporter was maintaining a hand-written account-id to tier map that silently rots whenever a subscription changes.

`plan` is now reported on the OAuth account summary, the management route (`GET /api/oauth/accounts`) and the CLI DTO (`ocx account list <provider> --json`), using the same field name and placement as the Codex side so consumers need no per-provider branching.

**The field is always present, and `null` when the tier is unknown.** That distinction is the substance of the change, not a detail: an **absent** key means the proxy predates this field, while `null` means this version looked and the provider did not report a tier. Collapsing the two is what lets a consumer quietly assume a tier, which is the failure mode the issue describes. The CLI forwards the server's answer verbatim rather than normalizing `null` away.

## For Anthropic the value is `null`, and that is upstream, not unfinished

Stating this plainly so a future reader does not read it as an oversight or a TODO.

`GET https://api.anthropic.com/api/oauth/usage` returns quota buckets only — `five_hour`, `seven_day`, the model-scoped weekly windows (`seven_day_fable`/`_opus`/`_sonnet`) and a `limits` array — and carries **no subscription or tier field**. The OAuth token response carries none either: `src/oauth/anthropic.ts` gets `account.uuid` and `account.email_address` and nothing else. There is no tier in anything this proxy receives, so nothing is mapped.

**No tier is inferred from what is there**, and the issue is explicit about why that would be wrong. Quota percentages are normalized per account, so a Max x5 seat at 50% is byte-identical to a Max x20 seat at 50%. The presence of a model-scoped weekly window tracks entitlement rather than seat size, so keying a tier off it would produce a confident wrong answer that is indistinguishable from data. A guess here is worse than `null`, because `null` is something a consumer can handle correctly and a wrong tier is not.

The reasoning is recorded in a comment at `fetchAnthropicUsageQuota` and in the providers guide, so the next person to look does not re-derive it. If upstream later returns the tier, populating this field is a one-line change at that call site with no contract change anywhere above it.

Issue item 4 (surfacing the tier in the dashboard Anthropic rows) is deliberately **not** included. There is nothing to display while every value is `null`, so it would be a GUI change with no user-visible effect; it belongs with the upstream field if it appears.

## Verification

- **Local checks were NOT RUN, per maintainer instruction for this lane** — no `bun run test`, `test:changed`, `typecheck`, `build:gui`, `lint:gui` or `bun install`. The exact-head remote CI on this PR is the gate, and the branch was pushed with `--no-verify`.
- Added `tests/oauth/oauth-accounts-api.test.ts` -> "GET reports an explicit null plan for an Anthropic account", which asserts `"plan" in account` **and** `plan === null`. Asserting presence separately from the value is what pins the contract this change exists to create; a test that only checked the value would still pass if the key were dropped.
- Documented in `docs-site/src/content/docs/guides/providers.md` under "Switching accounts from the terminal". English only; no translated locale is contradicted, since none of them describe this field.
- No `gui/` files are touched.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This touches `src/oauth/index.ts`, so specifically: the added field is a constant `null` and carries no credential-derived data; no token, refresh grant, account id or email reaches a new surface; the account summary's existing email masking is untouched; and the change is read-only with respect to the credential store.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account listings now include a `plan` field for every OAuth account.
  - The field is explicitly `null` when the subscription tier is unknown, including for Anthropic accounts.

- **Documentation**
  - Added guidance explaining the `plan` field, its possible values, and compatibility behavior across account-listing interfaces.

- **Tests**
  - Added coverage verifying that Anthropic account listings include `plan: null` when no tier is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->