### PR TITLE
docs(devlog): publish the 260911 lane branches and refresh the round ledger

### DIFF
--- a/devlog/_plan/260911_lane_dispatch_round/060_ledger.md
+++ b/devlog/_plan/260911_lane_dispatch_round/060_ledger.md
@@ -1,27 +1,34 @@
 # Round ledger
 
-Captured from live `git` and `gh` at **2026-09-10T15:49:33Z**. Every value below is a command result, not narration.
+Captured from live `git ls-remote` and `gh` at **2026-09-10T16:19:21Z**. Every value is a command
+result, not narration.
 
-## Round PR
+## Round unit
 
-`#4217` `555321ee5e6da84a73f8ad8eef21fb5e2f7989c6 OPEN`, base `dev`. Non-skipped checks at capture: IN_PROGRESS enforce-target, QUEUED ci, SUCCESS select windows runner, IN_PROGRESS react-doctor, SUCCESS changes, SUCCESS label, SUCCESS hygiene, SUCCESS resolve-pr, PENDING CodeRabbit.
-Product legs are SKIPPED by the `changes` filter because the PR is documentation only. Each further
-orchestrator commit advances this head, so the SHA above is the head at capture time and CI is
-re-evaluated per push; the merge gate uses the final head, not this one.
+PR #4217 merged into `dev` at `2026-09-10T16:13:35Z` from head
+`538668bb0b1c8cc9f28737df3dd574af85a733b3`, with `ci`, `enforce-target`, `changes`,
+`select windows runner`, `react-doctor`, `label`, `hygiene`, and `resolve-pr` all SUCCESS and the
+product legs SKIPPED by the `changes` filter on a documentation-only PR. Landing proven by
+`git merge-base --is-ancestor 538668bb0 origin/dev` after fetching; `dev` was `0aa685031` at that
+moment.
 
 ## Lanes
 
-| Lane | Worktree | Branch | Local head | PR | Head SHA | Final-head CI | State |
-|---|---|---|---|---|---|---|---|
-| L1 | `~/.codex/worktrees/260911-l1/opencodex` | `codex/260911-l1-responses-core` | `d2509a156da24e2f6d459103bffb73f5e6d0047f` | not yet opened | — | — | packet at revision 3, unpushed |
-| L2 | `~/.codex/worktrees/260911-l2/opencodex` | `codex/260911-l2-catalog-provider` | `d72d40ae2bc72c749ec3b61f4605351de14b561e` | not yet opened | — | — | packet at revision 3, unpushed |
-| L3 | `~/.codex/worktrees/260911-l3/opencodex` | `codex/260911-l3-account-pool` | `157119ecb0724feab15d9c38119b85cd8e55af93` | not yet opened | — | — | packet at revision 3, unpushed |
-| L4 | `~/.codex/worktrees/260911-l4/opencodex` | `codex/260911-l4-service-cli` | `72c87ba567dcf74ad2732094b3133583a631e149` | not yet opened | — | — | packet at revision 3, unpushed |
-| L5 | `~/.codex/worktrees/260911-l5/opencodex` | `codex/260911-l5-integrations-io` | `08ce233806727f3a76709bcc810581151e98dc2d` | not yet opened | — | — | packet at revision 3, unpushed |
-| L6 | `~/.codex/worktrees/260911-l6/opencodex` | `codex/260911-l6-streaming-tools` | `9942ff6b24ff09ebd55f54196196db62137d54b7` | not yet opened | — | — | packet at revision 3, unpushed |
-| L7 | `~/.codex/worktrees/260911-l7/opencodex` | `codex/260911-l7-docs` | `d5758f235c87d96164c7d5e85cf62c4cc921741e` | not yet opened | — | — | packet at revision 3, unpushed |
+All seven branches are published on `origin`. Each is exactly one commit on `6d3ad12e3` touching only
+its own packet file, verified before the push and re-read from the remote after it.
 
