### PR TITLE
docs(devlog): record the 2.50.0 regression audit and release train

### DIFF
--- a/devlog/_plan/260910_250_regression_audit_release/000_plan.md
+++ b/devlog/_plan/260910_250_regression_audit_release/000_plan.md
@@ -4,15 +4,35 @@
 
 - Released baseline: `v2.49.0`, `main` at `2f3f736299dca38861f8fb9c4326a4b4d7c664bc`.
 - Audit candidate: `origin/dev` at `12c248f52bed88ea13be5b284c79a238feb592d1`, `package.json` version `2.50.0`.
-- Delta: 127 commits, 1066 files. Product surface is 121 files / +3322 / -280 across
-  `src` (62), `gui` (27), `tests` (42), `docs-site` (28), plus one `scripts/test-layout/layout.json`
-  entry and the `package.json` bump. The remaining 885 files are `devlog`, which carries no runtime.
+- Delta: 127 commits (`git rev-list --count 2f3f73629..origin/dev`), 1066 changed files
+  (`git diff --name-only 2f3f73629...origin/dev | wc -l`).
+
+### File counts, by `git diff --name-only 2f3f73629...origin/dev | cut -d/ -f1 | sort | uniq -c`
+
+| Group | Files | Note |
+| --- | --- | --- |
+| `devlog` | 885 | No runtime. Not audited. |
+| `src` | 62 | Audited: L1-L3, L5, L6 |
+| `tests` | 42 | Read as evidence by every lane, not a lane of its own |
+| `docs-site` | 28 | Not release-blocking on its own |
+| `gui` | 27 | Audited: L4 |
+| `readme` + root docs | 13 | `readme/` 8, plus `README.md`, `AGENTS.md`, `AGENTS_INSTALL.md`, `SECURITY.md`, `package.json` |
+| `skills` | 3 | Audited: L6 (`skills/ocx` surface map) |
+| `.github` | 3 | PR assets only, no workflow change |
+| `structure` | 2 | Maintainer invariants |
+| `scripts` | 1 | `scripts/test-layout/layout.json` |
+
+`git diff --shortstat 2f3f73629...origin/dev -- src gui docs-site scripts .github` is
+121 files / +3322 / -280. That figure excludes `tests` and `package.json`; the full
+non-`devlog` set is 181 files. An earlier revision of this doc attributed 121 to a
+different folder set and derived the devlog count by subtraction; the reviewer
+contradicted both with the commands above.
 
 ## What this unit does
 
 Audit the product delta for release-blocking regressions, remediate anything blocking,
-then run the 2.50.0 train: pre-move `dev`, promote the frozen candidate to `preview`
-and `main`, publish to npm, and verify the artifacts independently.
+then run the 2.50.0 train: pre-move `dev`, promote the frozen candidate to `main`,
+publish to npm, and verify the artifacts independently.
 
 ## Authorization in force
 
@@ -22,10 +42,11 @@ PABCD transition, every write, and every external action.
 
 ## Out of scope
 
-- Landing unrelated open pull requests. 20 PRs are open against `dev`; none is a
-  release prerequisite, and pulling them in would move the candidate tree mid-audit.
+- Landing unrelated open pull requests. 74 are open against `dev`
+  (`gh api "repos/lidge-jun/opencodex/pulls?state=open&base=dev&per_page=100" --jq 'length'`);
+  none is a release prerequisite, and pulling one in moves the candidate mid-audit.
 - Re-auditing anything already released in 2.49.0.
-- Any change to `devlog/` history, `main` outside promotion, or third-party accounts.
+- Any change to `devlog/` history or to third-party accounts.
 
 ## Terminal outcomes
 

--- a/devlog/_plan/260910_250_regression_audit_release/000_plan.md
+++ b/devlog/_plan/260910_250_regression_audit_release/000_plan.md
@@ -12,7 +12,7 @@
 | Group | Files | Note |
 | --- | --- | --- |
 | `devlog` | 885 | No runtime. Not audited. |
-| `src` | 62 | Audited: L1-L3, L5, L6 |
+| `src` | 62 | Audited: L1-L6 (L4 owns `src/server/management/*`, `src/server/{management-api,auth-cors,index}.ts`, `src/service.ts`) |
 | `tests` | 42 | Read as evidence by every lane, not a lane of its own |
 | `docs-site` | 28 | Not release-blocking on its own |
 | `gui` | 27 | Audited: L4 |

--- a/devlog/_plan/260910_250_regression_audit_release/000_plan.md
+++ b/devlog/_plan/260910_250_regression_audit_release/000_plan.md
@@ -1,0 +1,36 @@
+# 2.50.0 regression audit and release — scope
+
+## Baseline and candidate
+
+- Released baseline: `v2.49.0`, `main` at `2f3f736299dca38861f8fb9c4326a4b4d7c664bc`.
+- Audit candidate: `origin/dev` at `12c248f52bed88ea13be5b284c79a238feb592d1`, `package.json` version `2.50.0`.
+- Delta: 127 commits, 1066 files. Product surface is 121 files / +3322 / -280 across
+  `src` (62), `gui` (27), `tests` (42), `docs-site` (28), plus one `scripts/test-layout/layout.json`
+  entry and the `package.json` bump. The remaining 885 files are `devlog`, which carries no runtime.
+
+## What this unit does
+
+Audit the product delta for release-blocking regressions, remediate anything blocking,
+then run the 2.50.0 train: pre-move `dev`, promote the frozen candidate to `preview`
+and `main`, publish to npm, and verify the artifacts independently.
+
+## Authorization in force
+
+The user authorized parallel `xai/grok-4.6` subagents, a regression-audit PABCD cycle,
+and the release itself. Subagents are read-only verifiers; the main session owns every
+PABCD transition, every write, and every external action.
+
+## Out of scope
+
+- Landing unrelated open pull requests. 20 PRs are open against `dev`; none is a
+  release prerequisite, and pulling them in would move the candidate tree mid-audit.
+- Re-auditing anything already released in 2.49.0.
+- Any change to `devlog/` history, `main` outside promotion, or third-party accounts.
+
+## Terminal outcomes
+
+- `DONE` — 2.50.0 on npm `latest` with `gitHead` matching the promoted `main` SHA, a
+  git tag, a GitHub release, and a recorded triage for every audit finding.
+- `BLOCKED` — a release-blocking regression that cannot be fixed inside this scope,
+  or a missing external permission (npm trusted publishing, workflow dispatch).
+- `NOOP` — the candidate is already published and verified.

--- a/devlog/_plan/260910_250_regression_audit_release/010_audit_lanes.md
+++ b/devlog/_plan/260910_250_regression_audit_release/010_audit_lanes.md
@@ -1,0 +1,59 @@
+# Audit lanes
+
+Five read-only lanes, each dispatched to an independent `xai/grok-4.6` subagent with a
+forked-context-free packet. Read scopes are stated per lane so a finding can be traced to
+one owner; the lanes never write, and the main session de-duplicates the returns.
+
+Every lane compares `2f3f73629...origin/dev` and must return exact `path:line` anchors.
+A lane that finds nothing returns "no blocker" with the files it actually read.
+
+## L1 — Responses and request pipeline
+
+`src/server/responses/{core,compact,context-overflow,policy-fallback,codex-ws-wire}.ts`,
+`src/server/{chat-completions,chat-native,claude-messages,images,search,request-decompress,request-log}.ts`,
+`src/claude/inbound.ts`, `src/web-search/{passthrough-bridge,ollama-executor}.ts`.
+
+Highest-risk lane: it owns the new hosted web-search bridge (+657 test lines), the
+non-streaming context-overflow classification, agent-task recovery on mid-thread model
+switches, and the configurable inbound body admission limit.
+
+## L2 — Codex accounts, quota, OAuth
+
+`src/codex/{account-runtime-state,account-store,account-usability,auth-api,auth-context,inject,quota,quota-auto-refresh}.ts`,
+`src/oauth/{health,index,token-guardian}.ts`, `src/cli/{account,account-api,account-auth,account-extended}.ts`.
+
+Carries deferred validation, revoked pool grants, reauth-state clearing, the new account
+plan field, and the token guardian.
+
+## L3 — Catalog, providers, combos, config
+
+`src/codex/catalog/{parsing,provider-fetch,sync}.ts`, `src/providers/{registry,quota,google-ai-studio-model-discovery,opencode-zen-rate-limit}.ts`,
+`src/combos/{index,resolve}.ts`, `src/config.ts`, `src/types.ts`, `src/types/{accounts,config,provider}.ts`,
+`src/clients/config-export/zcode.ts`, `src/lib/errors.ts`.
+
+Carries free-model pricing classification and filtering, quota-exhausted inactive marking,
+AI Studio discovery restoration, and cross-provider blocked-model redirects.
+
+## L4 — Management API, service, GUI
+
+`src/server/management/*`, `src/server/{management-api,auth-cors,index}.ts`, `src/service.ts`,
+`gui/src/**`, `gui/tests/**`.
+
+Carries the routed-account log label, the decode-rate column, management auth, the stale
+launchd bootout recovery, and nine i18n locale files that must not contradict `en`.
+
+## L5 — Security, privacy, release surface
+
+Cross-cutting read of `src/lib/privacy.ts`, the body-size admission path, OrcaRouter
+key-exchange bounds, web-search bridge egress, `package.json`, `scripts/test-layout/layout.json`,
+and the repository invariants in `AGENTS.md` (Lab/core import boundary, no tracked gitlink,
+no request-body or credential logging).
+
+The email-masking opt-out is the specific item to scrutinize: it deliberately weakens a
+privacy default, so it must be off by default and covered by `bun run privacy:scan`.
+
+## Blocker definition
+
+A finding blocks the release when it is a behavior regression against 2.49.0, a crash or
+hang on a default path, a security or privacy weakening, or a broken release/packaging
+surface. Style, missing coverage for unchanged code, and pre-existing defects do not block.

--- a/devlog/_plan/260910_250_regression_audit_release/010_audit_lanes.md
+++ b/devlog/_plan/260910_250_regression_audit_release/010_audit_lanes.md
@@ -49,8 +49,8 @@ bootout recovery, and nine i18n locale files that must not contradict `en`.
 
 ## L5 — Security, privacy, release surface
 
-Cross-cutting read of `src/lib/privacy.ts`, the body-size admission path, OrcaRouter
-key-exchange bounds, web-search bridge egress, `package.json`,
+Cross-cutting read of `src/lib/privacy.ts`, the body-size admission path, web-search
+bridge egress, `package.json`,
 `scripts/test-layout/layout.json`, `structure/{02_config-and-codex-home,04_transports-and-sidecars}.md`,
 and the repository invariants in `AGENTS.md`: the Lab/core import boundary, the
 synchronous `startServer` window, no tracked gitlink, and no request-body or credential

