### PR TITLE
docs(devlog): fold the seven-lane feasibility audit into lane ownership and scope

### DIFF
--- a/devlog/_plan/260911_lane_dispatch_round/000_plan.md
+++ b/devlog/_plan/260911_lane_dispatch_round/000_plan.md
@@ -34,6 +34,10 @@ Excluded on purpose, with the decision that blocks each one:
 - #4198, #4179 — publishing an official container image changes a documented policy
   ("opencodex does not publish an official container image").
 - #4173 — the atomic update design competes with #4185 and #4203 already in flight.
+- #4204 — removed after the feasibility audit: binding the reasoning-effort clamp to the Desktop
+  runtime needs `codex/runtime.ts`, `catalog/bundled.ts`, and `catalog/sync.ts`, because the catalog
+  probes one selected runtime and no caller passes a consumer identity. Resolving a catalog per
+  consumer is a design decision.
 - Contributor feature PRs (#4183, #4100, #4111, #4193, #4033, #4042) — these need review, not
   reimplementation, and reimplementing them would discard the author's work.
 
@@ -68,4 +72,3 @@ are repeated inside every packet so a lane thread that never reads this file sti
 Merges are serialized through the orchestrator because `dev` is protected and shared. A lane PR
 merges when its exact head is green on final-head CI; the landing is proven by fetching `origin/dev`
 and checking ancestry, never by the merge command's own output.
-

--- a/devlog/_plan/260911_lane_dispatch_round/010_lane_partition.md
+++ b/devlog/_plan/260911_lane_dispatch_round/010_lane_partition.md
@@ -38,13 +38,14 @@ Collision-free PRs, touching no file any other open PR touches: #4062, #4104, #4
 **L2** `codex/260911-l2-catalog-provider` — `src/providers/quota.ts`,
 `src/providers/quota-types.ts`, `src/providers/quota-wire.ts`,
 `src/providers/quota-routing-cache.ts`, `src/providers/quota-key-accounts.ts`,
-`src/providers/account-quota-disk.ts`, `src/providers/registry.ts`. Stack: #4201.
+`src/providers/account-quota-disk.ts`, `src/providers/registry.ts`, and the roster oracle
+`tests/providers/provider-registry-parity.test.ts`. Stack: #4201.
 
 **L3** `codex/260911-l3-account-pool` — `src/codex/account-usability.ts`,
 `src/codex/account-pause.ts`, `src/codex/account-store.ts`, `src/codex/account-runtime-state.ts`,
 `src/codex/plan.ts`, `src/codex/plan-from-token.ts`, `src/codex/warmup.ts`,
 `src/codex/model-entitlements.ts`, `src/server/responses/codex-auth-error.ts`,
-`src/server/management/oauth-account-routes.ts`, the single key `codexPool.excludedPlans` in
+`src/codex/auth-api.ts`, `src/codex/routing.ts`, `src/types/config.ts`, the single key `codexPool.excludedPlans` in
 `src/config.ts`, and `docs-site/src/content/docs/guides/codex-integration.md` and its seven locale copies under
 `docs-site/src/content/docs/{fr,ja,ko,ru,tr,zh-cn,zh-tw}/guides/codex-integration.md`.
 Stack: #4126 → #4212 → #4211.
@@ -53,10 +54,11 @@ Stack: #4126 → #4212 → #4211.
 `bin/ocx.mjs`, `src/cli.ts`, `src/service.ts`, `src/config/pending-teardown.ts`,
 `src/lib/bun-runtime.ts`, `src/lib/package-tree-integrity.ts`, `src/lib/process-control.ts`,
 `src/codex/catalog/effort.ts`, `src/codex/cli-install-provenance.ts`,
-`docs-site/src/content/docs/getting-started/installation.md`. Stack: #4202 → #4169 → #4204 → #4207.
+`docs-site/src/content/docs/getting-started/installation.md`. Stack: #4202 → #4169 → #4207.
 
-**L5** `codex/260911-l5-integrations-io` — directory `src/integrations/`; file
-`src/config/atomic-write.ts`. Stack: #4197 → #4214.
+**L5** `codex/260911-l5-integrations-io` — directory `src/integrations/`; files
+`src/config/atomic-write.ts`, `src/clients/config-export.ts`,
+`src/clients/config-export/contracts.ts`. Stack: #4197 → #4214.
 
 **L6** `codex/260911-l6-streaming-tools` — `src/server/responses/codex-ws-exchange.ts`,
 `src/server/responses/codex-ws-wire.ts`, directory `src/adapters/qoder/`. Stack: #4191 → #4190.
@@ -73,3 +75,10 @@ Stack: #4126 → #4212 → #4211.
 - `src/config.ts`: only L3, and only `codexPool.excludedPlans`.
 - `docs-site/src/content/docs/guides/providers.md`: L7 only. A lane whose carried PR edits it drops
   that hunk and reports the wording to the orchestrator.
+
+## Amendments from the seven-lane feasibility audit
+
+Ownership above already carries them; `130_wp4_feasibility.md` records why each was granted. In short:
+L2 gained the roster oracle it must update, L3 traded `oauth-account-routes.ts` for the Codex account
+surface `auth-api.ts` plus `routing.ts` and `types/config.ts`, L5 gained the export-client contract,
+and #4204 left the round because binding the clamp to the Desktop runtime is a design decision.

--- a/devlog/_plan/260911_lane_dispatch_round/020_lane_packets.md
+++ b/devlog/_plan/260911_lane_dispatch_round/020_lane_packets.md
@@ -95,7 +95,10 @@ Owned: `src/server/responses/core.ts`, `src/server/responses/compact.ts`,
 Worktree `~/.codex/worktrees/260911-l2/opencodex`, branch `codex/260911-l2-catalog-provider`.
 
 Owned: `src/providers/quota.ts`, `quota-types.ts`, `quota-wire.ts`, `quota-routing-cache.ts`,
-`quota-key-accounts.ts`, `account-quota-disk.ts`, `registry.ts` (all under `src/providers/`).
+`quota-key-accounts.ts`, `account-quota-disk.ts`, `registry.ts` (all under `src/providers/`), plus
+`tests/providers/provider-registry-parity.test.ts`, the oracle that locks the roster you are changing:
+it asserts the two-model list at `:464` and that `glm-5.3-flash` is absent at `:508`, so the catalog
+half cannot land without updating it.
 
 1. **#4201 — BigModel Responses Coding Plan: missing quota probe and GLM-5.3-Flash catalog support**
    (reporter `bluesmilery`). **Decision: do not build on #4210.** It is an open draft by `Ingwannu`
@@ -111,9 +114,9 @@ Owned: `src/providers/quota.ts`, `quota-types.ts`, `quota-wire.ts`, `quota-routi
 Worktree `~/.codex/worktrees/260911-l3/opencodex`, branch `codex/260911-l3-account-pool`.
 
 Owned: `src/codex/account-usability.ts`, `account-pause.ts`, `account-store.ts`,
-`account-runtime-state.ts`, `plan.ts`, `plan-from-token.ts`, `warmup.ts`, `model-entitlements.ts`
-(all under `src/codex/`), plus `src/server/responses/codex-auth-error.ts`,
-`src/server/management/oauth-account-routes.ts`, the single key `codexPool.excludedPlans` in
+`account-runtime-state.ts`, `plan.ts`, `plan-from-token.ts`, `warmup.ts`, `model-entitlements.ts`, `auth-api.ts`, `routing.ts`
+(all under `src/codex/`), plus `src/server/responses/codex-auth-error.ts`, `src/types/config.ts`,
+the single key `codexPool.excludedPlans` in
 `src/config.ts`, and `docs-site/src/content/docs/guides/codex-integration.md` and its seven locale copies under
 `docs-site/src/content/docs/{fr,ja,ko,ru,tr,zh-cn,zh-tw}/guides/codex-integration.md`.
 
@@ -124,10 +127,17 @@ Owned: `src/codex/account-usability.ts`, `account-pause.ts`, `account-store.ts`,
 2. **#4212 — an account stuck on a failed credential refresh silently drops its models.** The ask is
    attribution, not new routing. **Decision: this round covers the refusal string
    (`codex-auth-error.ts:35`), the account-health surface, and the management route
-   (`oauth-account-routes.ts`). It does not change the L1 refusal call sites at `core.ts:2243` and
-   `compact.ts:296`;** if review asks for those, open a follow-up issue rather than crossing into L1.
+   on the Codex account surface, which is `poolAccountDto` in `src/codex/auth-api.ts:377` under
+   `/api/codex-auth/accounts`. The feasibility audit found the earlier grant of
+   `oauth-account-routes.ts` was the wrong route: it serves the generic `/api/oauth/accounts` and
+   `src/oauth/index.ts:331` excludes ChatGPT from it. The reporter's 503 is inlined at
+   `responses/core.ts:2336` and `compact.ts:383`, which L1 owns, and the model-list drop is published
+   from `catalog/sync.ts:1777`. Both are out of scope: write `Refs #4212`, not `Closes`,** and record
+   them as follow-ups.
 3. **#4211 — keep Free-tier accounts out of pool selection.** **Decision: ship**
-   **`codexPool.excludedPlans` as an array, absent by default,** so an existing install sees no
+   **`codexPool.excludedPlans` as an array, absent by default, filtered in `getEligiblePoolAccounts`**
+   **at `src/codex/routing.ts:1248` rather than in `isCodexAccountUsable`, which is where pause already
+   lives, and explicit namespace selection at `auth-context.ts:922` keeps working,** so an existing install sees no
    behaviour change. Do not ship `minimumPlan`: ranking plans needs an ordering this repository does
    not have. **Decision: this round ships selection only.** If the dashboard or CLI display the issue
    also asks for needs `src/cli/account.ts`, a GUI component, or a locale key, stop and report; write
@@ -141,6 +151,11 @@ Owned: directories `src/update/`, `src/cli/`, `src/client/`; files `bin/ocx.mjs`
 `src/service.ts`, `src/config/pending-teardown.ts`, `src/lib/bun-runtime.ts`,
 `src/lib/package-tree-integrity.ts`, `src/lib/process-control.ts`, `src/codex/catalog/effort.ts`,
 `src/codex/cli-install-provenance.ts`, `docs-site/src/content/docs/getting-started/installation.md`.
+
+Your stack is #4202 → #4169 → #4207. **#4204 was removed from the round** by the feasibility audit:
+binding the clamp to the Desktop runtime needs `codex/runtime.ts:573`, `catalog/bundled.ts:239`, and
+`catalog/sync.ts:1945`, because the catalog probes one selected runtime and no caller passes a
+consumer identity. Resolving a catalog per consumer is a design decision this round does not make.
 
 1. **#4202 — global pnpm installations cannot self-update.** Carry PR #4203 by `oliver-mee` (open
    **draft**, `CHANGES_REQUESTED`, 36 files). **Decision: the keep-set is exactly** `bin/ocx.mjs`,
