### PR TITLE
fix(claude): allow deleting unavailable routes in desktop profile

### DIFF
--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -945,13 +945,19 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     let body: { profile?: unknown };
     try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
     try {
-      const { parseDesktopProfile, reconcileDesktopProfile } = await import("../../claude/desktop-profile");
-      const parsed = parseDesktopProfile(body.profile);
-      const current = await buildClaudeDesktopState(config);
-      for (const model of current.models.filter(item => !item.available)) {
+     const { parseDesktopProfile, reconcileDesktopProfile } = await import("../../claude/desktop-profile");
+     const parsed = parseDesktopProfile(body.profile);
+     const current = await buildClaudeDesktopState(config);
+      const availableRoutes = new Set(current.models.filter(item => item.available).map(item => item.route));
+      for (const route of Object.keys(parsed.assignments)) {
+        if (!current.profile.assignments[route] && !availableRoutes.has(route)) {
+          throw new Error(`현재 사용할 수 없는 모델은 추가할 수 없습니다: ${route}`);
+        }
+      }
+     for (const model of current.models.filter(item => !item.available)) {
         const before = current.profile.assignments[model.route];
         const after = parsed.assignments[model.route];
-        if (JSON.stringify(before) !== JSON.stringify(after)) {
+        if (after !== undefined && JSON.stringify(before) !== JSON.stringify(after)) {
           throw new Error(`현재 사용할 수 없는 모델은 옮길 수 없습니다: ${model.route}`);
         }
       }

--- a/src/server/management/agent-settings-routes.ts
+++ b/src/server/management/agent-settings-routes.ts
@@ -945,16 +945,16 @@ export async function handleAgentSettingsRoutes(ctx: ManagementContext): Promise
     let body: { profile?: unknown };
     try { body = await readManagementJsonBody(req); } catch (error) { rethrowManagementBodyTooLarge(error); return jsonResponse({ error: "invalid JSON body" }, 400); }
     try {
-     const { parseDesktopProfile, reconcileDesktopProfile } = await import("../../claude/desktop-profile");
-     const parsed = parseDesktopProfile(body.profile);
-     const current = await buildClaudeDesktopState(config);
+      const { parseDesktopProfile, reconcileDesktopProfile } = await import("../../claude/desktop-profile");
+      const parsed = parseDesktopProfile(body.profile);
+      const current = await buildClaudeDesktopState(config);
       const availableRoutes = new Set(current.models.filter(item => item.available).map(item => item.route));
       for (const route of Object.keys(parsed.assignments)) {
         if (!current.profile.assignments[route] && !availableRoutes.has(route)) {
           throw new Error(`현재 사용할 수 없는 모델은 추가할 수 없습니다: ${route}`);
         }
       }
-     for (const model of current.models.filter(item => !item.available)) {
+      for (const model of current.models.filter(item => !item.available)) {
         const before = current.profile.assignments[model.route];
         const after = parsed.assignments[model.route];
         if (after !== undefined && JSON.stringify(before) !== JSON.stringify(after)) {

--- a/tests/claude-integration/claude-management-api.test.ts
+++ b/tests/claude-integration/claude-management-api.test.ts
@@ -896,7 +896,7 @@ test("Claude Desktop PUT retains but cannot move an unavailable route", async ()
   }
 });
 
-test("Claude Desktop PUT allows deleting an unavailable route, but rejects adding one", async () => {
+test("Claude Desktop PUT allows deleting an unavailable route, but rejects modifying or adding one", async () => {
   const seeded = loadConfig();
   seeded.claudeCode = {
     desktopProfile: {
@@ -908,37 +908,51 @@ test("Claude Desktop PUT allows deleting an unavailable route, but rejects addin
     },
   };
   saveConfig(seeded);
- const server = startServer(0);
- try {
-   const state = await fetch(new URL("/api/claude-desktop", server.url)).then(r => r.json()) as Record<string, any>;
+  const server = startServer(0);
+  try {
+    const state = await fetch(new URL("/api/claude-desktop", server.url)).then(r => r.json()) as Record<string, any>;
     expect(state.models.find((model: { route: string }) => model.route === "missing/old-model")?.available).toBe(false);
 
-   const deleteEdit = structuredClone(state.profile);
-   delete deleteEdit.assignments["missing/old-model"];
-   deleteEdit.defaults.opus = Object.keys(deleteEdit.assignments).filter(route => deleteEdit.assignments[route].family === "opus").sort()[0] ?? null;
-   
-   const putDelete = await fetch(new URL("/api/claude-desktop", server.url), {
+    // Modifying an existing unavailable assignment (e.g. changing alias) is rejected with 400.
+    const modifyEdit = structuredClone(state.profile);
+    modifyEdit.assignments["missing/old-model"].alias = "claude-opus-4-8-20260202";
+    const putModify = await fetch(new URL("/api/claude-desktop", server.url), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-     body: JSON.stringify({ profile: deleteEdit }),
-   });
-   expect(putDelete.status).toBe(200);
+      body: JSON.stringify({ profile: modifyEdit }),
+    });
+    expect(putModify.status).toBe(400);
+    expect((await putModify.json() as { error: string }).error).toContain("현재 사용할 수 없는 모델은 옮길 수 없습니다: missing/old-model");
+    expect(loadConfig().claudeCode?.desktopProfile?.assignments["missing/old-model"]?.alias).toBe("claude-opus-4-8-20260101");
+
+    // Deleting an existing unavailable assignment succeeds with 200.
+    const deleteEdit = structuredClone(state.profile);
+    delete deleteEdit.assignments["missing/old-model"];
+    deleteEdit.defaults.opus = Object.keys(deleteEdit.assignments).filter(route => deleteEdit.assignments[route].family === "opus").sort()[0] ?? null;
+
+    const putDelete = await fetch(new URL("/api/claude-desktop", server.url), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: deleteEdit }),
+    });
+    expect(putDelete.status).toBe(200);
     const deleteResult = await putDelete.json() as Record<string, any>;
     expect(deleteResult.models.some((model: { route: string }) => model.route === "missing/old-model")).toBe(false);
     expect(deleteResult.profile.assignments["missing/old-model"]).toBeUndefined();
     expect(loadConfig().claudeCode?.desktopProfile?.assignments["missing/old-model"]).toBeUndefined();
-   
+
+    // Adding a newly unavailable assignment is rejected with 400.
     const addEdit = structuredClone(deleteResult.profile);
     addEdit.assignments["missing/new-model"] = { family: "fable", alias: "claude-opus-4-8-20260102" };
     addEdit.defaults.fable = "missing/new-model";
-  const putAdd = await fetch(new URL("/api/claude-desktop", server.url), {
-     method: "PUT",
-     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ profile: addEdit }),
-  });
-  expect(putAdd.status).toBe(400);
+    const putAdd = await fetch(new URL("/api/claude-desktop", server.url), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: addEdit }),
+    });
+    expect(putAdd.status).toBe(400);
     expect((await putAdd.json() as { error: string }).error).toContain("현재 사용할 수 없는 모델은 추가할 수 없습니다: missing/new-model");
-} finally {
-   await server.stop(true);
- }
+  } finally {
+    await server.stop(true);
+  }
 });