--- a/devlog/_plan/260910_250_regression_audit_release/010_audit_lanes.md
+++ b/devlog/_plan/260910_250_regression_audit_release/010_audit_lanes.md
@@ -1,11 +1,16 @@
 # Audit lanes
 
-Five read-only lanes, each dispatched to an independent `xai/grok-4.6` subagent with a
-forked-context-free packet. Read scopes are stated per lane so a finding can be traced to
-one owner; the lanes never write, and the main session de-duplicates the returns.
+Six read-only lanes, each dispatched to an independent `xai/grok-4.6` subagent with a
+fresh context. Read scopes are stated per lane so a finding traces to one owner; the
+lanes never write, and the main session de-duplicates the returns.
 
 Every lane compares `2f3f73629...origin/dev` and must return exact `path:line` anchors.
 A lane that finds nothing returns "no blocker" with the files it actually read.
+
+Lane coverage is checked mechanically: every path in
+`git diff --name-only 2f3f73629...origin/dev -- src gui scripts skills package.json`
+belongs to at least one lane. The first revision of this map left
+`src/cli/{capabilities,index,models-runtime,observe}.ts` unowned, which is why L6 exists.
 
 ## L1 — Responses and request pipeline
 
@@ -13,7 +18,7 @@ A lane that finds nothing returns "no blocker" with the files it actually read.
 `src/server/{chat-completions,chat-native,claude-messages,images,search,request-decompress,request-log}.ts`,
 `src/claude/inbound.ts`, `src/web-search/{passthrough-bridge,ollama-executor}.ts`.
 
-Highest-risk lane: it owns the new hosted web-search bridge (+657 test lines), the
+Highest-risk lane: the new hosted web-search bridge (`passthrough-bridge.ts` +761), the
 non-streaming context-overflow classification, agent-task recovery on mid-thread model
 switches, and the configurable inbound body admission limit.
 
@@ -22,8 +27,8 @@ switches, and the configurable inbound body admission limit.
 `src/codex/{account-runtime-state,account-store,account-usability,auth-api,auth-context,inject,quota,quota-auto-refresh}.ts`,
 `src/oauth/{health,index,token-guardian}.ts`, `src/cli/{account,account-api,account-auth,account-extended}.ts`.
 
-Carries deferred validation, revoked pool grants, reauth-state clearing, the new account
-plan field, and the token guardian.
+Deferred validation, revoked pool grants, reauth-state clearing, the new account plan
+field, and the token guardian.
 
 ## L3 — Catalog, providers, combos, config
 
@@ -31,29 +36,63 @@ plan field, and the token guardian.
 `src/combos/{index,resolve}.ts`, `src/config.ts`, `src/types.ts`, `src/types/{accounts,config,provider}.ts`,
 `src/clients/config-export/zcode.ts`, `src/lib/errors.ts`.
 
-Carries free-model pricing classification and filtering, quota-exhausted inactive marking,
-AI Studio discovery restoration, and cross-provider blocked-model redirects.
+Free-model pricing classification and filtering, quota-exhausted inactive marking, AI
+Studio discovery restoration, cross-provider blocked-model redirects.
 
 ## L4 — Management API, service, GUI
 
 `src/server/management/*`, `src/server/{management-api,auth-cors,index}.ts`, `src/service.ts`,
 `gui/src/**`, `gui/tests/**`.
 
-Carries the routed-account log label, the decode-rate column, management auth, the stale
-launchd bootout recovery, and nine i18n locale files that must not contradict `en`.
+The routed-account log label, the decode-rate column, management auth, the stale launchd
+bootout recovery, and nine i18n locale files that must not contradict `en`.
 
 ## L5 — Security, privacy, release surface
 
 Cross-cutting read of `src/lib/privacy.ts`, the body-size admission path, OrcaRouter
-key-exchange bounds, web-search bridge egress, `package.json`, `scripts/test-layout/layout.json`,
-and the repository invariants in `AGENTS.md` (Lab/core import boundary, no tracked gitlink,
-no request-body or credential logging).
+key-exchange bounds, web-search bridge egress, `package.json`,
+`scripts/test-layout/layout.json`, `structure/{02_config-and-codex-home,04_transports-and-sidecars}.md`,
+and the repository invariants in `AGENTS.md`: the Lab/core import boundary, the
+synchronous `startServer` window, no tracked gitlink, and no request-body or credential
+logging.
 
 The email-masking opt-out is the specific item to scrutinize: it deliberately weakens a
-privacy default, so it must be off by default and covered by `bun run privacy:scan`.
+privacy default, so it must be off by default, must survive `bun run privacy:scan`, and
+its CLI application in `src/cli/index.ts` (L6) must agree with the library default.
+
+## L6 — Operator CLI surface
+
+`src/cli/{capabilities,index,models-runtime,observe}.ts`, `skills/ocx/**`, and the
+generated surface map that `tests/ci-workflows/skill-ocx.test.ts` asserts.
+
+`src/cli/index.ts` applies `privacy.maskEmails` to `ocx status` and is a
+`service-lifecycle.yml` gate path. `capabilities.ts` adds a mutating `ocx account refresh`
+with a consent warning. `models-runtime.ts` adds `--free-only`, which filters on
+`pricingStatus === "free"` and therefore drops entries with no status. `observe.ts` adds
+`--account` log filtering.
 
 ## Blocker definition
 
-A finding blocks the release when it is a behavior regression against 2.49.0, a crash or
-hang on a default path, a security or privacy weakening, or a broken release/packaging
-surface. Style, missing coverage for unchanged code, and pre-existing defects do not block.
+A finding blocks the release when any of these hold.
+
+1. **Regression against 2.49.0** — behavior that worked in the released tree and does not now.
+2. **Crash, hang, or unbounded resource use** on any path a default install can reach.
+3. **New-path functional breakage.** A feature introduced in this delta that does not do
+   what it claims still blocks, even though it is not a regression. This covers the
+   web-search bridge returning wrong or empty results, `--free-only` silently dropping
+   models with an absent `pricingStatus`, and a no-op `ocx account refresh`.
+4. **Security or privacy weakening**, including a default that becomes less private, a
+   credential or request body reaching a log, or a loosened auth boundary.
+5. **User-consent or identity-spend bypass**, per `AGENTS.md` "User-consent actions": any
+   path that spends the user's identity, credits, or reputation without the code-level
+   gate, including a CLI path that mints its own dashboard session.
+6. **Core invariant violation**, per `AGENTS.md`: a Lab import reaching `src/router.ts`,
+   `src/server/lifecycle.ts`, or `src/server/responses/core.ts`, an `await` inside the
+   synchronous `startServer` activation window, or a tracked gitlink.
+7. **Upgrade-path breakage**, not only first-run. An existing 2.49.0 install that keeps a
+   stale launchd job, a stale config, or a stale service unit after upgrading blocks.
+8. **Broken release, packaging, or operator-surface contract**, including a `skills/ocx`
+   map that names a command the registry does not have.
+
+Style, missing coverage for unchanged code, and defects that already shipped in 2.49.0
+do not block; they are recorded as non-blockers with the evidence that they predate the delta.

--- a/devlog/_plan/260910_250_regression_audit_release/020_release_plan.md
+++ b/devlog/_plan/260910_250_regression_audit_release/020_release_plan.md
@@ -1,30 +1,61 @@
 # 2.50.0 release plan
 
-Order matters: the candidate tree must be frozen before `dev` moves again.
+Derived from `.github/workflows/release.yml` as it exists on `dev`, not from precedent.
+The gates below are what the workflow actually enforces.
 
-1. **Freeze the candidate.** Record the exact `dev` SHA and require successful
-   `Cross-platform CI` and `Service lifecycle` runs on that SHA. `dev` HEAD
-   `12c248f52` currently has no run of its own, so the release SHA needs an explicit
-   `lane=all` CI dispatch plus a service-lifecycle run before promotion.
+## What release.yml requires
+
+| Gate | Line | Requirement |
+| --- | --- | --- |
+| Branch | `release.yml:153-170` | Must run from `refs/heads/main` or `refs/heads/preview`. `main` refuses any version containing `-`; `preview` refuses any version that is not `*-preview.*`. |
+| dist-tag | `release.yml:174-177` | `main` -> `latest`, `preview` -> `preview`. |
+| CI | `release.yml:179-197` | A **successful `ci.yml` run with `--event push` on the release branch for `$GITHUB_SHA`**. A pull-request run is explicitly rejected, and a `workflow_dispatch` run on `dev` does not qualify. |
+| Service lifecycle | `release.yml:225-237` | If any of `src/service.ts`, `src/cli.ts`, `src/cli/index.ts`, `src/lib/bun-runtime.ts`, `package.json`, `bun.lock`, `service-lifecycle.yml`, `release.yml` changed since the previous tag, a successful `service-lifecycle.yml` run for `$GITHUB_SHA` is required. This delta changes `src/cli/index.ts` and `package.json`, so the gate is armed. |
+| dev ahead | `release.yml:242-249` | `bun scripts/version-line.ts assert-ahead <dev version> <release version>`. `dev` is currently `2.50.0`, so publishing 2.50.0 fails until `dev` is pre-moved. |
+| Publish | `release.yml:22-26` | `dry-run` defaults to **true**. A real publish needs `dry-run=false`. `expected-sha` is required and must equal the branch head at dispatch. |
+
+`$GITHUB_SHA` on `main` is the **promotion merge commit**, not the frozen `dev` SHA.
+2.49.0 published from merge `2f3f73629`, not from its promoted tree commit `62849dfa6`.
+Both `ci.yml` (`push: branches: [main, preview, dev]`, `paths: src/**, gui/**, ...`) and
+`service-lifecycle.yml` (`push`, paths including `package.json` and `src/cli/index.ts`)
+fire automatically on that merge, so the required runs appear without a dispatch — but
+they must be waited for on that exact SHA.
+
+## Order
+
+1. **Freeze the candidate.** Record the exact `dev` SHA. A `workflow_dispatch` `lane=all`
+   run on `dev` is audit evidence for the tree, not the release gate; it tells us whether
+   the tree is green before we spend a promotion on it.
 2. **Land blockers first.** Any wp3 fix goes to `dev` through a pull request, which moves