@@ -173,14 +188,20 @@ Owned: directories `src/update/`, `src/cli/`, `src/client/`; files `bin/ocx.mjs`
 
 Worktree `~/.codex/worktrees/260911-l5/opencodex`, branch `codex/260911-l5-integrations-io`.
 
-Owned: directory `src/integrations/`; file `src/config/atomic-write.ts`. No open PR touches either.
+Owned: directory `src/integrations/`; files `src/config/atomic-write.ts`,
+`src/clients/config-export.ts`, `src/clients/config-export/contracts.ts`. Note `src/clients/` (plural)
+is unrelated to L4's `src/client/` (singular). Open draft #3833 also edits the export-client surface;
+report the overlap rather than merging the two lines of work.
 
 1. **#4197 — the DSH integration's atomic replace changes file ownership and causes `EACCES` across
    UIDs.** **Decision: refuse the integration write when the target exists and its owner is not the
    process euid, with an explicit API error. Do not relax the `0600` hardening and do not attempt
    `fchown`.** A metadata-preserving replace can be proposed later as its own issue.
-2. **#4214 — add Cline as a supported client integration.** Follow the existing registry pattern in
-   `src/integrations/registry.ts`.
+2. **#4214 — add Cline as a supported client integration.** `IntegrationClientId` is an alias of
+   `ExportClientId` at `clients/config-export/contracts.ts:84`, and the writer needs `EXPORT_CLIENTS`
+   from `clients/config-export.ts:1112`, which is why both are yours. **Decision: ship the CLI and
+   registry path only. The dashboard tab needs a locale key this round forbids, so write `Refs #4214`**
+   and leave the tab as a follow-up.
 
 ## L6 — streaming and vendor tool leakage
 

