### PR TITLE
fix(stop): name the real refusal cause instead of asserting ownership

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -952,7 +952,7 @@ async function handleStop() {
       if (detail) console.error(`   ${detail}`);
       if (err instanceof ProxyOwnershipRefusedError) {
         ownershipBlocked = true;
-        console.error("   Skipping shared teardown (native Codex restore, Grok config): the foreign proxy is still running.");
+        console.error("   Skipping shared teardown (native Codex restore, Grok config): the refusing proxy is still running.");
       }
     }
   } else {
@@ -979,7 +979,7 @@ async function handleStop() {
         if (detail) console.error(`   ${detail}`);
         if (err instanceof ProxyOwnershipRefusedError) {
           ownershipBlocked = true;
-          console.error("   Skipping shared teardown (native Codex restore, Grok config): the foreign proxy is still running.");
+          console.error("   Skipping shared teardown (native Codex restore, Grok config): the refusing proxy is still running.");
         }
       }
     } else if (live) {

--- a/src/lib/process-control.ts
+++ b/src/lib/process-control.ts
@@ -142,9 +142,28 @@ export class ProxyOwnershipRefusedError extends Error {}
  * attest the process exit code or completion of every drain/shutdown hook.
  */
 export async function stopProxyGracefully(pid: number, io: GracefulStopIo = {}): Promise<GracefulStopResult> {
+  return (await stopProxyGracefullyDetailed(pid, io)).result;
+}
+
+/**
+ * The refusal a single stop attempt received, carried back to that attempt's caller.
+ *
+ * Module-scoped state cannot do this job: two overlapping stops race, and the first would
+ * report the second's cause. The exported accessors stay as observational state for callers
+ * that only want the last refusal, but the error text is built from this per-call value.
+ */
+type StopRefusal = { message: string | null; code: string | null };
+
+async function stopProxyGracefullyDetailed(
+  pid: number,
+  io: GracefulStopIo = {},
+): Promise<{ result: GracefulStopResult; refusal: StopRefusal }> {
+  const refusal: StopRefusal = { message: null, code: null };
+  const done = (result: GracefulStopResult): { result: GracefulStopResult; refusal: StopRefusal } =>
+    ({ result, refusal });
   const readRuntime = io.readRuntime ?? readRuntimePort;
   const runtime = io.runtimeEndpoint ?? readRuntime(pid);
-  if (!runtime?.port) return false;
+  if (!runtime?.port) return done(false);
   const env = io.env ?? process.env;
   const headers: Record<string, string> = {};
   const token = configuredAdminToken(env.OPENCODEX_HOME?.trim() || undefined, env as NodeJS.ProcessEnv);
@@ -173,7 +192,7 @@ export async function stopProxyGracefully(pid: number, io: GracefulStopIo = {}):
     // here would run the daemon's cleanup and strip shared config out from under the
     // still-running service. Report the refusal instead of forcing.
     if (res.status === 409) {
-      const refusal = await res.json()
+      const parsed = await res.json()
         .then(body => {
           const record = body as { message?: unknown; code?: unknown } | null;
           const message = record?.message;
@@ -184,11 +203,13 @@ export async function stopProxyGracefully(pid: number, io: GracefulStopIo = {}):
           };
         })
         .catch(() => ({ message: null, code: null }));
-      lastRefusalMessage = refusal.message;
-      lastRefusalCode = refusal.code;
-      return "refused";
+      refusal.message = parsed.message;
+      refusal.code = parsed.code;
+      lastRefusalMessage = parsed.message;
+      lastRefusalCode = parsed.code;
+      return done("refused");
     }
-    if (!res.ok) return false;
+    if (!res.ok) return done(false);
     const body: unknown = await res.json().catch(() => null);
     const expectedTeardown = io.deferSharedTeardownNonce ? "deferred" : "performed";
     sharedTeardownConfirmed = body !== null
@@ -197,14 +218,14 @@ export async function stopProxyGracefully(pid: number, io: GracefulStopIo = {}):
       && "success" in body && body.success === true
       && "sharedTeardown" in body && body.sharedTeardown === expectedTeardown;
   } catch {
-    return false;
+    return done(false);
   }
   const waitExit = io.waitExit ?? waitForExit;
   // Honor the server's own drain window: /api/stop answers 200 first, then drains for
   // config.shutdownTimeoutMs. Waiting less than that hard-kills mid-drain.
   const exitTimeoutMs = io.exitTimeoutMs ?? drainDeadlineMs();