--- a/tests/claude-integration/claude-management-api.test.ts
+++ b/tests/claude-integration/claude-management-api.test.ts
@@ -895,3 +895,50 @@ test("Claude Desktop PUT retains but cannot move an unavailable route", async ()
     await server.stop(true);
   }
 });
+
+test("Claude Desktop PUT allows deleting an unavailable route, but rejects adding one", async () => {
+  const seeded = loadConfig();
+  seeded.claudeCode = {
+    desktopProfile: {
+      version: 1,
+      assignments: {
+        "missing/old-model": { family: "opus", alias: "claude-opus-4-8-20260101" },
+      },
+      defaults: { opus: "missing/old-model", fable: null, sonnet: null, haiku: null },
+    },
+  };
+  saveConfig(seeded);
+ const server = startServer(0);
+ try {
+   const state = await fetch(new URL("/api/claude-desktop", server.url)).then(r => r.json()) as Record<string, any>;
+    expect(state.models.find((model: { route: string }) => model.route === "missing/old-model")?.available).toBe(false);
+
+   const deleteEdit = structuredClone(state.profile);
+   delete deleteEdit.assignments["missing/old-model"];
+   deleteEdit.defaults.opus = Object.keys(deleteEdit.assignments).filter(route => deleteEdit.assignments[route].family === "opus").sort()[0] ?? null;
+   
+   const putDelete = await fetch(new URL("/api/claude-desktop", server.url), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+     body: JSON.stringify({ profile: deleteEdit }),
+   });
+   expect(putDelete.status).toBe(200);
+    const deleteResult = await putDelete.json() as Record<string, any>;
+    expect(deleteResult.models.some((model: { route: string }) => model.route === "missing/old-model")).toBe(false);
+    expect(deleteResult.profile.assignments["missing/old-model"]).toBeUndefined();
+    expect(loadConfig().claudeCode?.desktopProfile?.assignments["missing/old-model"]).toBeUndefined();
+   
+    const addEdit = structuredClone(deleteResult.profile);
+    addEdit.assignments["missing/new-model"] = { family: "fable", alias: "claude-opus-4-8-20260102" };
+    addEdit.defaults.fable = "missing/new-model";
+  const putAdd = await fetch(new URL("/api/claude-desktop", server.url), {
+     method: "PUT",
+     headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ profile: addEdit }),
+  });
+  expect(putAdd.status).toBe(400);
+    expect((await putAdd.json() as { error: string }).error).toContain("현재 사용할 수 없는 모델은 추가할 수 없습니다: missing/new-model");
+} finally {
+   await server.stop(true);
+ }
+});


