### PR TITLE
feat(privacy): let an operator opt out of email masking

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/server.md
+++ b/docs-site/src/content/docs/reference/configuration/server.md
@@ -224,6 +224,32 @@ use `ssh -g -L`, broad container publishing, or forwarding modes that expose the
 `0.0.0.0`. Bind explicitly with `ssh -L 127.0.0.1:20100:localhost:10100` when unsure.
 :::
 
+## Account email masking (`privacy`)
+
+Stored account emails are masked everywhere they leave the proxy — the dashboard account lists,
+`GET /api/codex-auth/accounts`, `GET /api/oauth/status`, and the `ocx status` logins section all
+show `p***n@example.com` rather than the address on file.
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `privacy.maskEmails?` | `boolean` | `true` | Set to `false` to show stored account emails in full. Absent, `true`, and any malformed value all keep masking, so only a deliberate `false` reveals an address. |
+
+Turn it off when you run many accounts on a machine you control and cannot tell them apart from
+masked forms. Read the flag as a disclosure decision rather than a display preference: management
+is not always loopback, so on a hub configured with `remoteGui` an unmasked address reaches every
+management principal that can reach the hub, not only someone sitting at the machine. The flag
+moves only the email field — tokens, refresh tokens, and account identifiers stay redacted either
+way.
+
+```json
+{ "privacy": { "maskEmails": false } }
+```
+
+`ocx config set privacy.maskEmails false` fails with `config parent path not found` until the
+block exists, because `config set` walks into existing objects and never creates them. Write the
+whole object instead — `ocx config set privacy '{"maskEmails":false}'` — or add the block to
+`config.json` by hand.
+
 ## Storage cleanup
 
 `storageCleanupPolicy` is disabled by default. When enabled, it runs on `startup`, `daily`, `weekly`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1428,9 +1428,13 @@ async function handleStatus() {
     }
   }
   const { collectOAuthHealthEntriesForCli, oauthLoginSummary } = await import("../oauth");
+  const { emailMaskingEnabled } = await import("../lib/privacy");
   const { formatOAuthHealthForStatus } = await import("./status-oauth");
   console.log(`   OAuth logins:`);