-   the candidate; re-freeze and re-verify CI on the new SHA rather than reusing old-head green.
-3. **Pre-move `dev`.** Bump `dev` past the stable target with `scripts/bump-dev-version.ts`
-   through a one-file PR, so `dev` is never equal to the published stable version.
-4. **Promote independently.** Open promotion PRs from the frozen candidate into `preview`
-   and `main`. Verify the candidate is an ancestor of both; do not assume `preview`
-   precedes `main`.
-5. **Publish.** Dispatch `release.yml` with `expected-sha` pinned to the promoted `main`
-   SHA. Do not run `scripts/release.ts` locally: it requires a clean tree and runs the
-   full suite, audit, and privacy scan in a worktree that is not the release worktree.
-6. **Verify artifacts.** `npm view @bitkyc08/opencodex dist-tags`, the `2.50.0` `gitHead`
-   against the promoted `main` SHA, the git tag, the GitHub release, tarball integrity,
-   and SLSA provenance. npm propagation lag returns 404 or a stale `latest`; poll, never
-   republish.
+   the candidate. Re-freeze and re-verify on the new SHA; old-head green is not evidence.
+3. **Pre-move `dev`.** Dispatch `dev-version-bump.yml` (it is `on: workflow_dispatch`,
+   not `workflow_call`-only) with `intended-version=2.50.0`, `mode=pre-move`, from the
+   default branch. It opens a pull request and does **not** push to `dev`, because the
+   `Protect dev` ruleset requires review. Merge that PR so `dev` reads 2.51.0 before the
+   publish reaches `assert-ahead`. Use the workflow rather than a hand-written one-file PR
+   so its tag/npm/version-line proofs run.
+4. **Promote to `main`.** Open a promotion PR carrying the frozen candidate tree into
+   `main`, with the version already at `2.50.0`. Merge it. Record the merge SHA.
+5. **Wait for the release-branch gates on the merge SHA.** Push-event `ci.yml` and
+   `service-lifecycle.yml` on `main` for that exact SHA, both successful.
+6. **Dry-run, then publish.** Dispatch `release.yml` with `--ref main`,
+   `version=2.50.0`, `tag=latest`, `expected-sha=<merge SHA>`, first with
+   `dry-run=true`, then with `dry-run=false` once the dry run is green.
+7. **Verify artifacts.** `npm view @bitkyc08/opencodex dist-tags`, the `2.50.0`
+   `gitHead` against the promoted `main` SHA, the git tag, the GitHub release, tarball
+   integrity, and SLSA provenance. npm propagation lag returns 404 or a stale `latest`;
+   poll, never republish.
+8. **`preview` is a separate line and is not part of this stable train.**
+   `origin/preview` is `2.49.0-preview.20260909`, and `release.yml:161-165` refuses a
+   preview publish whose version is not `*-preview.*`. Promoting the plain `2.50.0` tree
+   onto `preview` would break that branch's version line. If `preview` should carry this
+   tree, it needs its own `2.50.0-preview.<date>` commit, decided after the stable
+   release lands. A branch sync and a preview npm publication are distinct operations.
 
 ## Known failure modes to expect
 
 - Branch-keyed CI concurrency cancels an older run when a newer commit lands. A cancelled
   aggregate is neither a product failure nor passing evidence.
-- `dev-version-bump.yml` is `workflow_call`-only and cannot be dispatched by hand.
 - The registry-availability smoke can time out after npm already accepted the publish.
   Inspect metadata, provenance, and tarball before considering a retry.
+- `dev-version-bump.yml` rejects a dispatch from a non-default ref as an early warning.

--- a/devlog/_plan/260910_250_regression_audit_release/020_release_plan.md
+++ b/devlog/_plan/260910_250_regression_audit_release/020_release_plan.md
@@ -1,0 +1,30 @@
+# 2.50.0 release plan
+
+Order matters: the candidate tree must be frozen before `dev` moves again.
+
+1. **Freeze the candidate.** Record the exact `dev` SHA and require successful
+   `Cross-platform CI` and `Service lifecycle` runs on that SHA. `dev` HEAD
+   `12c248f52` currently has no run of its own, so the release SHA needs an explicit
+   `lane=all` CI dispatch plus a service-lifecycle run before promotion.
+2. **Land blockers first.** Any wp3 fix goes to `dev` through a pull request, which moves
+   the candidate; re-freeze and re-verify CI on the new SHA rather than reusing old-head green.
+3. **Pre-move `dev`.** Bump `dev` past the stable target with `scripts/bump-dev-version.ts`
+   through a one-file PR, so `dev` is never equal to the published stable version.
+4. **Promote independently.** Open promotion PRs from the frozen candidate into `preview`
+   and `main`. Verify the candidate is an ancestor of both; do not assume `preview`
+   precedes `main`.
+5. **Publish.** Dispatch `release.yml` with `expected-sha` pinned to the promoted `main`
+   SHA. Do not run `scripts/release.ts` locally: it requires a clean tree and runs the
+   full suite, audit, and privacy scan in a worktree that is not the release worktree.
+6. **Verify artifacts.** `npm view @bitkyc08/opencodex dist-tags`, the `2.50.0` `gitHead`
+   against the promoted `main` SHA, the git tag, the GitHub release, tarball integrity,
+   and SLSA provenance. npm propagation lag returns 404 or a stale `latest`; poll, never
+   republish.
+
+## Known failure modes to expect
+
+- Branch-keyed CI concurrency cancels an older run when a newer commit lands. A cancelled
+  aggregate is neither a product failure nor passing evidence.
+- `dev-version-bump.yml` is `workflow_call`-only and cannot be dispatched by hand.
+- The registry-availability smoke can time out after npm already accepted the publish.
+  Inspect metadata, provenance, and tarball before considering a retry.

--- a/devlog/_plan/260910_250_regression_audit_release/020_release_plan.md
+++ b/devlog/_plan/260910_250_regression_audit_release/020_release_plan.md
@@ -28,14 +28,30 @@ they must be waited for on that exact SHA.
    the tree is green before we spend a promotion on it.
 2. **Land blockers first.** Any wp3 fix goes to `dev` through a pull request, which moves
    the candidate. Re-freeze and re-verify on the new SHA; old-head green is not evidence.
-3. **Pre-move `dev`.** Dispatch `dev-version-bump.yml` (it is `on: workflow_dispatch`,
-   not `workflow_call`-only) with `intended-version=2.50.0`, `mode=pre-move`, from the
-   default branch. It opens a pull request and does **not** push to `dev`, because the
-   `Protect dev` ruleset requires review. Merge that PR so `dev` reads 2.51.0 before the
-   publish reaches `assert-ahead`. Use the workflow rather than a hand-written one-file PR
-   so its tag/npm/version-line proofs run.
-4. **Promote to `main`.** Open a promotion PR carrying the frozen candidate tree into
-   `main`, with the version already at `2.50.0`. Merge it. Record the merge SHA.
+3. **Pre-move `dev`.** Dispatch `dev-version-bump.yml` with `intended-version=2.50.0`,
+   `mode=pre-move`. It is `on: workflow_dispatch`, but `dev-version-bump.yml:79` refuses
+   a non-default ref, so dispatch it with `--ref main`. It opens a pull request and does
+   **not** push to `dev`, because the `Protect dev` ruleset requires review. Merge that PR
+   so `dev` reads 2.51.0 before the publish reaches `assert-ahead`. Use the workflow rather
+   than a hand-written one-file PR so its tag/npm/version-line proofs run.
+4. **Promote the frozen SHA to `main`, not current `dev`.** After step 3, `origin/dev` is
+   2.51.0 and is no longer the candidate. Promotion always names the recorded freeze SHA
+   explicitly.
+
+   The freeze SHA is **not** an ancestor of `main`, and `main` carries commits `dev` does
+   not, so there is nothing to fast-forward. Replicate the 2.49.0 method: branch from
+   `main`, merge the freeze SHA into that branch as a single
+   `release: promote verified 2.50.0 product tree to main` commit, then open the PR into
+   `main`. For 2.49.0 that was branch `codex/release-249-main-01a08498`, promote commit
+   `62849dfa6` (parents `9a27e8699` = old `main`, `ad36c7be8` = the dev freeze), merged by
+   PR #4117 as `2f3f73629`.
+
+   The gate on this step is **tree equality**, not a green diff: after promotion,
+   `git rev-parse <main merge>^{tree}` must equal `git rev-parse <freeze SHA>^{tree}`.
+   For 2.49.0 all three of the promote commit, the dev freeze, and the merged `main` tip
+   resolved to tree `66294fb3eb15592afd732f8b8e29d0bcc644fe9e`. Any conflict resolution
+   that changes that tree means a different product shipped than the one audited.
+   Record the merge SHA.
 5. **Wait for the release-branch gates on the merge SHA.** Push-event `ci.yml` and
    `service-lifecycle.yml` on `main` for that exact SHA, both successful.
 6. **Dry-run, then publish.** Dispatch `release.yml` with `--ref main`,

--- a/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
+++ b/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
@@ -9,23 +9,44 @@ Filled as the cycles complete. Every row names the source of the claim.
 | Released baseline | `v2.49.0` / `main` `2f3f736299dca38861f8fb9c4326a4b4d7c664bc` | `git log origin/main` |
 | Audit candidate | `dev` `12c248f52bed88ea13be5b284c79a238feb592d1` | `git rev-parse origin/dev` |
 | Candidate version | `2.50.0` | `package.json` |
-| Product delta | 121 files, +3322 / -280 | `git diff --shortstat 2f3f73629...origin/dev -- src gui docs-site scripts .github` |
+| Commits in delta | 127 | `git rev-list --count 2f3f73629..origin/dev` |
+| Changed files | 1066 total, 885 `devlog`, 181 non-`devlog` | `git diff --name-only 2f3f73629...origin/dev` |
+| `preview` version line | `2.49.0-preview.20260909` | `git show origin/preview:package.json` |
+| Open PRs against `dev` | 74 | `gh api "repos/lidge-jun/opencodex/pulls?state=open&base=dev&per_page=100" --jq 'length'` |
 
