### PR TITLE
fix(live): fail the sideband upgrade when the upstream handshake fails

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -315,6 +315,29 @@ function withRemoteCatalogKeyId(response: Response, admission: DataPlaneAdmissio
 const LIVE_SIDEBAND_PENDING_MAX = 32;
 const LIVE_SIDEBAND_PENDING_BYTES_MAX = 1024 * 1024;
 const LIVE_SIDEBAND_CLOSE_FALLBACK_MS = 1_000;
+/**
+ * Bound the pre-upgrade upstream handshake. A sideband join that cannot reach 101
+ * must fail the client upgrade promptly rather than hold it open indefinitely.
+ */
+export const LIVE_SIDEBAND_UPSTREAM_OPEN_TIMEOUT_MS = 10_000;
+
+/**
+ * Outcome of the upstream sideband handshake performed before the client upgrade.
+ *
+ * `ok: false` carries the HTTP status the client upgrade must fail with. Only an
+ * upgrade failure reaches codex-rs as a connect error, and only a connect error
+ * ends its sideband reconnect loop (`realtime_conversation/sideband.rs`: the `Err`
+ * arm always breaks). A 101 followed by a close is instead read as `TransportLost`
+ * and retried forever against the same, permanently dead call id.
+ */
+export type LiveSidebandUpstreamOpenResult =
+  | {
+      ok: true;
+      socket: WebSocket;
+      /** Stops capture and returns the upstream frames seen before the client existed. */
+      drain: () => Array<string | Buffer>;
+    }
+  | { ok: false; status: number; code: string; message: string };
 
 export function exceedsLiveSidebandFrameByteLimit(frameBytes: number): boolean {
   return frameBytes > MAX_WS_FRAME_BYTES;
@@ -444,28 +467,137 @@ function closeLiveSideband(ws: ServerWebSocket<WsData>, code = 1000, reason = ""
   }
 }
 
+/**
+ * Dial the upstream sideband and report whether its handshake reached 101.
+ *
+ * Bun's client WebSocket does not surface the upstream handshake status, so the
+ * result is "opened" or "failed" and nothing finer. That is sufficient for the
+ * property this exists to guarantee: the client is never told the relay is live
+ * when it is not. Frames the upstream sends before the client socket exists are
+ * captured and handed back by `drain`, because a session preamble such as
+ * `session.created` arrives immediately after the upstream opens.
+ */
+export function openLiveSidebandUpstream(
+  url: string,
+  headers: Record<string, string>,
+  createWebSocket: LiveSidebandWebSocketFactory = (socketUrl, socketHeaders) => (
+    new WebSocket(socketUrl, { headers: socketHeaders } as unknown as string[])
+  ),
+  timeoutMs: number = LIVE_SIDEBAND_UPSTREAM_OPEN_TIMEOUT_MS,
+): Promise<LiveSidebandUpstreamOpenResult> {
+  return new Promise(resolve => {
+    let socket: WebSocket;
+    try {
+      socket = createWebSocket(url, headers);
+    } catch {
+      resolve({ ok: false, status: 502, code: "upstream_error", message: "voice upstream connect failed" });
+      return;
+    }
+
+    const buffered: Array<string | Buffer> = [];
+    let capturing = true;
+    let settled = false;
+
+    const finish = (result: LiveSidebandUpstreamOpenResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      finish({ ok: false, status: 504, code: "upstream_timeout", message: "voice upstream did not open in time" });
+      try {
+        socket.close();
+      } catch {
+        /* ignore */
+      }
+    }, timeoutMs);
+
+    socket.addEventListener("message", event => {
+      if (!capturing || buffered.length >= LIVE_SIDEBAND_PENDING_MAX) return;
+      if (typeof event.data === "string") buffered.push(event.data);
+      else if (event.data instanceof ArrayBuffer) buffered.push(Buffer.from(new Uint8Array(event.data)));
+      else if (ArrayBuffer.isView(event.data)) buffered.push(Buffer.from(event.data as Uint8Array));
+    });
+    socket.addEventListener("open", () => {
+      finish({
+        ok: true,
+        socket,
+        drain: () => {
+          capturing = false;
+          const frames = buffered.slice();
+          buffered.length = 0;
+          return frames;
+        },
+      });
+    });
+    socket.addEventListener("error", () => {
+      finish({ ok: false, status: 502, code: "upstream_error", message: "voice upstream rejected the sideband join" });
+    });
+    socket.addEventListener("close", event => {
+      finish({
+        ok: false,
+        status: 502,
+        code: "upstream_error",
+        message: `voice upstream closed before opening (code ${event.code})`,
+      });
+    });
+  });
+}
+
 function attachLiveSidebandUpstream(
   ws: ServerWebSocket<WsData>,
   createWebSocket: LiveSidebandWebSocketFactory = (url, headers) => (
     new WebSocket(url, { headers } as unknown as string[])
   ),
 ): void {
-  const url = ws.data.liveUpstreamUrl;
-  if (!url) {
-    closeLiveSideband(ws, 1011, "missing upstream");
-    return;
-  }
+  // A socket carried in from the upgrade handler already completed its handshake
+  // before the client was told 101. Reuse it rather than dialing a second upstream.
+  const preOpened = ws.data.liveUpstream;
   let upstream: WebSocket;
-  try {
-    // Bun accepts per-handshake headers; the DOM lib types only list protocol arrays.
-    upstream = createWebSocket(url, ws.data.liveUpstreamHeaders ?? {});
-  } catch {
-    closeLiveSideband(ws, 1011, "upstream connect failed");
-    return;
+  if (preOpened) {
+    upstream = preOpened;
+  } else {
+    const url = ws.data.liveUpstreamUrl;
+    if (!url) {
+      closeLiveSideband(ws, 1011, "missing upstream");
+      return;
+    }
+    try {
+      // Bun accepts per-handshake headers; the DOM lib types only list protocol arrays.
+      upstream = createWebSocket(url, ws.data.liveUpstreamHeaders ?? {});
+    } catch {
+      closeLiveSideband(ws, 1011, "upstream connect failed");
+      return;
+    }
   }
   ws.data.liveUpstream = upstream;
   ws.data.liveClosing = false;
   ws.data.cancel = () => closeLiveSideband(ws, 1000, "client closed");
+
+  if (preOpened) {
+    // The upstream opened before this socket existed, so its `open` event has already
+    // fired and the listener below will never run. Its early frames were captured for
+    // us; forward the capture now rather than dropping the session preamble.
+    ws.data.liveOpened = true;
+    const drain = ws.data.liveUpstreamDrain;
+    ws.data.liveUpstreamDrain = undefined;
+    for (const frame of drain ? drain() : []) {
+      try {
+        // Mirror the live message listener exactly: same ceiling, same diagnostic
+        // record. These frames are upstream-to-client like any other.
+        if (exceedsLiveSidebandFrameByteLimit(webSocketFrameBytes(frame))) {
+          closeLiveSideband(ws, 1009, "message too large");
+          return;
+        }
+        logLiveSidebandFrame("u2c", frame);
+        ws.send(frame);
+      } catch {
+        closeLiveSideband(ws, 1011, "client send failed");
+        return;
+      }
+    }
+  }
 
   upstream.addEventListener("open", () => {
     if (ws.data.liveUpstream !== upstream || ws.data.liveClosing) return;
@@ -2085,18 +2217,47 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
           addFinalRequestLog(requestId, start, logCtx, resolved.status);
           return withCors(resolved, req, policy);
         }
+        // Establish the upstream handshake BEFORE promising the client a 101. A 101
+        // followed by a close is indistinguishable from a mid-stream transport loss,
+        // which codex-rs recovers from by rejoining the same call id indefinitely. A
+        // failed upgrade reaches it as a connect error instead, which is the only
+        // outcome that ends that loop.
+        const upstreamHandshake = await openLiveSidebandUpstream(
+          resolved.upstreamWsUrl,
+          resolved.headers,
+          deps.liveSidebandWebSocketFactory,
+        );
+        if (!upstreamHandshake.ok) {
+          turnAdmissionLease.release();
+          addFinalRequestLog(requestId, start, logCtx, upstreamHandshake.status);
+          console.error(`[live] sideband upstream handshake failed: ${upstreamHandshake.message}`);
+          return withCors(
+            formatErrorResponse(upstreamHandshake.status, upstreamHandshake.code, upstreamHandshake.message),
+            req,
+            policy,
+          );
+        }
         addFinalRequestLog(requestId, start, logCtx, 101);
         if (requestServer.upgrade(req, {
           data: {
             kind: "live-sideband",
+            liveUpstream: upstreamHandshake.socket,
             liveUpstreamUrl: resolved.upstreamWsUrl,
             liveUpstreamHeaders: resolved.headers,
+            liveUpstreamDrain: upstreamHandshake.drain,
             livePending: [],
             livePendingBytes: 0,
-            liveOpened: false,
+            liveOpened: true,
             liveTurnAdmissionLease: turnAdmissionLease,
           } satisfies WsData,
         })) return undefined as unknown as Response;
+        // The upgrade was refused after the upstream had already opened; drop it.
+        try {
+          upstreamHandshake.drain();
+          upstreamHandshake.socket.close();
+        } catch {
+          /* ignore */
+        }
         turnAdmissionLease.release();
         return withCors(formatErrorResponse(426, "upgrade_required", "WebSocket upgrade failed"), req, policy);
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -339,7 +339,7 @@ export type LiveSidebandUpstreamOpenResult =
       /** Owns capture and terminal events until the downstream relay attaches. */
       handoff: LiveSidebandUpstreamHandoff;
     }
-  | { ok: false; status: number; code: string; message: string };
+  | { ok: false; status: number; code: string; message: string; socket?: WebSocket };
 
 export function exceedsLiveSidebandFrameByteLimit(frameBytes: number): boolean {
   return frameBytes > MAX_WS_FRAME_BYTES;
@@ -437,6 +437,48 @@ function armLiveSidebandCloseFallback(ws: ServerWebSocket<WsData>, upstream: Web
   }, LIVE_SIDEBAND_CLOSE_FALLBACK_MS);
 }
 
+function closeLiveSidebandBeforeUpgrade(
+  upstream: WebSocket,
+  release: () => void,
+  code = 1000,
+  reason = "",
+): void {
+  // There is no downstream socket to own this transport yet. Mirror
+  // closeLiveSideband's bounded close contract directly: release only after a
+  // close event or an observed CLOSED state, never merely after requesting close.
+  let released = false;
+  let fallback: ReturnType<typeof setTimeout> | undefined;
+  const releaseOnce = (): void => {
+    if (released) return;
+    released = true;
+    if (fallback !== undefined) clearTimeout(fallback);
+    release();
+  };
+  upstream.addEventListener("close", releaseOnce, { once: true });
+  if (upstream.readyState === WebSocket.CLOSED) {
+    releaseOnce();
+    return;
+  }
+  fallback = setTimeout(() => {
+    if (upstream.readyState === WebSocket.CLOSED) {
+      releaseOnce();
+      return;
+    }
+    try {
+      upstream.close(1000, "upstream close timeout");
+    } catch {
+      /* retain ownership until CLOSED is observed */
+    }
+    if ((upstream.readyState as number) === 3) releaseOnce();
+  }, LIVE_SIDEBAND_CLOSE_FALLBACK_MS);
+  try {
+    upstream.close(code, reason);
+  } catch {
+    /* the bounded fallback retries without releasing ownership */
+  }
+  if ((upstream.readyState as number) === 3) releaseOnce();
+}
+
 function closeLiveSideband(ws: ServerWebSocket<WsData>, code = 1000, reason = ""): void {
   if (ws.data.liveClosing) return;
   ws.data.liveClosing = true;
@@ -517,7 +559,7 @@ export function openLiveSidebandUpstream(
       capturing = false;
       buffered.length = 0;
       bufferedBytes = 0;
-      finish({ ok: false, ...failure });
+      finish({ ok: false, ...failure, socket });
       try {
         socket.close();
       } catch {
@@ -531,7 +573,7 @@ export function openLiveSidebandUpstream(
       capturing = false;
       buffered.length = 0;
       bufferedBytes = 0;
-      finish({ ok: false, ...failure });
+      finish({ ok: false, ...failure, socket });
       try {
         socket.close(1009, "sideband preamble overflow");
       } catch {
@@ -585,7 +627,7 @@ export function openLiveSidebandUpstream(
       capturing = false;
       buffered.length = 0;
       bufferedBytes = 0;
-      finish({ ok: false, ...terminalFailure });
+      finish({ ok: false, ...terminalFailure, socket });
       try {
         socket.close();
       } catch {
@@ -604,7 +646,7 @@ export function openLiveSidebandUpstream(
       capturing = false;
       buffered.length = 0;
       bufferedBytes = 0;
-      finish({ ok: false, ...terminalFailure });
+      finish({ ok: false, ...terminalFailure, socket });
     });
     const abortOpen = (): void => {
       const failure = { status: 499, code: "request_cancelled", message: "voice sideband join was cancelled" };
@@ -612,7 +654,7 @@ export function openLiveSidebandUpstream(
       capturing = false;
       buffered.length = 0;
       bufferedBytes = 0;
-      finish({ ok: false, ...terminalFailure });
+      finish({ ok: false, ...terminalFailure, socket });
       try {
         socket.close();
       } catch {
@@ -627,7 +669,7 @@ export function openLiveSidebandUpstream(
   });
 }
 
-function attachLiveSidebandUpstream(
+export function attachLiveSidebandUpstream(
   ws: ServerWebSocket<WsData>,
   createWebSocket: LiveSidebandWebSocketFactory = (url, headers) => (
     new WebSocket(url, { headers } as unknown as string[])
@@ -657,6 +699,21 @@ function attachLiveSidebandUpstream(
   ws.data.liveClosing = false;
   ws.data.cancel = () => closeLiveSideband(ws, 1000, "client closed");
 
+  upstream.addEventListener("close", (event) => {
+    if (ws.data.liveUpstream !== upstream) return;
+    ws.data.liveClosing = true;
+    finalizeLiveSideband(ws, upstream);
+    try {
+      ws.close(event.code || 1000, event.reason || "");
+    } catch {
+      /* ignore */
+    }
+  });
+  upstream.addEventListener("error", () => {
+    if (ws.data.liveUpstream !== upstream) return;
+    closeLiveSideband(ws, 1011, "upstream error");
+  });
+
   if (preOpened) {
     // The upstream opened before this socket existed, so its `open` event has already
     // fired and the listener below will never run. Its early frames were captured for
@@ -665,19 +722,12 @@ function attachLiveSidebandUpstream(
     ws.data.liveUpstreamHandoff = undefined;
     const takeover = handoff?.take();
     if (!takeover?.ok || preOpened.readyState !== WebSocket.OPEN) {
-      ws.data.liveClosing = true;
-      try {
-        if (preOpened.readyState !== WebSocket.CLOSED) preOpened.close();
-      } catch {
-        /* upstream is already terminal */
-      }
-      finalizeLiveSideband(ws, preOpened);
       const failure = takeover && !takeover.ok ? takeover.failure : undefined;
-      try {
-        ws.close(failure?.closeCode ?? 1011, failure?.closeReason ?? "upstream closed before relay attachment");
-      } catch {
-        /* client already gone */
-      }
+      closeLiveSideband(
+        ws,
+        failure?.closeCode ?? 1011,
+        failure?.closeReason ?? "upstream closed before relay attachment",
+      );
       return;
     }
     ws.data.liveOpened = true;
@@ -729,20 +779,6 @@ function attachLiveSidebandUpstream(
     } catch {
       closeLiveSideband(ws, 1011, "client send failed");
     }
-  });
-  upstream.addEventListener("close", (event) => {
-    if (ws.data.liveUpstream !== upstream) return;
-    ws.data.liveClosing = true;
-    finalizeLiveSideband(ws, upstream);
-    try {
-      ws.close(event.code || 1000, event.reason || "");
-    } catch {
-      /* ignore */
-    }
-  });
-  upstream.addEventListener("error", () => {
-    if (ws.data.liveUpstream !== upstream) return;
-    closeLiveSideband(ws, 1011, "upstream error");
   });
 }
 
@@ -2329,7 +2365,11 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
           req.signal,
         );
         if (!upstreamHandshake.ok) {
-          turnAdmissionLease.release();
+          if (upstreamHandshake.socket) {
+            closeLiveSidebandBeforeUpgrade(upstreamHandshake.socket, () => turnAdmissionLease.release());
+          } else {
+            turnAdmissionLease.release();
+          }
           addFinalRequestLog(requestId, start, logCtx, upstreamHandshake.status);
           console.error(`[live] sideband upstream handshake failed: ${upstreamHandshake.message}`);
           return withCors(
@@ -2340,12 +2380,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         }
         const handoffFailure = upstreamHandshake.handoff.failure();
         if (handoffFailure || upstreamHandshake.socket.readyState !== WebSocket.OPEN) {
-          try {
-            upstreamHandshake.socket.close();
-          } catch {
-            /* upstream is already terminal */
-          }
-          turnAdmissionLease.release();
+          closeLiveSidebandBeforeUpgrade(upstreamHandshake.socket, () => turnAdmissionLease.release());
           const failure = handoffFailure ?? {
             status: 502,
             code: "upstream_error",
@@ -2371,11 +2406,10 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         // The upgrade was refused after the upstream had already opened; drop it.
         try {
           upstreamHandshake.handoff.take();
-          upstreamHandshake.socket.close();
         } catch {
           /* ignore */
         }
-        turnAdmissionLease.release();
+        closeLiveSidebandBeforeUpgrade(upstreamHandshake.socket, () => turnAdmissionLease.release());
         return withCors(formatErrorResponse(426, "upgrade_required", "WebSocket upgrade failed"), req, policy);
       }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,8 @@ import {
   buildResponsesWsData,
   sendResponseToWebSocket,
   sendTextFrame,
+  type LiveSidebandUpstreamFailure,
+  type LiveSidebandUpstreamHandoff,
   type WsData,
 } from "./ws-bridge";
 import type { Server, ServerWebSocket } from "bun";
@@ -334,8 +336,8 @@ export type LiveSidebandUpstreamOpenResult =
   | {
       ok: true;
       socket: WebSocket;
-      /** Stops capture and returns the upstream frames seen before the client existed. */
-      drain: () => Array<string | Buffer>;
+      /** Owns capture and terminal events until the downstream relay attaches. */
+      handoff: LiveSidebandUpstreamHandoff;
     }
   | { ok: false; status: number; code: string; message: string };
 
@@ -484,6 +486,7 @@ export function openLiveSidebandUpstream(
     new WebSocket(socketUrl, { headers: socketHeaders } as unknown as string[])
   ),
   timeoutMs: number = LIVE_SIDEBAND_UPSTREAM_OPEN_TIMEOUT_MS,
+  signal?: AbortSignal,
 ): Promise<LiveSidebandUpstreamOpenResult> {
   return new Promise(resolve => {
     let socket: WebSocket;
@@ -495,17 +498,26 @@ export function openLiveSidebandUpstream(
     }
 
     const buffered: Array<string | Buffer> = [];
+    let bufferedBytes = 0;
     let capturing = true;
     let settled = false;
+    let terminalFailure: LiveSidebandUpstreamFailure | undefined;
+    let removeAbortListener = (): void => {};
 
     const finish = (result: LiveSidebandUpstreamOpenResult): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      removeAbortListener();
       resolve(result);
     };
     const timer = setTimeout(() => {
-      finish({ ok: false, status: 504, code: "upstream_timeout", message: "voice upstream did not open in time" });
+      const failure = { status: 504, code: "upstream_timeout", message: "voice upstream did not open in time" };
+      terminalFailure = failure;
+      capturing = false;
+      buffered.length = 0;
+      bufferedBytes = 0;
+      finish({ ok: false, ...failure });
       try {
         socket.close();
       } catch {
@@ -513,35 +525,105 @@ export function openLiveSidebandUpstream(
       }
     }, timeoutMs);
 
+    const failCapture = (failure: LiveSidebandUpstreamFailure): void => {
+      if (!capturing || terminalFailure) return;
+      terminalFailure = failure;
+      capturing = false;
+      buffered.length = 0;
+      bufferedBytes = 0;
+      finish({ ok: false, ...failure });
+      try {
+        socket.close(1009, "sideband preamble overflow");
+      } catch {
+        /* the terminal failure is already retained for the downstream handoff */
+      }
+    };
+    const handoff: LiveSidebandUpstreamHandoff = {
+      failure: () => terminalFailure,
+      take: () => {
+        capturing = false;
+        if (terminalFailure) return { ok: false, failure: terminalFailure };
+        const frames = buffered.slice();
+        buffered.length = 0;
+        bufferedBytes = 0;
+        return { ok: true, frames };
+      },
+    };
+
     socket.addEventListener("message", event => {
-      if (!capturing || buffered.length >= LIVE_SIDEBAND_PENDING_MAX) return;
+      if (!capturing) return;
+      const frameBytes = webSocketFrameBytes(event.data);
+      if (exceedsLiveSidebandFrameByteLimit(frameBytes)) {
+        failCapture({ status: 502, code: "upstream_overflow", message: "voice upstream preamble frame is too large" });
+        return;
+      }
+      if (buffered.length >= LIVE_SIDEBAND_PENDING_MAX) {
+        failCapture({ status: 502, code: "upstream_overflow", message: "voice upstream sent too many preamble frames" });
+        return;
+      }
+      if (exceedsLiveSidebandPendingByteLimit(bufferedBytes, frameBytes)) {
+        failCapture({ status: 502, code: "upstream_overflow", message: "voice upstream preamble is too large" });
+        return;
+      }
       if (typeof event.data === "string") buffered.push(event.data);
       else if (event.data instanceof ArrayBuffer) buffered.push(Buffer.from(new Uint8Array(event.data)));
-      else if (ArrayBuffer.isView(event.data)) buffered.push(Buffer.from(event.data as Uint8Array));
+      else if (ArrayBuffer.isView(event.data)) {
+        buffered.push(Buffer.from(new Uint8Array(event.data.buffer, event.data.byteOffset, event.data.byteLength)));
+      } else return;
+      bufferedBytes += frameBytes;
     });
     socket.addEventListener("open", () => {
       finish({
         ok: true,
         socket,
-        drain: () => {
-          capturing = false;
-          const frames = buffered.slice();
-          buffered.length = 0;
-          return frames;
-        },
+        handoff,
       });
     });
     socket.addEventListener("error", () => {
-      finish({ ok: false, status: 502, code: "upstream_error", message: "voice upstream rejected the sideband join" });
+      const failure = { status: 502, code: "upstream_error", message: "voice upstream rejected the sideband join" };
+      terminalFailure ??= failure;
+      capturing = false;
+      buffered.length = 0;
+      bufferedBytes = 0;
+      finish({ ok: false, ...terminalFailure });
+      try {
+        socket.close();
+      } catch {
+        /* the terminal failure is already retained */
+      }
     });
     socket.addEventListener("close", event => {
-      finish({
-        ok: false,
+      const failure = {
         status: 502,
         code: "upstream_error",
         message: `voice upstream closed before opening (code ${event.code})`,
-      });
+        closeCode: event.code,
+        closeReason: event.reason,
+      };
+      terminalFailure ??= failure;
+      capturing = false;
+      buffered.length = 0;
+      bufferedBytes = 0;
+      finish({ ok: false, ...terminalFailure });
     });
+    const abortOpen = (): void => {
+      const failure = { status: 499, code: "request_cancelled", message: "voice sideband join was cancelled" };
+      terminalFailure ??= failure;
+      capturing = false;
+      buffered.length = 0;
+      bufferedBytes = 0;
+      finish({ ok: false, ...terminalFailure });
+      try {
+        socket.close();
+      } catch {
+        /* the cancelled join no longer owns the socket */
+      }
+    };
+    if (signal) {
+      signal.addEventListener("abort", abortOpen, { once: true });
+      removeAbortListener = () => signal.removeEventListener("abort", abortOpen);
+      if (signal.aborted) abortOpen();
+    }
   });
 }
 
@@ -579,10 +661,27 @@ function attachLiveSidebandUpstream(
     // The upstream opened before this socket existed, so its `open` event has already
     // fired and the listener below will never run. Its early frames were captured for
     // us; forward the capture now rather than dropping the session preamble.
+    const handoff = ws.data.liveUpstreamHandoff;
+    ws.data.liveUpstreamHandoff = undefined;
+    const takeover = handoff?.take();
+    if (!takeover?.ok || preOpened.readyState !== WebSocket.OPEN) {
+      ws.data.liveClosing = true;
+      try {
+        if (preOpened.readyState !== WebSocket.CLOSED) preOpened.close();
+      } catch {
+        /* upstream is already terminal */
+      }
+      finalizeLiveSideband(ws, preOpened);
+      const failure = takeover && !takeover.ok ? takeover.failure : undefined;
+      try {
+        ws.close(failure?.closeCode ?? 1011, failure?.closeReason ?? "upstream closed before relay attachment");
+      } catch {
+        /* client already gone */
+      }
+      return;
+    }
     ws.data.liveOpened = true;
-    const drain = ws.data.liveUpstreamDrain;
-    ws.data.liveUpstreamDrain = undefined;
-    for (const frame of drain ? drain() : []) {
+    for (const frame of takeover.frames) {
       try {
         // Mirror the live message listener exactly: same ceiling, same diagnostic
         // record. These frames are upstream-to-client like any other.
@@ -2226,6 +2325,8 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
           resolved.upstreamWsUrl,
           resolved.headers,
           deps.liveSidebandWebSocketFactory,
+          LIVE_SIDEBAND_UPSTREAM_OPEN_TIMEOUT_MS,
+          req.signal,
         );
         if (!upstreamHandshake.ok) {
           turnAdmissionLease.release();
@@ -2237,6 +2338,22 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             policy,
           );
         }
+        const handoffFailure = upstreamHandshake.handoff.failure();
+        if (handoffFailure || upstreamHandshake.socket.readyState !== WebSocket.OPEN) {
+          try {
+            upstreamHandshake.socket.close();
+          } catch {
+            /* upstream is already terminal */
+          }
+          turnAdmissionLease.release();
+          const failure = handoffFailure ?? {
+            status: 502,
+            code: "upstream_error",
+            message: "voice upstream closed before client upgrade",
+          };
+          addFinalRequestLog(requestId, start, logCtx, failure.status);
+          return withCors(formatErrorResponse(failure.status, failure.code, failure.message), req, policy);
+        }
         addFinalRequestLog(requestId, start, logCtx, 101);
         if (requestServer.upgrade(req, {
           data: {
@@ -2244,7 +2361,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
             liveUpstream: upstreamHandshake.socket,
             liveUpstreamUrl: resolved.upstreamWsUrl,
             liveUpstreamHeaders: resolved.headers,
-            liveUpstreamDrain: upstreamHandshake.drain,
+            liveUpstreamHandoff: upstreamHandshake.handoff,
             livePending: [],
             livePendingBytes: 0,
             liveOpened: true,
@@ -2253,7 +2370,7 @@ export function startServer(port?: number, deps: StartServerDeps = {}): Server<W
         })) return undefined as unknown as Response;
         // The upgrade was refused after the upstream had already opened; drop it.
         try {
-          upstreamHandshake.drain();
+          upstreamHandshake.handoff.take();
           upstreamHandshake.socket.close();
         } catch {
           /* ignore */

--- a/src/server/ws-bridge.ts
+++ b/src/server/ws-bridge.ts
@@ -39,13 +39,8 @@ export interface WsData {
   /** Total encoded bytes retained in livePending while the upstream connects. */
   livePendingBytes?: number;
   liveOpened?: boolean;
-  /**
-   * Upstream frames captured while the pre-upgrade handshake completed, before the
-   * client socket existed. Drained exactly once when the relay attaches; capture
-   * stays live until then, so nothing is lost in the gap between the upstream
-   * opening and this socket registering its own upstream listener.
-   */
-  liveUpstreamDrain?: () => Array<string | Buffer>;
+  /** Owns captured frames and terminal state until the downstream relay attaches. */
+  liveUpstreamHandoff?: LiveSidebandUpstreamHandoff;
   /** Once teardown starts, ignore new client frames until the upstream closes. */
   liveClosing?: boolean;
   /** Schedules one bounded close retry without surrendering native-main ownership. */
@@ -53,6 +48,25 @@ export interface WsData {
   /** Turn/account ownership retained for the complete sideband socket lifetime. */
   liveTurnAdmissionLease?: AdmissionLease;
   admissionLease?: AdmissionReservation<ServerWebSocket<WsData>>;
+}
+
+export interface LiveSidebandUpstreamFailure {
+  status: number;
+  code: string;
+  message: string;
+  closeCode?: number;
+  closeReason?: string;
+}
+
+export type LiveSidebandUpstreamTakeover =
+  | { ok: true; frames: Array<string | Buffer> }
+  | { ok: false; failure: LiveSidebandUpstreamFailure };
+
+export interface LiveSidebandUpstreamHandoff {
+  /** Observe failure before the downstream upgrade without ending capture. */
+  failure(): LiveSidebandUpstreamFailure | undefined;
+  /** Atomically ends capture and transfers buffered frames or terminal state. */
+  take(): LiveSidebandUpstreamTakeover;
 }
 
 /**

--- a/src/server/ws-bridge.ts
+++ b/src/server/ws-bridge.ts
@@ -39,6 +39,13 @@ export interface WsData {
   /** Total encoded bytes retained in livePending while the upstream connects. */
   livePendingBytes?: number;
   liveOpened?: boolean;
+  /**
+   * Upstream frames captured while the pre-upgrade handshake completed, before the
+   * client socket existed. Drained exactly once when the relay attaches; capture
+   * stays live until then, so nothing is lost in the gap between the upstream
+   * opening and this socket registering its own upstream listener.
+   */
+  liveUpstreamDrain?: () => Array<string | Buffer>;
   /** Once teardown starts, ignore new client frames until the upstream closes. */
   liveClosing?: boolean;
   /** Schedules one bounded close retry without surrendering native-main ownership. */

--- a/tests/server/server-live.test.ts
+++ b/tests/server/server-live.test.ts
@@ -22,7 +22,12 @@ import {
   openLiveSidebandUpstream,
   startServer,
 } from "../../src/server";
-import { beginShutdownDrain, isDraining, resetLifecycleDrainStateForTests } from "../../src/server/lifecycle";
+import {
+  activeRegistryMetrics,
+  beginShutdownDrain,
+  isDraining,
+  resetLifecycleDrainStateForTests,
+} from "../../src/server/lifecycle";
 import type { OcxConfig } from "../../src/types";
 import { fakeChatGptJwt } from "../helpers/fake-chatgpt-jwt";
 import { installIsolatedCodexHome, type IsolatedCodexHome } from "../helpers/isolated-codex-home";
@@ -1749,21 +1754,26 @@ describe("GET /readyz while draining", () => {
  * loop. These cases pin the handshake result and its client-visible consequence.
  */
 class FakeUpstreamSocket {
-  private readonly listeners = new Map<string, Array<(event: { code?: number; data?: unknown }) => void>>();
+  private readonly listeners = new Map<string, Array<(event: { code?: number; data?: unknown; reason?: string }) => void>>();
   closed = false;
+  readyState = WebSocket.CONNECTING;
 
-  addEventListener(type: string, listener: (event: { code?: number; data?: unknown }) => void): void {
+  addEventListener(type: string, listener: (event: { code?: number; data?: unknown; reason?: string }) => void): void {
     const bucket = this.listeners.get(type) ?? [];
     bucket.push(listener);
     this.listeners.set(type, bucket);
   }
 
-  emit(type: string, event: { code?: number; data?: unknown } = {}): void {
+  emit(type: string, event: { code?: number; data?: unknown; reason?: string } = {}): void {
+    if (type === "open") this.readyState = WebSocket.OPEN;
+    if (type === "close") this.readyState = WebSocket.CLOSED;
     for (const listener of this.listeners.get(type) ?? []) listener(event);
   }
 
-  close(): void {
+  close(code = 1000, reason = ""): void {
     this.closed = true;
+    this.readyState = WebSocket.CLOSED;
+    this.emit("close", { code, reason });
   }
 }
 
@@ -1780,13 +1790,59 @@ describe("openLiveSidebandUpstream", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected an open upstream");
     expect(result.socket).toBe(socket);
-    const drained = result.drain();
+    const takeover = result.handoff.take();
+    expect(takeover.ok).toBe(true);
+    if (!takeover.ok) throw new Error("expected a successful handoff");
+    const drained = takeover.frames;
     expect(drained[0]).toBe("session.created");
     expect(Buffer.isBuffer(drained[1])).toBe(true);
+    expect(drained[1]).toEqual(Buffer.from([1, 2, 3]));
     // Drain is one-shot: the relay owns capture from here on.
-    expect(result.drain()).toEqual([]);
+    expect(result.handoff.take()).toEqual({ ok: true, frames: [] });
     socket.emit("message", { data: "after-drain" });
-    expect(result.drain()).toEqual([]);
+    expect(result.handoff.take()).toEqual({ ok: true, frames: [] });
+  });
+
+  test("fails explicitly before copying an aggregate preamble overflow", async () => {
+    const socket = new FakeUpstreamSocket();
+    const pending = openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 1_000);
+    const retained = new Uint8Array(1024 * 1024);
+    socket.emit("message", { data: retained });
+    const rejectedView = new Uint8Array(retained.buffer, 0, 1);
+    socket.emit("message", { data: rejectedView });
+
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected an overflow failure");
+    expect(result.code).toBe("upstream_overflow");
+    expect(socket.closed).toBe(true);
+  });
+
+  test("fails explicitly when the preamble frame-count limit is exceeded", async () => {
+    const socket = new FakeUpstreamSocket();
+    const pending = openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 1_000);
+    for (let index = 0; index < 33; index += 1) socket.emit("message", { data: String(index) });
+
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected an overflow failure");
+    expect(result.code).toBe("upstream_overflow");
+    expect(socket.closed).toBe(true);
+  });
+
+  test("preserves an open-then-close terminal event until relay handoff", async () => {
+    const socket = new FakeUpstreamSocket();
+    const pending = openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 1_000);
+    socket.emit("open", {});
+    socket.emit("close", { code: 1008 });
+
+    const result = await pending;
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected the completed opening handshake");
+    const takeover = result.handoff.take();
+    expect(takeover.ok).toBe(false);
+    if (takeover.ok) throw new Error("expected the terminal handoff");
+    expect(takeover.failure.closeCode).toBe(1008);
   });
 
   test("reports failure when the upstream rejects the handshake", async () => {
@@ -1809,6 +1865,25 @@ describe("openLiveSidebandUpstream", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected a failed handshake");
     expect(result.status).toBe(502);
+  });
+
+  test("cancels a pending join and closes its upstream socket", async () => {
+    const socket = new FakeUpstreamSocket();
+    const controller = new AbortController();
+    const pending = openLiveSidebandUpstream(
+      "ws://upstream/v1/live/x",
+      {},
+      () => socket as unknown as WebSocket,
+      1_000,
+      controller.signal,
+    );
+    controller.abort();
+
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a cancelled handshake");
+    expect(result.code).toBe("request_cancelled");
+    expect(socket.closed).toBe(true);
   });
 
   test("times out and drops the socket when the upstream never opens", async () => {
@@ -1861,6 +1936,7 @@ test("a sideband join whose upstream handshake fails never opens the client sock
   } as typeof WebSocket;
 
   const server = startServer(0);
+  const activeTurnsBefore = activeRegistryMetrics().activeTurns.active;
   try {
     const wsUrl = new URL(`/v1/realtime?call_id=rtc_dead_call`, server.url);
     wsUrl.protocol = "ws:";
@@ -1897,9 +1973,63 @@ test("a sideband join whose upstream handshake fails never opens the client sock
     // The relay never became live, so the client must not have been told it did.
     expect(events).not.toContain("open");
     expect(events.length).toBeGreaterThan(0);
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore);
   } finally {
     globalThis.WebSocket = RealWebSocket;
     await server.stop(true);
     await upstream.stop(true);
   }
 }, { timeout: 20_000 });
+
+test("an upstream that opens then closes before relay attachment refuses the client and releases admission", async () => {
+  saveConfig(forwardConfig());
+  const upstream = new FakeUpstreamSocket();
+  const server = startServer(0, {
+    liveSidebandWebSocketFactory: () => {
+      queueMicrotask(() => {
+        upstream.emit("open", {});
+        upstream.emit("close", { code: 1008, reason: "call ended" });
+      });
+      return upstream as unknown as WebSocket;
+    },
+  });
+  const activeTurnsBefore = activeRegistryMetrics().activeTurns.active;
+  try {
+    const wsUrl = new URL("/v1/realtime?call_id=rtc_closed_handoff", server.url);
+    wsUrl.protocol = "ws:";
+    const events: string[] = [];
+    const client = new WebSocket(wsUrl.toString(), {
+      headers: {
+        authorization: `Bearer ${DIRECT_CHATGPT_TOKEN}`,
+        "chatgpt-account-id": "acct-123",
+        "openai-alpha": "quicksilver=v2",
+        "x-session-id": "rts_closed_handoff",
+      },
+    } as unknown as string[]);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("client never settled")), 5_000);
+      const settle = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      client.addEventListener("open", () => {
+        events.push("open");
+        settle();
+      });
+      client.addEventListener("error", () => {
+        events.push("error");
+        settle();
+      });
+      client.addEventListener("close", () => {
+        events.push("close");
+        settle();
+      });
+    });
+
+    expect(events).not.toContain("open");
+    expect(events.length).toBeGreaterThan(0);
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore);
+  } finally {
+    await server.stop(true);
+  }
+}, { timeout: 10_000 });

--- a/tests/server/server-live.test.ts
+++ b/tests/server/server-live.test.ts
@@ -15,6 +15,7 @@ import {
   type ReadinessGate,
 } from "../../src/server/readiness";
 import {
+  attachLiveSidebandUpstream,
   enqueueLiveSidebandPendingFrame,
   exceedsLiveSidebandFrameByteLimit,
   exceedsLiveSidebandPendingByteLimit,
@@ -1756,6 +1757,8 @@ describe("GET /readyz while draining", () => {
 class FakeUpstreamSocket {
   private readonly listeners = new Map<string, Array<(event: { code?: number; data?: unknown; reason?: string }) => void>>();
   closed = false;
+  closeCalls = 0;
+  closeMode: "closed" | "closing" | "closing-then-close" = "closed";
   readyState = WebSocket.CONNECTING;
 
   addEventListener(type: string, listener: (event: { code?: number; data?: unknown; reason?: string }) => void): void {
@@ -1772,10 +1775,91 @@ class FakeUpstreamSocket {
 
   close(code = 1000, reason = ""): void {
     this.closed = true;
-    this.readyState = WebSocket.CLOSED;
+    this.closeCalls += 1;
+    if (this.closeMode === "closing") {
+      this.readyState = WebSocket.CLOSING;
+      return;
+    }
+    if (this.closeMode === "closing-then-close") this.readyState = WebSocket.CLOSING;
     this.emit("close", { code, reason });
   }
 }
+
+function fakeSidebandClient(
+  upstream: FakeUpstreamSocket,
+  handoff: {
+    failure(): undefined;
+    take(): { ok: true; frames: Array<string | Buffer> } | {
+      ok: false;
+      failure: { status: number; code: string; message: string; closeCode?: number; closeReason?: string };
+    };
+  },
+  send: (frame: string | Buffer) => void = () => {},
+) {
+  let releases = 0;
+  const ws = {
+    data: {
+      kind: "live-sideband" as const,
+      liveUpstream: upstream as unknown as WebSocket,
+      liveUpstreamHandoff: handoff,
+      liveOpened: true,
+      liveTurnAdmissionLease: {
+        release: () => { releases += 1; },
+      },
+    },
+    readyState: WebSocket.OPEN,
+    close: () => {},
+    send,
+  };
+  return { ws, releases: () => releases };
+}
+
+describe("attachLiveSidebandUpstream ownership", () => {
+  test("retains admission through a failed takeover until a CLOSING upstream actually closes", async () => {
+    const upstream = new FakeUpstreamSocket();
+    upstream.readyState = WebSocket.OPEN;
+    upstream.closeMode = "closing";
+    const client = fakeSidebandClient(upstream, {
+      failure: () => undefined,
+      take: () => ({
+        ok: false,
+        failure: { status: 502, code: "upstream_error", message: "closed", closeCode: 1008 },
+      }),
+    });
+
+    attachLiveSidebandUpstream(client.ws as never);
+
+    expect(upstream.readyState).toBe(WebSocket.CLOSING);
+    expect(client.releases()).toBe(0);
+    await Bun.sleep(1_100);
+    expect(upstream.closeCalls).toBe(2);
+    expect(client.releases()).toBe(0);
+    upstream.emit("close", { code: 1008, reason: "call ended" });
+    expect(client.releases()).toBe(1);
+    upstream.emit("close", { code: 1008, reason: "duplicate close" });
+    expect(client.releases()).toBe(1);
+  });
+
+  test("registers close ownership before forwarding a pre-opened preamble", () => {
+    const upstream = new FakeUpstreamSocket();
+    upstream.readyState = WebSocket.OPEN;
+    upstream.closeMode = "closing-then-close";
+    const client = fakeSidebandClient(
+      upstream,
+      {
+        failure: () => undefined,
+        take: () => ({ ok: true, frames: ["session.created"] }),
+      },
+      () => { throw new Error("downstream send failed"); },
+    );
+
+    attachLiveSidebandUpstream(client.ws as never);
+
+    expect(upstream.closeCalls).toBe(1);
+    expect(upstream.readyState).toBe(WebSocket.CLOSED);
+    expect(client.releases()).toBe(1);
+  });
+});
 
 describe("openLiveSidebandUpstream", () => {
   test("drains the preamble captured before the client socket exists", async () => {
@@ -1847,6 +1931,7 @@ describe("openLiveSidebandUpstream", () => {
 
   test("reports failure when the upstream rejects the handshake", async () => {
     const socket = new FakeUpstreamSocket();
+    socket.closeMode = "closing";
     const pending = openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 1_000);
     socket.emit("error", {});
 
@@ -1854,6 +1939,8 @@ describe("openLiveSidebandUpstream", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected a failed handshake");
     expect(result.status).toBe(502);
+    expect(result.socket).toBe(socket);
+    expect(socket.readyState).toBe(WebSocket.CLOSING);
   });
 
   test("reports failure when the upstream closes before opening", async () => {
@@ -1884,6 +1971,7 @@ describe("openLiveSidebandUpstream", () => {
     if (result.ok) throw new Error("expected a cancelled handshake");
     expect(result.code).toBe("request_cancelled");
     expect(socket.closed).toBe(true);
+    expect(result.socket).toBe(socket);
   });
 
   test("times out and drops the socket when the upstream never opens", async () => {
@@ -1902,8 +1990,100 @@ describe("openLiveSidebandUpstream", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected a failed handshake");
     expect(result.status).toBe(502);
+    expect(result.socket).toBeUndefined();
   });
 });
+
+test("a failed pre-upgrade handshake retains admission until its CLOSING upstream closes", async () => {
+  saveConfig(forwardConfig());
+  const upstream = new FakeUpstreamSocket();
+  upstream.closeMode = "closing";
+  const server = startServer(0, {
+    liveSidebandWebSocketFactory: () => {
+      queueMicrotask(() => upstream.emit("error", {}));
+      return upstream as unknown as WebSocket;
+    },
+  });
+  const activeTurnsBefore = activeRegistryMetrics().activeTurns.active;
+  try {
+    const wsUrl = new URL("/v1/realtime?call_id=rtc_failed_handshake_closing", server.url);
+    wsUrl.protocol = "ws:";
+    const client = new WebSocket(wsUrl.toString(), {
+      headers: {
+        authorization: `Bearer ${DIRECT_CHATGPT_TOKEN}`,
+        "chatgpt-account-id": "acct-123",
+        "openai-alpha": "quicksilver=v2",
+        "x-session-id": "rts_failed_handshake_closing",
+      },
+    } as unknown as string[]);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("client never observed failed upgrade")), 5_000);
+      const settle = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      client.addEventListener("error", settle, { once: true });
+      client.addEventListener("close", settle, { once: true });
+    });
+
+    expect(upstream.readyState).toBe(WebSocket.CLOSING);
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore + 1);
+    upstream.emit("close", { code: 1006, reason: "closed after handshake failure" });
+    await Bun.sleep(0);
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore);
+    upstream.emit("close", { code: 1006, reason: "duplicate close" });
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore);
+  } finally {
+    await server.stop(true);
+  }
+}, { timeout: 10_000 });
+
+test("a failed pre-upgrade handoff retains admission until its CLOSING upstream closes", async () => {
+  saveConfig(forwardConfig());
+  const upstream = new FakeUpstreamSocket();
+  upstream.closeMode = "closing";
+  const server = startServer(0, {
+    liveSidebandWebSocketFactory: () => {
+      queueMicrotask(() => {
+        upstream.emit("open", {});
+        upstream.emit("error", {});
+      });
+      return upstream as unknown as WebSocket;
+    },
+  });
+  const activeTurnsBefore = activeRegistryMetrics().activeTurns.active;
+  try {
+    const wsUrl = new URL("/v1/realtime?call_id=rtc_failed_handoff_closing", server.url);
+    wsUrl.protocol = "ws:";
+    const client = new WebSocket(wsUrl.toString(), {
+      headers: {
+        authorization: `Bearer ${DIRECT_CHATGPT_TOKEN}`,
+        "chatgpt-account-id": "acct-123",
+        "openai-alpha": "quicksilver=v2",
+        "x-session-id": "rts_failed_handoff_closing",
+      },
+    } as unknown as string[]);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("client never observed failed handoff")), 5_000);
+      const settle = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      client.addEventListener("error", settle, { once: true });
+      client.addEventListener("close", settle, { once: true });
+    });
+
+    expect(upstream.readyState).toBe(WebSocket.CLOSING);
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore + 1);
+    upstream.emit("close", { code: 1008, reason: "closed after failed handoff" });
+    await Bun.sleep(0);
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore);
+    upstream.emit("close", { code: 1008, reason: "duplicate close" });
+    expect(activeRegistryMetrics().activeTurns.active).toBe(activeTurnsBefore);
+  } finally {
+    await server.stop(true);
+  }
+}, { timeout: 10_000 });
 
 test("a sideband join whose upstream handshake fails never opens the client socket", async () => {
   // An upstream that refuses the upgrade: the shape OpenAI returns for a call id it

--- a/tests/server/server-live.test.ts
+++ b/tests/server/server-live.test.ts
@@ -19,6 +19,7 @@ import {
   exceedsLiveSidebandFrameByteLimit,
   exceedsLiveSidebandPendingByteLimit,
   MAX_WS_FRAME_BYTES,
+  openLiveSidebandUpstream,
   startServer,
 } from "../../src/server";
 import { beginShutdownDrain, isDraining, resetLifecycleDrainStateForTests } from "../../src/server/lifecycle";
@@ -1739,3 +1740,166 @@ describe("GET /readyz while draining", () => {
     }
   });
 });
+
+/**
+ * A sideband join must not report 101 unless the upstream handshake actually
+ * succeeded. A 101 followed by a close is read by codex-rs as `TransportLost`,
+ * which it recovers from by rejoining the same call id indefinitely; a failed
+ * upgrade is a connect error instead, and that is the only outcome that ends the
+ * loop. These cases pin the handshake result and its client-visible consequence.
+ */
+class FakeUpstreamSocket {
+  private readonly listeners = new Map<string, Array<(event: { code?: number; data?: unknown }) => void>>();
+  closed = false;
+
+  addEventListener(type: string, listener: (event: { code?: number; data?: unknown }) => void): void {
+    const bucket = this.listeners.get(type) ?? [];
+    bucket.push(listener);
+    this.listeners.set(type, bucket);
+  }
+
+  emit(type: string, event: { code?: number; data?: unknown } = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+describe("openLiveSidebandUpstream", () => {
+  test("drains the preamble captured before the client socket exists", async () => {
+    const socket = new FakeUpstreamSocket();
+    const pending = openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 1_000);
+    // The session preamble arrives the moment the upstream opens, before the client.
+    socket.emit("message", { data: "session.created" });
+    socket.emit("message", { data: new Uint8Array([1, 2, 3]) });
+    socket.emit("open", {});
+
+    const result = await pending;
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected an open upstream");
+    expect(result.socket).toBe(socket);
+    const drained = result.drain();
+    expect(drained[0]).toBe("session.created");
+    expect(Buffer.isBuffer(drained[1])).toBe(true);
+    // Drain is one-shot: the relay owns capture from here on.
+    expect(result.drain()).toEqual([]);
+    socket.emit("message", { data: "after-drain" });
+    expect(result.drain()).toEqual([]);
+  });
+
+  test("reports failure when the upstream rejects the handshake", async () => {
+    const socket = new FakeUpstreamSocket();
+    const pending = openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 1_000);
+    socket.emit("error", {});
+
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a failed handshake");
+    expect(result.status).toBe(502);
+  });
+
+  test("reports failure when the upstream closes before opening", async () => {
+    const socket = new FakeUpstreamSocket();
+    const pending = openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 1_000);
+    socket.emit("close", { code: 1006 });
+
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a failed handshake");
+    expect(result.status).toBe(502);
+  });
+
+  test("times out and drops the socket when the upstream never opens", async () => {
+    const socket = new FakeUpstreamSocket();
+    const result = await openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => socket as unknown as WebSocket, 20);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a timeout");
+    expect(result.status).toBe(504);
+    expect(socket.closed).toBe(true);
+  });
+
+  test("reports failure when the upstream socket cannot be constructed", async () => {
+    const result = await openLiveSidebandUpstream("ws://upstream/v1/live/x", {}, () => {
+      throw new Error("connect refused");
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a failed handshake");
+    expect(result.status).toBe(502);
+  });
+});
+
+test("a sideband join whose upstream handshake fails never opens the client socket", async () => {
+  // An upstream that refuses the upgrade: the shape OpenAI returns for a call id it
+  // no longer knows (`404 call_id_not_found`).
+  const upstream = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+        return new Response(JSON.stringify({ error: { code: "call_id_not_found" } }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  saveConfig(forwardConfig());
+
+  const RealWebSocket = globalThis.WebSocket;
+  const upstreamPort = upstream.port;
+  globalThis.WebSocket = class extends RealWebSocket {
+    constructor(url: string | URL, protocols?: string | string[] | Record<string, unknown>) {
+      const parsed = new URL(String(url));
+      const target = parsed.hostname === "api.openai.com"
+        ? `ws://127.0.0.1:${upstreamPort}${parsed.pathname}${parsed.search}`
+        : String(url);
+      super(target, protocols as string[]);
+    }
+  } as typeof WebSocket;
+
+  const server = startServer(0);
+  try {
+    const wsUrl = new URL(`/v1/realtime?call_id=rtc_dead_call`, server.url);
+    wsUrl.protocol = "ws:";
+    const events: string[] = [];
+    const client = new RealWebSocket(wsUrl.toString(), {
+      headers: {
+        authorization: `Bearer ${DIRECT_CHATGPT_TOKEN}`,
+        "chatgpt-account-id": "acct-123",
+        "openai-alpha": "quicksilver=v2",
+        "x-session-id": "rts_dead",
+      },
+    } as unknown as string[]);
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("client never settled")), 15_000);
+      const settle = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      client.addEventListener("open", () => {
+        events.push("open");
+        settle();
+      });
+      client.addEventListener("error", () => {
+        events.push("error");
+        settle();
+      });
+      client.addEventListener("close", () => {
+        events.push("close");
+        settle();
+      });
+    });
+
+    // The relay never became live, so the client must not have been told it did.
+    expect(events).not.toContain("open");
+    expect(events.length).toBeGreaterThan(0);
+  } finally {
+    globalThis.WebSocket = RealWebSocket;
+    await server.stop(true);
+    await upstream.stop(true);
+  }
+}, { timeout: 20_000 });


### PR DESCRIPTION
## Summary

A realtime sideband join is answered `101` as soon as the proxy accepts the client upgrade — before the upstream socket is even dialed. When the call has already ended, the upstream join fails and the relay closes with a generic `1011 "upstream error"`.

codex-rs reads that close as `TransportLost`, which is its **mid-stream recovery** path, so it rejoins the same, permanently dead call id on a backoff loop. Its terminal path for "the call is gone" keys on a **connect-time HTTP status** — `ApiError::Api { status: NOT_FOUND | GONE }` in `codex-rs/core/src/realtime_conversation/sideband.rs` (`webrtc_sideband_session_ended`). A close code after `101` always maps to `ApiError::Stream` in `realtime_websocket/methods.rs`, and the `Err` arm of the sideband loop breaks on any connect error. So an upgrade failure ends the loop and a post-`101` close never can.

Observed live: one dead call id drove ~45 rejoin attempts over 41 minutes, all rejected at the upstream handshake, at a measured 10.3s period.

### What changed

- Dial the upstream sideband **before** promising the client a `101`, and fail the upgrade with a real HTTP status when that handshake cannot be established.
- Capture and drain upstream frames that arrive before the client socket exists, so the session preamble (`session.created`) is not lost in the new gap. The drained frames keep the existing frame ceiling and the existing `u2c` diagnostic record.
- Reuse the pre-opened upstream in the relay instead of dialing a second socket.
- Bound pre-upgrade capture by frame size, total bytes, and frame count before copying; fail explicitly on overflow.
- Preserve early close/error state until handoff and retain native-main admission until an upstream close event or observed CLOSED state, including failed/cancelled joins. Register cleanup listeners before forwarding the preamble.

### Known limitation

Bun's client `WebSocket` does not expose the upstream handshake HTTP status (a non-101 response surfaces only as `"Expected 101 status code"`), so a failed handshake reports `502` (`504` on timeout) rather than a fabricated `404`. That is sufficient for the correctness property here — any connect error ends the retry loop — but it does mean the client logs a connect failure rather than "sideband session ended". Propagating the exact upstream status would need a handshake path that can read it.

## Verification

Correction head: `7a1ed215987104fafdd9a922996cbc2385b3bee9`, using Bun 1.4.0.

- `bun test tests/server/server-live.test.ts`: **53 passed, 0 failed**. Regressions cover CLOSING admission retention through failed attachment, failed pre-upgrade handshake and handoff, exact-once release after close, and synchronous close during preamble-send failure. Existing already-CLOSED and ordered-preamble cases remain covered.
- The attachment regressions failed against the previous implementation before the correction.
- `bun run typecheck`: passed.
- `bun run privacy:scan`: passed.
- `bun run test:changed`: **1,980 passed, 1 skipped, 5 failed**, across 99 selected files. Four failures are in `server-stop-config-hardening` hook/ACL timeout cases; one is a `server-auth` health assertion. The failures also reproduce in focused runs; this is not a green affected-suite claim.
- Full suite was not rerun for this scoped correction. This PR remains draft; no full-suite or cross-platform approval is claimed.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. (No doc describes the sideband failure semantics; the endpoint list in `docs-site/.../configuration/server.md` is unchanged.)
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live voice connection reliability by completing the upstream handshake before confirming the client connection.
  - Preserved session-opening messages received during connection setup so they are not lost.
  - Added clearer failure handling for unavailable, rejected, or timed-out upstream connections, including appropriate error responses.
  - Prevented clients from receiving a successful connection when the upstream service rejects the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