--- a/devlog/_plan/260911_lane_dispatch_round/120_wp4_plan.md
+++ b/devlog/_plan/260911_lane_dispatch_round/120_wp4_plan.md
@@ -1,0 +1,46 @@
+# wp4 — merges, and the readiness check the lane merges need
+
+wp4 owns serialized merges on final-head green CI with fetched ancestry proof. Three merges have
+already run under exactly that gate, all of them the round's own pull requests:
+
+| PR | Head merged | Landing proof |
+|---|---|---|
+| #4217 | `538668bb0` | `git merge-base --is-ancestor` against fetched `origin/dev` |
+| #4220 | `6a3774c15` | same |
+| #4221 | `9f550ae56` | same |
+
+No lane pull request exists yet, so the lane half of this phase has nothing to merge. That is an
+external dependency: a thread has to be opened against each worktree, which an agent cannot do.
+
+## What this phase does before deferring the lane merges
+
+Every defect the three round audits found had the same shape: a lane was told to fix something whose
+code does not live entirely inside the paths that lane owns. #4212 needed a management route L3 did
+not have. #4207 was client code in the wrong lane. #4190's leak sat in a directory no lane owned.
+Each was found by reading one issue against the tree.
+
+A lane that discovers this itself burns a cycle and stops, and the merge this phase waits for never
+arrives. So before deferring, check all seven at once: one read-only `xai/grok-4.6` subagent per lane,
+fresh context, asked a single question — can this lane's stack be implemented entirely inside its
+owned paths, and if not, which exact path is missing? The questions are independent, so the seven run
+concurrently. Their verdicts are this phase's audit.
+
+## Acceptance
+
+- The three completed merges are recorded with their exact heads and landing proofs.
+- Seven verdicts, one per lane, each naming either that the stack fits the owned paths or the exact
+  unowned `path:line` it needs.
+- Every finding is folded into that lane's packet, or recorded with a rebuttal the way the #4184
+  finding was rebutted with the issue text that disproved it.
+- Amended packets are pushed and their remote heads read back with `git ls-remote`.
+- The lane merges are recorded as deferred with the reason, not as done.
+
+## Out of scope
+
+No implementation. No lane pull request. No merge of a lane branch, because none exists. A subagent
+that proposes a fix has exceeded its packet; only the path gap is used.
+
+## Local checks
+
+`NOT RUN`. Every subagent is read-only.
+

