### PR TITLE
feat(cursor): surface first overflow before capped conversation remint

### DIFF
--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -3,7 +3,7 @@ import type { AdapterEvent, OcxProviderConfig } from "../types";
 import type { ProviderAdapter } from "./base";
 import { isTranslatorBudgetExceededError } from "../lib/translator-budget";
 import { cursorExecDeniedMessage, cursorRequestDeclaresFullAccess } from "./cursor/exec-policy";
-import { isCursorBenignCancelError, isCursorInvalidArgumentError, isCursorRootEnvelopeError, safeCursorErrorMessage, type CursorSizeContext } from "./cursor/cursor-errors";
+import { isCursorBenignCancelError, isCursorInvalidArgumentError, isCursorOverflowRemintCandidate, isCursorRootEnvelopeError, safeCursorErrorMessage, type CursorSizeContext } from "./cursor/cursor-errors";
 import { cursorCheckpointModelAffinityId, inferCursorContextWindow, isCursorExternalWireModel } from "./cursor/discovery";
 import { createCursorKvStore, type CursorKvStore } from "./cursor/kv-store";
 import { mapCursorServerMessage } from "./cursor/message-mapper";
@@ -29,7 +29,14 @@ import {
 import { debugProviderDiagnostic } from "../lib/debug";
 import { createAdapterTierMetadata } from "../providers/fastwire";
 import { estimateTokens } from "../lib/token-estimate";
-import { rememberCursorThreadConversation } from "./cursor/thread-continuity";
+import {
+  cursorOverflowRemintScopeKey,
+  markCursorOverflowSurfaced,
+  recordCursorOverflowRemint,
+  rememberCursorThreadConversation,
+  shouldSkipCursorOverflowRemint,
+  shouldSurfaceCursorOverflowFirst,
+} from "./cursor/thread-continuity";
 import { runCursorTurnWithRetry } from "./cursor/transport-retry";
 import { cursorRequestHasShellAlias, cursorRequestUsesCodeMode } from "./cursor/tool-definitions";
 import {
@@ -393,9 +400,35 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
           );
         };
 