### PR DESCRIPTION
## Summary

- Resolves #4167 by allowing clients to delete unavailable routes from Claude Desktop profile assignments via PUT /api/claude-desktop.
- Previously, PUT /api/claude-desktop checked JSON.stringify(before) !== JSON.stringify(after) for all unavailable models in current state. When an unavailable route was pruned from assignments, after became undefined, causing the check to throw "현재 사용할 수 없는 모델은 옮길 수 없습니다: <route>" and blocking deletion of defunct models.
- Guards deletion by ensuring after !== undefined before checking for modifications, so pruning unavailable routes succeeds while moving or altering them remains strictly prohibited.
- Adds an upfront validation guard rejecting the addition of brand-new unavailable routes that were neither previously assigned nor present in the active catalog ("현재 사용할 수 없는 모델은 추가할 수 없습니다: <route>").

Closes #4167

## Verification

- Added comprehensive integration test in tests/claude-integration/claude-management-api.test.ts:
  - Verified PUT /api/claude-desktop allows deleting an unavailable route (missing/old-model), confirming HTTP 200 and removing it from returned models and persisted config.
  - Verified PUT /api/claude-desktop rejects adding an unassigned unavailable route (missing/new-model) with HTTP 400 and expected error message.
  - Verified PUT /api/claude-desktop continues to reject moving or modifying an unavailable route.
- Verified test suite:
  - bun test tests/claude-integration/claude-management-api.test.ts (29 pass, 0 fail, 216 expect calls)
  - bun test tests/clients/desktop-profile.test.ts tests/clients/desktop-3p.test.ts (38 pass, 0 fail)
  - bun run typecheck (tsc strict, 0 errors)
  - bun run privacy:scan (clean)

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Claude Desktop profile updates now reject newly added unavailable models with a clear validation error.
  - Changes to existing assignments for unavailable models are rejected.
  - Removing an assignment for an unavailable model now succeeds and is reflected in the saved configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->