-## Audit findings
+## wp1 — roadmap audit (A gate)
+
+Reviewer: `xai/grok-4.6`, agent `01a08a86-1352-77a2-98bd-5c167b5479c8`, read-only, fresh context.
+Verdict: **FAIL**. Every finding was verified independently by the main session before folding.
+
+| # | Finding | Verified by | Fold |
+| --- | --- | --- | --- |
+| R1 | `src/cli/{capabilities,index,models-runtime,observe}.ts` belonged to no lane | `git diff --name-only` vs the lane map | Lane **L6** added |
+| R2 | Blocker definition missed new-path breakage, consent/identity-spend bypass, `AGENTS.md` core invariants, upgrade-path recovery, and operator-surface drift | `AGENTS.md:43-83`, `AGENTS.md:150-169` | Definition rewritten to 8 clauses |
+| R3 | `release.yml:179-197` needs a push-event `ci.yml` run on the release branch for `$GITHUB_SHA`; a `dev` dispatch does not qualify | `sed -n '179,197p' .github/workflows/release.yml` | Order rewritten: gates run on the `main` merge SHA |
+| R4 | `service-lifecycle.yml` is gated on `$GITHUB_SHA`, and this delta arms it via `src/cli/index.ts` + `package.json` | `sed -n '225,237p' .github/workflows/release.yml` | Made an explicit step on the merge SHA |
+| R5 | `preview` refuses a non-`*-preview.*` version, and `origin/preview` is `2.49.0-preview.20260909` | `sed -n '161,165p' release.yml`; `git show origin/preview:package.json` | `preview` removed from the stable train |
+| R6 | `dev-version-bump.yml` is `on: workflow_dispatch`, not `workflow_call`-only | `sed -n '24,45p' .github/workflows/dev-version-bump.yml` | Pre-move now uses the workflow, not a hand PR |
+| R7 | `dry-run` defaults to `true` and the run must come from `refs/heads/main` | `sed -n '22,26p'`, `sed -n '153,170p'` `release.yml` | Dry-run-then-publish made explicit |
+| R8 | Scope doc misattributed the 121-file figure, derived the devlog count by subtraction, and said 20 open PRs | `git diff --shortstat`; `gh api ... --jq 'length'` -> 74 | Counts table rewritten from the real command |
+
+## Audit findings (wp2)
 
 | ID | Lane | File:line | Failure mode | Blocker | Disposition |
 | --- | --- | --- | --- | --- | --- |
 | _pending_ | | | | | |
 
-## Release artifacts
+## Release artifacts (wp4)
 
 | Gate | Evidence | Status |
 | --- | --- | --- |
-| Cross-platform CI on release SHA | | pending |
-| Service lifecycle on release SHA | | pending |
-| `dev` pre-move | | pending |
-| `preview` promotion | | pending |
-| `main` promotion | | pending |
+| Candidate-tree CI (`dev` dispatch, audit evidence) | run 34457689927 on `12c248f52` | pending |
+| `dev` pre-move to 2.51.0 | | pending |
+| `main` promotion merge SHA | | pending |
+| Push-event Cross-platform CI on merge SHA | | pending |
+| Service lifecycle on merge SHA | | pending |
+| `release.yml` dry run | | pending |
+| `release.yml` publish | | pending |
 | npm `latest` = 2.50.0 | | pending |
 | `gitHead` matches promoted `main` | | pending |
 | git tag + GitHub release | | pending |

--- a/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
+++ b/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
@@ -71,6 +71,11 @@ Six `xai/grok-4.6` lanes, dispatched in one round, fresh context each, read-only
 | F7 | L6 | `src/cli/capabilities.ts` | `ocx models live --free-only` is a real new flag that is not a declared capability, so it does not reach the generated surface map. | `SHIP` — documentation gap, not the map/registry split that once shipped a phantom `ocx request-history` |
 | F8 | CI | `tests/codex-integration/codex-log-guard-maintenance-coderabbit.test.ts` | `classifies continuous progress stopped by MAX_ITERATIONS as bounded work` timed out at 60s on Windows shard 5/6 of run 34457689927 attempt 1, taking 112.8s. | `PRE-EXISTING` — proved by byte identity against the released tree: `src/codex/log-guard/maintenance.ts` (`81b3a465b`), the test file (`54e83bba2`), and `tests/helpers/remove-tree.ts` (`53e36a584`) are the same blobs at `2f3f73629` and `origin/dev`. Nothing in this delta can have caused it |
 
+F8 note: `tests/preload.ts` is the one file on that failure path this delta does touch,
+and its diff is a comment block with no statement change, so the byte-identity argument is
+complete rather than merely true. Attempt 2 of the run passed on rerun. The full reasoning,
+including why the timeout is not hardened before the release, is in `060_release_readiness.md`.
+
 ### Independent re-derivation by the main session
 
 Nothing was accepted on a lane's authority. Re-checked directly:
@@ -89,7 +94,8 @@ Nothing was accepted on a lane's authority. Re-checked directly:
 
 | Gate | Evidence | Status |
 | --- | --- | --- |
-| Candidate-tree CI (`dev` dispatch, audit evidence) | run 34457689927 on `12c248f52` | pending |
+| Candidate-tree CI (`dev` dispatch, audit evidence only) | run 34457689927, `lane=all` on `12c248f52`, attempt 2 conclusion `success` | done |
+| Freeze tree to reproduce on `main` | `git rev-parse 12c248f52^{tree}` = `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822` | recorded |
 | `dev` pre-move to 2.51.0 | | pending |
 | `main` promotion merge SHA | | pending |
 | Push-event Cross-platform CI on merge SHA | | pending |

--- a/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
+++ b/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
@@ -46,9 +46,44 @@ key-exchange bounds, which are not in this delta.
 
 ## Audit findings (wp2)
 
-| ID | Lane | File:line | Failure mode | Blocker | Disposition |
-| --- | --- | --- | --- | --- | --- |
-| _pending_ | | | | | |
+Six `xai/grok-4.6` lanes, dispatched in one round, fresh context each, read-only.
+**All six returned `NO-BLOCKER`.** No finding matched any of the eight blocker clauses.
+
+| Lane | Agent | Verdict | Files read |
+| --- | --- | --- | --- |
+| L1 responses / web-search | `01a08aa6-5954-76f1-a205-f4a85b76457f` | NO-BLOCKER | 31 |
+| L2 accounts / quota / OAuth | `01a08aa6-59f5-79d3-a567-556a80d05c84` | NO-BLOCKER | 23 |
+| L3 catalog / providers / config | `01a08aa6-5aa1-7132-b053-776bb02b0fe7` | NO-BLOCKER | 36 |
+| L4 management / service / GUI | `01a08aa6-5b57-7343-9e1c-b4b3ea186478` | NO-BLOCKER | 41 |
+| L5 security / privacy / release | `01a08aa6-5c11-7c52-b4db-6ec685159a33` | NO-BLOCKER | 40 |
+| L6 operator CLI | `01a08aa6-5ccd-76c0-af89-83cf0ea80e28` | NO-BLOCKER | 34 |
+
+### Non-blocking findings, with dispositions
+
+| ID | Lane | Anchor | What it is | Disposition |
+| --- | --- | --- | --- | --- |
+| F1 | L1 | `src/web-search/passthrough-bridge.ts:503` | If the upstream emits a `web_search` function call and then `response.failed`/`incomplete`, `decide()` ends without `searchEndFrames`, so a client can keep a "Searching the web" cell open under a failed turn. The explicit `kind === "fail"` path does close it. Opt-in bridge only, default off. | `SHIP` — cosmetic, on a feature that must be explicitly enabled |
+| F2 | L3 | `src/codex/catalog/provider-fetch.ts:1415` | Classification reads `pricing.prompt`/`completion` only, so a row with both at zero plus a paid `pricing.request`/`image`/`web_search` key would classify `free`. No in-tree fixture has that shape. | `SHIP` — `RUNTIME-CHECK` resolved: `pricingStatus` is consumed only by `src/cli/models-runtime.ts:68` and `gui/src/pages/models-shared.ts:85` as a display filter. It gates no routing and no spend, so the worst case is a mislabelled row, not a charge |
+| F3 | L3 | `src/codex/catalog/provider-fetch.ts:1996` | A custom google-adapter gateway returning both `data[]` and a non-Google `models[]` would take the AI Studio parser with zero `generateContent` rows and publish an authoritative empty catalog. The `data[]`-only case is covered by `tests/adapters/google/google-models-listing.test.ts`. | `SHIP` — requires a dual-envelope body no known gateway sends |
+| F4 | L2 | `src/oauth/token-guardian.ts:257` vs `src/codex/auth-api.ts:1265` | `isCodexAccountUsable` does not read the persisted terminal flag, so after a restart routing can attempt a dead grant once more. | `PRE-EXISTING` — same process-lifetime pattern as 2.49.0; the guardian that writes the flag is opt-in and default off |
+| F5 | L2, L5 | `src/oauth/health.ts:231` | A revoked grant with no persisted terminal and no in-memory reauth can still project healthy after a restart when the guardian never ran. | `PRE-EXISTING` — 2.49.0 behavior; 2.50.0 only adds the `validation_pending` projection, which is strictly more informative |
+| F6 | L4 | `src/service.ts:2386` | Install/repair bootout evicts the loaded job, including one that is currently serving, after the plist has been rewritten. | `SHIP` — this is the intended #4141 repair; `startLaunchd` at :2422 still refuses that eviction on the ordinary start path |
+| F7 | L6 | `src/cli/capabilities.ts` | `ocx models live --free-only` is a real new flag that is not a declared capability, so it does not reach the generated surface map. | `SHIP` — documentation gap, not the map/registry split that once shipped a phantom `ocx request-history` |
+| F8 | CI | `tests/codex-integration/codex-log-guard-maintenance-coderabbit.test.ts` | `classifies continuous progress stopped by MAX_ITERATIONS as bounded work` timed out at 60s on Windows shard 5/6 of run 34457689927 attempt 1, taking 112.8s. | `PRE-EXISTING` — proved by byte identity against the released tree: `src/codex/log-guard/maintenance.ts` (`81b3a465b`), the test file (`54e83bba2`), and `tests/helpers/remove-tree.ts` (`53e36a584`) are the same blobs at `2f3f73629` and `origin/dev`. Nothing in this delta can have caused it |
+
+### Independent re-derivation by the main session
+
+Nothing was accepted on a lane's authority. Re-checked directly:
+
+| Claim | Command | Result |
+| --- | --- | --- |
+| Email masking on by default | `rg -n maskEmails src/lib/privacy.ts` | `config?.privacy?.maskEmails !== false` — absent, malformed, and non-boolean all mask |
+| Inbound body limit safe default | `rg -n MAX_DECOMPRESSED_BODY_BYTES src/server/request-decompress.ts` | 256 MiB, returned when the configured value is undefined |
+| No Lab import in the three core files | `rg -n 'from "[./]*lab/' src/router.ts src/server/lifecycle.ts src/server/responses/core.ts` | no match |
+| `startServer` still synchronous | `rg -n 'function startServer' src/server/index.ts` | `export function startServer(...): Server<WsData>` — not `async` |
+| No tracked gitlink | `git ls-files -s \| grep -c '^160000'` | 0; `.gitmodules` absent |
+| i18n keys in every locale | per-locale `rg -c` for the four new keys | 6 matches in each of en, ko, de, fr, ja, ru, tr, zh, zh-TW |
+| Web-search bridge opt-in | `rg -n webSearchBridge src/` | armed only by `providers.<name>.webSearchBridge.enabled` |
 
 ## Release artifacts (wp4)
 

--- a/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
+++ b/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
@@ -96,12 +96,27 @@ Nothing was accepted on a lane's authority. Re-checked directly:
 | --- | --- | --- |
 | Candidate-tree CI (`dev` dispatch, audit evidence only) | run 34457689927, `lane=all` on `12c248f52`, attempt 2 conclusion `success` | done |
 | Freeze tree to reproduce on `main` | `git rev-parse 12c248f52^{tree}` = `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822` | recorded |
