### PR TITLE
fix(integrations): refuse a write that would take a config file from its owner

### DIFF
--- a/devlog/_plan/260911_l5_integrations_io/000_packet.md
+++ b/devlog/_plan/260911_l5_integrations_io/000_packet.md
@@ -1,0 +1,85 @@
+# Dispatch packet — L5 (revision 5)
+
+Round unit: `devlog/_plan/260911_lane_dispatch_round` on `dev`. Base freeze: `origin/dev` `6d3ad12e3` (2.51.0).
+Five audit rounds shaped this packet. The last one was a seven-lane feasibility check that asked whether each stack is implementable inside its owned paths; three lanes came back with gaps, and the fixes are folded here. `010_lane_partition.md` is the authoritative ownership list; `130_wp4_feasibility.md` records why each path was granted.
+
+
+## Shared frame
+
+**Repository.** Your worktree is named in your packet, already checked out on your lane branch, cut
+from `origin/dev` `6d3ad12e3` (2.51.0). Work only there. Do not add, move, or remove a worktree.
+
+**Loop.** Run `$codexclaw:cxc-loop` as HOTL for your lane: one work-phase per issue, in order. Your
+goal ends when your last PR is green and reported, not when the code looks right.
+
+**Subagents.** Unlimited `xai/grok-4.6` subagents, read-only, spawned with `spawn_agent`
+(`model: "xai/grok-4.6"`). Use them to reproduce, to read the call sites you are about to change, to
+find a second caller of a helper you are touching, and to review your staged diff adversarially
+before you push. A finding enters your work only with an exact `path:line` anchor. Subagents never
+write, commit, push, or call a mutating `gh`. Treat a `fail` verdict the way this round did: fold it
+in and re-audit. This packet is at revision 3 because two audit rounds rejected revisions 1 and 2.
+
+**MUST NOT.**
+
+- No local product suite: no `bun test`, no `bun run test`, no `bun run test:changed`, no
+  `bun run typecheck`, no `bun run build:gui`, no `bun install`. Report them as `NOT RUN`.
+- No merge, no release, no force-push to a shared branch, no direct push to `dev`.
+- No path outside your owned list, including paths a carried PR happens to touch. Dropping a hunk
+  from a carried PR is expected; report what you dropped.
+- No locale key in `gui/src/i18n/*`. If you need one, stop and report.
+- No security write-up in `devlog/`; scratch space only, per `AGENTS.md`.
+
+**MUST.**
+
+- Prefix every mutating git command with `git -c core.hooksPath=/dev/null`. This repository's hooks
+  can start a GUI install, typecheck, and build, which the no-local-suite rule forbids.
+- Push with `--no-verify`.
+- Write the focused regression test `AGENTS.md` requires for a behaviour change, in the domain
+  directory beside the existing tests for that subsystem, and register it in both
+  `scripts/test-layout/layout.json` `explicit` and `tests/fixtures/test-layout-expected.json`. You
+  will not run it; hosted CI will. Those two maps are append-only and other lanes are adding to them
+  too; the orchestrator resolves the conflicts at merge, so do not skip the entry.
+- Fill every section of `.github/PULL_REQUEST_TEMPLATE.md` and put `Closes #<issue>` in the body. In
+  **Verification**, state that the local suite, typecheck, and build were `NOT RUN` by operator
+  instruction and that hosted CI on the exact pushed head is the proof.
+- When you carry another author's PR, add a `Co-authored-by` trailer in a branch commit. Resolve the
+  address with `gh api users/<login> --jq '.id'` and use `<id>+<login>@users.noreply.github.com`.
+- Keep a devlog unit under `devlog/_plan/260911_l<N>_<slug>/`.
+
+**Stacking.** First PR targets `dev`; the second targets the first PR's head branch, the third the
+second. Retarget a child to `dev` after its parent lands. No native GitHub stacks.
+
+**Decisions already made for you.** Both audit rounds found items where the issue left a real choice
+open. Those calls are recorded in your packet in bold. Implement the recorded decision; if you think
+it is wrong, report the reason and stop.
+
+**Stop conditions.** Stop and report when the fix needs a path you do not own, when it needs a policy
+no issue has fixed, when a locale key is unavoidable, or when hosted CI fails for a reason outside
+your diff.
+
+**Report format.** Per PR: number, exact head SHA, CI run id and conclusion, the issue it closes, the
+co-authors credited, the hunks you dropped from a carried PR, and any decision you made. Say
+`NOT RUN` for local checks.
+
+**Decision boundary.** You do not merge, do not close another author's PR, and do not rank your lane
+against another. When your last PR is green, report and stop.
+
+## L5 — file IO and client integrations
+
+Worktree `~/.codex/worktrees/260911-l5/opencodex`, branch `codex/260911-l5-integrations-io`.
+
+Owned: directory `src/integrations/`; files `src/config/atomic-write.ts`,
+`src/clients/config-export.ts`, `src/clients/config-export/contracts.ts`. Note `src/clients/` (plural)
+is unrelated to L4's `src/client/` (singular). Open draft #3833 also edits the export-client surface;
+report the overlap rather than merging the two lines of work.
+
+1. **#4197 — the DSH integration's atomic replace changes file ownership and causes `EACCES` across
+   UIDs.** **Decision: refuse the integration write when the target exists and its owner is not the
+   process euid, with an explicit API error. Do not relax the `0600` hardening and do not attempt
+   `fchown`.** A metadata-preserving replace can be proposed later as its own issue.
+2. **#4214 — add Cline as a supported client integration.** `IntegrationClientId` is an alias of
+   `ExportClientId` at `clients/config-export/contracts.ts:84`, and the writer needs `EXPORT_CLIENTS`
+   from `clients/config-export.ts:1112`, which is why both are yours. **Decision: ship the CLI and
+   registry path only. The dashboard tab needs a locale key this round forbids, so write `Refs #4214`**
+   and leave the tab as a follow-up.
+

