### PR TITLE
fix(claude): keep mid-conversation system messages in the timeline

### DIFF
--- a/src/claude/inbound.ts
+++ b/src/claude/inbound.ts
@@ -150,10 +150,17 @@ function blockedSkillCallIds(messages: readonly unknown[], blocked: readonly str
 
 /**
  * Claude Code (observed 2026-07-11, real CLI smoke) sends `role:"system"` entries in
- * `messages` despite the published API having no system role. Map them to Responses
- * instructions text: the native ChatGPT backend rejects system message items in
- * `input` ("System messages are not allowed", verified live), so folding into
- * `instructions` is the only shape that works on every route.
+ * `messages` despite the published API having no system role. They are emitted as
+ * chronological `role:"developer"` input items, which keeps the timeline intact and
+ * leaves `instructions` owned solely by the top-level Anthropic `system` field.
+ *
+ * The original mapping folded them into `instructions` because the native ChatGPT
+ * backend rejects `role:"system"` items in `input` ("System messages are not allowed",
+ * verified live). That constraint is real and still respected — but it only rules out
+ * `system`, not `developer`, which every Responses route accepts. Folding meant each
+ * mid-conversation reminder mutated the prompt head, invalidating the upstream KV
+ * prefix and rotating the Desktop `prompt_cache_key` fallback below on every turn
+ * (#4148).
  */
 function systemMessageText(content: unknown): string {
   if (typeof content === "string") return content;
@@ -333,7 +340,12 @@ function translateAnthropicRequest(raw: unknown, cc: OcxClaudeCodeConfig | undef
     else if (msg.role === "assistant") assistantMessageToItems(msg.content, input, budget);
     else if (msg.role === "system") {
       const text = systemMessageText(msg.content);
-      if (text.length > 0) systemParts.push(text);
+      // Keep it where the client put it. `developer` is first-class in the Responses
+      // schema and survives parseRequest as a chronological message, where `system`
+      // would be re-hoisted back onto the system prompt and defeat the point.
+      if (text.length > 0) {
+        input.push({ type: "message", role: "developer", content: [{ type: "input_text", text }] });
+      }
     }
     else throw new AnthropicRequestError(`unsupported message role: ${String(msg.role)}`);
   }

--- a/tests/claude-integration/claude-inbound.test.ts
+++ b/tests/claude-integration/claude-inbound.test.ts
@@ -9,6 +9,23 @@ import { createResponsesPassthroughAdapter } from "../../src/adapters/openai-res
 import { withTestTranslatorBudget } from "../helpers/translator-budget";
 import type { OcxProviderConfig } from "../../src/types";
 
+// The translator returns an untyped wire body. These aliases name just the fields the
+// system-message cases assert on, so the assertions read as a contract instead of a cast.
+type TranslatedInputItem = {
+  type?: string;
+  role?: string;
+  content?: Array<{ type?: string; text?: string }>;
+};
+type TranslatedBody = {
+  instructions?: string;
+  prompt_cache_key?: string;
+  input: TranslatedInputItem[];
+};
+
+function translatedBody(raw: Record<string, unknown>): TranslatedBody {
+  return anthropicToResponsesBody(raw) as TranslatedBody;
+}
+
 // Full Claude Code-shaped request: system array, tool cycle, image, thinking, options.
 function claudeCodeRequest(): Record<string, unknown> {
   return {
@@ -310,8 +327,13 @@ describe("claude inbound translation", () => {
     expect(() => parseRequest(body)).not.toThrow();
   });
 
-  test("system role messages fold into instructions (real Claude Code sends them; native backend rejects system items)", () => {
-    const body = anthropicToResponsesBody({
+  // Claude Code sends role:"system" entries in `messages`. They used to be folded into
+  // `instructions` alongside the top-level system field; now each one becomes a
+  // chronological role:"developer" input item, so `instructions` belongs to the
+  // top-level Anthropic `system` field alone and the prompt head stops moving
+  // mid-conversation.
+  test("in-messages system role becomes a chronological developer item, never a system item", () => {
+    const body = translatedBody({
       model: "m", max_tokens: 10,
       system: "top-level",
       messages: [
@@ -319,14 +341,61 @@ describe("claude inbound translation", () => {
         { role: "system", content: [{ type: "text", text: "block form" }] },
         { role: "user", content: "hi" },
       ],
-    }) as any;
-    expect(body.instructions).toBe("top-level\n\nbe terse\n\nblock form");
-    // No system message items in input — native ChatGPT backend 400s on them.
-    expect((body.input as any[]).every(item => item.role !== "system")).toBe(true);
-    expect(body.input).toHaveLength(1);
-    expect(body.input[0].role).toBe("user");
+    });
+    // Only the top-level system reaches instructions now.
+    expect(body.instructions).toBe("top-level");
+    // Still no system message items in input — the native ChatGPT backend 400s on them.
+    expect(body.input.every(item => item.role !== "system")).toBe(true);
+    expect(body.input.map(item => item.role)).toEqual(["developer", "developer", "user"]);
+    expect(body.input[0]?.content).toEqual([{ type: "input_text", text: "be terse" }]);
+    expect(body.input[1]?.content).toEqual([{ type: "input_text", text: "block form" }]);
     expect(() => responsesRequestSchema.parse(body)).not.toThrow();
     expect(() => parseRequest(body)).not.toThrow();
+  });
+
+  // #4148: a client that injects a fresh reminder each turn used to rewrite the prompt
+  // head every time, which invalidates the upstream KV prefix and — with no
+  // metadata.user_id — rotated the Desktop prompt_cache_key fallback along with it.
+  test("a mid-conversation system message leaves the cache prefix and cache key alone", () => {
+    const turn = (messages: unknown[]) =>
+      translatedBody({ model: "m", max_tokens: 10, system: "S", messages });
+
+    const turn1 = turn([
+      { role: "user", content: "u1" },
+      { role: "system", content: "r1" },
+    ]);
+    const turn2 = turn([
+      { role: "user", content: "u1" },
+      { role: "system", content: "r1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+      { role: "system", content: "r2" },
+    ]);
+
+    // The prompt head is the whole point: identical across turns, and equal to the
+    // top-level system field on its own.
+    expect(turn1.instructions).toBe("S");
+    expect(turn2.instructions).toBe("S");
+
+    expect(turn1.input.map(item => item.role)).toEqual(["user", "developer"]);
+    expect(turn2.input.map(item => item.role))
+      .toEqual(["user", "developer", "assistant", "user", "developer"]);
+    expect(turn2.input.map(item => item.content?.[0]?.text))
+      .toEqual(["u1", "r1", "a1", "u2", "r2"]);
+    expect(turn2.input.every(item => item.role !== "system")).toBe(true);
+
+    // Turn 1's items are still a prefix of turn 2's, which is what the KV cache matches on.
+    expect(turn2.input.slice(0, 2)).toEqual(turn1.input);
+
+    // No metadata.user_id, so the Desktop cohort fallback applies. It hashes the
+    // post-translation system text, which no longer absorbs the injected reminders.
+    expect(turn1.prompt_cache_key).toBeDefined();
+    expect(turn2.prompt_cache_key).toBe(turn1.prompt_cache_key);
+
+    for (const body of [turn1, turn2]) {
+      expect(() => responsesRequestSchema.parse(body)).not.toThrow();
+      expect(() => parseRequest(body)).not.toThrow();
+    }
   });
 
   test("tool_result is_error and string content", () => {


### PR DESCRIPTION
## Summary

Claude Code sends `role: "system"` entries inside `messages`, and every one of them was folded into `instructions`. `parseRequest` pushes `data.instructions` onto the system prompt before anything else, so each injected reminder rewrote the **head** of the prompt — which is exactly the span an upstream KV cache matches on. Every mid-conversation reminder therefore invalidated the cache prefix. When the client sends no `metadata.user_id`, the Desktop `prompt_cache_key` fallback hashes the same system parts, so the cache key rotated along with the prefix and the request could not even land on the same routing cohort.

Each non-empty in-messages system message now becomes a chronological input item:

```json
{ "type": "message", "role": "developer", "content": [{ "type": "input_text", "text": "..." }] }
```

Top-level Anthropic `system` keeps flowing through `systemToInstructions` into `body.instructions` unchanged. `instructions` now has exactly one source and stops moving mid-conversation.

**Why `developer` and not `system`.** The schema admits a `system` role in `input`, but ChatGPT Codex rejects it live, `parseRequest` re-hoists it onto the system prompt, and the canonical Responses forward folds text-only system items back into `instructions` — so it would land back where it started. `developer` is first-class in the schema, survives `parseRequest` as an ordinary chronological message, and preserves timeline order.

**The original fold was deliberate**, not an oversight: `cee918ce3` introduced it so the native ChatGPT backend would not 400 on a system input item. That constraint is real and is still respected here — it rules out `system`, not `developer`. What turned out to be stale is the accompanying 2026-07-11 note that folding is "the only shape that works on every route".

### A scope decision a reviewer may want to object to

**All** in-messages system messages become developer items, not only the ones after the first user turn.

The narrower alternative — hoist a leading system message, keep only mid-conversation ones in the timeline — would have left the old contract test untouched, but it does not close the issue. A client that injects a fresh leading system message on every turn still mutates `instructions` every turn, and that is the reported failure. Taking the narrow option would have meant shipping something that looks like a fix and still rotates the prefix for the reporter.

The cost is that privileged system text now arrives as developer text. On Anthropic and Google outbound, developer items are presented as chronological `user` messages, so there is real semantic drift from "this is a system instruction" to "this is part of the conversation". That is prefix-stable, which is the property this change is buying.

`systemParts` deliberately keeps its **array** shape inside the cache-key hash. Joining it to a string would rotate every existing cohort key for a reason unrelated to this bug.

### Deliberately out of scope

`src/adapters/openai-chat.ts` re-hoists all text developer messages into a leading `system` chat message for non-`api.openai.com` Chat Completions, locked by `tests/adapters/openai/openai-chat-system-order.test.ts`. That is what keeps the reporter's DeepSeek/SenseNova path broken, and reversing it is a separate compatibility tradeoff with its own regression surface. OpenCode Go's Muse is `openai-responses`, so this inbound fix does reach it. `src/chat/inbound.ts` has the same anti-pattern for Chat inbound; also not this issue.

## Verification

Remote CI at this PR's exact head SHA is the gate for this change.

Local checks: **NOT RUN.** `bun test`, `bun run test:changed`, `bun run typecheck`, `bun install`, `bun run build:gui`, `bun run lint:gui`, and `bun run privacy:scan` were all skipped by explicit maintainer instruction for this delivery round, which overrides the PR-ready gate in `AGENTS.md`. Nothing here claims a local check passed.

Independent review that **was** done: a read-only reviewer confirmed that `developer` is admitted by `src/responses/schema.ts` and kept chronological by `src/responses/parser.ts` while a `system` item would be re-hoisted; that the `prompt_cache_key` fallback hashes an array whose shape is unchanged; that the canonical Responses forward folds only `role: "system"`, so developer items survive it; and — the part that mattered most — searched `tests/` exhaustively for any other assertion encoding the old fold and found none.

Regression coverage in `tests/claude-integration/claude-inbound.test.ts`:

- the old fold-contract case is **rewritten**, not deleted. It is the test that encoded the previous behavior, so it now asserts `instructions === "top-level"` and input roles `["developer", "developer", "user"]`, and it still asserts that no input item carries `role: "system"`.
- a new two-turn case: `system: "S"` with a reminder injected on each turn. `instructions` is `"S"` on both turns, turn 2's roles are `["user", "developer", "assistant", "user", "developer"]` with texts `u1, r1, a1, u2, r2`, turn 1's items are a byte-equal prefix of turn 2's, and with no `metadata.user_id` the two turns produce the **same** `prompt_cache_key`. Both bodies pass `responsesRequestSchema.parse` and `parseRequest`.

The cases using top-level `system` and the prompt-cache-key provenance suite are untouched and must stay green.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. No documented behavior changes: the Anthropic surface contract is unchanged, and the wire shape this produces was already valid.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No credential, auth, or logging path is touched; message text that was already being forwarded is forwarded in a different position.

Closes #4148.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Anthropic system messages included within a conversation are now preserved in chronological order as developer messages.
  - Top-level system instructions remain separate and are used exclusively for the conversation’s instructions.
  - Mid-conversation system reminders no longer alter prompt-cache prefixes or cache keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->