-  if (!waitExit(pid, exitTimeoutMs)) return false;
-  return sharedTeardownConfirmed ? true : "teardown-unconfirmed";
+  if (!waitExit(pid, exitTimeoutMs)) return done(false);
+  return done(sharedTeardownConfirmed ? true : "teardown-unconfirmed");
 }
 
 function drainDeadlineMs(): number {
@@ -219,13 +240,14 @@ function drainDeadlineMs(): number {
 export async function stopProxy(pid: number, io: GracefulStopIo = {}): Promise<boolean> {
   if (!isProcessAlive(pid)) return false;
   const runtime = io.runtimeEndpoint ?? readRuntimePort(pid);
-  const graceful = await stopProxyGracefully(pid, io);
+  const { result: graceful, refusal } = await stopProxyGracefullyDetailed(pid, io);
   if (graceful === "refused") {
     // The proxy refused on purpose. Forcing would strip shared config while whatever owns
     // the process keeps it alive. The server's own message is preferred; the fallback is
-    // selected from its code so an empty body still names the right cause.
+    // selected from its code so an empty body still names the right cause. Both come from
+    // THIS attempt, so an overlapping stop cannot lend it the wrong reason.
     throw new ProxyOwnershipRefusedError(
-      lastRefusalMessage ?? refusalFallbackMessage(lastRefusalCode),
+      refusal.message ?? refusalFallbackMessage(refusal.code),
     );
   }
   if (graceful === "teardown-unconfirmed") {

--- a/src/lib/process-control.ts
+++ b/src/lib/process-control.ts
@@ -80,9 +80,47 @@ export type GracefulStopResult = boolean | "refused" | "teardown-unconfirmed";
  */
 let lastRefusalMessage: string | null = null;
 
+/**
+ * The server's machine-readable reason for the most recent 409, captured alongside the
+ * message so a refusal that arrives without a body still names the right cause. Without it
+ * the fallback has to guess, and guessing "ownership" sent operators to re-check
+ * CODEX_HOME for a refusal the scheduler wrapper had issued (#4169).
+ */
+let lastRefusalCode: string | null = null;
+
 /** The server's explanation for the most recent 409, or `null` when it sent none. */
 export function lastStopRefusalMessage(): string | null {
   return lastRefusalMessage;
+}
+
+/** The server's `code` for the most recent 409, or `null` when it sent none. */
+export function lastStopRefusalCode(): string | null {
+  return lastRefusalCode;
+}
+
+/**
+ * Wording for a refusal whose body carried no message. Each branch mirrors a refusal the
+ * management API can return from `POST /api/stop`; the default stays cause-neutral because
+ * naming the wrong cause is worse than naming none — it costs the operator the time they
+ * spend acting on it.
+ */
+function refusalFallbackMessage(code: string | null): string {
+  switch (code) {
+    case "respawnable_service":
+      return "The running proxy refused to stop: a service manager that can respawn it owns "
+        + "the process. Run `ocx stop`, which verifies the respawn window.";
+    case "self_unload_service":
+      return "The running proxy refused to stop: it is the installed service itself, so "
+        + "stopping the manager from inside it would end the process before native Codex is "
+        + "restored. Run `ocx stop`.";
+    case "service_state_unknown":
+      return "The running proxy refused to stop: the service manager state could not be read, "
+        + "so it cannot tell whether a wrapper would respawn it. Run `ocx service status` to "
+        + "see the query error.";
+    default:
+      return "The running proxy refused to stop and sent no reason. Run `ocx service status` "
+        + "to inspect the service state.";
+  }
 }
 
 /**
@@ -128,17 +166,26 @@ export async function stopProxyGracefully(pid: number, io: GracefulStopIo = {}):
       // longer than a health poll so we prefer drain over taskkill /F.
       signal: AbortSignal.timeout(io.exitTimeoutMs ? Math.min(io.exitTimeoutMs, 10_000) : 10_000),
     });
-    // 409 is the proxy REFUSING to stop (a service installed under another home owns it and
-    // would respawn it anyway). That is a policy answer, not a dead endpoint — escalating to
-    // SIGTERM here would run the daemon's cleanup and strip shared config out from under the
+    // 409 is the proxy REFUSING to stop. There is more than one reason it can say no — a
+    // respawning service manager, the proxy being the installed service itself, or an
+    // unreadable scheduler state — so both the message and the code are captured rather
+    // than assumed. That is a policy answer, not a dead endpoint — escalating to SIGTERM
+    // here would run the daemon's cleanup and strip shared config out from under the
     // still-running service. Report the refusal instead of forcing.
     if (res.status === 409) {
-      lastRefusalMessage = await res.json()
+      const refusal = await res.json()
         .then(body => {
-          const message = (body as { message?: unknown } | null)?.message;
-          return typeof message === "string" && message.trim() ? message.trim() : null;
+          const record = body as { message?: unknown; code?: unknown } | null;
+          const message = record?.message;
+          const code = record?.code;
+          return {
+            message: typeof message === "string" && message.trim() ? message.trim() : null,
+            code: typeof code === "string" && code.trim() ? code.trim() : null,
+          };
         })
-        .catch(() => null);
+        .catch(() => ({ message: null, code: null }));
+      lastRefusalMessage = refusal.message;
+      lastRefusalCode = refusal.code;
       return "refused";
     }
     if (!res.ok) return false;
@@ -174,12 +221,11 @@ export async function stopProxy(pid: number, io: GracefulStopIo = {}): Promise<b
   const runtime = io.runtimeEndpoint ?? readRuntimePort(pid);
   const graceful = await stopProxyGracefully(pid, io);
   if (graceful === "refused") {
-    // The proxy refused on purpose (foreign service owns it). Forcing would strip shared
-    // config while that service keeps the proxy alive.
+    // The proxy refused on purpose. Forcing would strip shared config while whatever owns
+    // the process keeps it alive. The server's own message is preferred; the fallback is
+    // selected from its code so an empty body still names the right cause.
     throw new ProxyOwnershipRefusedError(
-      lastRefusalMessage
-      ?? "The running proxy refused to stop: a service installed under a different "
-        + "CODEX_HOME/OPENCODEX_HOME owns it. Run the stop from that home.",
+      lastRefusalMessage ?? refusalFallbackMessage(lastRefusalCode),
     );
   }
   if (graceful === "teardown-unconfirmed") {

--- a/tests/lib/process-control-graceful.test.ts
+++ b/tests/lib/process-control-graceful.test.ts
@@ -263,4 +263,41 @@ describe("409 refusal reporting", () => {
       expect(message).not.toContain("OPENCODEX_HOME");
     }
   });
+
+  test("overlapping refusals each keep their own cause", async () => {
+    // Reading the reason from module state would let the second stop overwrite the first
+    // one's cause before it is read, so the earlier caller reports a refusal it never got.
+    let releaseFirst: (() => void) | null = null;
+    const firstReached = new Promise<void>(resolve => { releaseFirst = resolve; });
+
+    const refusalOf = (code: string, gate?: Promise<void>) => async (): Promise<string> => {
+      try {
+        await stopProxy(process.pid, {
+          readRuntime: () => ({ port: 10100 }),
+          fetchFn: (async () => {
+            if (gate) await gate;
+            return new Response(JSON.stringify({ success: false, code }), {
+              status: 409,
+              headers: { "content-type": "application/json" },
+            });
+          }) as typeof fetch,
+          waitExit: () => { throw new Error("must not wait for a refused stop"); },
+          env: {},
+        });
+      } catch (err) {
+        if (err instanceof ProxyOwnershipRefusedError) return err.message;
+        throw err;
+      }
+      throw new Error("stopProxy must throw on a refusal");
+    };
+
+    // The first call parks inside fetch until the second has already resolved and written
+    // its own code, which is exactly the interleaving module-scoped state cannot survive.
+    const first = refusalOf("respawnable_service", firstReached)();
+    const second = await refusalOf("self_unload_service")();
+    releaseFirst?.();
+
+    expect(await first).toContain("respawn");
+    expect(second).toContain("installed service itself");
+  });
 });

--- a/tests/lib/process-control-graceful.test.ts
+++ b/tests/lib/process-control-graceful.test.ts
@@ -224,7 +224,7 @@ describe("409 refusal reporting", () => {
     expect(lastStopRefusalCode()).toBeNull();
   });
 
-  test("a bodyless refusal falls back to its code, never to an ownership claim", async () => {
+  test("a refusal without a message falls back by code, never to an ownership claim", async () => {
     const refusalFor = async (code: string | null): Promise<string> => {
       const body = code === null ? "not json" : JSON.stringify({ success: false, code });
       try {
@@ -264,23 +264,22 @@ describe("409 refusal reporting", () => {
     }
   });
 
-  test("overlapping refusals each keep their own cause", async () => {
-    // Reading the reason from module state would let the second stop overwrite the first
-    // one's cause before it is read, so the earlier caller reports a refusal it never got.
-    let releaseFirst: (() => void) | null = null;
-    const firstReached = new Promise<void>(resolve => { releaseFirst = resolve; });
-
-    const refusalOf = (code: string, gate?: Promise<void>) => async (): Promise<string> => {
+  test("concurrent refusals each keep their own cause", async () => {
+    // Reading the reason from module state lets one stop publish its refusal and a second
+    // overwrite it before the first continuation consumes it. Starting both together is
+    // what actually reproduces that: verified against the pre-fix global handoff, where
+    // this schedule fails with the first call throwing the second's cause
+    // ("...it is the installed service itself..." for the respawnable_service stop).
+    // A schedule that lets one call finish entirely before resuming the other does NOT
+    // discriminate — the parked call republishes its own globals last and passes either way.
+    const refusalOf = (code: string) => async (): Promise<string> => {
       try {
         await stopProxy(process.pid, {
           readRuntime: () => ({ port: 10100 }),
-          fetchFn: (async () => {
-            if (gate) await gate;
-            return new Response(JSON.stringify({ success: false, code }), {
-              status: 409,
-              headers: { "content-type": "application/json" },
-            });
-          }) as typeof fetch,
+          fetchFn: (async () => new Response(JSON.stringify({ success: false, code }), {
+            status: 409,
+            headers: { "content-type": "application/json" },
+          })) as typeof fetch,
           waitExit: () => { throw new Error("must not wait for a refused stop"); },
           env: {},
         });
@@ -291,13 +290,15 @@ describe("409 refusal reporting", () => {
       throw new Error("stopProxy must throw on a refusal");
     };
 
-    // The first call parks inside fetch until the second has already resolved and written
-    // its own code, which is exactly the interleaving module-scoped state cannot survive.
-    const first = refusalOf("respawnable_service", firstReached)();
-    const second = await refusalOf("self_unload_service")();
-    releaseFirst?.();
-
-    expect(await first).toContain("respawn");
-    expect(second).toContain("installed service itself");
+    // Repeated because the interleaving is scheduler-dependent; the pre-fix code fails on
+    // the first iteration, but a single run would be a weak guard against reintroduction.
+    for (let i = 0; i < 20; i++) {
+      const [respawnable, selfUnload] = await Promise.all([
+        refusalOf("respawnable_service")(),
+        refusalOf("self_unload_service")(),
+      ]);
+      expect(respawnable).toContain("respawn");
+      expect(selfUnload).toContain("installed service itself");
+    }
   });
 });

--- a/tests/lib/process-control-graceful.test.ts
+++ b/tests/lib/process-control-graceful.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { gracefulStopHost, lastStopRefusalMessage, stopProxyGracefully } from "../../src/lib/process-control";
+import { gracefulStopHost, lastStopRefusalCode, lastStopRefusalMessage, ProxyOwnershipRefusedError, stopProxy, stopProxyGracefully } from "../../src/lib/process-control";
 
 function okResponse(): Response {
   return new Response(JSON.stringify({ success: true, sharedTeardown: "performed" }), { status: 200 });
@@ -197,5 +197,70 @@ describe("409 refusal reporting", () => {
     });
     expect(result).toBe("refused");
     expect(lastStopRefusalMessage()).toBeNull();
+  });
+
+  test("the refusal code is captured alongside the message", async () => {
+    // The message alone cannot drive the fallback: a refusal that arrives with an empty or
+    // unparseable body still has to name a cause, and #4169 showed what happens when the
+    // fallback guesses one — the operator re-checks CODEX_HOME for a refusal the scheduler
+    // wrapper issued.
+    await stopProxyGracefully(7, {
+      readRuntime: () => ({ port: 10100 }),
+      fetchFn: (async () => new Response(
+        JSON.stringify({ success: false, code: "respawnable_service", message: "wrapper owns it" }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      )) as typeof fetch,
+      waitExit: () => true,
+      env: {},
+    });
+    expect(lastStopRefusalCode()).toBe("respawnable_service");
+
+    await stopProxyGracefully(7, {
+      readRuntime: () => ({ port: 10100 }),
+      fetchFn: (async () => new Response("not json", { status: 409 })) as typeof fetch,
+      waitExit: () => true,
+      env: {},
+    });
+    expect(lastStopRefusalCode()).toBeNull();
+  });
+
+  test("a bodyless refusal falls back to its code, never to an ownership claim", async () => {
+    const refusalFor = async (code: string | null): Promise<string> => {
+      const body = code === null ? "not json" : JSON.stringify({ success: false, code });
+      try {
+        await stopProxy(process.pid, {
+          readRuntime: () => ({ port: 10100 }),
+          fetchFn: (async () => new Response(body, {
+            status: 409,
+            headers: { "content-type": "application/json" },
+          })) as typeof fetch,
+          waitExit: () => { throw new Error("must not wait for a refused stop"); },
+          env: {},
+        });
+      } catch (err) {
+        if (err instanceof ProxyOwnershipRefusedError) return err.message;
+        throw err;
+      }
+      throw new Error("stopProxy must throw on a refusal");
+    };
+
+    const respawnable = await refusalFor("respawnable_service");
+    expect(respawnable).toContain("respawn");
+    expect(respawnable).toContain("ocx stop");
+
+    const selfUnload = await refusalFor("self_unload_service");
+    expect(selfUnload).toContain("installed service itself");
+
+    const unknownState = await refusalFor("service_state_unknown");
+    expect(unknownState).toContain("ocx service status");
+
+    const noBody = await refusalFor(null);
+    expect(noBody).toContain("sent no reason");
+
+    // None of them may assert the cause that #4169 was filed for.
+    for (const message of [respawnable, selfUnload, unknownState, noBody]) {
+      expect(message).not.toContain("CODEX_HOME");
+      expect(message).not.toContain("OPENCODEX_HOME");
+    }
   });
 });

--- a/tests/providers/xai/grok-lifecycle.test.ts
+++ b/tests/providers/xai/grok-lifecycle.test.ts
@@ -150,7 +150,7 @@ describe("Grok fence lifecycle wiring", () => {
     // shared teardown must be skipped at both call sites, exactly like the service-manager path.
     const ownershipRefusals = stopFn.match(/err instanceof ProxyOwnershipRefusedError[\s\S]{0,200}?ownershipBlocked = true;/g);
     expect(ownershipRefusals).toHaveLength(2);
-    expect(stopFn.match(/Skipping shared teardown \(native Codex restore, Grok config\): the foreign proxy is still running\./g)).toHaveLength(2);
+    expect(stopFn.match(/Skipping shared teardown \(native Codex restore, Grok config\): the refusing proxy is still running\./g)).toHaveLength(2);
     expect(PROCESS_CONTROL_SOURCE).toContain("throw new ProxyOwnershipRefusedError(");
   });
 

--- a/tests/providers/xai/grok-lifecycle.test.ts
+++ b/tests/providers/xai/grok-lifecycle.test.ts
@@ -507,10 +507,12 @@ describe("POST /api/stop teardown", () => {
   });
 
   test("a 409 does not escalate to a forced kill", () => {
-    // Escalating would run the daemon's cleanup and strip shared config while the foreign
-    // service keeps the proxy alive — the exact hole the ownership gate exists to close.
+    // Escalating would run the daemon's cleanup and strip shared config while the refusing
+    // service keeps the proxy alive — the exact hole the refusal gate exists to close.
     // The 409 branch may capture the server's reason first (#4023 added a second refusal
-    // cause), but it must still return "refused" without falling through to !res.ok.
+    // cause, #4169 the code that names it), but it must still yield "refused" without
+    // falling through to !res.ok. Matched loosely so a wrapped return (`done("refused")`)
+    // still satisfies the invariant this guards, which is ordering, not spelling.
     const stopGracefully = sliceFn(
       PROCESS_CONTROL_SOURCE,
       "export async function stopProxyGracefully(",
@@ -518,9 +520,12 @@ describe("POST /api/stop teardown", () => {
     );
     const four09At = stopGracefully.indexOf("res.status === 409");
     expect(four09At).toBeGreaterThan(-1);
-    expect(stopGracefully.slice(four09At)).toContain('return "refused"');
-    expect(stopGracefully.indexOf('return "refused"', four09At))
-      .toBeLessThan(stopGracefully.indexOf("if (!res.ok) return false;", four09At));
+    const refusedReturn = /return (?:done\()?"refused"/;
+    const okFallthrough = /if \(!res\.ok\) return (?:done\()?false/;
+    const afterFour09 = stopGracefully.slice(four09At);
+    expect(afterFour09).toMatch(refusedReturn);
+    expect(afterFour09.search(refusedReturn))
+      .toBeLessThan(afterFour09.search(okFallthrough));
 
     const stopProxyFn = sliceFn(PROCESS_CONTROL_SOURCE, "export async function stopProxy(", "export function killProxy(");
     const refusedAt = stopProxyFn.indexOf('graceful === "refused"');


### PR DESCRIPTION
Fixes #4169.

## What was wrong

`POST /api/stop` refuses for three distinct reasons:

| code | meaning |
| --- | --- |
| `respawnable_service` | a service manager can respawn the proxy |
| `self_unload_service` | the proxy **is** the installed service (#4023) |
| `service_state_unknown` | the scheduler state could not be read |

`stopProxy` preferred the server's own message, but when no readable message arrived it fell back to a single hardcoded sentence naming a fourth cause that the server never reported:

```ts
throw new ProxyOwnershipRefusedError(
  lastRefusalMessage
  ?? "The running proxy refused to stop: a service installed under a different "
    + "CODEX_HOME/OPENCODEX_HOME owns it. Run the stop from that home.",
);
```

#4023 already carried the message through precisely because there is more than one cause. The fallback was the half of that fix still guessing, and the existing test says so in its own comment — *"stopProxy used to report the first of those unconditionally, sending an operator whose proxy is simply the service to a CODEX_HOME that does not exist."*

The cost is not cosmetic. On Windows with the Task Scheduler backend, the two commands point at each other:

- `POST /api/stop` → 409 `respawnable_service`: *"the stop must be run by `ocx stop`"*
- `ocx stop` → *"a service installed under a different CODEX_HOME/OPENCODEX_HOME owns it. Run the stop from that home."*

I hit this with matching homes (`service-state.json.codexHome` equal to the invoking `CODEX_HOME`) and spent three attempts re-exporting `CODEX_HOME` before probing the endpoint directly and seeing `respawnable_service`. The printed advice names a home that is already correct, and neither message mentions the wrapper that is actually refusing.

## What this changes

- Capture the refusal `code` next to the message (`lastStopRefusalCode()`), so a refusal with an empty or unparseable body still knows its cause.
- Select the fallback wording from that code. The default is **cause-neutral** — naming no cause is better than naming the wrong one, because the operator acts on what it says.
- Drop "foreign" from the CLI's teardown notice. A respawning wrapper, or the service itself, is not another home's proxy.

No behavioral change when the server sends a message: that path is unchanged and still wins.

## Tests

Added to `tests/lib/process-control-graceful.test.ts`:

- the refusal code is captured alongside the message, and is `null` when the body cannot be parsed (no JSON means no code to recover — the fallback then has to be cause-neutral, not code-selected)
- a refusal **without a message** falls back by code (`respawnable_service` / `self_unload_service` / `service_state_unknown`), and a refusal with neither falls back to cause-neutral wording. **None of the four may contain `CODEX_HOME` or `OPENCODEX_HOME`** — the regression this PR is named after
- concurrent refusals each keep their own cause (see below)

`tests/providers/xai/grok-lifecycle.test.ts` asserted the old "foreign proxy" wording and was updated with it. The source-oracle assertions in that file (409 does not escalate to a forced kill; `graceful === "refused"` precedes `killProxy`) still hold and pass unchanged.

Verified locally on Windows:

- `bun test tests/lib/ tests/providers/xai/grok-lifecycle.test.ts tests/cli/uninstall.test.ts tests/service/service.test.ts` → 579 pass, 0 fail
- `bun run typecheck` → clean
- `bun run privacy:scan` → passed

## Per-call refusal, and a counterfactual for it

Review follow-up: `stopProxyGracefully` published the 409 message and code to module-scoped state that `stopProxy` read after awaiting it, so two overlapping stops could interleave and the first would throw with the second's cause. That applied to the pre-existing `lastRefusalMessage` as well, not only the code this PR adds.

`stopProxyGracefullyDetailed` now returns `{ result, refusal }` and `stopProxy` builds the error from that value. The exported `stopProxyGracefully` signature and `GracefulStopResult` are unchanged (it is a thin wrapper), and `lastStopRefusalMessage()` / `lastStopRefusalCode()` remain as observational accessors.

The first version of the overlap test did not actually guard this. It parked one call inside `fetch` and let the other finish completely before resuming — a schedule the global handoff also passes, because the parked call republishes its own globals last. **I checked that against the pre-fix commit and it passed there, so it was proving nothing.**

The test now starts both stops together. Counterfactual, run against the pre-fix implementation (506473d):

```
error: expect(received).toContain(expected)
Expected to contain: "respawn"
Received: "The running proxy refused to stop: it is the installed service itself, ..."
(fail) concurrent stops keep their own cause
```

The `respawnable_service` call throws the `self_unload_service` cause. It passes on the per-call result.

## What I did not do

- I did not rename `ProxyOwnershipRefusedError`. The name now overstates what it carries, but it is used across `src/cli/index.ts` and renaming it is a separate, wider change — happy to follow up if you want it.
- Issue #4169 also notes that in my run the server's message was present when probed directly yet the hardcoded fallback was printed. I could not isolate why `lastRefusalMessage` was null on that path, so this PR does not claim to fix it. It does make that class of failure non-misleading: whatever the reason a message goes missing, the operator is no longer sent to the wrong home.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