-  for (const e of oauthLoginSummary()) {
+  // The operator's own `privacy.maskEmails` decision applies to the CLI too: `ocx status` is not
+  // the dashboard, but it reads the same stored addresses, and a flag that only moved one of the
+  // two would leave the operator unable to tell which surface they had configured.
+  for (const e of oauthLoginSummary(emailMaskingEnabled(loadConfig()))) {
     console.log(`     ${e.provider.padEnd(10)} ${e.loggedIn ? `✓ logged in${e.email ? ` (${e.email})` : ""}` : "✗ not logged in"}`);
   }
   const oauthHealthBlock = formatOAuthHealthForStatus(await collectOAuthHealthEntriesForCli());

--- a/src/codex/auth-api.ts
+++ b/src/codex/auth-api.ts
@@ -115,7 +115,7 @@ export { clearMainAccountInfoCache } from "./main-account-cache";
 import type { CodexQuotaRefreshOutcome } from "./quota-refresh-outcome";
 import { getMainAccountHardLockStatus, type MainAccountHardLockStatus } from "./main-account-hard-lock";
 import { observeMainReserveRevocation } from "./reserve-availability";
-import { maskEmail } from "../lib/privacy";
+import { emailMaskingEnabled, projectEmail } from "../lib/privacy";
 import { codexWarmupFailureReason, warmCodexAccount } from "./warmup";
 export { maskEmail } from "../lib/privacy";
 import type { CodexAccount, CodexAccountCredentials, OcxConfig } from "../types";
@@ -370,6 +370,7 @@ function poolAccountDto(
   hasCredential: boolean,
   paused: boolean,
   priority: number,
+  maskEmails: boolean,
 ): CodexAuthAccountDto {
   const plan = codexPlanValue(account.plan);
   const quota = quotaForPlan(quotaResult.quota, plan);
@@ -377,7 +378,7 @@ function poolAccountDto(
   const health = projectCodexAccountHealth({ accountId: account.id, needsReauth });
   return {
     id: account.id,
-    email: maskEmail(account.email) ?? account.email,
+    email: projectEmail(account.email, maskEmails) ?? account.email,
     ...(account.alias !== undefined ? { alias: account.alias } : {}),
     ...(plan !== undefined ? { plan } : {}),
     logLabel: codexAccountLogLabel(account),
@@ -1929,6 +1930,8 @@ export async function listCodexAuthAccountsSnapshot(
 ): Promise<CodexAuthAccountsSnapshot> {
   const runtimeConfig = getRuntimeConfig(config);
   const poolAccounts = (runtimeConfig.codexAccounts ?? []).filter(isSelectableCodexPoolAccount);
+  // One redaction decision for the whole snapshot, read once from the operator's config (#3859).
+  const maskEmails = emailMaskingEnabled(runtimeConfig);
   const mainResult = await fetchMainAccountInfoAttempt(forceRefresh, 1);
   const refreshedPool = await mapWithConcurrency(poolAccounts, POOL_QUOTA_REFRESH_CONCURRENCY, async account => {
     const cred = getCodexAccountCredential(account.id);
@@ -1973,6 +1976,7 @@ export async function listCodexAuthAccountsSnapshot(
         false,
         isCodexAccountPaused(runtimeConfig, accountId),
         getCodexAccountPriority(runtimeConfig, accountId),
+        maskEmails,
       )];
     }
     const resultGeneration = quotaResult.credentialGeneration ?? quotaResult.freshCredentialGeneration;
@@ -1992,6 +1996,7 @@ export async function listCodexAuthAccountsSnapshot(
       true,
       isCodexAccountPaused(runtimeConfig, accountId),
       getCodexAccountPriority(runtimeConfig, accountId),
+      maskEmails,
     )];
   });
   const fetchedMainGeneration = mainResult.identityGeneration ?? captureMainAccountIdentityGeneration();
@@ -2008,7 +2013,7 @@ export async function listCodexAuthAccountsSnapshot(
   });
   const main: CodexAuthAccountDto = {
     id: MAIN_CODEX_ACCOUNT_ID,
-    email: maskEmail(mainInfo.email) ?? "Codex App login",
+    email: projectEmail(mainInfo.email, maskEmails) ?? "Codex App login",
     plan: mainInfo.plan,
     ...(mainSnapshotLive && mainResult.quotaRefresh && mainResult.quotaRefreshGeneration !== undefined
       && isMainAccountIdentityGenerationLive(mainResult.quotaRefreshGeneration)
@@ -3026,6 +3031,9 @@ export async function handleCodexAuthAPI(
   if (url.pathname === "/api/codex-auth/login-status" && req.method === "GET") {
     const flowId = url.searchParams.get("flowId");
     const accountId = url.searchParams.get("accountId")?.trim();
+    // Transient flow state carries the address of the account being added, so it follows the
+    // same operator policy as the stored accounts it is about to become.
+    const maskFlowEmails = emailMaskingEnabled(config);
     // Reauth always has a pre-existing credential; never treat "credential exists" as success
     // when the flow map entry is gone (would false-complete on lost/expired flow state).
     const reauthStatus = url.searchParams.get("reauth") === "1";
@@ -3042,11 +3050,11 @@ export async function handleCodexAuthAPI(
           ...(readCodexAccountRecord(accountId)?.codexValidationPending ? { validationPending: true } : {}),
         });
       }
-      return jsonResponse(st ? { ...st, email: maskEmail(st.email) ?? undefined } : { status: "expired" });
+      return jsonResponse(st ? { ...st, email: projectEmail(st.email, maskFlowEmails) ?? undefined } : { status: "expired" });
     }
     // Legacy fallback: return latest pending flow
     for (const [, st] of codexAuthLoginState) {
-      if (st.status === "pending") return jsonResponse({ ...st, email: maskEmail(st.email) ?? undefined });
+      if (st.status === "pending") return jsonResponse({ ...st, email: projectEmail(st.email, maskFlowEmails) ?? undefined });
     }
     return jsonResponse({ status: "idle" });
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1146,6 +1146,9 @@ const configSchema = z.object({
   // candidates are rejected explicitly by remoteGuiConfigError below.
   hub: hubConfigSchema.optional().catch(undefined),
   remoteGui: remoteGuiConfigSchema.optional().catch(undefined),
+  // A malformed privacy block must never be read as "unmask": .catch(undefined) drops it and
+  // emailMaskingEnabled then falls back to masked, which is also what an absent block means.
+  privacy: z.object({ maskEmails: z.boolean().optional() }).strict().optional().catch(undefined),
   // A malformed present client block must remain diagnosable from raw config and
   // fail closed through src/client/state.ts; unrelated provider state still loads.
   client: clientConnectionSchema.optional().catch(undefined),

--- a/src/lib/privacy.ts
+++ b/src/lib/privacy.ts
@@ -10,6 +10,31 @@ export function maskEmail(value: string | null | undefined): string | null {
   return `${local[0]}***${local[local.length - 1]}@${domain}`;
 }
 
+/**
+ * Whether stored account emails are masked in management and CLI projections (#3859).
+ *
+ * Fail closed on every ambiguity: a missing config, a missing `privacy` block, and a missing or
+ * malformed `maskEmails` all mask. Only the literal boolean `false` unmasks, so a hand-edited
+ * `"false"` string or a typo cannot silently disclose an address. Callers read this once at the
+ * request boundary and pass the answer down — the projection helpers take a boolean rather than
+ * a config so that `getLoginStatus` stays free of config I/O.
+ */
+export function emailMaskingEnabled(config: { privacy?: { maskEmails?: boolean } } | null | undefined): boolean {
+  return config?.privacy?.maskEmails !== false;
+}
+
+/**
+ * Project a stored account email for a surface outside the proxy (#3859).
+ *
+ * One redaction decision for every call site, rather than each one forking on the flag: an
+ * unmasked projection still normalises an empty or absent address to `null`, so a consumer's
+ * "is there an email" test cannot start answering differently just because masking is off.
+ */
+export function projectEmail(value: string | null | undefined, mask: boolean): string | null {
+  if (!mask) return value ? value : null;
+  return maskEmail(value);
+}
+
 export function maskAccountId(value: string | null | undefined): string | null {
   if (!value) return null;
   const id = value.trim();

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -4,7 +4,7 @@ import { parseCallbackInput } from "./callback-server";
 import type { OcxConfig, OcxProviderConfig, RefreshPolicy } from "../types";
 import { ConfigMutationLockError, loadConfig, mutatePersistedConfig, saveConfig } from "../config";
 import { resolveProviderApiKey } from "../providers/key-store";
-import { maskEmail } from "../lib/privacy";
+import { projectEmail } from "../lib/privacy";
 import { KiroTokenRefreshError, environmentKiroRoutingMetadata, loginKiro, refreshKiroToken, settleKiroLoginTransaction } from "./kiro";
 import {
   OAuthMutationBusyError,
@@ -1805,14 +1805,22 @@ export interface OAuthAccountSummary {
   plan: string | null;
 }
 
-export function getLoginStatus(provider: string): { loggedIn: boolean; email?: string; source?: OAuthCredentials["source"]; error?: string; done: boolean; activeAccountId?: string; accounts?: OAuthAccountSummary[] } {
+/**
+ * Token-safe login state for one provider.
+ *
+ * `maskEmails` is an explicit boolean rather than a config read (#3859). This module must not
+ * acquire a dependency on config I/O to answer a redaction question: the caller already holds
+ * the config at its request boundary and resolves the policy there with `emailMaskingEnabled`.
+ * The default masks, so every existing caller keeps today's behaviour.
+ */
+export function getLoginStatus(provider: string, maskEmails = true): { loggedIn: boolean; email?: string; source?: OAuthCredentials["source"]; error?: string; done: boolean; activeAccountId?: string; accounts?: OAuthAccountSummary[] } {
   const cred = getCredential(provider);
   const st = loginState.get(provider);
   const set = getAccountSet(provider);
   const accounts: OAuthAccountSummary[] | undefined = set?.accounts.map(a => ({
     id: a.id,
     ...(a.alias ? { alias: a.alias } : {}),
-    email: maskEmail(a.credential.email) ?? undefined,
+    email: projectEmail(a.credential.email, maskEmails) ?? undefined,
     active: a.id === set.activeAccountId,
     ...(a.needsReauth ? { needsReauth: true } : {}),
     expiresAt: a.credential.expires,
@@ -1832,7 +1840,7 @@ export function getLoginStatus(provider: string): { loggedIn: boolean; email?: s
     .find(a => a.id === set.activeAccountId)?.needsReauth === true;
   return {
     loggedIn: !!cred && !activeNeedsReauth,
-    email: maskEmail(cred?.email) ?? undefined,
+    email: projectEmail(cred?.email, maskEmails) ?? undefined,
     source: cred?.source,
     error: st?.error,
     done: st?.done ?? false,
@@ -1840,10 +1848,13 @@ export function getLoginStatus(provider: string): { loggedIn: boolean; email?: s
   };
 }
 
-/** Token-safe per-provider login state for the CLI `ocx status` logins section (no tokens, masked email). */
-export function oauthLoginSummary(): Array<{ provider: string; loggedIn: boolean; email?: string }> {
+/**
+ * Token-safe per-provider login state for the CLI `ocx status` logins section. Never tokens; the
+ * email follows the operator's `privacy.maskEmails` policy, masked by default (#3859).
+ */
+export function oauthLoginSummary(maskEmails = true): Array<{ provider: string; loggedIn: boolean; email?: string }> {
   return listOAuthProviders().map(provider => {
-    const status = getLoginStatus(provider);
+    const status = getLoginStatus(provider, maskEmails);
     return { provider, loggedIn: status.loggedIn, ...(status.email ? { email: status.email } : {}) };
   });
 }

--- a/src/server/management/oauth-account-routes.ts
+++ b/src/server/management/oauth-account-routes.ts
@@ -25,6 +25,7 @@ import {
 } from "../../oauth";
 import { OAuthMutationBusyError, removeCredential } from "../../oauth/store";
 import { providerDestinationResolvedError } from "../../lib/destination-policy";
+import { emailMaskingEnabled } from "../../lib/privacy";
 import { reconcileLiveStateStores } from "../../lib/state-store-registrations";
 import { enrichProviderFromCatalog, listKeyLoginProviders } from "../../oauth/key-providers";
 import { deriveProviderPresets } from "../../providers/derive";
@@ -233,7 +234,10 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
   if (url.pathname === "/api/oauth/status" && req.method === "GET") {
     const provider = (url.searchParams.get("provider") ?? "").trim().toLowerCase();
     if (!isPublicOAuthProvider(provider)) return jsonResponse({ error: "unknown oauth provider" }, 400);
-    const status = getLoginStatus(provider);
+    // Resolved here, at the request boundary that already holds the config, and passed down.
+    // getLoginStatus stays free of config I/O. This route does not re-mask afterwards: it
+    // consumes the already-projected status rather than redacting a second time.
+    const status = getLoginStatus(provider, emailMaskingEnabled(config));
     return jsonResponse(status);
   }
 
@@ -269,7 +273,7 @@ export async function handleOauthAccountRoutes(ctx: ManagementContext): Promise<
     } = await import("../../oauth/health");
     const projectAccounts = () => {
       const set = getAccountSet(provider);
-      const current = getLoginStatus(provider);
+      const current = getLoginStatus(provider, emailMaskingEnabled(config));
       return {
         activeAccountId: current.activeAccountId ?? null,
         accounts: (current.accounts ?? []).map(summary => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -288,6 +288,26 @@ export interface OcxRemoteGuiConfig {
 
 export type OcxConnectedClientId = "codex" | "claude";
 
+/**
+ * Redaction policy for management and CLI projections (#3859).
+ *
+ * `privacy` rather than `dashboard`: `ocx status` and `ocx account` are not the dashboard, and
+ * they read the same projections.
+ */
+export interface OcxPrivacyConfig {
+  /**
+   * Mask stored account emails before they leave the proxy. Omitted or `true` is the historical
+   * behaviour and the default.
+   *
+   * Setting this to `false` is a real disclosure decision, not a display preference. Management
+   * is not always loopback — under `remoteGui` the unmasked address reaches every management
+   * principal that can reach the hub, not only someone sitting at the machine. The default
+   * therefore stays masked, and turning it off is an explicit opt-in by the operator who owns
+   * those accounts.
+   */
+  maskEmails?: boolean;
+}
+
 export interface OcxClientConnectionConfig {
   serverUrl: string;
   managementUrl: string;
@@ -335,6 +355,8 @@ export interface OcxConfig {
   remoteGui?: OcxRemoteGuiConfig;
   /** Remote-hub client state. The admission secret is stored only in service-api-token. */
   client?: OcxClientConnectionConfig;
+  /** Operator-facing redaction policy for management and CLI projections. */
+  privacy?: OcxPrivacyConfig;
   /** Opt in to one identical-turn retry when a Responses completion has no text or tool call. */
   emptyCompletionRetry?: boolean;
   /**

--- a/tests/codex-integration/codex-auth-api.test.ts
+++ b/tests/codex-integration/codex-auth-api.test.ts
@@ -1305,6 +1305,61 @@ describe("codex-auth API", () => {
     expect(data.accounts.find(a => a.id === "pool-mask")?.email).toBe("p***n@example.test");
   });
 
+  /**
+   * #3859 — a self-hosted operator managing many Codex accounts could not tell them apart,
+   * because every projection masked unconditionally. The opt-out is config-scoped and defaults
+   * to masked; these two cases pin both ends of that switch on the surface the operator uses.
+   */
+  test("GET /api/codex-auth/accounts reveals pool and main emails when the operator opts out", async () => {
+    const config = makeConfig({
+      codexAccounts: [{ id: "pool-reveal", email: "person@example.test", isMain: false }],
+      privacy: { maskEmails: false },
+    });
+    saveCodexAccountCredential("pool-reveal", {
+      accessToken: "access-reveal",
+      refreshToken: "refresh-reveal",
+      expiresAt: Date.now() + 5 * 60_000,
+      chatgptAccountId: "acct-reveal",
+    });
+    updateAccountQuota("pool-reveal", 10);
+
+    const req = new Request("http://localhost/api/codex-auth/accounts", { method: "GET" });
+    const resp = await handleCodexAuthAPI(req, new URL(req.url), config);
+    const data = await resp!.json() as { accounts: Array<{ id: string; email: string }> };
+
+    expect(data.accounts.find(a => a.id === "pool-reveal")?.email).toBe("person@example.test");
+    // The flag moves the projection, never the credential store: no token may ride along.
+    expect(JSON.stringify(data)).not.toContain("access-reveal");
+    expect(JSON.stringify(data)).not.toContain("refresh-reveal");
+  });
+
+  test("GET /api/codex-auth/accounts keeps masking for an explicit true and a malformed value", async () => {
+    for (const privacy of [
+      { maskEmails: true },
+      {},
+      { maskEmails: "false" } as unknown as { maskEmails?: boolean },
+    ]) {
+      const config = makeConfig({
+        codexAccounts: [{ id: "pool-still-masked", email: "person@example.test", isMain: false }],
+        privacy,
+      });
+      saveCodexAccountCredential("pool-still-masked", {
+        accessToken: "access-still-masked",
+        refreshToken: "refresh-still-masked",
+        expiresAt: Date.now() + 5 * 60_000,
+        chatgptAccountId: "acct-still-masked",
+      });
+      updateAccountQuota("pool-still-masked", 10);
+
+      const req = new Request("http://localhost/api/codex-auth/accounts", { method: "GET" });
+      const resp = await handleCodexAuthAPI(req, new URL(req.url), config);
+      const data = await resp!.json() as { accounts: Array<{ id: string; email: string }> };
+
+      expect(data.accounts.find(a => a.id === "pool-still-masked")?.email).toBe("p***n@example.test");
+      expect(JSON.stringify(data)).not.toContain("person@example.test");
+    }
+  });
+
   test("GET /api/codex-auth/accounts omits a malformed persisted plan", async () => {
     const config = makeConfig({
       codexAccounts: [
@@ -5767,10 +5822,16 @@ describe("codex-auth API", () => {
     expect(source).toContain("withCodexAccountLogLabel({ id: accountId, email, plan, isMain: false }, accounts)");
   });
 
-  test("GET /api/codex-auth/login-status masks transient flow-state emails at response boundaries", async () => {
+  test("GET /api/codex-auth/login-status projects transient flow-state emails at response boundaries", async () => {
     const source = await Bun.file("src/codex/auth-api.ts").text();
-    expect(source).toContain("st ? { ...st, email: maskEmail(st.email) ?? undefined } : { status: \"expired\" }");
-    expect(source).toContain("return jsonResponse({ ...st, email: maskEmail(st.email) ?? undefined });");
+    // #3859 turned the unconditional mask into a policy projection. The guarantee is unchanged:
+    // BOTH boundaries redact through the shared helper, and the route resolves the policy from
+    // config rather than defaulting to reveal.
+    expect(source).toContain("st ? { ...st, email: projectEmail(st.email, maskFlowEmails) ?? undefined } : { status: \"expired\" }");
+    expect(source).toContain("return jsonResponse({ ...st, email: projectEmail(st.email, maskFlowEmails) ?? undefined });");
+    expect(source).toContain("const maskFlowEmails = emailMaskingEnabled(config);");
+    // No boundary may spread flow state carrying its raw address.
+    expect(source).not.toMatch(/\{ \.\.\.st, email: st\.email/);
   });
 
   test("GET /api/codex-auth/accounts reuses cached pool quota without fetching usage", async () => {

--- a/tests/lib/privacy-mask-account.test.ts
+++ b/tests/lib/privacy-mask-account.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { maskAccountId } from "../../src/lib/privacy";
+import { emailMaskingEnabled, maskAccountId, maskEmail, projectEmail } from "../../src/lib/privacy";
 
 describe("maskAccountId", () => {
   test("redacts long account ids to account-…suffix", () => {
@@ -21,6 +21,57 @@ describe("maskAccountId", () => {
       expect(masked).toBe("account-…");
       expect(masked!.endsWith(id)).toBe(false);
       expect(masked).not.toBe(id);
+    }
+  });
+});
+
+/**
+ * #3859 — an operator running many accounts on their own machine could not read the addresses
+ * they own, because `maskEmail` had no reveal argument and every management projection applied
+ * it unconditionally.
+ *
+ * The opt-in fails closed at every ambiguity. Management is not always loopback: under
+ * `remoteGui`, an unmasked projection discloses operator PII to every management principal that
+ * can reach the hub, so anything short of an explicit `false` keeps masking.
+ */
+describe("emailMaskingEnabled (#3859)", () => {
+  test("masking is the default for every shape that is not an explicit false", () => {
+    expect(emailMaskingEnabled(undefined)).toBe(true);
+    expect(emailMaskingEnabled(null)).toBe(true);
+    expect(emailMaskingEnabled({})).toBe(true);
+    expect(emailMaskingEnabled({ privacy: {} })).toBe(true);
+    expect(emailMaskingEnabled({ privacy: { maskEmails: true } })).toBe(true);
+  });
+
+  test("only the literal boolean false unmasks", () => {
+    expect(emailMaskingEnabled({ privacy: { maskEmails: false } })).toBe(false);
+    // A hand-edited config is the expected way in, and the schema drops a malformed block, but
+    // the predicate must not disclose an address on a truthy string or a stray zero either.
+    for (const value of ["false", "", 0, null] as unknown[]) {
+      expect(emailMaskingEnabled({ privacy: { maskEmails: value as boolean } })).toBe(true);
+    }
+  });
+});
+
+describe("projectEmail (#3859)", () => {
+  test("masking on reproduces maskEmail exactly", () => {
+    for (const address of ["person@example.test", "a@example.test", "ab@example.test", "no-at-sign"]) {
+      expect(projectEmail(address, true)).toBe(maskEmail(address));
+    }
+    expect(projectEmail("person@example.test", true)).toBe("p***n@example.test");
+  });
+
+  test("masking off returns the stored address unchanged", () => {
+    expect(projectEmail("person@example.test", false)).toBe("person@example.test");
+  });
+
+  test("absence normalises to null on both paths", () => {
+    // A consumer's "is there an email" test must not start answering differently just because
+    // the operator turned masking off.
+    for (const mask of [true, false]) {
+      expect(projectEmail(null, mask)).toBeNull();
+      expect(projectEmail(undefined, mask)).toBeNull();
+      expect(projectEmail("", mask)).toBeNull();
     }
   });
 });

--- a/tests/oauth/oauth-status-privacy.test.ts
+++ b/tests/oauth/oauth-status-privacy.test.ts
@@ -72,6 +72,34 @@ describe("OAuth status privacy", () => {
     expect(JSON.stringify(status)).not.toContain("refresh-token");
   });
 
+  /**
+   * #3859 — the operator running many accounts on their own machine had no way to read the
+   * addresses they own. The reveal is an explicit boolean argument rather than a config read
+   * inside getLoginStatus: coupling this module to config I/O to answer a redaction question
+   * is what the caller's request boundary is for.
+   */
+  test("an explicit unmask returns the full address, and tokens stay redacted either way", async () => {
+    await saveCredential("xai", {
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "person@example.test",
+      accountId: "acct-xai",
+      source: "local-cli",
+    });
+
+    const revealed = getLoginStatus("xai", false);
+    expect(revealed.email).toBe("person@example.test");
+    // The flag moves ONE field. A credential dump would also satisfy an email assertion, so the
+    // token checks are repeated on the unmasked path rather than assumed from the masked one.
+    expect(JSON.stringify(revealed)).not.toContain("access-token");
+    expect(JSON.stringify(revealed)).not.toContain("refresh-token");
+
+    // Omitted and explicit-true are both today's behaviour, unchanged.
+    expect(getLoginStatus("xai").email).toBe("p***n@example.test");
+    expect(getLoginStatus("xai", true).email).toBe("p***n@example.test");
+  });
+
   test("saveCredential persists only the credential allowlist", async () => {
     writeFileSync(join(TEST_DIR, "auth.json"), JSON.stringify({
       legacy: {


### PR DESCRIPTION
## Summary

`maskEmail()` had no reveal argument, and every management projection applied it before the dashboard or the CLI ever saw the DTO — `poolAccountDto`, the main account DTO, the login-status wire, and `getLoginStatus`. An operator running many Codex or OAuth accounts on their own machine therefore could not tell those accounts apart from `p***n@example.com` forms, and there was nowhere to say otherwise: `OcxConfig` had no `privacy` or `dashboard` key, and because the schema passes through, a hand-edited flag would sit on disk and do nothing at all.

`privacy.maskEmails` is now a real key. Omitted, `true`, and any malformed value all keep today's behaviour; only a literal `false` unmasks.

That asymmetry is the point rather than defensiveness. Management is not always loopback — on a hub configured with `remoteGui`, an unmasked address reaches every management principal that can reach the hub, not only someone sitting at the machine. So the default stays masked, the schema drops a malformed block instead of letting it read as "reveal", and the predicate treats a string `"false"` or a stray `0` as masked.

The implementation collapses the fork rather than spreading it. One helper, `projectEmail(value, mask)`, replaces a per-call-site conditional, and it normalises an absent address to `null` on both paths so a consumer's "is there an email" test cannot start answering differently just because the flag moved. Each caller resolves the policy once at its own request boundary with `emailMaskingEnabled(config)` and passes a boolean down. `getLoginStatus` takes that boolean rather than loading config itself, which would couple the oauth module to config I/O for a redaction question the caller has already answered. `oauth-account-routes` does not re-mask, because it already consumes the projected status.

`privacy` rather than `dashboard`, because `ocx status` and `ocx account` are not the dashboard and read the same projections. The CLI honours the same flag for that reason — a switch that moved only one of the two surfaces would leave the operator unable to tell which one they had configured.

The flag moves exactly one field. Tokens, refresh tokens, and account identifiers stay redacted either way.

Surface choice: the plan asked the maintainer to choose between a persisted config flag, a CLI-only flag, and both plus a dashboard session reveal. **This PR implements the recommendation: the persisted flag, with masking as the default.** The reporter's case is a self-hosted admin managing many accounts, and a CLI-only flag would not help the dashboard they actually use. If you would rather have the session-scoped reveal instead, say so and I will rework it.

## Verification

Local checks: **NOT RUN**. The maintainer set an explicit constraint for this delivery round that no local product suite runs — no `bun test`, `bun install`, `bun run typecheck`, `bun run build`, `bun run test:changed`, lint, or `privacy:scan`. Exact-head remote CI is the only gate for this PR.

New coverage:

- `tests/lib/privacy-mask-account.test.ts` — `emailMaskingEnabled` masks for undefined, null, `{}`, an empty `privacy` block, and explicit `true`, and unmasks only for the literal `false`; a `"false"` string, an empty string, `0`, and `null` all still mask. `projectEmail` reproduces `maskEmail` exactly when masking, returns the stored address when not, and normalises absent input to `null` on both paths.
- `tests/oauth/oauth-status-privacy.test.ts` — `getLoginStatus("xai", false)` returns the full address, which is red today, while omitted and explicit `true` still return the masked form. The token assertions are repeated on the unmasked path rather than inferred from the masked one, because a credential dump would satisfy an email assertion too.
- `tests/codex-integration/codex-auth-api.test.ts` — `GET /api/codex-auth/accounts` reveals the pool account address under the opt-out with no token riding along, and keeps masking for explicit `true`, an empty block, and a malformed value.

The pre-existing "always masked" assertions in `codex-auth-api`, `oauth-status-privacy`, `oauth-accounts-api`, `oauth-login-summary`, `cli-status-oauth-health`, and `provider-workspace-auth` are untouched and stay green, because the default is unchanged.

One existing test did need rewriting. `GET /api/codex-auth/login-status` was covered by a source-contains assertion on the literal `maskEmail(st.email)`, so it broke on any refactor even with behaviour preserved. It now pins the actual guarantee: both response boundaries project through the shared helper, the route resolves the policy from config rather than defaulting to reveal, and no boundary spreads flow state carrying a raw address.

`privacy:scan` does not cover this and cannot: it scans tracked source for email-shaped text and allows `example.test`, so runtime unmasking is invisible to it. The practical rule followed here is that no fixture uses a non-`example.*` address.

Docs: the new key is documented in the server configuration reference, including the disclosure caveat and the fact that `ocx config set privacy.maskEmails false` fails until the parent object exists.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. The server configuration reference gains an "Account email masking" section.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. This change is itself a disclosure boundary, so it was reviewed as one: the default is unchanged and masked, every ambiguous value fails closed to masked, the schema drops a malformed block rather than honouring it, only the email field moves, and the token and account-identifier redactions are asserted on the unmasked path. No auth flow, credential store, workflow, or release automation is touched.

Closes #3859.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable account email masking through `privacy.maskEmails`.
  - Emails remain masked by default across the dashboard, API responses, OAuth status, and CLI status output.
  - Setting the option to `false` reveals email addresses while continuing to redact tokens and account identifiers.
  - Added documentation covering configuration behavior, privacy implications, and setup requirements.

- **Bug Fixes**
  - Malformed or missing privacy settings now safely preserve email masking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->