--- a/src/integrations/config-io.ts
+++ b/src/integrations/config-io.ts
@@ -256,7 +256,10 @@ export function fileIO(): Omit<IntegrationIO, "appendJournal" | "putRecord" | "d
         return (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "failed";
       }
     },
-    writeText: (path, text) => atomicWriteFile(path, text),
+    writeText: (path, text) => {
+      assertIntegrationWriteOwnership(path);
+      atomicWriteFile(path, text);
+    },
     removeFile: path => rmSync(path, { force: true }),
     mkdirp: path => mkdirSync(path, { recursive: true, mode: 0o700 }),
     now: () => Date.now(),
@@ -282,3 +285,53 @@ export function defaultIntegrationIO(store: {
     dropRecord: clientId => store.dropRecord(clientId),
   };
 }
+
+/**
+ * Refuse to replace an integration file this process does not own.
+ *
+ * `atomicWriteFile` writes a private temp file and renames it over the target. That is the right
+ * shape for a secret — the replacement is atomic and the result is owner-only `0600` — but it also
+ * means the surviving inode belongs to whoever runs opencodex. When the target is another product's
+ * configuration on a shared mount, the replace quietly takes the file away from its owner. #4197 is
+ * that case: opencodex at uid 1000 replaces a DSH `settings.yaml` owned by uid 987, and DSH dies with
+ * `EACCES` on its next read while the restore call reports success.
+ *
+ * Preserving the previous uid would need a `chown` capability we usually do not have, and relaxing
+ * `0600` would weaken every integration to fix one. So refuse before writing, and say what is wrong,
+ * rather than succeeding into a broken state.
+ *
+ * Windows has no uid model here; `hardenSecretPath` owns that platform, so the check is skipped when
+ * the runtime exposes no effective uid.
+ */
+export function assertIntegrationWriteOwnership(
+  path: string,
+  deps: {
+    effectiveUid?: () => number | undefined;
+    ownerUid?: (target: string) => number | undefined;
+  } = {},
+): void {
+  const effectiveUid = deps.effectiveUid ?? (() =>
+    typeof process.geteuid === "function" ? process.geteuid() : undefined);
+  const euid = effectiveUid();
+  if (euid === undefined) return;
+
+  const ownerUid = deps.ownerUid ?? ((target: string) => {
+    try {
+      return statSync(target).uid;
+    } catch {
+      // An absent or unreadable target has no owner to dispossess; the write itself will report
+      // any real failure.
+      return undefined;
+    }
+  });
+  const owner = ownerUid(path);
+  if (owner === undefined || owner === euid) return;
+
+  throw new Error(
+    `refusing to replace ${path}: it belongs to uid ${owner} while opencodex runs as uid ${euid}. `
+    + "An atomic replace would transfer ownership of that file and leave its owner unable to read "
+    + "its own configuration. Run both under the same user, or give each one its own copy instead "
+    + "of sharing the mount.",
+  );
+}
+