-        try {
-          await runOnce(request);
-        } catch (err) {
+        const overflowRemintBaseId = _parsed._clientThreadId
+          ? undefined
+          : (previousConversationId ?? _parsed._cursorConversationId);
+
+        const remintConversationId = (failedConversationId: string) => {
+          lastTransport = undefined;
+          _parsed._cursorConversationId = undefined;
+          const next = createCursorRequest(_parsed, { forceFreshConversation: true });
+          rekeyContextUsage(failedConversationId, next.conversationId);
+          _parsed._cursorConversationId = next.conversationId;
+          // Persist recovery for store:false clients that send any stable Cursor thread owner, so
+          // the next turn does not recompute the stale deterministic thread hash. Isolated helper /
+          // compaction turns must not park their throwaway id under the parent or Desktop owner.
+          const threadOwner = cursorClientThreadOwner(_parsed);
+          if (threadOwner && _parsed._cursorIsolateConversation !== true) {
+            rememberCursorThreadConversation(
+              threadOwner,
+              next.conversationId,
+              _parsed._cursorIdentityScope,
+            );
+          }
+          return next;
+        };
+
+        for (;;) {
+          try {
+            await runOnce(request);
+            break;
+          } catch (err) {
           const outputGuardRetryText =
             err instanceof CursorToolResultEchoError
               ? CURSOR_ECHO_RETRY_CONTINUATION_TEXT
@@ -422,24 +455,39 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
               },
             );
             const echoedConversationId = request.conversationId;
-            lastTransport = undefined;
-            _parsed._cursorConversationId = undefined;
             request = {
-              ...createCursorRequest(_parsed, { forceFreshConversation: true }),
+              ...remintConversationId(echoedConversationId),
               echoRetryContinuationText: outputGuardRetryText,
             };
-            rekeyContextUsage(echoedConversationId, request.conversationId);
-            _parsed._cursorConversationId = request.conversationId;
-            const echoThreadOwner = cursorClientThreadOwner(_parsed);
-            if (echoThreadOwner && _parsed._cursorIsolateConversation !== true) {
-              rememberCursorThreadConversation(
-                echoThreadOwner,
-                request.conversationId,
-                _parsed._cursorIdentityScope,
-              );
-            }
             await runOnce(request);
+            break;
           } else {
+            const overflowRemintSafe =
+              !lastRawIsToolResult
+              && !emittedOutput
+              && !replayUnsafe
+              && request.contextUsageStoreCheckpoints !== false
+              && !incoming.abortSignal?.aborted;
+            const overflowScopeKey = cursorOverflowRemintScopeKey(
+              _parsed,
+              overflowRemintBaseId ?? request.conversationId,
+            );
+            if (
+              overflowScopeKey
+              && overflowRemintSafe
+              && isCursorOverflowRemintCandidate(err, requestSizeContext)
+            ) {
+              if (shouldSkipCursorOverflowRemint(overflowScopeKey)) throw err;
+              if (shouldSurfaceCursorOverflowFirst(overflowScopeKey)) {
+                markCursorOverflowSurfaced(overflowScopeKey);
+                throw err;
+              }
+              if (!recordCursorOverflowRemint(overflowScopeKey)) throw err;
+              if (inheritedCheckpointRef) invalidateCursorCheckpoint(inheritedCheckpointRef);
+              request = remintConversationId(request.conversationId);
+              continue;
+            }
+
             // One-shot fallback for external-model Connect invalid_argument before any
             // non-heartbeat output. Retries apply only to safe plain-user turns; tool-result
             // resumes, local exec/MCP side effects, and already-emitted output fail closed.
@@ -453,24 +501,10 @@ export function createCursorAdapter(provider: OcxProviderConfig, deps: CursorAda
             ) {
               throw err;
             }
-            const failedConversationId = request.conversationId;
-            lastTransport = undefined;
-            _parsed._cursorConversationId = undefined;
-            request = createCursorRequest(_parsed, { forceFreshConversation: true });
-            rekeyContextUsage(failedConversationId, request.conversationId);
-            _parsed._cursorConversationId = request.conversationId;
-            // Persist recovery for store:false clients that send any stable Cursor thread owner, so
-            // the next turn does not recompute the stale deterministic thread hash. Isolated helper /
-            // compaction turns must not park their throwaway id under the parent or Desktop owner.
-            const threadOwner = cursorClientThreadOwner(_parsed);
-            if (threadOwner && _parsed._cursorIsolateConversation !== true) {
-              rememberCursorThreadConversation(
-                threadOwner,
-                request.conversationId,
-                _parsed._cursorIdentityScope,
-              );
-            }
+            request = remintConversationId(request.conversationId);
             await runOnce(request);
+            break;
+          }
           }
         }
         if (

--- a/src/adapters/cursor/cursor-errors.ts
+++ b/src/adapters/cursor/cursor-errors.ts
@@ -191,6 +191,18 @@ function bareReLooksLikeOverflow(context?: CursorSizeContext): boolean {
   return estimatedInputTokens >= OVERFLOW_MIN_FRACTION * contextWindow;
 }
 
+/**
+ * True when a transport error is the bare 0-token resource_exhausted overflow shape
+ * (not quota/rate) that should surface for Codex compact or remint on later hits.
+ */
+export function isCursorOverflowRemintCandidate(err: unknown, sizeContext?: CursorSizeContext): boolean {
+  const message = errorMessage(err);
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  if (!isCursorZeroTokenResourceExhausted(lower)) return false;
+  return classifyCursorError(message, sizeContext) === "Cursor context limit exceeded";
+}
+
 export function isCursorZeroTokenResourceExhausted(lowerMessage: string): boolean {
   if (!lowerMessage.includes("resource_exhausted") && !lowerMessage.includes("resource exhausted")) return false;
   // Any explicit quota/rate cue wins: this is a real 429.

--- a/src/adapters/cursor/thread-continuity.ts
+++ b/src/adapters/cursor/thread-continuity.ts
@@ -65,3 +65,102 @@ export function lookupCursorThreadConversation(
 export function clearCursorThreadContinuityForTests(): void {
   overrides.clear();
 }
+
+/** Max conversation-id remints after the first surfaced overflow (senpi cap). */
+export const CURSOR_OVERFLOW_REMINT_MAX = 3;
+export const CURSOR_OVERFLOW_REMINT_TTL_MS = 60 * 60 * 1000;
+export const CURSOR_OVERFLOW_REMINT_MAX_ENTRIES = 2_048;
+
+type OverflowRemintState = {
+  surfaced: boolean;
+  remintCount: number;
+  skip: boolean;
+  updatedAt: number;
+};
+
+const overflowRemintByScope = new Map<string, OverflowRemintState>();
+
+function pruneOverflowRemints(at: number): void {
+  for (const [scopeKey, entry] of overflowRemintByScope) {
+    if (at - entry.updatedAt > CURSOR_OVERFLOW_REMINT_TTL_MS) overflowRemintByScope.delete(scopeKey);
+  }
+  while (overflowRemintByScope.size > CURSOR_OVERFLOW_REMINT_MAX_ENTRIES) {
+    const oldest = overflowRemintByScope.keys().next().value;
+    if (oldest === undefined) break;
+    overflowRemintByScope.delete(oldest);
+  }
+}
+
+function overflowRemintEntry(scopeKey: string): OverflowRemintState {
+  const at = now();
+  pruneOverflowRemints(at);
+  const existing = overflowRemintByScope.get(scopeKey);
+  if (existing) {
+    existing.updatedAt = at;
+    overflowRemintByScope.delete(scopeKey);
+    overflowRemintByScope.set(scopeKey, existing);
+    return existing;
+  }
+  const fresh: OverflowRemintState = { surfaced: false, remintCount: 0, skip: false, updatedAt: at };
+  overflowRemintByScope.set(scopeKey, fresh);
+  pruneOverflowRemints(at);
+  return fresh;
+}
+
+/**
+ * Stable scope for overflow remint accounting. Thread-identified clients key by
+ * thread + identity; conversation-only clients key by the base conversation id
+ * captured before any remint (wire id may rotate).
+ */
+export function cursorOverflowRemintScopeKey(
+  parsed: {
+    _clientThreadId?: string;
+    _cursorIdentityScope?: string;
+  },
+  baseConversationId?: string,
+): string | null {
+  if (parsed._clientThreadId) {
+    return `overflow\0${cursorThreadScopeKey(parsed._clientThreadId, parsed._cursorIdentityScope)}`;
+  }
+  const base = baseConversationId?.trim();
+  if (!base) return null;
+  const scope = parsed._cursorIdentityScope?.trim() || "local";
+  return `overflow\0${scope}\0conv\0${base}`;
+}
+
+/** True until the first overflow for this scope has been surfaced for Codex compact. */
+export function shouldSurfaceCursorOverflowFirst(scopeKey: string): boolean {
+  pruneOverflowRemints(now());
+  return overflowRemintByScope.get(scopeKey)?.surfaced !== true;
+}
+
+export function markCursorOverflowSurfaced(scopeKey: string): void {
+  const entry = overflowRemintEntry(scopeKey);
+  entry.surfaced = true;
+}
+
+export function shouldSkipCursorOverflowRemint(scopeKey: string): boolean {
+  pruneOverflowRemints(now());
+  const entry = overflowRemintByScope.get(scopeKey);
+  return entry?.skip === true || (entry?.remintCount ?? 0) >= CURSOR_OVERFLOW_REMINT_MAX;
+}
+
+/** Record one overflow remint; returns false when the cap is exhausted. */
+export function recordCursorOverflowRemint(scopeKey: string): boolean {
+  const entry = overflowRemintEntry(scopeKey);
+  if (entry.skip || entry.remintCount >= CURSOR_OVERFLOW_REMINT_MAX) {
+    entry.skip = true;
+    return false;
+  }
+  entry.remintCount += 1;
+  return true;
+}
+
+export function clearCursorOverflowRemintForTests(): void {
+  overflowRemintByScope.clear();
+}
+
+export function cursorOverflowRemintCountForTests(): number {
+  pruneOverflowRemints(now());
+  return overflowRemintByScope.size;
+}

--- a/tests/providers/cursor/cursor-adapter.test.ts
+++ b/tests/providers/cursor/cursor-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   cursorExecDeniedMessage,
 } from "../../../src/adapters/cursor";
 import {
+  clearCursorOverflowRemintForTests,
   clearCursorThreadContinuityForTests,
   lookupCursorThreadConversation,
 } from "../../../src/adapters/cursor/thread-continuity";
@@ -815,5 +816,267 @@ describe("Cursor adapter live transport", () => {
     const done = events.find(event => event.type === "done");
     expect(done && done.type === "done" ? done.providerState?.cursor?.checkpointRef : undefined).toBeUndefined();
     clearCursorCheckpointsForTests();
+  });
+});
+const LARGE_OVERFLOW_CONTENT = "word ".repeat(100_000);
+
+function bareOverflowError(): Error {
+  return Object.assign(
+    new Error("Cursor context limit exceeded: Cursor Connect error resource_exhausted: Error"),
+    { code: "resource_exhausted" },
+  );
+}
+
+function overflowTurnBody(threadId?: string): OcxParsedRequest {
+  return {
+    modelId: "cursor/auto",
+    context: { messages: [{ role: "user", content: LARGE_OVERFLOW_CONTENT, timestamp: 1 }] },
+    stream: false,
+    options: {},
+    _cursorIdentityScope: "acct-overflow-remint",
+    ...(threadId ? { _clientThreadId: threadId } : { _cursorConversationId: "cursor_overflow_base" }),
+  };
+}
+
+describe("Cursor overflow conversation remint", () => {
+  test("first bare overflow surfaces without reminting the conversation id", async () => {
+    clearCursorOverflowRemintForTests();
+    let attempts = 0;
+    const seen: string[] = [];
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run(request) {
+          attempts += 1;
+          seen.push(request.conversationId);
+          throw bareOverflowError();
+        },
+        writeClient() {},
+      }),
+    });
+
+    const body = overflowTurnBody("overflow-surface-first");
+    const events: AdapterEvent[] = [];
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(1);
+    expect(seen).toHaveLength(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("Cursor context limit exceeded"),
+    });
+  });
+
+  test("second overflow remints and persists thread override", async () => {
+    clearCursorOverflowRemintForTests();
+    clearCursorThreadContinuityForTests();
+    let attempts = 0;
+    const seen: string[] = [];
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run(request) {
+          attempts += 1;
+          seen.push(request.conversationId);
+          if (attempts === 1) {
+            throw bareOverflowError();
+          }
+          yield { type: "done" } satisfies CursorServerMessage;
+        },
+        writeClient() {},
+      }),
+      rekeyContextUsage: () => {},
+    });
+
+    const threadId = "overflow-remint-thread";
+    const body = overflowTurnBody(threadId);
+
+    const surfaceEvents: AdapterEvent[] = [];
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => surfaceEvents.push(event));
+    expect(attempts).toBe(1);
+    expect(surfaceEvents.some(event => event.type === "error")).toBe(true);
+
+    seen.length = 0;
+    attempts = 0;
+    const remintEvents: AdapterEvent[] = [];
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => remintEvents.push(event));
+
+    expect(attempts).toBe(2);
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).not.toBe(seen[0]);
+    expect(remintEvents.some(event => event.type === "done")).toBe(true);
+    expect(lookupCursorThreadConversation(threadId, "acct-overflow-remint")).toBe(seen[1]);
+    expect(body._cursorConversationId).toBe(seen[1]);
+  });
+
+  test("fourth overflow skips remint after surface-first and three remints", async () => {
+    clearCursorOverflowRemintForTests();
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run() {
+          attempts += 1;
+          throw bareOverflowError();
+        },
+        writeClient() {},
+      }),
+    });
+
+    const body = overflowTurnBody("overflow-cap-skip");
+    await adapter.runTurn?.(body, { headers: new Headers() }, () => {});
+    expect(attempts).toBe(1);
+
+    attempts = 0;
+    const events: AdapterEvent[] = [];
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(4);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("Cursor context limit exceeded"),
+    });
+  });
+
+  test("quota-cue resource_exhausted does not remint and surfaces as rate limit", async () => {
+    clearCursorOverflowRemintForTests();
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run() {
+          attempts += 1;
+          throw Object.assign(
+            new Error("Cursor rate limit exceeded: resource_exhausted: too many requests"),
+            { code: "resource_exhausted" },
+          );
+        },
+        writeClient() {},
+      }),
+    });
+
+    const body = overflowTurnBody("overflow-quota-cue");
+    const events: AdapterEvent[] = [];
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      message: expect.stringContaining("Cursor rate limit exceeded"),
+    });
+  });
+
+  test("does not overflow-remint on tool-result resumes", async () => {
+    clearCursorOverflowRemintForTests();
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run() {
+          attempts += 1;
+          throw bareOverflowError();
+        },
+        writeClient() {},
+      }),
+    });
+
+    const body: OcxParsedRequest = {
+      modelId: "cursor/auto",
+      context: {
+        messages: [
+          { role: "user", content: LARGE_OVERFLOW_CONTENT, timestamp: 1 },
+          {
+            role: "assistant",
+            model: "cursor/auto",
+            timestamp: 2,
+            content: [{ type: "toolCall", id: "call_1", name: "read_file", namespace: "mcp__fs", arguments: { path: "a.txt" } }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read_file",
+            toolNamespace: "mcp__fs",
+            content: "FILE CONTENTS HERE",
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+      },
+      stream: false,
+      options: {},
+      _cursorConversationId: "cursor_overflow_tool",
+      _cursorIdentityScope: "acct-overflow-remint",
+    };
+
+    await adapter.runTurn?.(body, { headers: new Headers() }, () => {});
+    expect(attempts).toBe(1);
+  });
+
+  test("does not overflow-remint compaction turns", async () => {
+    clearCursorOverflowRemintForTests();
+    let attempts = 0;
+    const seen: string[] = [];
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run(request) {
+          attempts += 1;
+          seen.push(request.conversationId);
+          throw bareOverflowError();
+        },
+        writeClient() {},
+      }),
+    });
+
+    const body = overflowTurnBody("overflow-compaction");
+    await adapter.runTurn?.(body, { headers: new Headers() }, () => {});
+    attempts = 0;
+    seen.length = 0;
+    body._compactionRequest = true;
+    body._cursorIsolateConversation = true;
+    await adapter.runTurn?.(body, { headers: new Headers() }, () => {});
+
+    expect(attempts).toBe(1);
+    expect(seen).toHaveLength(1);
+  });
+
+  test("does not overflow-remint after non-heartbeat output was emitted", async () => {
+    clearCursorOverflowRemintForTests();
+    let attempts = 0;
+    const adapter = createCursorAdapter({
+      ...provider,
+      apiKey: "cursor-token",
+    }, {
+      createTransport: () => ({
+        async *run() {
+          attempts += 1;
+          yield { type: "text", text: "partial" } satisfies CursorServerMessage;
+          throw bareOverflowError();
+        },
+        writeClient() {},
+      }),
+    });
+
+    const body = overflowTurnBody("overflow-after-output");
+    const events: AdapterEvent[] = [];
+    await adapter.runTurn?.(body, { headers: new Headers() }, event => events.push(event));
+
+    expect(attempts).toBe(1);
+    expect(events.some(event => event.type === "text_delta")).toBe(true);
+    expect(events.some(event => event.type === "error")).toBe(true);
   });
 });