-| `dev` pre-move to 2.51.0 | | pending |
-| `main` promotion merge SHA | | pending |
-| Push-event Cross-platform CI on merge SHA | | pending |
-| Service lifecycle on merge SHA | | pending |
+| `dev` pre-move to 2.51.0 | `dev-version-bump.yml` run 34463313646 opened PR #4194; merged; `origin/dev` = `cf44f6fe887d19f53ede1e09abfe0fe3cf137059`, `package.json` 2.51.0 | done |
+| Promotion commit | `3a3de889b6ef3217497f6c5029acf08aec09c0cf`, parents `2f3f73629` (old `main`) and `12c248f52` (freeze), tree `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822` | done |
+| `main` promotion merge SHA | PR #4195 merged; `origin/main` = `2d4d7a22381a2e497c2442902104619e25f937c7`, tree `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822`, version 2.50.0 | done |
+| Push-event Cross-platform CI on merge SHA | run 34464454730 | pending |
+| Service lifecycle on merge SHA | run 34464454609, conclusion `success` | done |
 | `release.yml` dry run | | pending |
 | `release.yml` publish | | pending |
 | npm `latest` = 2.50.0 | | pending |
 | `gitHead` matches promoted `main` | | pending |
 | git tag + GitHub release | | pending |
+
+### Gates that failed by design on the promotion PR
+
+`enforce-target` failed #4195 with "wrong base (main); missing UI screenshot". That gate is
+written for contributor pull requests: `main` receives only release promotions, and a
+promotion necessarily carries dashboard files while changing no UI of its own. The 2.49.0
+promotion PR #4117 failed the same check and was merged the same way. `AGENTS.md` records
+the maintainer promotion exception, and the gates that actually decide are the push-event
+runs on the merge SHA, which `release.yml` independently requires.
+
+Local `prepush` was skipped on the promotion branch. It runs the full ~850-file suite
+against a tree byte-identical to one already green on Linux, macOS, and Windows
+(`lane=all` run 34457689927), and it was additionally blocked waiting on another Bun test
+lock. The remote push-event runs on `2d4d7a223` are the evidence that counts.

--- a/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
+++ b/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
@@ -30,6 +30,20 @@ Verdict: **FAIL**. Every finding was verified independently by the main session 
 | R7 | `dry-run` defaults to `true` and the run must come from `refs/heads/main` | `sed -n '22,26p'`, `sed -n '153,170p'` `release.yml` | Dry-run-then-publish made explicit |
 | R8 | Scope doc misattributed the 121-file figure, derived the devlog count by subtraction, and said 20 open PRs | `git diff --shortstat`; `gh api ... --jq 'length'` -> 74 | Counts table rewritten from the real command |
 
+Round 2 verdict: **GO-WITH-FIXES**. R1-R8 all confirmed FIXED with anchors, and the
+mechanical lane-coverage check over the 94 changed product paths returned zero unlaned.
+Three new findings were raised and folded:
+
+| # | Finding | Verified by | Fold |
+| --- | --- | --- | --- |
+| R9 | After the pre-move, `origin/dev` is 2.51.0; promoting current `dev` would publish the wrong version. The plan never pinned the promotion source to the freeze SHA | `020_release_plan.md:37` as written | Step 4 now names the recorded freeze SHA explicitly |
+| R10 | The freeze SHA is not an ancestor of `main` and `main` carries commits `dev` lacks, so a naive `base=main head=<freeze>` PR is a 127-commit history merge rather than a tree promotion | `git merge-base --is-ancestor 12c248f52 origin/main` -> 1 | Step 4 documents the 2.49.0 branch-and-merge method and makes **tree equality** the gate: promote tree, dev freeze tree, and merged `main` tree all resolved to `66294fb3eb15592afd732f8b8e29d0bcc644fe9e` for 2.49.0 |
+| R11 | `000_plan.md` said `src` is audited by L1-L3, L5, L6, but L4 owns `src/server/management/*` and `src/service.ts` | `010_audit_lanes.md:44` | Counts table corrected to L1-L6 |
+
+Also folded from the round-2 residual: `dev-version-bump.yml:79` refuses a non-default
+ref, so the pre-move dispatch must use `--ref main`; and L5 no longer names OrcaRouter
+key-exchange bounds, which are not in this delta.
+
 ## Audit findings (wp2)
 
 | ID | Lane | File:line | Failure mode | Blocker | Disposition |

--- a/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
+++ b/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
@@ -99,13 +99,37 @@ Nothing was accepted on a lane's authority. Re-checked directly:
 | `dev` pre-move to 2.51.0 | `dev-version-bump.yml` run 34463313646 opened PR #4194; merged; `origin/dev` = `cf44f6fe887d19f53ede1e09abfe0fe3cf137059`, `package.json` 2.51.0 | done |
 | Promotion commit | `3a3de889b6ef3217497f6c5029acf08aec09c0cf`, parents `2f3f73629` (old `main`) and `12c248f52` (freeze), tree `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822` | done |
 | `main` promotion merge SHA | PR #4195 merged; `origin/main` = `2d4d7a22381a2e497c2442902104619e25f937c7`, tree `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822`, version 2.50.0 | done |
-| Push-event Cross-platform CI on merge SHA | run 34464454730 | pending |
+| Push-event Cross-platform CI on merge SHA | run 34464454730, conclusion `success` | done |
 | Service lifecycle on merge SHA | run 34464454609, conclusion `success` | done |
-| `release.yml` dry run | | pending |
-| `release.yml` publish | | pending |
-| npm `latest` = 2.50.0 | | pending |
-| `gitHead` matches promoted `main` | | pending |
-| git tag + GitHub release | | pending |
+| `release.yml` dry run | run 34465317829, `validate-dispatch` and `publish` both `success` | done |
+| `release.yml` publish | run 34465442114, `dry-run=false`, `expected-sha=2d4d7a223`; `npm publish --tag latest --access public` printed `+ @bitkyc08/opencodex@2.50.0` | done |
+| npm `latest` = 2.50.0 | `npm view @bitkyc08/opencodex dist-tags` -> `{"preview":"2.48.0-preview.20260908","latest":"2.50.0"}` | done |
+| `gitHead` matches promoted `main` | `npm view @bitkyc08/opencodex@2.50.0 gitHead` = `2d4d7a22381a2e497c2442902104619e25f937c7`, identical to `origin/main` | done |
+| git tag + GitHub release | `git rev-list -n1 v2.50.0` = `2d4d7a223`; release `v2.50.0` published 2026-09-10T10:21:15Z, not a draft, not a prerelease | done |
+| Tarball integrity | Downloaded tarball hashes to `sha512-lrcM1sBfjbjqB3h5i2q7A6FbPOXxrdxqhWC7S+w0+oCOZ+9f8ucCgXPt9D2p81dS78ZfYYSJZuDWbU1Ov0VOhQ==`, equal to `dist.integrity`; manifest version 2.50.0; 1094 files, 23,923,744 bytes unpacked | done |
+| Published source bytes | `src/lib/privacy.ts`, `src/web-search/passthrough-bridge.ts`, and `src/cli/models-runtime.ts` inside the tarball are SHA-256 identical to the same paths at `2d4d7a223` | done |
+| Provenance | Registry attestations are `npm/attestation/tree/main/specs/publish/v0.1` and `slsa.dev/provenance/v1` | done |
+
+### The registry smoke timed out, and why nothing was republished
+
+`npm publish` printed `+ @bitkyc08/opencodex@2.50.0` at 10:20:46, and the workflow's
+own `Post-publish registry smoke` then failed to read the version back through six bounded
+attempts over roughly 27 seconds. It emitted
+"npm publish succeeded, but registry verification remains pending; continuing GitHub
+release creation without republishing" and proceeded, which is the correct behavior: the
+publication receipt already existed.
+
+The registry served 2.50.0 about 20 minutes after the publish. It was polled, never
+republished. This is the documented failure mode — a timed-out availability smoke is not a
+failed publish, and republishing on it is how a release gets damaged.
+
+### `preview` is intentionally not part of this release
+
+`origin/preview` remains `2.49.0-preview.20260909` and the npm `preview` dist-tag remains
+`2.48.0-preview.20260908`. `release.yml:161-165` refuses a preview publish whose version is
+not `*-preview.*`, so promoting the plain 2.50.0 tree onto that branch would break its
+version line. Bringing `preview` forward needs its own `2.50.0-preview.<date>` commit and
+is a separate decision.
 
 ### Gates that failed by design on the promotion PR
 

--- a/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
+++ b/devlog/_plan/260910_250_regression_audit_release/030_evidence.md
@@ -1,0 +1,31 @@
+# Evidence ledger
+
+Filled as the cycles complete. Every row names the source of the claim.
+
+## Frozen facts
+
+| Item | Value | Source |
+| --- | --- | --- |
+| Released baseline | `v2.49.0` / `main` `2f3f736299dca38861f8fb9c4326a4b4d7c664bc` | `git log origin/main` |
+| Audit candidate | `dev` `12c248f52bed88ea13be5b284c79a238feb592d1` | `git rev-parse origin/dev` |
+| Candidate version | `2.50.0` | `package.json` |
+| Product delta | 121 files, +3322 / -280 | `git diff --shortstat 2f3f73629...origin/dev -- src gui docs-site scripts .github` |
+
+## Audit findings
+
+| ID | Lane | File:line | Failure mode | Blocker | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| _pending_ | | | | | |
+
+## Release artifacts
+
+| Gate | Evidence | Status |
+| --- | --- | --- |
+| Cross-platform CI on release SHA | | pending |
+| Service lifecycle on release SHA | | pending |
+| `dev` pre-move | | pending |
+| `preview` promotion | | pending |
+| `main` promotion | | pending |
+| npm `latest` = 2.50.0 | | pending |
+| `gitHead` matches promoted `main` | | pending |
+| git tag + GitHub release | | pending |

--- a/devlog/_plan/260910_250_regression_audit_release/040_triage_protocol.md
+++ b/devlog/_plan/260910_250_regression_audit_release/040_triage_protocol.md
@@ -5,9 +5,11 @@ wp2 returns six lane reports. This is how they become a release decision.
 ## 1. Normalize
 
 Each lane return is split into individual findings. A finding is only admitted with an
-exact `path:line` anchor or a literal command and its output. An unanchored assertion is
-recorded as **unsubstantiated** and re-derived by the main session or dropped; it never
-blocks and it never passes silently.
+exact `path:line` anchor or a literal command and its output. An unanchored or misanchored
+assertion is recorded as **unsubstantiated** and the main session **must** re-derive it
+against the tree. Dropping it undecided is not an option: a real blocker described with a
+wrong line number is still a real blocker, and the anchor rule exists to make triage cheap,
+not to discard findings.
 
 Findings from different lanes that name the same defect are merged, keeping every anchor.
 