--- a/devlog/_plan/260911_lane_dispatch_round/130_wp4_feasibility.md
+++ b/devlog/_plan/260911_lane_dispatch_round/130_wp4_feasibility.md
@@ -1,0 +1,60 @@
+# wp4 — seven-lane feasibility audit
+
+Seven read-only `xai/grok-4.6` subagents, one per lane, dispatched in one round with fresh context.
+Each was asked a single question: can this lane's stack be implemented entirely inside its owned
+paths, and if not, which exact path is missing? Four came back `fits`, three came back `gaps`.
+
+Three of seven lanes would have started, hit an unowned file, and stopped. That is the cost this
+phase removed.
+
+## Verdicts
+
+| Lane | Verdict | Substance |
+|---|---|---|
+| L1 | fits | #4172 lands at `opencode-go-transport.ts:32` with every fanout call site owned; #4176 at `responses-undeclared-tool-guard.ts:324` and `types/tools.ts:69`. |
+| L2 | gaps | The quota half fits `quota.ts:2909`, but seeding `glm-5.3-flash` at `registry.ts:2651` fails `tests/providers/provider-registry-parity.test.ts:464` and `:508`, which lock the roster and assert Flash is absent. |
+| L3 | gaps | #4126 fits `warmup.ts:31` and `:290`. #4212 was pointed at the wrong surface. #4211 was pointed at the wrong function. |
+| L4 | gaps | #4202, #4169, and #4207 fit. #4204 cannot bind the clamp to the Desktop runtime from `effort.ts` alone. |
+| L5 | gaps | #4197 fits `integrations/config-io.ts:259`. #4214 needs the export-client contract, which L5 does not own. |
+| L6 | fits | #4191 at `codex-ws-exchange.ts:214`; #4190 by wrapping the `emit` callback inside `adapters/qoder/adapter.ts:58-67`. |
+| L7 | fits | #4215 at `guides/providers.md:70`; #4200 at `guides/remote-hub.md:77`. |
+
+## Dispositions
+
+**L2 — #4201.** Grant `tests/providers/provider-registry-parity.test.ts`. A lane that changes a
+registry roster owns the oracle that asserts the roster; otherwise the change cannot land at all.
+
+**L3 — #4212.** The packet granted `oauth-account-routes.ts`, which is the wrong route: it serves the
+generic `/api/oauth/accounts`, and `oauth/index.ts:331` excludes ChatGPT from it. Codex pool accounts
+are served by `poolAccountDto` in `src/codex/auth-api.ts:377` under `/api/codex-auth/accounts`, so
+that file is granted instead. The reporter's 503 is inlined at `responses/core.ts:2336` and
+`compact.ts:383`, which L1 owns, and the model-list drop is published from `catalog/sync.ts:1777`.
+**Decision: #4212 is narrowed to per-account refresh-failure attribution on the Codex account
+surface.** The 503 wording and the catalog-drop attribution are recorded as follow-ups, and the pull
+request says `Refs #4212` rather than `Closes`.
+
+**L3 — #4211.** Auto-selection filters in `getEligiblePoolAccounts` at `codex/routing.ts:1248`, not in
+`isCodexAccountUsable`, which is why pause does not appear in the latter either. Grant
+`src/codex/routing.ts` and `src/types/config.ts`, since the field needs a type next to
+`pausedCodexAccountIds` and the schema alone does not provide one. **Decision: the filter applies to
+automatic selection only; explicit namespace selection at `auth-context.ts:922` keeps working,** which
+is what the issue asks for.
+
+**L4 — #4204. Removed from the round.** Binding the clamp to the Desktop runtime requires
+`codex/runtime.ts:573`, `catalog/bundled.ts:239`, and `catalog/sync.ts:1945`: the catalog probes one
+selected runtime and no caller passes a consumer identity. Deciding that a catalog should be resolved
+per consumer is a design decision, which is exactly what this round's decision-free filter excludes.
+L4's stack becomes #4202 → #4169 → #4207.
+
+**L5 — #4214.** `IntegrationClientId` is an alias of `ExportClientId` from
+`clients/config-export/contracts.ts:84`, and the writer needs `EXPORT_CLIENTS` from
+`clients/config-export.ts:1112`. Grant both. The dashboard tab additionally needs a locale key, which
+this round forbids. **Decision: ship the CLI and registry path; the dashboard tab is a follow-up, and
+the pull request says `Refs #4214`.** Note that open draft #3833 also edits the export-client surface;
+L5 reports the overlap rather than merging the two lines of work.
+
+## What this does not change
+
+No lane gained a path another lane owns. `src/clients/` (plural) is unrelated to L4's `src/client/`
+(singular). The four `fits` lanes are untouched.
+