--- a/tests/providers/cursor/cursor-continuity-retention.test.ts
+++ b/tests/providers/cursor/cursor-continuity-retention.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clearCursorOverflowRemintForTests,
+  CURSOR_OVERFLOW_REMINT_MAX_ENTRIES,
+  cursorOverflowRemintCountForTests,
+  markCursorOverflowSurfaced,
+  shouldSkipCursorOverflowRemint,
+  shouldSurfaceCursorOverflowFirst,
+} from "../../../src/adapters/cursor/thread-continuity";
+
+describe("Cursor overflow remint retention", () => {
+  test("bounds per-scope state", () => {
+    clearCursorOverflowRemintForTests();
+    for (let index = 0; index < CURSOR_OVERFLOW_REMINT_MAX_ENTRIES + 20; index++) {
+      markCursorOverflowSurfaced(`scope-${index}`);
+    }
+    expect(cursorOverflowRemintCountForTests()).toBe(CURSOR_OVERFLOW_REMINT_MAX_ENTRIES);
+    clearCursorOverflowRemintForTests();
+  });
+
+  test("read-only checks do not allocate retention entries", () => {
+    clearCursorOverflowRemintForTests();
+    expect(shouldSurfaceCursorOverflowFirst("missing")).toBe(true);
+    expect(shouldSkipCursorOverflowRemint("missing")).toBe(false);
+    expect(cursorOverflowRemintCountForTests()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Surface the first bare context overflow on Cursor Connect transport before allowing capped conversation remints.

- Surfaces the initial `resource_exhausted` context overflow error directly so clients (e.g. Codex) can trigger compaction or surface the context boundary to the user.
- On subsequent overflows in the same thread/scope, remints the conversation ID to recover conversation continuity up to a hard cap of 3 remints.
- Bounded LRU and TTL retention (max 2,048 entries, 1-hour TTL) for scope tracking.
- Preserves quota/rate-limit signals (does not remint on rate limits), tool-result resumes, compaction requests, and streams with partial output already emitted.

## Verification

All verification commands executed via the isolated testing wrapper with clean temporary `OPENCODEX_HOME` and isolated ports:

- `bun test tests/providers/cursor/cursor-adapter.test.ts tests/providers/cursor/cursor-continuity-retention.test.ts`: 31 passed, 0 failed (104 expect calls).
- `bun test tests/test-layout.test.ts tests/test-layout-tooling.test.ts`: 17 passed, 0 failed (551 expect calls).
- `bun run typecheck`: zero diagnostics.
- `bun run privacy:scan`: passed cleanly.
- Verified live config fingerprint and backup inventory in `/Users/user/.opencodex` remained completely untouched.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Added/updated regression coverage or verified existing coverage for the affected behavior.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Cursor conversation context-limit errors.
  * The first overflow is surfaced clearly, while eligible follow-up attempts can recover by starting a fresh conversation.
  * Recovery is limited and preserves conversation continuity across retries.
  * Prevented automatic recovery in scenarios where it could disrupt tool results, compaction, or already-streamed responses.
  * Rate-limit errors continue to be surfaced as rate limits rather than treated as context overflows.

* **Tests**
  * Added coverage for overflow recovery, retry limits, retention, and excluded scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->