-Base freeze for every lane: `6d3ad12e3`. Lane branches are local until their thread pushes.
+| Lane | Worktree | Branch | Remote head | PR | Final-head CI | State |
+|---|---|---|---|---|---|---|
+| L1 | `~/.codex/worktrees/260911-l1/opencodex` | `codex/260911-l1-responses-core` | `29c342da74f89f9b6f21b501bef99fcf53a1d536` | none open | — | thread not opened yet |
+| L2 | `~/.codex/worktrees/260911-l2/opencodex` | `codex/260911-l2-catalog-provider` | `b28f06ee04603698c2dc2bf134c80d3b7796c480` | none open | — | thread not opened yet |
+| L3 | `~/.codex/worktrees/260911-l3/opencodex` | `codex/260911-l3-account-pool` | `6fd401636a6e1f26f8f8f6067c471db7900722aa` | none open | — | thread not opened yet |
+| L4 | `~/.codex/worktrees/260911-l4/opencodex` | `codex/260911-l4-service-cli` | `f48cede91719257f8ae1565f8907b1a0b09df7dd` | none open | — | thread not opened yet |
+| L5 | `~/.codex/worktrees/260911-l5/opencodex` | `codex/260911-l5-integrations-io` | `a7a92089cbbd7da539a71d74f7d8abda4724ba41` | none open | — | thread not opened yet |
+| L6 | `~/.codex/worktrees/260911-l6/opencodex` | `codex/260911-l6-streaming-tools` | `3760f81fddc5b7af6d742c1216c894838c762ee9` | none open | — | thread not opened yet |
+| L7 | `~/.codex/worktrees/260911-l7/opencodex` | `codex/260911-l7-docs` | `cd5dcd6a253109e60f6f2fb30ac08a1692c43a73` | none open | — | thread not opened yet |
+
+The `PR` column is a `gh pr list --head` snapshot at the capture time above. A lane thread that opens
+its pull request afterwards supersedes this column; refresh it rather than trusting it.
 
 ## Local checks
 
@@ -31,7 +38,10 @@ head is the only product evidence this round cites.
 
 ## Audit history
 
-Round 1 (`030_audit_round1.md`): **fail**, seven findings, all folded in.
-Round 2 (`040_audit_round2.md`): **fail**, six findings, all folded in; it confirmed four round-1
-fixes were real and three were only described as fixed.
+| Round | Verdict | Outcome |
+|---|---|---|
+| 1 (`030`) | fail | Seven findings, all folded in. |
+| 2 (`040`) | fail | Six findings; it separated four real round-1 fixes from three that were only described as fixed. |
+| 3 (`050`) | near-pass | Five findings: four folded, one rebutted with the issue text that disproved it. |
+| wp2 (`080`) | near-pass | Three acceptance-criteria gaps folded before the pushes. |
 