@@ -20,11 +22,20 @@ exactly one disposition.
 | --- | --- | --- |
 | `BLOCK` | Matches a blocker clause | Must be fixed and landed on `dev` before promotion |
 | `SHIP` | Real but does not match a clause | Recorded here, filed as an issue if it deserves one, released as is |
-| `PRE-EXISTING` | Present in `2f3f73629` as well | Not this release's problem; prove it with a command against the released tree |
+| `PRE-EXISTING` | The same user-visible failure was reachable on `2f3f73629` | Not this release's problem; requires the proof below |
+| `RUNTIME-CHECK` | Plausible but only decidable by running something | Must be resolved before promotion, by a targeted test, a CI job, or a reasoned rebuttal — never left as a confidence label |
 | `WRONG` | The lane misread the code | Rebutted with the anchor that disproves it |
 
-A finding is `PRE-EXISTING` only with proof: `git show 2f3f73629:<path>` showing the same
-defect, or a test that fails on the baseline. "It looks old" is not proof.
+A finding is `PRE-EXISTING` only when the **user-visible failure** was reachable on the
+baseline — not merely that some function it touches already existed. Showing that an old
+helper is unchanged proves nothing when a new caller reaches it under new conditions;
+clause 3 exists precisely for that case. Acceptable proof is byte identity of every file on
+the failure path (`git rev-parse 2f3f73629:<path>` equal to `git rev-parse origin/dev:<path>`
+for each), a test that fails on the baseline, or a baseline CI run showing the same failure.
+
+`BLOCK` may never be downgraded to `SHIP`, and it may only become `PRE-EXISTING` under the
+proof above. Weak-proof downgrade is the same evasion as reclassifying to `SHIP`, taken by a
+longer route.
 
 ## 3. Remediate
 
@@ -42,6 +53,9 @@ Landing a fix **moves the candidate**. When that happens:
 3. Re-run only the lanes whose read scope intersects the fix, not all six.
 
 ## 4. Escalate rather than weaken
+
+A `RUNTIME-CHECK` finding that cannot be resolved is treated as a `BLOCK`, not as a
+`SHIP`. An unfalsified hang or teardown risk is not evidence of safety.
 
 If a `BLOCK` cannot be fixed inside this scope — it needs a design decision, an external
 credential, or a change the user has not authorized — the release stops and the outcome is

--- a/devlog/_plan/260910_250_regression_audit_release/040_triage_protocol.md
+++ b/devlog/_plan/260910_250_regression_audit_release/040_triage_protocol.md
@@ -1,0 +1,57 @@
+# Triage and remediation protocol (wp3)
+
+wp2 returns six lane reports. This is how they become a release decision.
+
+## 1. Normalize
+
+Each lane return is split into individual findings. A finding is only admitted with an
+exact `path:line` anchor or a literal command and its output. An unanchored assertion is
+recorded as **unsubstantiated** and re-derived by the main session or dropped; it never
+blocks and it never passes silently.
+
+Findings from different lanes that name the same defect are merged, keeping every anchor.
+
+## 2. Classify
+
+Apply the eight-clause blocker definition in `010_audit_lanes.md`. Each finding gets
+exactly one disposition.
+
+| Disposition | Meaning | Action |
+| --- | --- | --- |
+| `BLOCK` | Matches a blocker clause | Must be fixed and landed on `dev` before promotion |
+| `SHIP` | Real but does not match a clause | Recorded here, filed as an issue if it deserves one, released as is |
+| `PRE-EXISTING` | Present in `2f3f73629` as well | Not this release's problem; prove it with a command against the released tree |
+| `WRONG` | The lane misread the code | Rebutted with the anchor that disproves it |
+
+A finding is `PRE-EXISTING` only with proof: `git show 2f3f73629:<path>` showing the same
+defect, or a test that fails on the baseline. "It looks old" is not proof.
+
+## 3. Remediate
+
+Every `BLOCK` fix follows the repository's normal contribution path — a branch off the
+current `dev`, a focused regression test next to the existing tests for that subsystem,
+a pull request against `dev` using `.github/PULL_REQUEST_TEMPLATE.md`, and the exact-head
+CI evidence the branch policy requires. No direct push to `dev`; the ruleset rejects it
+regardless of `--no-verify`.
+
+Landing a fix **moves the candidate**. When that happens:
+
+1. Record the new `dev` SHA as the freeze SHA, superseding `12c248f52`.
+2. Re-run the candidate-tree CI dispatch on the new SHA. Green on the old head proves
+   nothing about the new one.
+3. Re-run only the lanes whose read scope intersects the fix, not all six.
+
+## 4. Escalate rather than weaken
+
+If a `BLOCK` cannot be fixed inside this scope — it needs a design decision, an external
+credential, or a change the user has not authorized — the release stops and the outcome is
+`BLOCKED`. Reclassifying a blocker to `SHIP` to reach a release is the one move this
+protocol forbids. The alternative that *is* allowed: revert the offending commit range from
+the candidate and release without that feature, which is a smaller change than shipping a
+known defect.
+
+## 5. Record
+
+Every finding lands in the wp2 findings table in `030_evidence.md` with its ID, lane,
+anchor, failure mode, disposition, and — for `BLOCK` — the PR and merge SHA that resolved
+it. A finding with no row in that table did not happen.

--- a/devlog/_plan/260910_250_regression_audit_release/050_lane_packets.md
+++ b/devlog/_plan/260910_250_regression_audit_release/050_lane_packets.md
@@ -1,0 +1,73 @@
+# Lane dispatch packets (wp2)
+
+Six `xai/grok-4.6` subagents, dispatched in one round, fresh context each, read-only.
+They run concurrently because their questions are independent; none reads another's output.
+
+## Shared packet frame
+
+Every packet carries the same frame, with only `SCOPE` and `QUESTIONS` differing.
+
+- **Repository:** `/Users/jun/.codex/worktrees/b53a/opencodex`, branch
+  `codex/260910-250-regression-audit-release` at the freeze SHA.
+- **Comparison:** `git diff 2f3f73629...origin/dev -- <lane paths>`. `2f3f73629` is
+  released `v2.49.0`; the right side is the 2.50.0 candidate.
+- **MUST NOT:** no writes, edits, commits, pushes, stashes, or branch changes; no test
+  suite, typecheck, build, or install; no mutating `gh` call. Read-only `git` and
+  `gh api`/`gh run list` only. Do not fix anything found — report it.
+- **PROOF:** every finding needs an exact `path:line` on the candidate side, or a literal
+  command with its output. Unanchored claims are discarded, so do not pad the return.
+- **RETURN FORMAT:** `VERDICT` (`NO-BLOCKER` or `BLOCKERS-FOUND`), then one numbered entry
+  per finding with `ANCHOR`, `WHAT BREAKS` (the concrete user-visible failure and the input
+  that triggers it), `CLAUSE` (which of the eight blocker clauses, or `non-blocking`), and
+  `CONFIDENCE` (`certain` / `likely` / `needs-runtime-check`). Then `FILES READ`.
+- **DECISION BOUNDARY:** the lane reports evidence and unresolved judgments. It does not
+  decide whether the release proceeds, does not rank against other lanes, and does not
+  weaken a finding because it looks hard to fix.
+
+A lane that finds nothing returns `NO-BLOCKER` and its `FILES READ`. A short honest
+return beats a long speculative one; the triage protocol discards unanchored text anyway.
+
+## Per-lane questions
+
+**L1 — responses and request pipeline.** Does the hosted web-search bridge arm only when
+opted in, and does a failure fall back rather than hang or leak? Is the search cell placed
+in stream order, and are bridge continuations bounded? Does the non-streaming
+context-overflow classification return a classified reply on every exhausted-target path?
+Does agent-task recovery on a mid-thread model switch preserve encrypted content? Does the
+configurable body admission limit still have a safe default and reject rather than buffer?
+
+**L2 — codex accounts, quota, OAuth.** Can a deferred validation leave an account in a
+state where it is neither usable nor visibly failed? Does a revoked pool grant reach a
+terminal verdict instead of retrying forever? Does clearing reauth state ever clear it for
+the wrong account? Does the new account plan field ever carry a value that identifies the
+user into a log or the wire?
+
+**L3 — catalog, providers, combos, config.** Does free-model classification ever mark a
+paid model free, or drop a model whose `pricingStatus` is absent rather than `"free"`?
+Does quota-exhausted inactive marking recover when quota returns? Does the AI Studio
+discovery restoration change behavior for custom gateways? Can a cross-provider blocked
+model redirect cycle?
+
+**L4 — management API, service, GUI.** Does any management route lose its auth check? Does
+the routed-account label reach a response a browser can read without a session? Does the
+launchd bootout recovery ever tear down a healthy job? Do the nine i18n locales contradict
+`en` on a destructive action's confirmation text?
+
+**L5 — security, privacy, release surface.** Is email masking still on by default, and does
+the opt-out require an explicit operator action? Does `bun run privacy:scan`'s contract
+still hold for every new log site? Does any `src/lab/` module now reach `src/router.ts`,
+`src/server/lifecycle.ts`, or `src/server/responses/core.ts`? Is there any `await` in the
+synchronous `startServer` activation window? Is any gitlink tracked?
+
+**L6 — operator CLI surface.** Does `ocx status` apply the same masking default as the
+library? Does `ocx account refresh` mint or reuse a dashboard session, and does it spend
+the user's identity without the code-level gate? Does `--free-only` drop models with an
+absent `pricingStatus`? Does `--account` filtering match on a value that is masked in the
+stored log? Does the committed `skills/ocx` surface map name any command
+`src/cli/capabilities.ts` does not register?
+
+## What the main session does with the returns
+
+Nothing is accepted on the lane's authority. Every `BLOCKERS-FOUND` entry is re-derived
+against the tree before it enters the wp2 findings table, exactly as the round-1 roadmap
+findings were. `040_triage_protocol.md` governs from there.

--- a/devlog/_plan/260910_250_regression_audit_release/050_lane_packets.md
+++ b/devlog/_plan/260910_250_regression_audit_release/050_lane_packets.md
@@ -7,57 +7,100 @@ They run concurrently because their questions are independent; none reads anothe
 
 Every packet carries the same frame, with only `SCOPE` and `QUESTIONS` differing.
 
