### PR TITLE
fix(responses): keep the retryable main-refresh refusal an overload, not a bad key

### DIFF
--- a/src/server/responses/codex-auth-error.ts
+++ b/src/server/responses/codex-auth-error.ts
@@ -33,11 +33,23 @@ export function nativeMainRefreshFailureResponse(error: unknown): Response {
     // concluded the proxy had broken while one account was the thing that needed them. The refusal
     // stays a retryable 503 because the refresh genuinely may succeed, but it now names what is
     // failing and what to do when retrying stops helping.
+    //
+    // It says "sign in to the main Codex account again" and deliberately does NOT say
+    // "reauthentication", for the same reason the pool counterpart does not — see
+    // `poolCredentialRefreshIncompleteResponse` in ./core.ts. `classifyError` runs
+    // `isAuthenticationMessage` before it reaches the `status === 503` arm, and that check is
+    // status-blind on the bare substring "authentication", which "reauthentication" contains.
+    // A body carrying that word is reclassified to `authentication_error` / `invalid_api_key`
+    // even though the HTTP status stays 503, and Codex keys its retry-after backoff on
+    // `server_is_overloaded` — so the word alone turns a transient refresh into what reads as a
+    // bad API key and the client stops retrying. The pool path documented this trap and this one
+    // walked into it anyway, which is why the test below now asserts the classification and not
+    // just the sentence.
     const response = formatErrorResponse(
       503,
       "server_busy",
       "Codex main credential refresh did not complete; retry this request. "
-        + "If it keeps failing, the main Codex account needs reauthentication.",
+        + "If it keeps failing, sign in to the main Codex account again.",
     );
     const headers = new Headers(response.headers);
     headers.set("Retry-After", "1");

--- a/tests/codex-integration/codex-account-unusable-reason.test.ts
+++ b/tests/codex-integration/codex-account-unusable-reason.test.ts
@@ -130,7 +130,25 @@ describe("native main refresh refusal", () => {
     expect(response.headers.get("Retry-After")).toBe("1");
     const message = ((await response.json()) as { error: { message: string } }).error.message;
     expect(message).toContain("Codex main credential refresh did not complete");
-    expect(message).toContain("reauthentication");
+    expect(message).toContain("sign in to the main Codex account again");
+  });
+
+  // The regression this pins is not the sentence, it is the CLASSIFICATION the sentence causes.
+  // `classifyError` runs `isAuthenticationMessage` before the `status === 503` arm, and that check
+  // is status-blind on the bare substring "authentication" -- which "reauthentication" contains.
+  // A retryable refusal that says that word is served as `authentication_error` /
+  // `invalid_api_key` while still returning 503, and Codex keys its retry-after backoff on
+  // `server_is_overloaded`, so the client reads a transient refresh as a bad API key and stops
+  // retrying. The previous version of the test above asserted only the status and the word, which
+  // is exactly why the reclassification shipped unnoticed.
+  test("the retryable refusal is served as an overload, not as a bad key", async () => {
+    const response = nativeMainRefreshFailureResponse(new MainAccountTokenRefreshError("transient"));
+    const error = ((await response.json()) as { error: { type: string; code: string; message: string } }).error;
+    expect(response.status).toBe(503);
+    expect(error.type).toBe("server_error");
+    expect(error.code).toBe("server_is_overloaded");
+    // Load-bearing: the substring, not the phrasing, is what reclassifies the body.
+    expect(error.message.toLowerCase()).not.toContain("authentication");
   });
 
   test("a terminal reauth failure still refuses with 401 rather than a retry promise", async () => {


### PR DESCRIPTION
## Summary

The 2.51.0 release candidate reworded the retryable main-account refresh refusal to end with "the main Codex account needs reauthentication". That single word changes how the body is classified.

`classifyError` runs `isAuthenticationMessage` (`src/lib/errors.ts:111`) before it reaches the `status === 503` arm, and the check is status-blind on the bare substring `authentication` — which `reauthentication` contains. So the refusal was served as `authentication_error` / `invalid_api_key` while still returning HTTP 503.

Measured against this tree:

| build | HTTP | `error.type` | `error.code` |
|---|---|---|---|
| 2.50.0 wording | 503 | `server_error` | `server_is_overloaded` |
| 2.51.0 candidate | 503 | `authentication_error` | `invalid_api_key` |
| pool path (same release) | 503 | `server_error` | `server_is_overloaded` |

Codex keys its retry-after backoff on `server_is_overloaded`, not on the HTTP status. A transient main-token refresh — the case the 503 exists to cover, and one a default Codex install reaches — therefore started reading to the client as a bad API key, and the client stopped retrying instead of backing off. That is a regression against 2.50.0.

The pool counterpart added in the same release already documents this trap in `src/server/responses/core.ts:2282-2286` and deliberately words itself around it. The main path walked into it anyway. This commit gives it the same construction: **sign in to the main Codex account again**.

The intent of #4212 is preserved — the refusal still names what is failing and what to do when retrying stops helping. It just stops saying the one word that reclassifies it.

The terminal `reason === "reauth"` branch above is untouched: that one is a 401 and is *meant* to classify as `authentication_error`.

## Verification

- `bun run typecheck` — exit 0.
- `bun test tests/codex-integration/codex-account-unusable-reason.test.ts` — 10 pass / 0 fail.
- Red-green confirmed on the new test: with the candidate's wording it fails on `error.code` being `invalid_api_key`; with the fix it passes.

The pre-existing test asserted only the 503, the `Retry-After`, and that the message contained "reauthentication" — never `error.type` or `error.code`. That is precisely why the reclassification shipped unnoticed, so the added test asserts the classification, and asserts the message carries no `authentication` substring at all. The substring is the thing that reclassifies; pinning the phrasing would not have caught this and would not catch the next rewording either.

Found by the 2.51.0 pre-release regression audit (lane L1), reproduced independently before the fix.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed — no user-facing docs describe this string.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The change makes an auth-adjacent error *less* likely to be mistaken for a credential fault; no credential, token, or account identifier enters the body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling when the main Codex account refresh fails.
  * Retryable refresh failures are now correctly reported as server errors instead of authentication errors.
  * Updated guidance to clearly prompt users to sign in to the main Codex account again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->