### PR DESCRIPTION
## Summary

- Records a seven-lane feasibility audit run before any lane thread starts: one read-only
  `xai/grok-4.6` subagent per lane, each asked whether its stack can be implemented entirely inside
  that lane's owned paths. Four lanes came back `fits`; three came back with gaps that would have
  stopped the thread on its first cycle.
- L2 gains `tests/providers/provider-registry-parity.test.ts`. Seeding `glm-5.3-flash` in the registry
  fails that oracle at `:464` and `:508`, which lock the two-model roster and assert Flash is absent,
  so the lane could not land its own change without owning the assertion.
- L3 trades `oauth-account-routes.ts` for `src/codex/auth-api.ts`. The earlier grant was the wrong
  route: it serves the generic `/api/oauth/accounts` and `src/oauth/index.ts:331` excludes ChatGPT
  from it, while Codex pool accounts are served by `poolAccountDto` under `/api/codex-auth/accounts`.
  #4212 is narrowed to per-account refresh-failure attribution there and marked `Refs`, because the
  reporter's 503 is inlined in files L1 owns and the model-list drop is published from `catalog/sync.ts`.
- L3 also gains `src/codex/routing.ts` and `src/types/config.ts`: the plan filter belongs in
  `getEligiblePoolAccounts`, where pause already lives, not in `isCodexAccountUsable`, and the new
  key needs a type beside `pausedCodexAccountIds`.
- L5 gains `src/clients/config-export.ts` and `src/clients/config-export/contracts.ts`, since
  `IntegrationClientId` is an alias of `ExportClientId` and the writer needs `EXPORT_CLIENTS`. The
  Cline dashboard tab needs a locale key this round freezes, so that half is a follow-up.
- #4204 leaves the round. Binding the reasoning-effort clamp to the Desktop runtime needs
  `codex/runtime.ts`, `catalog/bundled.ts`, and `catalog/sync.ts`, because the catalog probes one
  selected runtime and no caller passes a consumer identity. Resolving a catalog per consumer is a
  design decision, which this round's decision-free filter excludes.

Documentation only. No `src`, `gui`, `tests`, or `scripts` file changes.

## Verification

- Seven subagent verdicts collected, each anchored to `path:line` in the current tree; recorded in
  `130_wp4_feasibility.md`.
- Amended packets pushed to all seven lane branches and re-read from the remote with `git ls-remote`:
  `32a4dc0de`, `6a8454323`, `ff94d623c`, `a82987366`, `2574e5caf`, `22def0aa8`, `70ca3cd15`.
- Local product suite, typecheck, build, and install: **NOT RUN** by operator instruction. Hosted CI
  on this head is the proof for this PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated lane planning documents with revised ownership assignments and work-item decisions.
  * Documented feasibility-audit results, including scope adjustments and deferred items requiring further design decisions.
  * Added serialized merge-readiness guidance, acceptance criteria, audit requirements, and records of completed or deferred merges.
  * Clarified that merge operations are coordinated sequentially through the orchestrator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->