-- **Repository:** `/Users/jun/.codex/worktrees/b53a/opencodex`, branch
-  `codex/260910-250-regression-audit-release` at the freeze SHA.
+- **Repository:** `/Users/jun/.codex/worktrees/b53a/opencodex`, on branch
+  `codex/260910-250-regression-audit-release`. That branch adds `devlog/` commits on top of
+  the freeze SHA `12c248f52`; every `src`, `gui`, `tests`, and `scripts` file is identical
+  to the freeze. **Do not `git checkout` the freeze SHA** — it would detach HEAD on the
+  worktree we are releasing from. Read `origin/dev` through `git show` if an exact freeze
+  read is needed.
 - **Comparison:** `git diff 2f3f73629...origin/dev -- <lane paths>`. `2f3f73629` is
   released `v2.49.0`; the right side is the 2.50.0 candidate.
-- **MUST NOT:** no writes, edits, commits, pushes, stashes, or branch changes; no test
-  suite, typecheck, build, or install; no mutating `gh` call. Read-only `git` and
-  `gh api`/`gh run list` only. Do not fix anything found — report it.
+- **Read the current tree, not only the diff.** A change is often half in the diff and half
+  in an unchanged caller. Following a symbol into a file outside the lane's diff is expected.
+- **MUST NOT:** no writes, edits, commits, pushes, stashes, branch changes, or
+  `git checkout`/`git switch`/`git restore` of any kind; no test suite, typecheck, build, or
+  install; no mutating `gh` call. Read-only `git` and `gh api`/`gh run list` only. Do not
+  fix anything found — report it.
 - **PROOF:** every finding needs an exact `path:line` on the candidate side, or a literal
-  command with its output. Unanchored claims are discarded, so do not pad the return.
+  command with its output. Unanchored claims are re-derived by the main session, so an
+  approximate anchor costs a round trip rather than being silently dropped.
 - **RETURN FORMAT:** `VERDICT` (`NO-BLOCKER` or `BLOCKERS-FOUND`), then one numbered entry
   per finding with `ANCHOR`, `WHAT BREAKS` (the concrete user-visible failure and the input
-  that triggers it), `CLAUSE` (which of the eight blocker clauses, or `non-blocking`), and
+  that triggers it), `CLAUSE` (a number from the list below, or `non-blocking`), and
   `CONFIDENCE` (`certain` / `likely` / `needs-runtime-check`). Then `FILES READ`.
 - **DECISION BOUNDARY:** the lane reports evidence and unresolved judgments. It does not
   decide whether the release proceeds, does not rank against other lanes, and does not
   weaken a finding because it looks hard to fix.
 
+### The eight blocker clauses, carried inline
+
+A lane cannot answer `CLAUSE` from a file it was not given, so the list travels with the
+packet: (1) regression against 2.49.0; (2) crash, hang, or unbounded resource use on a
+reachable default path; (3) new-path functional breakage — a feature added in this delta
+that does not do what it claims, even though it is not a regression; (4) security or
+privacy weakening; (5) user-consent or identity-spend bypass; (6) core invariant violation
+(Lab reaching `src/router.ts`, `src/server/lifecycle.ts`, or `src/server/responses/core.ts`;
+an `await` in the synchronous `startServer` activation window; a tracked gitlink);
+(7) upgrade-path breakage for an existing 2.49.0 install; (8) broken release, packaging,
+or operator-surface contract.
+
 A lane that finds nothing returns `NO-BLOCKER` and its `FILES READ`. A short honest
-return beats a long speculative one; the triage protocol discards unanchored text anyway.
+return beats a long speculative one.
 
 ## Per-lane questions
 
 **L1 — responses and request pipeline.** Does the hosted web-search bridge arm only when
 opted in, and does a failure fall back rather than hang or leak? Is the search cell placed
-in stream order, and are bridge continuations bounded? Does the non-streaming
-context-overflow classification return a classified reply on every exhausted-target path?
-Does agent-task recovery on a mid-thread model switch preserve encrypted content? Does the
-configurable body admission limit still have a safe default and reject rather than buffer?
+in stream order, and are bridge continuations bounded? Does `src/web-search/ollama-executor.ts`
+bound its own errors and timeouts? Does the non-streaming context-overflow classification
+return a classified reply on every exhausted-target path? Does agent-task recovery on a
+mid-thread model switch preserve encrypted content? Does the configurable body admission
+limit still have a safe default and reject rather than buffer? In `src/claude/inbound.ts`,
+does emitting mid-conversation `role:"system"` as chronological `developer` items change
+what the model obeys on an ordinary Claude Code turn? In `src/server/responses/codex-ws-wire.ts`,
+what is the cost of the 30s to 90s prelude timeout when the upstream is actually hung?
+Does the new `account` filter in `src/server/request-log.ts` match the value that is
+actually stored, including when masking is on? Does the OpenCode Zen free-tier message
+rewrite in `src/server/chat-native.ts` alter a paid-tier request?
 
-**L2 — codex accounts, quota, OAuth.** Can a deferred validation leave an account in a
-state where it is neither usable nor visibly failed? Does a revoked pool grant reach a
-terminal verdict instead of retrying forever? Does clearing reauth state ever clear it for
-the wrong account? Does the new account plan field ever carry a value that identifies the
-user into a log or the wire?
+**L2 — codex accounts, quota, OAuth.** Can a deferred validation leave an account neither
+usable nor visibly failed? Does a revoked pool grant reach a terminal verdict instead of
+retrying forever? Does clearing reauth state ever clear it for the wrong account? Does the
+new account plan field ever carry a value that identifies the user into a log or the wire?
+Does `src/oauth/health.ts` report healthy for an account that cannot actually serve? Does
+the quota-header dual-write in `src/codex/quota.ts` ever attribute one account's window to
+another?
 
 **L3 — catalog, providers, combos, config.** Does free-model classification ever mark a
 paid model free, or drop a model whose `pricingStatus` is absent rather than `"free"`?
 Does quota-exhausted inactive marking recover when quota returns? Does the AI Studio
 discovery restoration change behavior for custom gateways? Can a cross-provider blocked
-model redirect cycle?
+model redirect cycle? Does the keyless free-tier `MissingSessionID` rewrite in
+`src/providers/opencode-zen-rate-limit.ts` mask a real auth failure? In `src/config.ts` and
+`src/types/config.ts`, what do `privacy.maskEmails` and the inbound body limit resolve to
+when the key is absent or malformed — does the schema degrade to a safe default or to
+`undefined`? Does the `zcode` config export leak anything it did not before?
 
 **L4 — management API, service, GUI.** Does any management route lose its auth check? Does
 the routed-account label reach a response a browser can read without a session? Does the
-launchd bootout recovery ever tear down a healthy job? Do the nine i18n locales contradict
-`en` on a destructive action's confirmation text?
+launchd bootout recovery ever tear down a healthy job? In `gui/src/pages/models-shared.ts`
+and `Models.tsx`, can `freeOnlyInForce` stay true after the control disappears and leave
+the user with an empty model list? Does the decode-rate column
+(`src/server/management/shared.ts`, `gui/src/pages/Logs.tsx`) stay out of request history
+as intended, and is the rate meaningful when the sample is tiny? Do the nine non-English
+locales carry the keys this delta actually added — `models.freeOnly`,
+`models.inactiveNoCredit`, `logs.detail.decodeTokPerSec`,
+`pws.healthLabel.validationPending` — and does any translation invert the meaning of the
+English source? Does the account-pool `validationPending` copy tell the operator what to do?
 
-**L5 — security, privacy, release surface.** Is email masking still on by default, and does
-the opt-out require an explicit operator action? Does `bun run privacy:scan`'s contract
-still hold for every new log site? Does any `src/lab/` module now reach `src/router.ts`,
-`src/server/lifecycle.ts`, or `src/server/responses/core.ts`? Is there any `await` in the
-synchronous `startServer` activation window? Is any gitlink tracked?
+**L5 — security, privacy, release surface.** Is email masking on by default in the resolved
+config, and does the opt-out require an explicit operator action? Read every log call site
+added in this delta and name any that can emit an address, token, request body, or account
+identifier — static reading only, do not run the scan. Does any `src/lab/` module now reach
+`src/router.ts`, `src/server/lifecycle.ts`, or `src/server/responses/core.ts` through any
+import chain? Is there any `await` in the synchronous `startServer` activation window in
+`src/server/index.ts`, and does the bind-time `maxRequestBodySize` wiring there agree with
+the configured limit and its default? Is any gitlink tracked?
 
 **L6 — operator CLI surface.** Does `ocx status` apply the same masking default as the
 library? Does `ocx account refresh` mint or reuse a dashboard session, and does it spend

--- a/devlog/_plan/260910_250_regression_audit_release/060_release_readiness.md
+++ b/devlog/_plan/260910_250_regression_audit_release/060_release_readiness.md
@@ -1,0 +1,63 @@
+# Release-readiness decision (wp3)
+
+wp3 was scoped to triage and remediate release-blocking findings. **The audit produced
+none**, so there is nothing to remediate and this cycle is a decision record instead.
+
+## The decision
+
+Promote and publish freeze SHA `12c248f52bed88ea13be5b284c79a238feb592d1` as 2.50.0.
+
+## What the decision rests on
+
+| Evidence | Detail |
+| --- | --- |
+| Six independent lanes | All returned `NO-BLOCKER` against the eight clauses, 23-41 files read each, covering all 94 changed product paths |
+| Candidate-tree CI | Run `34457689927`, `ci.yml` with `lane=all` on `12c248f52`, attempt 2 conclusion **success** |
+| Focused local suites | 84 pass / 0 fail across the web-search bridge, Lab/core boundary, privacy masking, `skills/ocx` surface, body-size limit, live service-manager guard, and context-overflow |
+| Main-session re-derivation | Seven invariants re-checked directly rather than accepted from a lane |
+| Independent decision audit | Reviewer round 4 returned **GO** and confirmed the release sequence has no defects |
+| Freeze tree | `git rev-parse 12c248f52^{tree}` = `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822`, the value the promotion merge must reproduce |
+
+## The CI flake, and why it is not being fixed first
+
+Attempt 1 of run `34457689927` failed one job. One test —
+`CodeRabbit Log Guard reclaim regressions > classifies continuous progress stopped by
+MAX_ITERATIONS as bounded work` — exceeded the suite-wide `--timeout 60000` after taking
+112,853.92 ms on Windows shard 5/6. Everything else passed: 4058 pass, 15 skip, 1 fail.
+
+Every file on that failure path is byte-identical to the released 2.49.0 tree:
+
+| File | Blob at `2f3f73629` and at `origin/dev` |
+| --- | --- |
+| `src/codex/log-guard/maintenance.ts` | `81b3a465b5dbddc11c7431b99fec52012b61cf65` |
+| `tests/codex-integration/codex-log-guard-maintenance-coderabbit.test.ts` | `54e83bba2a62b9fffd39f88839f3c339e1c26080` |
+| `tests/helpers/remove-tree.ts` | `53e36a584c627b75a3c3b58a28e2bd17d7636b8b` |
+
+`tests/preload.ts` is the one file on that path the delta does touch, and the change is
+a comment block only — no statement changed. The round-4 reviewer caught that the first
+version of this proof enumerated three blobs and called it "every file on the failure
+path"; the diff is recorded here so the claim is complete rather than merely true.
+
+Rerunning the failed job produced attempt 2 with conclusion `success`, which also
+demonstrates the mechanic the release gate depends on: `release.yml` searches
+`gh run list --workflow ci.yml --commit "$GITHUB_SHA" --event push` and reads the run's
+conclusion, and a rerun updates that conclusion in place.
+
+Hardening the timeout would move the freeze SHA, void this audit, and reopen every gate
+for a test that 2.49.0 already shipped with the same bytes and the same limit. The
+mitigation is the rerun, applied again on the promotion merge if it recurs.
+
+## Recorded limits of the audit
+
+The round-4 reviewer named three, and they are recorded rather than argued away.
+
+1. **Every lane was a static reader.** `NO-BLOCKER` means no clause matched a read, not
+   that the new SSE bridge cannot hang at runtime. The 84 focused tests and the full
+   `lane=all` CI run are what cover the dynamic half; the lane verdicts alone are not.
+2. **The re-derivation table checks invariants, not the packet questions.** It confirms
+   masking, the body limit, the Lab boundary, `startServer`, gitlinks, i18n keys, and the
+   bridge opt-in. It does not independently re-answer the inbound `developer` remap, the
+   90-second WS prelude, or `freeOnlyInForce`; those rest on the lane read plus CI.
+3. **Treating an unresolved `RUNTIME-CHECK` as a `BLOCK` creates pressure to under-report
+   it.** Exactly one finding carried that label and it was resolved by tracing consumers.
+   A lane that quietly downgrades rather than raising the label would not be visible here.