--- a/devlog/_plan/260911_lane_dispatch_round/080_wp2_publish_plan.md
+++ b/devlog/_plan/260911_lane_dispatch_round/080_wp2_publish_plan.md
@@ -1,0 +1,46 @@
+# wp2 — publish the lane branches
+
+wp1 closed with the round unit merged into `dev` (`0aa685031`, PR #4217) and seven lane worktrees
+holding a committed packet. The packets exist only locally, which leaves two real gaps: a lane thread
+cannot open a pull request until its branch exists on `origin`, and a lost worktree would take its
+packet with it.
+
+## What this phase does
+
+1. Push each of the seven lane branches to `origin` with `--no-verify` and
+   `git -c core.hooksPath=/dev/null`. Audit confirmed each branch is exactly one commit on top of
+   `6d3ad12e3` touching only its own packet file, and that no `codex/260911-l*` ref exists on
+   `origin` yet, so no push overwrites anything.
+2. Verify each pushed ref from the remote with `git ls-remote`, not from the local tree.
+3. Record the pushed heads in `060_ledger.md` on the follow-up branch
+   `codex/260911-round-ledger-1`, and open that as a pull request targeting `dev` with the full PR
+   template, since `enforce-target` rejects a thin description.
+
+## Acceptance
+
+- `git ls-remote origin 'refs/heads/codex/260911-l*'` lists all seven refs, and each remote SHA equals
+  the local head of its worktree at `~/.codex/worktrees/260911-l1/opencodex` through
+  `~/.codex/worktrees/260911-l7/opencodex`.
+- Each pushed commit's diff against `6d3ad12e3` contains only its own
+  `devlog/_plan/260911_l<N>_<slug>/000_packet.md`.
+- `060_ledger.md` on `codex/260911-round-ledger-1` carries the live remote head per lane, replacing
+  the stale seed SHAs, plus the `gh pr list --head` snapshot and its capture time. A lane pull request
+  opened after that capture supersedes the snapshot; the ledger says so rather than pretending the
+  value is durable.
+
+## Out of scope
+
+No lane implementation. No pull request for a lane branch: a lane thread opens its own so the
+description and checklist come from the thread that did the work. No merge of a lane branch.
+
+## Why this is safe
+
+Pushing a `codex/260911-l*` ref touches none of the protected branches, and `enforce-target` is a
+pull-request gate rather than a push gate. The only policy surface in this phase is the ledger pull
+request, which targets `dev` and fills the template.
+
+## Local checks
+
+`NOT RUN`, as everywhere in this round. The pushed branches carry documentation only, so hosted CI
+has nothing to run on them until a lane pushes code.
+

--- a/devlog/_plan/260911_lane_dispatch_round/090_wp2_execution.md
+++ b/devlog/_plan/260911_lane_dispatch_round/090_wp2_execution.md
@@ -1,0 +1,34 @@
+# wp2 — execution record
+
+## What ran
+
+Seven pushes, each from its own worktree, each
+`git -c core.hooksPath=/dev/null push --no-verify -u origin <branch>`. The hooks path override is not
+decoration: this repository's hooks can start a GUI install, typecheck, and build, which the
+no-local-suite rule forbids.
+
+| Lane | Branch | Remote head after push |
+|---|---|---|
+| L1 | `codex/260911-l1-responses-core` | `29c342da74f89f9b6f21b501bef99fcf53a1d536` |
+| L2 | `codex/260911-l2-catalog-provider` | `b28f06ee04603698c2dc2bf134c80d3b7796c480` |
+| L3 | `codex/260911-l3-account-pool` | `6fd401636a6e1f26f8f8f6067c471db7900722aa` |
+| L4 | `codex/260911-l4-service-cli` | `f48cede91719257f8ae1565f8907b1a0b09df7dd` |
+| L5 | `codex/260911-l5-integrations-io` | `a7a92089cbbd7da539a71d74f7d8abda4724ba41` |
+| L6 | `codex/260911-l6-streaming-tools` | `3760f81fddc5b7af6d742c1216c894838c762ee9` |
+| L7 | `codex/260911-l7-docs` | `cd5dcd6a253109e60f6f2fb30ac08a1692c43a73` |
+
+Every remote SHA was read back with `git ls-remote origin 'refs/heads/codex/260911-l*'` and matched
+the local head of its worktree.
+
+## Ledger pull request
+
+`codex/260911-round-ledger-1`, cut from `origin/dev` after the round unit landed, carries the refreshed
+ledger and the wp2 plan. Opened as PR #4220 against `dev` with the template filled, because
+`enforce-target` rejects a thin description.
+
+## What did not happen
+
+No lane pull request was opened by this phase. A lane thread opens its own so the description and the
+readiness checklist come from the thread that did the work. No lane branch was merged. No local
+product suite, typecheck, build, or install ran: `NOT RUN`.
+


### PR DESCRIPTION
## Summary

- Publishes the seven lane branches of the 260911 dispatch round to `origin` and records their exact
  remote heads in the round ledger, so a lane thread can open its pull request immediately and a lost
  worktree cannot take its packet with it.
- Each lane branch is exactly one commit on `6d3ad12e3` touching only its own
  `devlog/_plan/260911_l<N>_<slug>/000_packet.md`. That was verified before the pushes and re-read
  from the remote with `git ls-remote` afterwards; no `codex/260911-l*` ref existed before, so nothing
  was overwritten.
- Replaces the ledger's stale seed SHAs with the live remote heads, and marks the `PR` column as a
  `gh pr list --head` snapshot with its capture time rather than a durable value.
- Adds `080_wp2_publish_plan.md`, the plan this phase executed, including the three acceptance-criteria
  gaps an independent review found before the pushes ran.

Documentation only. No `src`, `gui`, `tests`, or `scripts` file changes.

## Verification

- `git ls-remote origin 'refs/heads/codex/260911-l*'` returns all seven refs, each equal to the local
  head of its worktree: `29c342da7`, `b28f06ee0`, `6fd401636`, `f48cede91`, `a7a92089c`, `3760f81fd`,
  `cd5dcd6a2`.
- `gh pr list --head codex/260911-l*` returned no open pull request for any lane at
  `2026-09-10T16:19:21Z`.
- Local product suite, typecheck, build, and install: **NOT RUN** by operator instruction. Hosted CI
  on this head is the proof for this PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the lane dispatch ledger with verified remote heads, commit, CI, merge-base, merge, and timestamp details.
  - Reformatted audit history and recorded an additional near-pass entry.
  - Added planning documentation for publishing seven lane branches and verifying remote references.
  - Added an execution record covering lane pushes, remote verification, and the ledger pull request.
  - Documented actions that were not performed, including lane pull request creation, merging, and local product checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->