### PR TITLE
fix(responses): gracefully handle code-mode view_image calls via unified exec

### DIFF
--- a/src/responses/code-mode-helper-compat.ts
+++ b/src/responses/code-mode-helper-compat.ts
@@ -54,6 +54,16 @@ export function compileCodeModeHelperInput(argumentsText: unknown, toolName: str
   if (toolName === "write_stdin") {
     return `const result = await tools.write_stdin(${JSON.stringify(args)});\ntext(result);`;
   }
+  if (toolName === "view_image") {
+    let target = "";
+    if (isPlainObject(args)) {
+      if (typeof args.path === "string") target = ` for ${JSON.stringify(args.path)}`;
+      else if (typeof args.file_path === "string") target = ` for ${JSON.stringify(args.file_path)}`;
+      else if (typeof args.file === "string") target = ` for ${JSON.stringify(args.file)}`;
+    }
+    const msg = `Error: 'view_image' is not available in Code Mode${target}. Inspect files or visual assets programmatically using tools.exec_command or code.`;
+    return `text(${JSON.stringify(msg)});\n`;
+  }
   return `const result = await tools.exec_command(${JSON.stringify(args)});\ntext(result);`;
 }
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -57,6 +57,7 @@ const CODE_MODE_HELPER_TOOL_NAMES = [
   ...LEGACY_SHELL_BRIDGE_TOOL_NAMES,
   "write_stdin",
   "apply_patch",
+  "view_image",
 ] as const;
 
 /**

--- a/tests/responses/legacy-shell-compat.test.ts
+++ b/tests/responses/legacy-shell-compat.test.ts
@@ -112,4 +112,16 @@ describe("code-mode helper compatibility", () => {
       expect(received).toEqual(input === "[]" ? [] : input);
     }
   });
+
+  test("view_image emits a friendly code-mode error message via text()", async () => {
+    const source = compileCodeModeHelperInput(
+      JSON.stringify({ path: "/root/banner.png" }),
+      "view_image",
+    );
+    let output: unknown;
+    const run = new AsyncFunction("tools", "text", source);
+    await run({}, (value: unknown) => { output = value; });
+    expect(output).toContain("Error: 'view_image' is not available in Code Mode for \"/root/banner.png\"");
+    expect(output).toContain("tools.exec_command");
+  });
 });

--- a/tests/responses/responses-undeclared-tool-guard.test.ts
+++ b/tests/responses/responses-undeclared-tool-guard.test.ts
@@ -1640,6 +1640,16 @@ describe("undeclaredToolCallNameInResponse", () => {
     expect(undeclaredToolCallNameInResponse(response, new Set())).toBe("write_stdin");
   });
 
+  test("accepts view_image through a bare unified exec declaration", () => {
+    const response = {
+      output: [{ type: "function_call", name: "view_image" }],
+    };
+
+    expect(undeclaredToolCallNameInResponse(response, new Set(["exec"]))).toBeUndefined();
+    expect(undeclaredToolCallNameInResponse(response, new Set(["view_image"]))).toBeUndefined();
+    expect(undeclaredToolCallNameInResponse(response, new Set())).toBe("view_image");
+  });
+
   test("never legacy-normalizes a namespaced shell bridge call", () => {
     // A namespaced call (e.g. an MCP server advertising its own exec_command) must be
     // matched by its full wire name only — never normalized to bare `exec`.


### PR DESCRIPTION
## Summary

- Resolves an abrupt `HTTP 502 / response.failed` failure when routed models under Code Mode (`tool_mode: code_mode_only` / `features.code_mode_host=true`) emit an undeclared client tool call to `view_image`.
- In Code Mode, Codex only declares the top-level `exec` tool. Routed models (e.g. Gemini 3.8 Flash, Claude) occasionally attempt to invoke `view_image` upon seeing visual assets or file paths in the conversation history.
- Previously, `responses-undeclared-tool-guard.ts` failed closed on `view_image`, killing the turn abruptly.
- This PR adds `view_image` to `CODE_MODE_HELPER_TOOL_NAMES` in `src/types/tools.ts`, matching the behavior of other Codex client helpers (`apply_patch`, `write_stdin`), and compiles it into an informative code-mode `text()` response informing the model that `view_image` is not available in Code Mode and guiding it to inspect files programmatically via `tools.exec_command` or code.

## Verification

- Ran targeted test suites:
  - `bun test tests/responses/legacy-shell-compat.test.ts` (7 pass, 0 fail)
  - `bun test tests/responses/responses-undeclared-tool-guard.test.ts` (83 pass, 0 fail)
  - `bun test tests/adapters/tool-catalog-nudge.test.ts` (20 pass, 0 fail)
  - `bun test tests/responses/responses-custom-tool-repair.test.ts` (55 pass, 0 fail)
  - `bun test tests/responses/apply-patch-envelope.test.ts` (18 pass, 0 fail)
- Ran static analysis & security scans:
  - `bun run typecheck` (passed with 0 errors)
  - `bun run privacy:scan` (passed)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of image-view requests in code mode by returning a clear availability message instead of attempting to execute them as shell commands.
  - Error messages may identify the requested image path and reference the supported command interface.
  - Image-view requests are now correctly recognized when supported execution tools are declared, while undeclared requests continue to be reported appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->