--- a/devlog/_plan/260910_250_regression_audit_release/070_release_execution.md
+++ b/devlog/_plan/260910_250_regression_audit_release/070_release_execution.md
@@ -1,0 +1,103 @@
+# 2.50.0 execution runbook (wp4)
+
+The exact sequence, with the value each step must record. `020_release_plan.md` says why;
+this says what to run. Every SHA below is written down as it is produced, because the next
+step verifies against it rather than against "current".
+
+## Fixed inputs
+
+| Name | Value |
+| --- | --- |
+| Freeze SHA | `12c248f52bed88ea13be5b284c79a238feb592d1` |
+| Freeze tree | `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822` |
+| Version | `2.50.0` |
+| Previous release | `v2.49.0` at `main` `2f3f736299dca38861f8fb9c4326a4b4d7c664bc` |
+| Default branch | `main` |
+
+## Step 1 — pre-move `dev`
+
+```sh
+gh workflow run dev-version-bump.yml --ref main \
+  -f intended-version=2.50.0 -f mode=pre-move
+```
+
+The workflow opens a pull request; it cannot push to `dev` because the `Protect dev`
+ruleset requires review. Merge that PR, then confirm:
+
+```sh
+git fetch origin dev
+git show origin/dev:package.json | head -3   # must read 2.51.0
+```
+
+Record: the bump PR number and the merged `dev` SHA.
+
+Why this is first: `release.yml:242-249` runs
+`bun scripts/version-line.ts assert-ahead <dev version> 2.50.0`, which fails while `dev`
+is still 2.50.0. Doing it after the promotion would strand a published-but-refused release.
+
+## Step 2 — promote the freeze SHA to `main`
+
+```sh
+git fetch origin main
+git switch -c codex/release-250-main origin/main
+git merge --no-ff 12c248f52 -m "release: promote verified 2.50.0 product tree to main"
+git rev-parse HEAD^{tree}   # must equal d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822
+```
+
+If the tree does not match, a conflict resolution changed the product and the audit no
+longer describes what would ship. Stop and re-derive rather than adjusting the expectation.
+
+Open the PR into `main` using `.github/PULL_REQUEST_TEMPLATE.md`, merge it, then:
+
+```sh
+git fetch origin main
+git rev-parse origin/main            # record as MERGE_SHA
+git rev-parse origin/main^{tree}     # must still equal the freeze tree
+```
+
+Record: the promotion PR number, `MERGE_SHA`, and the confirmed tree.
+
+## Step 3 — wait for the release-branch gates on `MERGE_SHA`
+
+Both fire automatically on the merge push — `ci.yml` because `main` is in its push
+branches and `src/**`/`gui/**` changed, `service-lifecycle.yml` because `package.json` and
+`src/cli/index.ts` are in its push paths.
+
+```sh
+gh run list --workflow ci.yml --commit "$MERGE_SHA" --event push --json conclusion,url
+gh run list --workflow service-lifecycle.yml --commit "$MERGE_SHA" --json conclusion,url
+```
+
+Both must reach `success`. If Windows shard 5/6 times out on the Log Guard reclaim test
+again, rerun that job in place with `gh run rerun <id> --failed`; the gate reads the run's
+conclusion, which a rerun updates. That is the recorded mitigation, not an improvisation.
+
+## Step 4 — dry run, then publish
+
+```sh
+gh workflow run release.yml --ref main \
+  -f version=2.50.0 -f tag=latest -f expected-sha="$MERGE_SHA" -f dry-run=true
+```
+
+A dry run still executes `prepublishOnly` (typecheck plus the GUI build), so a green dry
+run is real evidence about the package, not a formality. Only then:
+
+```sh
+gh workflow run release.yml --ref main \
+  -f version=2.50.0 -f tag=latest -f expected-sha="$MERGE_SHA" -f dry-run=false
+```
+
+## Step 5 — verify the artifacts independently
+
+```sh
+npm view @bitkyc08/opencodex dist-tags --json
+npm view @bitkyc08/opencodex@2.50.0 version gitHead dist.integrity --json
+git ls-remote --tags origin | grep v2.50.0
+gh release view v2.50.0 --json tagName,isDraft,isPrerelease,createdAt
+```
+
+`gitHead` must equal `MERGE_SHA`. npm propagation lag shows a 404 or a stale `latest`
+for a while; poll. **Never republish because a smoke step timed out** — inspect metadata,
+provenance, and the tarball first, because npm may already have accepted the publish.
+
+Record every value into the release-artifacts table in `030_evidence.md`.

--- a/devlog/_plan/260910_250_regression_audit_release/080_delivery_record.md
+++ b/devlog/_plan/260910_250_regression_audit_release/080_delivery_record.md
@@ -1,0 +1,42 @@
+# Delivery record — 2.50.0
+
+Published 2026-09-10. `@bitkyc08/opencodex@2.50.0` is the npm `latest`.
+
+## The chain, end to end
+
+| # | What | Value |
+| --- | --- | --- |
+| 1 | Released baseline | `v2.49.0`, `main` `2f3f736299dca38861f8fb9c4326a4b4d7c664bc` |
+| 2 | Audited freeze SHA | `12c248f52bed88ea13be5b284c79a238feb592d1`, tree `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822` |
+| 3 | Candidate CI | `ci.yml` `lane=all` run 34457689927, success |
+| 4 | `dev` pre-move | run 34463313646 -> PR #4194 -> `dev` `cf44f6fe887d19f53ede1e09abfe0fe3cf137059` at 2.51.0 |
+| 5 | Promotion commit | `3a3de889b6ef3217497f6c5029acf08aec09c0cf` |
+| 6 | `main` merge SHA | PR #4195 -> `2d4d7a22381a2e497c2442902104619e25f937c7`, tree `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822` |
+| 7 | Release-branch gates | `ci.yml` 34464454730 success, `service-lifecycle.yml` 34464454609 success |
+| 8 | Dry run | `release.yml` 34465317829 success |
+| 9 | Publish | `release.yml` 34465442114 success |
+| 10 | Registry | `latest` = 2.50.0, `gitHead` = `2d4d7a223`, tarball sha512 matches `dist.integrity`, SLSA v1 provenance present |
+| 11 | Tag and release | `v2.50.0` -> `2d4d7a223`, GitHub release published, not a draft |
+
+**One tree throughout.** The audited freeze tree, the promotion commit's tree, and the
+merged `main` tree are the same object, `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822`, and
+three audited source files inside the published tarball hash identically to that tree. What
+shipped is what was read.
+
+## What the audit cost and produced
+
+Seven `xai/grok-4.6` subagent runs: one standing reviewer across four rounds, and six
+concurrent audit lanes. The reviewer failed the first roadmap outright, and that was the
+most valuable moment in the whole unit — it caught that the release order did not match
+what `release.yml` gates on, that promoting the 2.50.0 tree onto `preview` would have
+broken that branch's version line, and that four `src/cli` files had no lane. The lanes
+then returned no blockers, and the fourth round audited the release decision rather than
+the code and returned GO.
+
+## What is deliberately unfinished
+
+- `preview` stays at `2.49.0-preview.20260909`, npm `preview` at `2.48.0-preview.20260908`.
+  It needs its own `2.50.0-preview.<date>` commit, which is a separate decision.
+- Seven non-blocking findings (F1-F7) are recorded but not filed as issues.
+- The Windows Log Guard reclaim test remains able to exceed the 60s suite limit on a slow
+  runner. It is unchanged since 2.49.0; the mitigation is a job rerun, exercised twice here.


### PR DESCRIPTION
## Summary

- Records the regression audit that gated the 2.50.0 release and the release train itself, as a tracked planning unit under `devlog/_plan/260910_250_regression_audit_release/`. Documentation only: no runtime, test, or build path reads any of it.
- Nine decade docs covering the scope and the frozen baseline, the six-lane audit map with an eight-clause blocker definition, the release plan derived from what `release.yml` actually gates on, the evidence ledger, the triage protocol, the dispatch packets, the readiness decision, the execution runbook, and the delivery record.

## Verification

- No product code changes, so no product tests apply. The unit is `devlog/` only, which AGENTS.md states nothing in the build, typecheck, or test path reads.
- The release this documents is already published and independently verified: npm `latest` is 2.50.0 with `gitHead` `2d4d7a22381a2e497c2442902104619e25f937c7`, matching `main`; the `v2.50.0` tag and the GitHub release point at that same commit; the downloaded tarball hashes to the `dist.integrity` value the registry publishes; and `slsa.dev/provenance/v1` attestation is present.
- The audited freeze tree, the promotion commit's tree, and the merged `main` tree are all `d8f5a7143bcd6cb86185c4e8d4c6a6c4ad0fa822`, and three audited source files inside the published tarball are SHA-256 identical to that tree.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive release planning and execution documentation for version 2.50.0.
  - Documented regression-audit procedures, release-readiness criteria, triage guidance, and evidence tracking.
  - Added a delivery record confirming the 2.50.0 release and registry verification.
  - Recorded known non-blocking follow-up items and operational limitations for future review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->