### PR TITLE
fix(bigmodel): restore Responses preset quota visibility

### DIFF
--- a/docs-site/src/content/docs/guides/providers.md
+++ b/docs-site/src/content/docs/guides/providers.md
@@ -764,6 +764,12 @@ Select **Zhipu AI — BigModel Coding Plan (Responses)** (`zhipu-bigmodel-respon
 for the `openai-responses` endpoint `https://open.bigmodel.cn/api/v1`. This is separate
 from `zhipu-bigmodel-coding`, which uses Chat Completions at `/api/coding/paas/v4`.
 
+Both Coding Plan presets use the existing domestic quota monitor with the raw API key
+in `Authorization` and refuse redirects. A custom noncanonical destination remains
+unsupported by that quota probe. Quota-reader support does not expand the Responses
+model roster or establish Flash/model-discovery support; those require separate
+endpoint-specific evidence.
+
 The preset uses a **static roster** (`liveModels: false`) taken from the
 [official BigModel Codex example](https://docs.bigmodel.cn/cn/coding-plan/tool/codex.md):
 

--- a/src/providers/quota.ts
+++ b/src/providers/quota.ts
@@ -2906,7 +2906,8 @@ function keyQuotaReaderForProvider(name: string, provider: OcxProviderConfig): K
   if (name === "deepseek" && isCanonicalDeepSeekBaseUrl(provider.baseUrl)) return fetchDeepSeekQuota;
   if (name === "cline-pass" && isCanonicalClineBaseUrl(provider.baseUrl)) return fetchClineQuota;
   if (isCanonicalOllamaCloudBaseUrl(provider.baseUrl ?? getProviderRegistryEntry(name)?.baseUrl)) return fetchOllamaCloudQuota;
-  if (["zai", "glm", "glm-cn", "zhipu-bigmodel-coding"].includes(name) && isCanonicalZaiBaseUrl(provider.baseUrl)) return fetchZaiQuota;
+  // The domestic Responses preset uses the same Coding Plan monitor, not model discovery.
+  if (["zai", "glm", "glm-cn", "zhipu-bigmodel-coding", "zhipu-bigmodel-responses"].includes(name) && isCanonicalZaiBaseUrl(provider.baseUrl)) return fetchZaiQuota;
   if (["minimax", "minimax-cn"].includes(name) && isCanonicalMinimaxBaseUrl(provider.baseUrl)) return fetchMinimaxQuota;
   if (name === "moonshot" && isCanonicalMoonshotBaseUrl(provider.baseUrl)) return fetchMoonshotQuota;
   if (name === "venice" && isCanonicalVeniceBaseUrl(provider.baseUrl)) return fetchVeniceQuota;

--- a/tests/providers/provider-quota.test.ts
+++ b/tests/providers/provider-quota.test.ts
@@ -1077,12 +1077,12 @@ describe("fetchProviderQuotaReports", () => {
     expect(seen[0]?.url).toBe("https://api.z.ai/api/monitor/usage/quota/limit");
   });
 
-  test("Z.AI quota probes the BigModel Responses endpoint at /api/v1", async () => {
-    const seen: Array<{ url: string; authorization?: string }> = [];
+  test.each(["zhipu-bigmodel-coding", "zhipu-bigmodel-responses"])("Z.AI quota probes BigModel /api/v1 for %s", async name => {
+    const seen: Array<{ url: string; authorization?: string; redirect?: RequestRedirect }> = [];
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       const headers = init?.headers as Record<string, string> | undefined;
-      seen.push({ url, authorization: headers?.Authorization });
+      seen.push({ url, authorization: headers?.Authorization, redirect: init?.redirect });
       return new Response(JSON.stringify({
         success: true,
         data: {
@@ -1095,10 +1095,9 @@ describe("fetchProviderQuotaReports", () => {
       }), { status: 200 });
     }) as typeof fetch;
 
-    const result = await fetchProviderQuotaReports(
-      keyQuotaConfig("zhipu-bigmodel-coding", "https://open.bigmodel.cn/api/v1", "zai-secret"),
-      true,
-    );
+    const config = keyQuotaConfig(name, "https://open.bigmodel.cn/api/v1", "zai-secret");
+    config.providers[name]!.adapter = name === "zhipu-bigmodel-responses" ? "openai-responses" : "openai-chat";
+    const result = await fetchProviderQuotaReports(config, true);
 
     expect(result.reports).toHaveLength(1);
     expect(result.reports[0]?.source).toBe("zai:quota-limit");
@@ -1110,6 +1109,23 @@ describe("fetchProviderQuotaReports", () => {
     expect(seen).toHaveLength(1);
     expect(seen[0]?.url).toBe("https://open.bigmodel.cn/api/monitor/usage/quota/limit");
     expect(seen[0]?.authorization).toBe("zai-secret");
+    expect(seen[0]?.redirect).toBe("error");
+  });
+
+  test.each([
+    "https://gateway.example.test/api/v1",
+    "https://open.bigmodel.cn/api/paas/v4",
+  ])("BigModel Responses quota does not probe unsupported destination %s", async baseUrl => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response("unexpected", { status: 500 });
+    }) as typeof fetch;
+    const config = keyQuotaConfig("zhipu-bigmodel-responses", baseUrl);
+    config.providers["zhipu-bigmodel-responses"]!.adapter = "openai-responses";
+
+    expect((await fetchProviderQuotaReports(config, true)).reports).toEqual([]);
+    expect(calls).toBe(0);
   });
 
   test("Z.AI quota treats an unsuccessful payload as a no-report", async () => {


### PR DESCRIPTION
## Summary

Refs #4201 — **quota-reader omission only**; the Flash model-support request remains open.

- Admit the existing `zhipu-bigmodel-responses` preset to the existing canonical Z.ai/BigModel quota reader.
- Preserve domestic monitor selection, raw Authorization, redirect refusal, parsing and inference configuration.
- Parameterize the existing domestic /api/v1 regression across both Coding Plan preset IDs and their wire adapters; add custom-host and pay-as-you-go no-dispatch controls.
- Document why quota support is separate from the deliberately static Responses model roster. No provider preset or model metadata is added.

The installed-source report is confirmed in dev at `6d3ad12e3fbfd8423f1515a467db4d3349732886`: the URL is already admitted, but the provider-name selector omits this preset. This is independent of #4174's international endpoint fix.

## Verification

- `git diff --check`: passed.
- Existing read-only `scripts/privacy-scan.ts`: passed using fresh HOME, OPENCODEX_HOME, CODEX_HOME and transpiler cache.
- Protected local runtime file existence/mode/size/SHA-256 unchanged; no process restart or live credential/provider probe.
- Added mocked regression coverage has **not been run locally**: product execution remains blocked on reliable filesystem/network isolation in this environment. Typecheck, product tests and documentation build are not claimed green.
- Exact-head upstream Cross-platform CI **34491624277**: successful at `b9109a151aef864cdfe4d22bdac6623164a4ca0a`. Linux/macOS shards, typecheck/privacy, Docker, keyring and npm-global smoke passed. Full Windows shards and macOS control were skipped, not executed.
- Verified macOS shard 2 logs include all four BigModel positive/negative regression cases passing.
- Draft pending documentation build and independent review; local test execution remains unclaimed.

Review must preserve the exact destination guard and domestic authorization format. Do not broaden to custom gateways or infer Flash support from the Chat preset.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

### Review readiness

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.
- [ ] My PR is ready for review.