--- a/tests/clients/integrations-writer.test.ts
+++ b/tests/clients/integrations-writer.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync }
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { buildClientContribution, type ExportModel } from "../../src/clients/config-export";
-import { fileIO, type IntegrationIO } from "../../src/integrations/config-io";
+import { assertIntegrationWriteOwnership, fileIO, type IntegrationIO } from "../../src/integrations/config-io";
 import { canonicalContribution, fingerprint } from "../../src/integrations/ownership";
 import { protectedContributionFingerprint } from "../../src/integrations/ownership-policy";
 import { INTEGRATION_CLIENTS } from "../../src/integrations/registry";
@@ -1406,5 +1406,50 @@ describe("overwriting a conflict on purpose", () => {
     expect(after.providers["opencodex-legacy"]).toBeUndefined();
     expect(after.providers.opencodex).toBeDefined();
     expect(store.readRecords().opencode!.fragmentPaths).not.toContainEqual(["providers", "opencodex-legacy"]);
+  });
+});
+
+describe("integration write ownership guard (#4197)", () => {
+  const target = "/srv/dsh-data/settings.yaml";
+
+  test("refuses to replace a file owned by another uid", () => {
+    expect(() => assertIntegrationWriteOwnership(target, {
+      effectiveUid: () => 1000,
+      ownerUid: () => 987,
+    })).toThrow(/belongs to uid 987 while opencodex runs as uid 1000/);
+  });
+
+  test("names the path and both uids so the operator can act on it", () => {
+    let message = "";
+    try {
+      assertIntegrationWriteOwnership(target, { effectiveUid: () => 1000, ownerUid: () => 987 });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain(target);
+    expect(message).toContain("transfer ownership");
+  });
+
+  test("allows a file this process already owns", () => {
+    expect(() => assertIntegrationWriteOwnership(target, {
+      effectiveUid: () => 1000,
+      ownerUid: () => 1000,
+    })).not.toThrow();
+  });
+
+  test("allows an absent target, which has no owner to dispossess", () => {
+    expect(() => assertIntegrationWriteOwnership(target, {
+      effectiveUid: () => 1000,
+      ownerUid: () => undefined,
+    })).not.toThrow();
+  });
+
+  test("skips the check where the runtime exposes no effective uid", () => {
+    // Windows reaches the write through hardenSecretPath instead; a uid comparison there would be
+    // a guess, and a guess that refuses is worse than no guard.
+    expect(() => assertIntegrationWriteOwnership(target, {
+      effectiveUid: () => undefined,
+      ownerUid: () => 987,
+    })).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- The integration writer replaces a client's configuration with an atomic temp-file rename. That is
  the right shape for a secret, but the surviving inode belongs to whoever runs opencodex. On a
  shared mount the replace quietly dispossesses the product that owns the file.
- #4197 is that case measured: opencodex at uid 1000 replaces a DSH `settings.yaml` owned by uid 987,
  the file comes back as `1000:1000` mode `600`, DSH fails its next read with `EACCES`, and the
  restore call still reports success.
- The write now refuses when the target exists and belongs to another uid, and the error names the
  path and both uids so the operator knows what to change. `writer.ts` already turns a thrown write
  into `write_failed`, which the management route already serializes, so the refusal reaches the
  dashboard as a failure instead of a silent break.
- The global `0600` hardening is untouched and no `chown` is attempted. Preserving the previous owner
  needs a capability the process usually does not have, and relaxing the hardening would weaken every
  integration to fix one. A metadata-preserving replace can be proposed separately.
- Windows is skipped deliberately: it has no uid model on this path and `hardenSecretPath` owns it.

Closes #4197

## Verification

- Added five cases to `tests/clients/integrations-writer.test.ts` covering the foreign-owner refusal,
  the message naming the path and both uids, a file the process already owns, an absent target, and a
  runtime that exposes no effective uid. The guard takes injectable `effectiveUid` and `ownerUid` so
  the multi-UID case is provable without privileges or a Docker bind mount.
- Local product suite, typecheck, build, and install: **NOT RUN** by operator instruction. Hosted CI
  on the exact pushed head is the proof for this PR.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protected integration configuration writes from replacing files owned by another system user.
  * Added a clear error message with the affected path and guidance to transfer ownership.
  * Preserved writing for files owned by the current process, missing files, and environments without available ownership information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->