### PR TITLE
docs(structure): close the review findings on the SSOT gate

### DIFF
--- a/scripts/structure-ssot.ts
+++ b/scripts/structure-ssot.ts
@@ -43,12 +43,47 @@ export type Manifest = {
   };
 };
 
-const REPO_ROOTS = ["src", "tests", "gui", "scripts", "docs", "docs-site", "bin", "go", "devlog", ".github", "structure"];
 const GENERATED_DOCS = ["INDEX.md"];
 const RULE_DOCS = ["AGENTS.md"];
 
 const toPosix = (p: string) => p.split("\\").join("/");
 const trimSlash = (p: string) => p.replace(/\/+$/, "");
+
+/** Parse and validate the manifest, so a malformed file is an actionable failure, not a stack trace. */
+export function loadManifest(raw: string): { manifest: Manifest } | { error: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    return { error: "structure/manifest.json is not valid JSON: " + (cause as Error).message };
+  }
+  const m = parsed as Partial<Manifest>;
+  const problems: string[] = [];
+  const isArray = (v: unknown) => Array.isArray(v);
+  if (typeof m.sizeBudgetLines !== "number") problems.push("sizeBudgetLines must be a number");
+  if (!isArray(m.generatedPaths)) problems.push("generatedPaths must be an array");
+  if (!isArray(m.absentPaths)) problems.push("absentPaths must be an array");
+  if (!isArray(m.tiers)) problems.push("tiers must be an array");
+  if (!isArray(m.docs)) problems.push("docs must be an array");
+  else {
+    m.docs.forEach((doc, i) => {
+      if (typeof doc?.path !== "string") problems.push("docs[" + i + "].path must be a string");
+      if (typeof doc?.tier !== "number") problems.push("docs[" + i + "].tier must be a number");
+      if (typeof doc?.title !== "string") problems.push("docs[" + i + "].title must be a string");
+      if (typeof doc?.scope !== "string") problems.push("docs[" + i + "].scope must be a string");
+      if (!isArray(doc?.documents)) problems.push("docs[" + i + "].documents must be an array");
+    });
+  }
+  const grace = m.grace as Partial<Manifest["grace"]> | undefined;
+  if (!grace) problems.push("grace must be an object");
+  else {
+    for (const key of ["undocumentedSourceAreas", "unboundInvariants", "oversizeDocs", "staleRefs"] as const) {
+      if (!isArray(grace[key])) problems.push("grace." + key + " must be an array");
+    }
+  }
+  if (problems.length > 0) return { error: "structure/manifest.json is malformed: " + problems.join("; ") };
+  return { manifest: parsed as Manifest };
+}
 
 function listMarkdown(dir: string, root: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -181,23 +216,33 @@ export function runStructureChecks(repoRoot: string): string[] {
 
   const manifestPath = join(structureDir, "manifest.json");
   if (!existsSync(manifestPath)) return ["structure/manifest.json is missing"];
-  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest;
+  const loaded = loadManifest(readFileSync(manifestPath, "utf8"));
+  if ("error" in loaded) return [loaded.error];
+  const manifest = loaded.manifest;
 
   const tracked = trackedPaths(repoRoot);
   const trackedLower = new Map<string, string>();
   if (tracked) for (const p of tracked) trackedLower.set(p.toLowerCase(), p);
 
-  /** A repository path is real when git tracks it, or when it exists and is not merely a case variant. */
+  /**
+   * A repository path is real when git tracks it. The filesystem is consulted only when the index
+   * could not be read at all: CI checks out a clean tree, so an untracked local leftover that
+   * satisfied the gate here would still fail there, which is the split verdict this module exists
+   * to remove. The cost is that a newly written file has to be staged before the gate can see it.
+   */
   const pathIsReal = (raw: string): "ok" | "missing" | string => {
     const p = trimSlash(raw);
-    if (tracked?.has(p)) return "ok";
-    if (tracked) {
-      const variant = trackedLower.get(p.toLowerCase());
-      if (variant && variant !== p) return variant;
-    }
-    return existsSync(join(repoRoot, p)) ? "ok" : "missing";
+    if (!tracked) return existsSync(join(repoRoot, p)) ? "ok" : "missing";
+    if (tracked.has(p)) return "ok";
+    const variant = trackedLower.get(p.toLowerCase());
+    if (variant && variant !== p) return variant;
+    return "missing";
   };
   const isTracked = (raw: string) => tracked?.has(trimSlash(raw)) ?? existsSync(join(repoRoot, trimSlash(raw)));
+  // Top-level tracked entries, so a backticked root file is validated like a directory path is.
+  const rootEntries = new Set<string>();
+  if (tracked) for (const p of tracked) rootEntries.add(p.split("/")[0]!);
+  else for (const entry of readdirSync(repoRoot, { withFileTypes: true })) rootEntries.add(entry.name);
 
   const present = listMarkdown(structureDir, structureDir);
   const sotOnDisk = present.filter((p) => !p.startsWith("decisions/") && !GENERATED_DOCS.includes(p) && !RULE_DOCS.includes(p));
@@ -238,7 +283,7 @@ export function runStructureChecks(repoRoot: string): string[] {
 
   // 3. links, anchors, repository paths, and the inline-decision ban
   const linkRe = /\]\(([^)\s]+)\)/g;
-  const pathRe = new RegExp(BT + "((?:" + REPO_ROOTS.join("|") + ")/[A-Za-z0-9_.@/-]*)" + BT, "g");
+  const pathRe = new RegExp(BT + "([A-Za-z0-9_.@-]+(?:/[A-Za-z0-9_.@-]*)*)" + BT, "g");
   const anchorCache = new Map<string, Set<string>>();
   for (const rel of present) {
     const abs = join(structureDir, rel);
@@ -254,12 +299,21 @@ export function runStructureChecks(repoRoot: string): string[] {
     linkRe.lastIndex = 0;
     while ((m = linkRe.exec(body))) {
       const target = m[1];
-      if (/^(?:https?|mailto):/.test(target) || target.startsWith("#")) continue;
+      if (/^(?:https?|mailto):/.test(target)) continue;
       const [file, fragment] = target.split("#");
-      const resolved = resolve(dirname(abs), file);
-      if (!existsSync(resolved)) {
-        fail("structure/" + rel + " links " + target + ", which does not exist");
-        continue;
+      // A fragment-only link points at this same document; it still has to name a real heading.
+      const resolved = file === "" ? abs : resolve(dirname(abs), file);
+      if (file !== "") {
+        const repoRel = toPosix(relative(repoRoot, resolved));
+        const verdict = pathIsReal(repoRel);
+        if (verdict === "missing") {
+          fail("structure/" + rel + " links " + target + ", which does not exist");
+          continue;
+        }
+        if (verdict !== "ok") {
+          fail("structure/" + rel + " links " + target + ", but the tracked path is " + verdict);
+          continue;
+        }
       }
       if (fragment && resolved.endsWith(".md")) {
         if (!anchorCache.has(resolved)) anchorCache.set(resolved, headingAnchors(readFileSync(resolved, "utf8")));
@@ -273,6 +327,8 @@ export function runStructureChecks(repoRoot: string): string[] {
     pathRe.lastIndex = 0;
     while ((m = pathRe.exec(body))) {
       const named = trimSlash(m[1]);
+      // Only tokens rooted at a real top-level entry are paths; the rest are ordinary code spans.
+      if (!rootEntries.has(named.split("/")[0]!)) continue;
       if (manifest.generatedPaths.some((g) => named === trimSlash(g) || named.startsWith(trimSlash(g) + "/"))) continue;
       if (manifest.absentPaths.some((a) => trimSlash(a.path) === named)) continue;
       if (manifest.grace.staleRefs.map(trimSlash).includes(named)) continue;
@@ -291,12 +347,19 @@ export function runStructureChecks(repoRoot: string): string[] {
   // 4. decision records
   const adrFiles = present.filter((p) => p.startsWith("decisions/"));
   const referenced = new Map<string, Set<string>>();
+  // Ownership is the declared link form, read with fences removed. A record path mentioned in prose
+  // or shown inside an example is not a claim of ownership, and counting it made an orphaned record
+  // look owned while reporting a second owner nobody could remove.
+  const ownerLinkRe = /^>\s*Decision record:\s*\[[^\]]*\]\(([^)\s]+)\)/gm;
   for (const doc of manifest.docs) {
     const abs = join(structureDir, doc.path);
     if (!existsSync(abs)) continue;
-    for (const hit of readFileSync(abs, "utf8").match(/decisions\/ADR-[0-9]{4}-[a-z0-9-]*\.md/g) ?? []) {
-      const key = "decisions/" + hit.split("/")[1];
-      referenced.set(key, (referenced.get(key) ?? new Set<string>()).add(doc.path));
+    const body = withoutFences(readFileSync(abs, "utf8"));
+    ownerLinkRe.lastIndex = 0;
+    let hit: RegExpExecArray | null;
+    while ((hit = ownerLinkRe.exec(body))) {
+      const file = hit[1].split("#")[0]!.split("/").pop()!;
+      referenced.set("decisions/" + file, (referenced.get("decisions/" + file) ?? new Set<string>()).add(doc.path));
     }
   }
   const ids = new Set<string>();
@@ -317,7 +380,9 @@ export function runStructureChecks(repoRoot: string): string[] {
 
   // 5. invariant-to-test bindings
   const overviewPath = join(structureDir, "overview.md");
-  if (existsSync(overviewPath)) {
+  if (!existsSync(overviewPath)) {
+    fail("structure/overview.md is missing; it is the invariant index, and its absence would silence every binding check");
+  } else {
     const body = readFileSync(overviewPath, "utf8");
     const blocks: { id: string; text: string }[] = [];
     let current: { id: string; text: string } | null = null;
@@ -370,6 +435,18 @@ export function runStructureChecks(repoRoot: string): string[] {
 
   // 6. source-to-doc map
   const described = new Map<string, string[]>();
+  // What a doc actually names, so a manifest claim cannot invent coverage the prose does not have.
+  const namedByDoc = new Map<string, string[]>();
+  for (const doc of manifest.docs) {
+    const abs = join(structureDir, doc.path);
+    if (!existsSync(abs)) continue;
+    const body = withoutFences(readFileSync(abs, "utf8"));
+    const found: string[] = [];
+    const re = new RegExp(pathRe.source, "g");
+    let hit: RegExpExecArray | null;
+    while ((hit = re.exec(body))) found.push(hit[1]);
+    namedByDoc.set(doc.path, found);
+  }
   for (const doc of manifest.docs) {
     const own = new Set<string>();
     for (const area of doc.documents) {
@@ -379,6 +456,10 @@ export function runStructureChecks(repoRoot: string): string[] {
       const verdict = pathIsReal(area);
       if (verdict === "missing") fail("structure/" + doc.path + " claims " + area + ", which this tree does not have");
       else if (verdict !== "ok") fail("structure/" + doc.path + " claims " + area + ", but the tracked path is " + verdict);
+      const names = namedByDoc.get(doc.path) ?? [];
+      if (!names.some((n) => n === area || n === trimSlash(area) || n.startsWith(area))) {
+        fail("structure/" + doc.path + " claims " + area + " but never names a path in it; describing an area means citing one");
+      }
     }
   }
   const graced = new Map(manifest.grace.undocumentedSourceAreas.map((g) => [g.path, g.reason]));

--- a/scripts/structure-ssot.ts
+++ b/scripts/structure-ssot.ts
@@ -45,6 +45,13 @@ export type Manifest = {
 
 const GENERATED_DOCS = ["INDEX.md"];
 const RULE_DOCS = ["AGENTS.md"];
+/**
+ * Roots that stay checked even after they are deleted. Deriving the root set from the tree alone
+ * means a reference becomes INVISIBLE exactly when the directory disappears, which is the moment
+ * stale references start appearing. go/ is the live example: it is retired and untracked, and
+ * without this list every remaining go/ mention would go unchecked.
+ */
+const HISTORICAL_ROOTS = ["src", "tests", "gui", "scripts", "docs", "docs-site", "bin", "go", "devlog", ".github", "structure", "readme"];
 
 const toPosix = (p: string) => p.split("\\").join("/");
 const trimSlash = (p: string) => p.replace(/\/+$/, "");
@@ -63,6 +70,12 @@ export function loadManifest(raw: string): { manifest: Manifest } | { error: str
   if (typeof m.sizeBudgetLines !== "number") problems.push("sizeBudgetLines must be a number");
   if (!isArray(m.generatedPaths)) problems.push("generatedPaths must be an array");
   if (!isArray(m.absentPaths)) problems.push("absentPaths must be an array");
+  else {
+    m.absentPaths.forEach((entry, i) => {
+      if (typeof entry?.path !== "string") problems.push("absentPaths[" + i + "].path must be a string");
+      if (typeof entry?.reason !== "string") problems.push("absentPaths[" + i + "].reason must be a string");
+    });
+  }
   if (!isArray(m.tiers)) problems.push("tiers must be an array");
   if (!isArray(m.docs)) problems.push("docs must be an array");
   else {
@@ -79,6 +92,24 @@ export function loadManifest(raw: string): { manifest: Manifest } | { error: str
   else {
     for (const key of ["undocumentedSourceAreas", "unboundInvariants", "oversizeDocs", "staleRefs"] as const) {
       if (!isArray(grace[key])) problems.push("grace." + key + " must be an array");
+    }
+    if (isArray(grace.undocumentedSourceAreas)) {
+      grace.undocumentedSourceAreas.forEach((entry, i) => {
+        if (typeof entry?.path !== "string") problems.push("grace.undocumentedSourceAreas[" + i + "].path must be a string");
+        if (typeof entry?.reason !== "string") problems.push("grace.undocumentedSourceAreas[" + i + "].reason must be a string");
+      });
+    }
+    if (isArray(grace.unboundInvariants)) {
+      grace.unboundInvariants.forEach((entry, i) => {
+        if (typeof entry?.id !== "string") problems.push("grace.unboundInvariants[" + i + "].id must be a string");
+        if (typeof entry?.reason !== "string") problems.push("grace.unboundInvariants[" + i + "].reason must be a string");
+      });
+    }
+    for (const key of ["oversizeDocs", "staleRefs"] as const) {
+      if (!isArray(grace[key])) continue;
+      grace[key].forEach((entry, i) => {
+        if (typeof entry !== "string") problems.push("grace." + key + "[" + i + "] must be a string");
+      });
     }
   }
   if (problems.length > 0) return { error: "structure/manifest.json is malformed: " + problems.join("; ") };
@@ -239,8 +270,9 @@ export function runStructureChecks(repoRoot: string): string[] {
     return "missing";
   };
   const isTracked = (raw: string) => tracked?.has(trimSlash(raw)) ?? existsSync(join(repoRoot, trimSlash(raw)));
-  // Top-level tracked entries, so a backticked root file is validated like a directory path is.
-  const rootEntries = new Set<string>();
+  // Top-level entries, so a backticked root FILE is validated directly, the same as a directory
+  // path. The historical roots are unioned in so a deleted tree keeps being checked.
+  const rootEntries = new Set<string>(HISTORICAL_ROOTS);
   if (tracked) for (const p of tracked) rootEntries.add(p.split("/")[0]!);
   else for (const entry of readdirSync(repoRoot, { withFileTypes: true })) rootEntries.add(entry.name);
 
@@ -358,8 +390,15 @@ export function runStructureChecks(repoRoot: string): string[] {
     ownerLinkRe.lastIndex = 0;
     let hit: RegExpExecArray | null;
     while ((hit = ownerLinkRe.exec(body))) {
-      const file = hit[1].split("#")[0]!.split("/").pop()!;
-      referenced.set("decisions/" + file, (referenced.get("decisions/" + file) ?? new Set<string>()).add(doc.path));
+      const target = hit[1].split("#")[0]!;
+      const repoRel = toPosix(relative(structureDir, resolve(dirname(abs), target)));
+      // The link has to land in decisions/; a basename match would let a record elsewhere claim
+      // ownership of a file it does not point at.
+      if (!repoRel.startsWith("decisions/")) {
+        fail("structure/" + doc.path + " points a Decision record line at " + target + ", which is not in decisions/");
+        continue;
+      }
+      referenced.set(repoRel, (referenced.get(repoRel) ?? new Set<string>()).add(doc.path));
     }
   }
   const ids = new Set<string>();
@@ -458,7 +497,7 @@ export function runStructureChecks(repoRoot: string): string[] {
       else if (verdict !== "ok") fail("structure/" + doc.path + " claims " + area + ", but the tracked path is " + verdict);
       const names = namedByDoc.get(doc.path) ?? [];
       if (!names.some((n) => n === area || n === trimSlash(area) || n.startsWith(area))) {
-        fail("structure/" + doc.path + " claims " + area + " but never names a path in it; describing an area means citing one");
+        fail("structure/" + doc.path + " claims " + area + " but never names it or a path in it");
       }
     }
   }
@@ -467,15 +506,28 @@ export function runStructureChecks(repoRoot: string): string[] {
     if (pathIsReal(g) !== "ok") fail("grace.undocumentedSourceAreas lists " + g + ", which this tree does not have");
     if (described.has(g)) fail(g + " is both described and listed as undescribed");
   }
-  const srcDir = join(repoRoot, "src");
-  if (existsSync(srcDir)) {
-    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
-      const area = entry.isDirectory() ? "src/" + entry.name + "/" : "src/" + entry.name;
-      if (!entry.isDirectory() && !entry.name.endsWith(".ts")) continue;
-      // A claim on one file inside a directory does not cover the directory.
-      if (described.has(area) || graced.has(area)) continue;
-      fail(area + " is described by no doc; add it to a doc's " + BT + "documents" + BT + " list or record it in grace.undocumentedSourceAreas with a reason");
+  // Enumerated from the index when it is readable, for the same reason paths are resolved there:
+  // an untracked scratch directory under src/ must not produce a failure CI cannot reproduce.
+  const srcAreas = new Set<string>();
+  if (tracked) {
+    for (const p of tracked) {
+      if (!p.startsWith("src/")) continue;
+      const rest = p.slice("src/".length);
+      const slash = rest.indexOf("/");
+      if (slash === -1) {
+        if (rest.endsWith(".ts")) srcAreas.add("src/" + rest);
+      } else srcAreas.add("src/" + rest.slice(0, slash) + "/");
     }
+  } else if (existsSync(join(repoRoot, "src"))) {
+    for (const entry of readdirSync(join(repoRoot, "src"), { withFileTypes: true })) {
+      if (entry.isDirectory()) srcAreas.add("src/" + entry.name + "/");
+      else if (entry.name.endsWith(".ts")) srcAreas.add("src/" + entry.name);
+    }
+  }
+  for (const area of [...srcAreas].sort()) {
+    // A claim on one file inside a directory does not cover the directory.
+    if (described.has(area) || graced.has(area)) continue;
+    fail(area + " is described by no doc; add it to a doc's " + BT + "documents" + BT + " list or record it in grace.undocumentedSourceAreas with a reason");
   }
 
   // 7. generated index parity

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,7 +8,7 @@ This file applies to `src/` and inherits the repository-wide rules in `/AGENTS.m
 - Do not assume a separate server compilation step.
 - Prefer Bun and Web-platform APIs. Introduce a Node-only runtime dependency only when the task explicitly requires compatibility code and the owning module already has that role.
 - Preserve existing public exports and configuration compatibility unless the task explicitly changes them.
-- Read the applicable documents in `structure/` before changing shared routing, adapters, transports, sidecars, authentication, configuration, or server architecture. [`structure/INDEX.md`](../structure/INDEX.md) maps each source area to its owning doc, and that doc is updated in the same change that changes the area.
+- Read the applicable documents in `structure/` before changing shared routing, adapters, transports, sidecars, authentication, configuration, or server architecture. [`structure/INDEX.md`](../structure/INDEX.md) maps each source area to the docs that describe it — usually more than one, because those docs are organised by topic while `src/` is organised by module — and every doc listed for an area is updated in the same change that changes the area.
 
 ## Implementation rules
 

--- a/structure/AGENTS.md
+++ b/structure/AGENTS.md
@@ -51,8 +51,10 @@ the inverse.
 - Describing an area means naming a path inside it. If a doc explains a subsystem without ever citing
   a path, the map cannot see it, and the area lands in `grace.undocumentedSourceAreas` instead — which
   is a signal to add the path reference, not a place to park work.
-  The gate enforces this in both directions: a `documents` entry whose doc never names a path inside
-  the area is rejected, so the map cannot claim coverage the prose does not have.
+  The gate checks the weak form of this: a `documents` entry is rejected when the doc never names the
+  area or any path under it. Naming the directory itself passes, which a table of directory names
+  does, so the check catches an invented claim but does not prove the doc says anything useful about
+  the area. That part is review.
 - A new `src/<area>/` or top-level `src/*.ts` either joins a doc's `documents` list or is recorded in
   `grace.undocumentedSourceAreas` with a reason. The gate rejects one that is neither.
 
@@ -78,6 +80,8 @@ choice, why, and consequences.
   like a decision name but was not would send a maintainer to the wrong record. Read the body.
 - Ownership is the `> Decision record:` link, and nothing else. A record path mentioned in prose or
   shown inside a fenced example is not a claim, so an illustration cannot make a doc a second owner.
+  The link has to land inside `decisions/`; pointing it elsewhere is rejected rather than matched on
+  the filename.
 
 ## Invariants
 
@@ -116,7 +120,10 @@ verifies that:
   the filesystem — `existsSync` cannot tell a tracked file from untracked local leftovers, and it is
   case-insensitive on Windows and case-sensitive on Linux CI, which would make the gate mean
   something different on each machine;
-- no doc body carries inline decision-log reasoning;
+- no doc body carries either inline decision-log marker: the bracketed Decision-Log heading that the
+  old layout used, or the Korean bullet template that followed it. Reasoning written as ordinary
+  prose is not detectable and stays a review judgement. The check is a literal match, which is why
+  this line describes the marker instead of quoting it;
 - every decision record is linked from exactly one doc, and no number is reused;
 - every bound invariant names an existing test that names the id back, and every unbound one is
   recorded with a reason;
@@ -124,14 +131,20 @@ verifies that:
 - the manifest itself parses and has the shape the gate expects, reported as a failure rather than a
   stack trace;
 - `overview.md` exists, because its absence would otherwise silence every invariant check at once;
-- `INDEX.md` matches the manifest byte for byte.
+- `INDEX.md` matches what the manifest generates, compared after newline normalisation so a CRLF
+  checkout is not a failure.
 
 Checks are scanned with fenced code blocks removed, so an example inside a fence does not trip a rule
 it is only illustrating.
 
 One boundary worth stating, because it looks like a gap and is a deliberate one: a backticked token is
-treated as a repository path only when it is rooted at a real top-level entry, such as `src/` or
-`package.json`. A bare filename is not checked, because these docs name runtime files that are not in
-the repository at all — `config.toml`, `models_cache.json`, `ocx.pid` — and validating every
-filename-shaped token would reject them. Root documents are still covered where it matters, since a
-reference like [`MAINTAINERS.md`](../MAINTAINERS.md) is a link, and links are checked.
+treated as a repository path only when its first segment is a top-level entry this repository has or
+used to have. That covers root files too, so `package.json` and `MAINTAINERS.md` are checked directly,
+not only through the links that point at them. What is NOT checked is a bare filename that was never
+a top-level entry, because these docs name runtime files that live in a user's home rather than in
+the repository — `config.toml`, `models_cache.json`, `ocx.pid` — and validating every filename-shaped
+token would reject them.
+
+The top-level set deliberately includes roots that no longer exist, such as `go/`. Deriving it from
+the current tree alone would make every reference to a deleted directory invisible at exactly the
+moment those references go stale.

--- a/structure/AGENTS.md
+++ b/structure/AGENTS.md
@@ -28,6 +28,10 @@ structure doc.
 - A doc stays under the line budget in `manifest.json`. Over budget, split it along a topic boundary
   and give each half its own manifest entry. A `grace.oversizeDocs` entry is for a split already
   planned; the gate drops it again once the doc is back under budget.
+- **Stage a new file before running the gate.** Repository paths are resolved through the git index,
+  so a file you have written but not `git add`ed does not exist as far as the check is concerned. That
+  is deliberate: CI runs on a clean checkout, and a gate that passed on untracked local files would
+  disagree with it.
 - Know what the budget does and does not do: it is a line count, so a doc written as a wide table can
   carry far more prose per line than one written as paragraphs. It bounds the runaway-file failure,
   not density.
@@ -47,6 +51,8 @@ the inverse.
 - Describing an area means naming a path inside it. If a doc explains a subsystem without ever citing
   a path, the map cannot see it, and the area lands in `grace.undocumentedSourceAreas` instead — which
   is a signal to add the path reference, not a place to park work.
+  The gate enforces this in both directions: a `documents` entry whose doc never names a path inside
+  the area is rejected, so the map cannot claim coverage the prose does not have.
 - A new `src/<area>/` or top-level `src/*.ts` either joins a doc's `documents` list or is recorded in
   `grace.undocumentedSourceAreas` with a reason. The gate rejects one that is neither.
 
@@ -66,8 +72,12 @@ choice, why, and consequences.
   rewrite an old one to match. For the same reason the gate does not validate the repository paths a
   record names — a record describes a past tree, and holding it against the present one would force
   you to falsify it.
-- Records extracted during the 2026-09-11 reorganisation are titled after the doc section they were
-  taken from, which is where they belonged, not necessarily what they decided. Read the body.
+- A record's title names the doc section it was recorded under, not the decision it contains. That is
+  why every title reads `decision recorded under "<section>"`: the records extracted during the
+  2026-09-11 reorganisation took their heading from the section they sat in, and a title that looked
+  like a decision name but was not would send a maintainer to the wrong record. Read the body.
+- Ownership is the `> Decision record:` link, and nothing else. A record path mentioned in prose or
+  shown inside a fenced example is not a claim, so an illustration cannot make a doc a second owner.
 
 ## Invariants
 
@@ -101,6 +111,7 @@ verifies that:
 - file names are kebab-case, letter-initial, and at most one directory deep;
 - no doc exceeds the line budget, and no grace entry outlives the split it promised;
 - every relative link resolves, including its `#anchor`;
+- a fragment-only link resolves against its own document, which is where one broken anchor was hiding;
 - every backticked repository path a doc names is real, checked against the **git index** rather than
   the filesystem — `existsSync` cannot tell a tracked file from untracked local leftovers, and it is
   case-insensitive on Windows and case-sensitive on Linux CI, which would make the gate mean
@@ -110,7 +121,17 @@ verifies that:
 - every bound invariant names an existing test that names the id back, and every unbound one is
   recorded with a reason;
 - every `src/` directory and top-level module is described by a doc or recorded as undescribed;
+- the manifest itself parses and has the shape the gate expects, reported as a failure rather than a
+  stack trace;
+- `overview.md` exists, because its absence would otherwise silence every invariant check at once;
 - `INDEX.md` matches the manifest byte for byte.
 
 Checks are scanned with fenced code blocks removed, so an example inside a fence does not trip a rule
 it is only illustrating.
+
+One boundary worth stating, because it looks like a gap and is a deliberate one: a backticked token is
+treated as a repository path only when it is rooted at a real top-level entry, such as `src/` or
+`package.json`. A bare filename is not checked, because these docs name runtime files that are not in
+the repository at all — `config.toml`, `models_cache.json`, `ocx.pid` — and validating every
+filename-shaped token would reject them. Root documents are still covered where it matters, since a
+reference like [`MAINTAINERS.md`](../MAINTAINERS.md) is a link, and links are checked.

--- a/structure/adapters/registry.md
+++ b/structure/adapters/registry.md
@@ -42,8 +42,3 @@ request when a node carries both. Codex's own deferred tool catalog emits exactl
 so the schema is not something a user can fix from configuration (issue #2673).
 
 > Decision record: [ADR-0093](../decisions/ADR-0093-moonshot-ref-with-siblings-normalization.md)
-
-예산은 세 가지다. 확장 횟수만으로는 참조가 하나도 없는 깊은 스키마를 막지 못해서, 깊이와
-노드 수를 따로 둔다 — `google-tool-schema.ts`가 이미 쓰는 형태다. 두 가드 모두 제거했을 때
-실제로 red가 되는지 확인했고, 예산을 풀면 20k 깊이에서 `RangeError: Maximum call stack size
-exceeded`가 난다.

--- a/structure/decisions/ADR-0001-product-boundary.md
+++ b/structure/decisions/ADR-0001-product-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0001 — Product boundary
+# ADR-0001 — decision recorded under "Product boundary"
 
 - Contract owner: [overview.md](../overview.md#product-boundary)
 

--- a/structure/decisions/ADR-0002-lifecycle.md
+++ b/structure/decisions/ADR-0002-lifecycle.md
@@ -1,4 +1,4 @@
-# ADR-0002 — Lifecycle
+# ADR-0002 — decision recorded under "Lifecycle"
 
 - Contract owner: [runtime.md](../runtime.md#lifecycle)
 

--- a/structure/decisions/ADR-0003-lifecycle.md
+++ b/structure/decisions/ADR-0003-lifecycle.md
@@ -1,4 +1,4 @@
-# ADR-0003 — Lifecycle
+# ADR-0003 — decision recorded under "Lifecycle"
 
 - Contract owner: [runtime.md](../runtime.md#lifecycle)
 

--- a/structure/decisions/ADR-0004-lifecycle.md
+++ b/structure/decisions/ADR-0004-lifecycle.md
@@ -1,4 +1,4 @@
-# ADR-0004 — Lifecycle
+# ADR-0004 — decision recorded under "Lifecycle"
 
 - Contract owner: [runtime.md](../runtime.md#lifecycle)
 

--- a/structure/decisions/ADR-0005-codex-home.md
+++ b/structure/decisions/ADR-0005-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0005 — Codex home
+# ADR-0005 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0006-codex-home.md
+++ b/structure/decisions/ADR-0006-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0006 — Codex home
+# ADR-0006 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0007-codex-home.md
+++ b/structure/decisions/ADR-0007-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0007 — Codex home
+# ADR-0007 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0008-codex-home.md
+++ b/structure/decisions/ADR-0008-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0008 — Codex home
+# ADR-0008 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0009-codex-home.md
+++ b/structure/decisions/ADR-0009-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0009 — Codex home
+# ADR-0009 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0010-codex-home.md
+++ b/structure/decisions/ADR-0010-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0010 — Codex home
+# ADR-0010 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0011-codex-home.md
+++ b/structure/decisions/ADR-0011-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0011 — Codex home
+# ADR-0011 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0012-codex-home.md
+++ b/structure/decisions/ADR-0012-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0012 — Codex home
+# ADR-0012 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0013-codex-home.md
+++ b/structure/decisions/ADR-0013-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0013 — Codex home
+# ADR-0013 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0014-codex-home.md
+++ b/structure/decisions/ADR-0014-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0014 — Codex home
+# ADR-0014 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0015-codex-home.md
+++ b/structure/decisions/ADR-0015-codex-home.md
@@ -1,4 +1,4 @@
-# ADR-0015 — Codex home
+# ADR-0015 — decision recorded under "Codex home"
 
 - Contract owner: [codex-home.md](../codex-home.md#codex-home)
 

--- a/structure/decisions/ADR-0016-config-surface.md
+++ b/structure/decisions/ADR-0016-config-surface.md
@@ -1,4 +1,4 @@
-# ADR-0016 — Config surface
+# ADR-0016 — decision recorded under "Config surface"
 
 - Contract owner: [config.md](../config.md#config-surface)
 

--- a/structure/decisions/ADR-0017-config-injection.md
+++ b/structure/decisions/ADR-0017-config-injection.md
@@ -1,4 +1,4 @@
-# ADR-0017 — Config injection
+# ADR-0017 — decision recorded under "Config injection"
 
 - Contract owner: [config.md](../config.md#config-injection)
 

--- a/structure/decisions/ADR-0018-config-injection.md
+++ b/structure/decisions/ADR-0018-config-injection.md
@@ -1,4 +1,4 @@
-# ADR-0018 — Config injection
+# ADR-0018 — decision recorded under "Config injection"
 
 - Contract owner: [config.md](../config.md#config-injection)
 

--- a/structure/decisions/ADR-0019-config-injection.md
+++ b/structure/decisions/ADR-0019-config-injection.md
@@ -1,4 +1,4 @@
-# ADR-0019 — Config injection
+# ADR-0019 — decision recorded under "Config injection"
 
 - Contract owner: [config.md](../config.md#config-injection)
 

--- a/structure/decisions/ADR-0020-provider-validation-ownership.md
+++ b/structure/decisions/ADR-0020-provider-validation-ownership.md
@@ -1,4 +1,4 @@
-# ADR-0020 — Provider validation ownership
+# ADR-0020 — decision recorded under "Provider validation ownership"
 
 - Contract owner: [config.md](../config.md#provider-validation-ownership)
 

--- a/structure/decisions/ADR-0021-shared-catalog.md
+++ b/structure/decisions/ADR-0021-shared-catalog.md
@@ -1,4 +1,4 @@
-# ADR-0021 — Shared catalog
+# ADR-0021 — decision recorded under "Shared catalog"
 
 - Contract owner: [catalog.md](../catalog.md#shared-catalog)
 

--- a/structure/decisions/ADR-0022-routed-tool-discovery-and-hosted-search.md
+++ b/structure/decisions/ADR-0022-routed-tool-discovery-and-hosted-search.md
@@ -1,4 +1,4 @@
-# ADR-0022 — Routed tool discovery and hosted search
+# ADR-0022 — decision recorded under "Routed tool discovery and hosted search"
 
 - Contract owner: [catalog.md](../catalog.md#routed-tool-discovery-and-hosted-search)
 

--- a/structure/decisions/ADR-0023-ultra-reasoning-level.md
+++ b/structure/decisions/ADR-0023-ultra-reasoning-level.md
@@ -1,4 +1,4 @@
-# ADR-0023 — Ultra reasoning level
+# ADR-0023 — decision recorded under "Ultra reasoning level"
 
 - Contract owner: [catalog.md](../catalog.md#ultra-reasoning-level)
 

--- a/structure/decisions/ADR-0024-ultra-reasoning-level.md
+++ b/structure/decisions/ADR-0024-ultra-reasoning-level.md
@@ -1,4 +1,4 @@
-# ADR-0024 — Ultra reasoning level
+# ADR-0024 — decision recorded under "Ultra reasoning level"
 
 - Contract owner: [catalog.md](../catalog.md#ultra-reasoning-level)
 

--- a/structure/decisions/ADR-0025-ultra-reasoning-level.md
+++ b/structure/decisions/ADR-0025-ultra-reasoning-level.md
@@ -1,4 +1,4 @@
-# ADR-0025 — Ultra reasoning level
+# ADR-0025 — decision recorded under "Ultra reasoning level"
 
 - Contract owner: [catalog.md](../catalog.md#ultra-reasoning-level)
 

--- a/structure/decisions/ADR-0026-ultra-reasoning-level.md
+++ b/structure/decisions/ADR-0026-ultra-reasoning-level.md
@@ -1,4 +1,4 @@
-# ADR-0026 — Ultra reasoning level
+# ADR-0026 — decision recorded under "Ultra reasoning level"
 
 - Contract owner: [catalog.md](../catalog.md#ultra-reasoning-level)
 

--- a/structure/decisions/ADR-0027-subagents.md
+++ b/structure/decisions/ADR-0027-subagents.md
@@ -1,4 +1,4 @@
-# ADR-0027 — Subagents
+# ADR-0027 — decision recorded under "Subagents"
 
 - Contract owner: [subagents.md](../subagents.md#subagents)
 

--- a/structure/decisions/ADR-0028-background-service-command-selection.md
+++ b/structure/decisions/ADR-0028-background-service-command-selection.md
@@ -1,4 +1,4 @@
-# ADR-0028 — Background service command selection
+# ADR-0028 — decision recorded under "Background service command selection"
 
 - Contract owner: [ops/service-and-sidecars.md](../ops/service-and-sidecars.md#background-service-command-selection)
 

--- a/structure/decisions/ADR-0029-windows-startup-ownership-listing-reuse.md
+++ b/structure/decisions/ADR-0029-windows-startup-ownership-listing-reuse.md
@@ -1,4 +1,4 @@
-# ADR-0029 — Windows startup ownership listing reuse
+# ADR-0029 — decision recorded under "Windows startup ownership listing reuse"
 
 - Contract owner: [ops/service-and-sidecars.md](../ops/service-and-sidecars.md#windows-startup-ownership-listing-reuse)
 

--- a/structure/decisions/ADR-0030-stable-service-launcher-launchd-and-systemd.md
+++ b/structure/decisions/ADR-0030-stable-service-launcher-launchd-and-systemd.md
@@ -1,4 +1,4 @@
-# ADR-0030 — Stable service launcher (launchd and systemd)
+# ADR-0030 — decision recorded under "Stable service launcher (launchd and systemd)"
 
 - Contract owner: [ops/service-and-sidecars.md](../ops/service-and-sidecars.md#stable-service-launcher-launchd-and-systemd)
 

--- a/structure/decisions/ADR-0031-responses-http-sse.md
+++ b/structure/decisions/ADR-0031-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0031 — Responses HTTP/SSE
+# ADR-0031 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0032-responses-http-sse.md
+++ b/structure/decisions/ADR-0032-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0032 — Responses HTTP/SSE
+# ADR-0032 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0033-responses-http-sse.md
+++ b/structure/decisions/ADR-0033-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0033 — Responses HTTP/SSE
+# ADR-0033 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0034-responses-http-sse.md
+++ b/structure/decisions/ADR-0034-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0034 — Responses HTTP/SSE
+# ADR-0034 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0035-responses-http-sse.md
+++ b/structure/decisions/ADR-0035-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0035 — Responses HTTP/SSE
+# ADR-0035 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0036-responses-http-sse.md
+++ b/structure/decisions/ADR-0036-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0036 — Responses HTTP/SSE
+# ADR-0036 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0037-responses-http-sse.md
+++ b/structure/decisions/ADR-0037-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0037 — Responses HTTP/SSE
+# ADR-0037 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0038-responses-http-sse.md
+++ b/structure/decisions/ADR-0038-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0038 — Responses HTTP/SSE
+# ADR-0038 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0039-responses-http-sse.md
+++ b/structure/decisions/ADR-0039-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0039 — Responses HTTP/SSE
+# ADR-0039 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0040-responses-http-sse.md
+++ b/structure/decisions/ADR-0040-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0040 — Responses HTTP/SSE
+# ADR-0040 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0041-responses-http-sse.md
+++ b/structure/decisions/ADR-0041-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0041 — Responses HTTP/SSE
+# ADR-0041 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0042-responses-http-sse.md
+++ b/structure/decisions/ADR-0042-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0042 — Responses HTTP/SSE
+# ADR-0042 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0043-responses-http-sse.md
+++ b/structure/decisions/ADR-0043-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0043 — Responses HTTP/SSE
+# ADR-0043 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0044-responses-http-sse.md
+++ b/structure/decisions/ADR-0044-responses-http-sse.md
@@ -1,4 +1,4 @@
-# ADR-0044 — Responses HTTP/SSE
+# ADR-0044 — decision recorded under "Responses HTTP/SSE"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#responses-httpsse)
 

--- a/structure/decisions/ADR-0045-standalone-images.md
+++ b/structure/decisions/ADR-0045-standalone-images.md
@@ -1,4 +1,4 @@
-# ADR-0045 — Standalone Images
+# ADR-0045 — decision recorded under "Standalone Images"
 
 - Contract owner: [data-planes/images.md](../data-planes/images.md#standalone-images)
 

--- a/structure/decisions/ADR-0046-claude-desktop-config-library-resolution.md
+++ b/structure/decisions/ADR-0046-claude-desktop-config-library-resolution.md
@@ -1,4 +1,4 @@
-# ADR-0046 — Claude Desktop config-library resolution
+# ADR-0046 — decision recorded under "Claude Desktop config-library resolution"
 
 - Contract owner: [clients/claude-desktop.md](../clients/claude-desktop.md#claude-desktop-config-library-resolution)
 

--- a/structure/decisions/ADR-0047-cursor-native-exec.md
+++ b/structure/decisions/ADR-0047-cursor-native-exec.md
@@ -1,4 +1,4 @@
-# ADR-0047 — Cursor Native Exec
+# ADR-0047 — decision recorded under "Cursor Native Exec"
 
 - Contract owner: [providers/cursor.md](../providers/cursor.md#cursor-native-exec)
 

--- a/structure/decisions/ADR-0048-cursor-native-exec.md
+++ b/structure/decisions/ADR-0048-cursor-native-exec.md
@@ -1,4 +1,4 @@
-# ADR-0048 — Cursor Native Exec
+# ADR-0048 — decision recorded under "Cursor Native Exec"
 
 - Contract owner: [providers/cursor.md](../providers/cursor.md#cursor-native-exec)
 

--- a/structure/decisions/ADR-0049-heartbeat-and-stall-deadline.md
+++ b/structure/decisions/ADR-0049-heartbeat-and-stall-deadline.md
@@ -1,4 +1,4 @@
-# ADR-0049 — Heartbeat and stall deadline
+# ADR-0049 — decision recorded under "Heartbeat and stall deadline"
 
 - Contract owner: [transports/streaming-health.md](../transports/streaming-health.md#heartbeat-and-stall-deadline)
 

--- a/structure/decisions/ADR-0050-heartbeat-and-stall-deadline.md
+++ b/structure/decisions/ADR-0050-heartbeat-and-stall-deadline.md
@@ -1,4 +1,4 @@
-# ADR-0050 — Heartbeat and stall deadline
+# ADR-0050 — decision recorded under "Heartbeat and stall deadline"
 
 - Contract owner: [transports/streaming-health.md](../transports/streaming-health.md#heartbeat-and-stall-deadline)
 

--- a/structure/decisions/ADR-0051-reasoning-and-tool-result-compatibility.md
+++ b/structure/decisions/ADR-0051-reasoning-and-tool-result-compatibility.md
@@ -1,4 +1,4 @@
-# ADR-0051 — Reasoning and tool-result compatibility
+# ADR-0051 — decision recorded under "Reasoning and tool-result compatibility"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#reasoning-and-tool-result-compatibility)
 

--- a/structure/decisions/ADR-0052-reasoning-and-tool-result-compatibility.md
+++ b/structure/decisions/ADR-0052-reasoning-and-tool-result-compatibility.md
@@ -1,4 +1,4 @@
-# ADR-0052 — Reasoning and tool-result compatibility
+# ADR-0052 — decision recorded under "Reasoning and tool-result compatibility"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#reasoning-and-tool-result-compatibility)
 

--- a/structure/decisions/ADR-0053-cursor-active-context-usage.md
+++ b/structure/decisions/ADR-0053-cursor-active-context-usage.md
@@ -1,4 +1,4 @@
-# ADR-0053 — Cursor active-context usage
+# ADR-0053 — decision recorded under "Cursor active-context usage"
 
 - Contract owner: [providers/cursor.md](../providers/cursor.md#cursor-active-context-usage)
 

--- a/structure/decisions/ADR-0054-cursor-conversation-checkpoint-reuse.md
+++ b/structure/decisions/ADR-0054-cursor-conversation-checkpoint-reuse.md
@@ -1,4 +1,4 @@
-# ADR-0054 — Cursor conversation checkpoint reuse
+# ADR-0054 — decision recorded under "Cursor conversation checkpoint reuse"
 
 - Contract owner: [providers/cursor.md](../providers/cursor.md#cursor-conversation-checkpoint-reuse)
 

--- a/structure/decisions/ADR-0055-google-thought-text-visibility-boundary.md
+++ b/structure/decisions/ADR-0055-google-thought-text-visibility-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0055 — Google thought-text visibility boundary
+# ADR-0055 — decision recorded under "Google thought-text visibility boundary"
 
 - Contract owner: [providers/google.md](../providers/google.md#google-thought-text-visibility-boundary)
 

--- a/structure/decisions/ADR-0056-google-response-part-field-boundary.md
+++ b/structure/decisions/ADR-0056-google-response-part-field-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0056 — Google response-part field boundary
+# ADR-0056 — decision recorded under "Google response-part field boundary"
 
 - Contract owner: [providers/google.md](../providers/google.md#google-response-part-field-boundary)
 

--- a/structure/decisions/ADR-0057-google-tool-call-thought-signature-replay.md
+++ b/structure/decisions/ADR-0057-google-tool-call-thought-signature-replay.md
@@ -1,4 +1,4 @@
-# ADR-0057 — Google tool-call thought-signature replay
+# ADR-0057 — decision recorded under "Google tool-call thought-signature replay"
 
 - Contract owner: [providers/google.md](../providers/google.md#google-tool-call-thought-signature-replay)
 

--- a/structure/decisions/ADR-0058-google-tool-result-adjacency-repair.md
+++ b/structure/decisions/ADR-0058-google-tool-result-adjacency-repair.md
@@ -1,4 +1,4 @@
-# ADR-0058 — Google tool-result adjacency repair
+# ADR-0058 — decision recorded under "Google tool-result adjacency repair"
 
 - Contract owner: [providers/google.md](../providers/google.md#google-tool-result-adjacency-repair)
 

--- a/structure/decisions/ADR-0059-xai-grok-hardening-official-grok-build-contract.md
+++ b/structure/decisions/ADR-0059-xai-grok-hardening-official-grok-build-contract.md
@@ -1,4 +1,4 @@
-# ADR-0059 — xAI Grok hardening (official Grok Build contract parity)
+# ADR-0059 — decision recorded under "xAI Grok hardening (official Grok Build contract parity)"
 
 - Contract owner: [providers/xai-grok.md](../providers/xai-grok.md#xai-grok-hardening-official-grok-build-contract-parity)
 

--- a/structure/decisions/ADR-0060-kiro-client-parallel-tool-hint.md
+++ b/structure/decisions/ADR-0060-kiro-client-parallel-tool-hint.md
@@ -1,4 +1,4 @@
-# ADR-0060 — Kiro client parallel-tool hint
+# ADR-0060 — decision recorded under "Kiro client parallel-tool hint"
 
 - Contract owner: [providers/kiro.md](../providers/kiro.md#kiro-client-parallel-tool-hint)
 

--- a/structure/decisions/ADR-0061-kiro-responses-text-controls.md
+++ b/structure/decisions/ADR-0061-kiro-responses-text-controls.md
@@ -1,4 +1,4 @@
-# ADR-0061 — Kiro Responses text controls
+# ADR-0061 — decision recorded under "Kiro Responses text controls"
 
 - Contract owner: [providers/kiro.md](../providers/kiro.md#kiro-responses-text-controls)
 

--- a/structure/decisions/ADR-0062-chat-streaming-client-with-a-json-upstream-resul.md
+++ b/structure/decisions/ADR-0062-chat-streaming-client-with-a-json-upstream-resul.md
@@ -1,4 +1,4 @@
-# ADR-0062 — Chat streaming client with a JSON upstream result
+# ADR-0062 — decision recorded under "Chat streaming client with a JSON upstream result"
 
 - Contract owner: [data-planes/inbound-compat.md](../data-planes/inbound-compat.md#chat-streaming-client-with-a-json-upstream-result)
 

--- a/structure/decisions/ADR-0063-volcengine-ark-assistant-continuation-shapes.md
+++ b/structure/decisions/ADR-0063-volcengine-ark-assistant-continuation-shapes.md
@@ -1,4 +1,4 @@
-# ADR-0063 — Volcengine Ark assistant continuation shapes
+# ADR-0063 — decision recorded under "Volcengine Ark assistant continuation shapes"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#volcengine-ark-assistant-continuation-shapes)
 

--- a/structure/decisions/ADR-0064-chat-structured-output-compatibility.md
+++ b/structure/decisions/ADR-0064-chat-structured-output-compatibility.md
@@ -1,4 +1,4 @@
-# ADR-0064 — Chat structured-output compatibility
+# ADR-0064 — decision recorded under "Chat structured-output compatibility"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#chat-structured-output-compatibility)
 

--- a/structure/decisions/ADR-0065-chat-structured-output-compatibility.md
+++ b/structure/decisions/ADR-0065-chat-structured-output-compatibility.md
@@ -1,4 +1,4 @@
-# ADR-0065 — Chat structured-output compatibility
+# ADR-0065 — decision recorded under "Chat structured-output compatibility"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#chat-structured-output-compatibility)
 

--- a/structure/decisions/ADR-0066-anthropic-structured-output-compatibility.md
+++ b/structure/decisions/ADR-0066-anthropic-structured-output-compatibility.md
@@ -1,4 +1,4 @@
-# ADR-0066 — Anthropic structured-output compatibility
+# ADR-0066 — decision recorded under "Anthropic structured-output compatibility"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#anthropic-structured-output-compatibility)
 

--- a/structure/decisions/ADR-0067-reasoning-display-parity-hidethinkingsummary.md
+++ b/structure/decisions/ADR-0067-reasoning-display-parity-hidethinkingsummary.md
@@ -1,4 +1,4 @@
-# ADR-0067 — Reasoning display parity (hideThinkingSummary)
+# ADR-0067 — decision recorded under "Reasoning display parity (hideThinkingSummary)"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#reasoning-display-parity-hidethinkingsummary)
 

--- a/structure/decisions/ADR-0068-reasoning-display-parity-hidethinkingsummary.md
+++ b/structure/decisions/ADR-0068-reasoning-display-parity-hidethinkingsummary.md
@@ -1,4 +1,4 @@
-# ADR-0068 — Reasoning display parity (hideThinkingSummary)
+# ADR-0068 — decision recorded under "Reasoning display parity (hideThinkingSummary)"
 
 - Contract owner: [providers/chat-compat.md](../providers/chat-compat.md#reasoning-display-parity-hidethinkingsummary)
 

--- a/structure/decisions/ADR-0069-chat-to-responses-message-phase-inference.md
+++ b/structure/decisions/ADR-0069-chat-to-responses-message-phase-inference.md
@@ -1,4 +1,4 @@
-# ADR-0069 — Chat-to-Responses message phase inference
+# ADR-0069 — decision recorded under "Chat-to-Responses message phase inference"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#chat-to-responses-message-phase-inference)
 

--- a/structure/decisions/ADR-0070-same-provider-combo-quota-fallback.md
+++ b/structure/decisions/ADR-0070-same-provider-combo-quota-fallback.md
@@ -1,4 +1,4 @@
-# ADR-0070 — Same-provider combo quota fallback
+# ADR-0070 — decision recorded under "Same-provider combo quota fallback"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#same-provider-combo-quota-fallback)
 

--- a/structure/decisions/ADR-0071-combo-streaming-commit-boundary.md
+++ b/structure/decisions/ADR-0071-combo-streaming-commit-boundary.md
@@ -1,4 +1,4 @@
-# ADR-0071 — Combo streaming commit boundary
+# ADR-0071 — decision recorded under "Combo streaming commit boundary"
 
 - Contract owner: [transports/responses.md](../transports/responses.md#combo-streaming-commit-boundary)
 

--- a/structure/decisions/ADR-0072-transport-inventory.md
+++ b/structure/decisions/ADR-0072-transport-inventory.md
@@ -1,4 +1,4 @@
-# ADR-0072 — Transport inventory
+# ADR-0072 — decision recorded under "Transport inventory"
 
 - Contract owner: [transports/inventory.md](../transports/inventory.md#transport-inventory)
 

--- a/structure/decisions/ADR-0073-authentication-boundaries.md
+++ b/structure/decisions/ADR-0073-authentication-boundaries.md
@@ -1,4 +1,4 @@
-# ADR-0073 — Authentication boundaries
+# ADR-0073 — decision recorded under "Authentication boundaries"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#authentication-boundaries)
 

--- a/structure/decisions/ADR-0074-api-ownership.md
+++ b/structure/decisions/ADR-0074-api-ownership.md
@@ -1,4 +1,4 @@
-# ADR-0074 — API ownership
+# ADR-0074 — decision recorded under "API ownership"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#api-ownership)
 

--- a/structure/decisions/ADR-0075-startup-safety.md
+++ b/structure/decisions/ADR-0075-startup-safety.md
@@ -1,4 +1,4 @@
-# ADR-0075 — Startup safety
+# ADR-0075 — decision recorded under "Startup safety"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#startup-safety)
 

--- a/structure/decisions/ADR-0076-startup-safety.md
+++ b/structure/decisions/ADR-0076-startup-safety.md
@@ -1,4 +1,4 @@
-# ADR-0076 — Startup safety
+# ADR-0076 — decision recorded under "Startup safety"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#startup-safety)
 

--- a/structure/decisions/ADR-0077-startup-safety.md
+++ b/structure/decisions/ADR-0077-startup-safety.md
@@ -1,4 +1,4 @@
-# ADR-0077 — Startup safety
+# ADR-0077 — decision recorded under "Startup safety"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#startup-safety)
 

--- a/structure/decisions/ADR-0078-usage-accounting.md
+++ b/structure/decisions/ADR-0078-usage-accounting.md
@@ -1,4 +1,4 @@
-# ADR-0078 — Usage accounting
+# ADR-0078 — decision recorded under "Usage accounting"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#usage-accounting)
 

--- a/structure/decisions/ADR-0079-usage-accounting.md
+++ b/structure/decisions/ADR-0079-usage-accounting.md
@@ -1,4 +1,4 @@
-# ADR-0079 — Usage accounting
+# ADR-0079 — decision recorded under "Usage accounting"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#usage-accounting)
 

--- a/structure/decisions/ADR-0080-github-pages.md
+++ b/structure/decisions/ADR-0080-github-pages.md
@@ -1,4 +1,4 @@
-# ADR-0080 — GitHub Pages
+# ADR-0080 — decision recorded under "GitHub Pages"
 
 - Contract owner: [ops/docs-and-release.md](../ops/docs-and-release.md#github-pages)
 

--- a/structure/decisions/ADR-0081-container-deployment-recipe.md
+++ b/structure/decisions/ADR-0081-container-deployment-recipe.md
@@ -1,4 +1,4 @@
-# ADR-0081 — Container deployment recipe
+# ADR-0081 — decision recorded under "Container deployment recipe"
 
 - Contract owner: [ops/docs-and-release.md](../ops/docs-and-release.md#container-deployment-recipe)
 

--- a/structure/decisions/ADR-0082-windows-service-wrapper-and-incomplete-updates.md
+++ b/structure/decisions/ADR-0082-windows-service-wrapper-and-incomplete-updates.md
@@ -1,4 +1,4 @@
-# ADR-0082 — Windows service wrapper and incomplete updates
+# ADR-0082 — decision recorded under "Windows service wrapper and incomplete updates"
 
 - Contract owner: [ops/docs-and-release.md](../ops/docs-and-release.md#windows-service-wrapper-and-incomplete-updates)
 

--- a/structure/decisions/ADR-0083-maintenance-governance.md
+++ b/structure/decisions/ADR-0083-maintenance-governance.md
@@ -1,4 +1,4 @@
-# ADR-0083 — Maintenance governance
+# ADR-0083 — decision recorded under "Maintenance governance"
 
 - Contract owner: [ops/docs-and-release.md](../ops/docs-and-release.md#maintenance-governance)
 

--- a/structure/decisions/ADR-0084-public-provider-contract.md
+++ b/structure/decisions/ADR-0084-public-provider-contract.md
@@ -1,4 +1,4 @@
-# ADR-0084 — Public provider contract
+# ADR-0084 — decision recorded under "Public provider contract"
 
 - Contract owner: [providers/openai-tiers.md](../providers/openai-tiers.md#public-provider-contract)
 

--- a/structure/decisions/ADR-0085-public-provider-contract.md
+++ b/structure/decisions/ADR-0085-public-provider-contract.md
@@ -1,4 +1,4 @@
-# ADR-0085 — Public provider contract
+# ADR-0085 — decision recorded under "Public provider contract"
 
 - Contract owner: [providers/openai-tiers.md](../providers/openai-tiers.md#public-provider-contract)
 

--- a/structure/decisions/ADR-0086-public-provider-contract.md
+++ b/structure/decisions/ADR-0086-public-provider-contract.md
@@ -1,4 +1,4 @@
-# ADR-0086 — Public provider contract
+# ADR-0086 — decision recorded under "Public provider contract"
 
 - Contract owner: [providers/openai-tiers.md](../providers/openai-tiers.md#public-provider-contract)
 

--- a/structure/decisions/ADR-0087-model-and-wire-identity.md
+++ b/structure/decisions/ADR-0087-model-and-wire-identity.md
@@ -1,4 +1,4 @@
-# ADR-0087 — Model and wire identity
+# ADR-0087 — decision recorded under "Model and wire identity"
 
 - Contract owner: [providers/openai-tiers.md](../providers/openai-tiers.md#model-and-wire-identity)
 

--- a/structure/decisions/ADR-0088-model-and-wire-identity.md
+++ b/structure/decisions/ADR-0088-model-and-wire-identity.md
@@ -1,4 +1,4 @@
-# ADR-0088 — Model and wire identity
+# ADR-0088 — decision recorded under "Model and wire identity"
 
 - Contract owner: [providers/openai-tiers.md](../providers/openai-tiers.md#model-and-wire-identity)
 

--- a/structure/decisions/ADR-0089-process-local-affinity-diagnostics.md
+++ b/structure/decisions/ADR-0089-process-local-affinity-diagnostics.md
@@ -1,4 +1,4 @@
-# ADR-0089 — Process-local affinity diagnostics
+# ADR-0089 — decision recorded under "Process-local affinity diagnostics"
 
 - Contract owner: [providers/openai-tiers.md](../providers/openai-tiers.md#process-local-affinity-diagnostics)
 

--- a/structure/decisions/ADR-0090-hermes-model-capabilities.md
+++ b/structure/decisions/ADR-0090-hermes-model-capabilities.md
@@ -1,4 +1,4 @@
-# ADR-0090 — Hermes Model Capabilities
+# ADR-0090 — decision recorded under "Hermes Model Capabilities"
 
 - Contract owner: [clients/integrations.md](../clients/integrations.md#hermes-model-capabilities)
 

--- a/structure/decisions/ADR-0091-ownership-axes.md
+++ b/structure/decisions/ADR-0091-ownership-axes.md
@@ -1,4 +1,4 @@
-# ADR-0091 — Ownership Axes
+# ADR-0091 — decision recorded under "Ownership Axes"
 
 - Contract owner: [clients/integrations.md](../clients/integrations.md#ownership-axes)
 

--- a/structure/decisions/ADR-0092-zcode-runtime-metadata.md
+++ b/structure/decisions/ADR-0092-zcode-runtime-metadata.md
@@ -1,4 +1,4 @@
-# ADR-0092 — ZCode Runtime Metadata
+# ADR-0092 — decision recorded under "ZCode Runtime Metadata"
 
 - Contract owner: [clients/integrations.md](../clients/integrations.md#zcode-runtime-metadata)
 

--- a/structure/decisions/ADR-0093-moonshot-ref-with-siblings-normalization.md
+++ b/structure/decisions/ADR-0093-moonshot-ref-with-siblings-normalization.md
@@ -1,4 +1,4 @@
-# ADR-0093 — Moonshot `$ref`-with-siblings normalization
+# ADR-0093 — decision recorded under "Moonshot `$ref`-with-siblings normalization"
 
 - Contract owner: [adapters/registry.md](../adapters/registry.md#moonshot-ref-with-siblings-normalization)
 
@@ -22,3 +22,10 @@
   큰 정의를 여러 노드가 참조하면 출력이 커질 수 있고, 예산이 소진되면 해당 노드는 빈 객체나
   순수 `$ref`로 닫힌다 — 약해진 스키마를 절반만 내보내는 것보다 낫다. Moonshot 계열
   `openai-chat` baseUrl에만 적용되고 다른 provider는 손대지 않는다.
+
+## Why three budgets
+
+예산은 세 가지다. 확장 횟수만으로는 참조가 하나도 없는 깊은 스키마를 막지 못해서, 깊이와
+노드 수를 따로 둔다 — `google-tool-schema.ts`가 이미 쓰는 형태다. 두 가드 모두 제거했을 때
+실제로 red가 되는지 확인했고, 예산을 풀면 20k 깊이에서 `RangeError: Maximum call stack size
+exceeded`가 난다.

--- a/structure/decisions/ADR-0094-canonical-forward-continuation-extensions.md
+++ b/structure/decisions/ADR-0094-canonical-forward-continuation-extensions.md
@@ -1,4 +1,4 @@
-# ADR-0094 — Canonical forward continuation extensions
+# ADR-0094 — decision recorded under "Canonical forward continuation extensions"
 
 - Contract owner: [adapters/compatibility-contracts.md](../adapters/compatibility-contracts.md#canonical-forward-continuation-extensions)
 

--- a/structure/decisions/ADR-0095-canonical-forward-continuation-extensions.md
+++ b/structure/decisions/ADR-0095-canonical-forward-continuation-extensions.md
@@ -1,4 +1,4 @@
-# ADR-0095 — Canonical forward continuation extensions
+# ADR-0095 — decision recorded under "Canonical forward continuation extensions"
 
 - Contract owner: [adapters/compatibility-contracts.md](../adapters/compatibility-contracts.md#canonical-forward-continuation-extensions)
 

--- a/structure/decisions/ADR-0096-z-ai-quota-destination-ownership.md
+++ b/structure/decisions/ADR-0096-z-ai-quota-destination-ownership.md
@@ -1,4 +1,4 @@
-# ADR-0096 — Z.ai quota destination ownership
+# ADR-0096 — decision recorded under "Z.ai quota destination ownership"
 
 - Contract owner: [gui-and-management-api.md](../gui-and-management-api.md#zai-quota-destination-ownership)
 

--- a/structure/subagents.md
+++ b/structure/subagents.md
@@ -131,7 +131,7 @@ whole-config overwrite. Existing disabled-model visibility rules remain unchange
 Quota-aware fallback walks a configured chain when the featured model is exhausted, probing
 availability on a bounded interval (default 60 s, `src/codex/subagent-model-fallback.ts`). It rewrites
 the requested model id only; effort remains owned by the caps described under
-[Ultra reasoning level](#ultra-reasoning-level).
+[Ultra reasoning level](catalog.md#ultra-reasoning-level).
 
 `injectionModel` and `injectionEffort` are shared selections with two independent consumers.
 `multiAgentGuidanceEnabled` controls only OpenCodex-authored delegation guidance.

--- a/tests/ci-workflows/structure-ssot.test.ts
+++ b/tests/ci-workflows/structure-ssot.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { renderIndex, runStructureChecks, type Manifest } from "../../scripts/structure-ssot";
+import { loadManifest, renderIndex, runStructureChecks, type Manifest } from "../../scripts/structure-ssot";
 import { repoRoot } from "../helpers/repo-root";
 
 /**
@@ -66,6 +66,8 @@ function scaffold(): string {
       "",
       "- **INV-A-01** — alpha keeps working.",
       "  Enforced by " + BT + "tests/alpha/alpha.test.ts" + BT + ".",
+      "",
+      "Alpha lives in " + BT + "src/alpha/keep.ts" + BT + ".",
       "",
       "> Decision record: [ADR-0001](decisions/ADR-0001-alpha.md)",
       "",
@@ -267,6 +269,59 @@ describe("structure/ SSOT", () => {
     manifest.docs[0]!.documents.push("src/imaginary/");
     saveManifest(root, manifest);
     fires(root, "claims src/imaginary/, which this tree does not have");
+  });
+
+  test("a described area the doc never names", () => {
+    const root = scaffold();
+    write(root, "src/beta/new.ts", "export const beta = 1;\n");
+    const manifest = manifestOf(root);
+    manifest.docs[0]!.documents.push("src/beta/");
+    saveManifest(root, manifest);
+    fires(root, "claims src/beta/ but never names a path in it");
+  });
+
+  test("a fragment-only link that names no heading in its own document", () => {
+    const root = scaffold();
+    const body = readFileSync(join(root, "structure/overview.md"), "utf8");
+    write(root, "structure/overview.md", body + "\nSee [that rule](#no-such-heading).\n");
+    fires(root, "links #no-such-heading, but that heading anchor does not exist");
+  });
+
+  test("overview.md missing fails instead of silencing every invariant check", () => {
+    const root = scaffold();
+    const manifest = manifestOf(root);
+    manifest.docs = [];
+    saveManifest(root, manifest);
+    rmSync(join(root, "structure/overview.md"));
+    fires(root, "structure/overview.md is missing");
+  });
+
+  test("a record named in prose but not linked is not owned", () => {
+    const root = scaffold();
+    const body = readFileSync(join(root, "structure/overview.md"), "utf8").replace(
+      "> Decision record: [ADR-0001](decisions/ADR-0001-alpha.md)",
+      "The reasoning sits in decisions/ADR-0001-alpha.md for anyone curious.",
+    );
+    write(root, "structure/overview.md", body);
+    fires(root, "ADR-0001-alpha.md is not linked from any doc");
+  });
+
+  test("a bare filename is not treated as a repository path", () => {
+    const root = scaffold();
+    const body = readFileSync(join(root, "structure/overview.md"), "utf8");
+    write(root, "structure/overview.md", body + "\nCodex reads " + BT + "models_cache.json" + BT + " at startup.\n");
+    expect(runStructureChecks(root)).toEqual([]);
+  });
+
+  test("a malformed manifest is an actionable failure, not a stack trace", () => {
+    expect(loadManifest("{not json")).toHaveProperty("error");
+    const shapeless = loadManifest(JSON.stringify({ sizeBudgetLines: 600 }));
+    expect(shapeless).toHaveProperty("error");
+    expect((shapeless as { error: string }).error).toContain("docs must be an array");
+
+    const root = scaffold();
+    write(root, "structure/manifest.json", "{not json");
+    fires(root, "is not valid JSON");
   });
 
   test("INDEX.md that drifted from the manifest", () => {

--- a/tests/ci-workflows/structure-ssot.test.ts
+++ b/tests/ci-workflows/structure-ssot.test.ts
@@ -86,6 +86,22 @@ const fires = (root: string, needle: string): void => {
   expect(runStructureChecks(root).join("\n")).toContain(needle);
 };
 
+/**
+ * The negative cases above run in a plain temp directory, where git has no index and the gate falls
+ * back to the filesystem. That leaves the index branch — the one the module argues hardest for —
+ * untested, so these cases build a real repository and drive it.
+ */
+function gitScaffold(): string {
+  const root = scaffold();
+  expect(Bun.spawnSync(["git", "init", "-q"], { cwd: root }).exitCode).toBe(0);
+  stage(root);
+  return root;
+}
+
+function stage(root: string): void {
+  expect(Bun.spawnSync(["git", "add", "-A"], { cwd: root }).exitCode).toBe(0);
+}
+
 describe("structure/ SSOT", () => {
   test("the maintainer docs still describe this tree", () => {
     expect(runStructureChecks(repoRoot())).toEqual([]);
@@ -277,7 +293,7 @@ describe("structure/ SSOT", () => {
     const manifest = manifestOf(root);
     manifest.docs[0]!.documents.push("src/beta/");
     saveManifest(root, manifest);
-    fires(root, "claims src/beta/ but never names a path in it");
+    fires(root, "claims src/beta/ but never names it or a path in it");
   });
 
   test("a fragment-only link that names no heading in its own document", () => {
@@ -333,5 +349,56 @@ describe("structure/ SSOT", () => {
   test("INDEX.md in this repository is the generated file", () => {
     const root = repoRoot();
     expect(readFileSync(join(root, "structure/INDEX.md"), "utf8").replace(/\r\n/g, "\n")).toBe(renderIndex(manifestOf(root)));
+  });
+
+  test("a tracked tree is judged by the index: a case variant is named, not silently accepted", () => {
+    const root = gitScaffold();
+    expect(runStructureChecks(root)).toEqual([]);
+    const body = readFileSync(join(root, "structure/overview.md"), "utf8").replace(
+      BT + "src/alpha/keep.ts" + BT,
+      BT + "src/Alpha/keep.ts" + BT,
+    );
+    write(root, "structure/overview.md", body);
+    stage(root);
+    fires(root, "but the tracked path is src/alpha/keep.ts");
+  });
+
+  test("a tracked tree rejects an untracked leftover that CI would never see", () => {
+    const root = gitScaffold();
+    const body = readFileSync(join(root, "structure/overview.md"), "utf8");
+    write(root, "src/alpha/scratch.ts", "export const scratch = 1;\n");
+    write(root, "structure/overview.md", body + "\nAlso " + BT + "src/alpha/scratch.ts" + BT + ".\n");
+    // overview.md is staged so the reference is read; scratch.ts deliberately is not.
+    expect(Bun.spawnSync(["git", "add", "structure/overview.md"], { cwd: root }).exitCode).toBe(0);
+    fires(root, "names src/alpha/scratch.ts, which this tree does not have");
+  });
+
+  test("a record shown inside a fenced example is not a second owner", () => {
+    const root = scaffold();
+    const manifest = manifestOf(root);
+    manifest.docs.push({ path: "second.md", tier: 1, title: "Second", scope: "s", documents: [] });
+    const fence = BT.repeat(3);
+    write(root, "structure/second.md", "# Second\n\n" + fence + "text\n> Decision record: [ADR-0001](decisions/ADR-0001-alpha.md)\n" + fence + "\n");
+    saveManifest(root, manifest);
+    expect(runStructureChecks(root)).toEqual([]);
+  });
+
+  test("a Decision record line pointing outside decisions/ is rejected", () => {
+    const root = scaffold();
+    write(root, "structure/elsewhere.md", "# Elsewhere\n");
+    const body = readFileSync(join(root, "structure/overview.md"), "utf8").replace(
+      "> Decision record: [ADR-0001](decisions/ADR-0001-alpha.md)",
+      "> Decision record: [ADR-0001](elsewhere.md)",
+    );
+    write(root, "structure/overview.md", body);
+    fires(root, "which is not in decisions/");
+  });
+
+  test("a malformed grace element is a failure line, not a thrown TypeError", () => {
+    const root = scaffold();
+    const manifest = manifestOf(root) as unknown as { absentPaths: unknown[] };
+    manifest.absentPaths = ["go/"];
+    write(root, "structure/manifest.json", JSON.stringify(manifest, null, 2) + "\n");
+    fires(root, "absentPaths[0].path must be a string");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #4276, closing the review findings on the SSOT gate. CodeRabbit posted twelve findings;
these are the ones still true against the merged code.

The gate was claiming more than it checked in four places:

- A fragment-only link was skipped entirely — and one was already broken. `structure/subagents.md`
  pointed at `#ultra-reasoning-level`, a heading that moved to `catalog.md` during the split. Fragment
  targets now resolve against their own document, which found it on the first run.
- Link targets were resolved with `existsSync` while backticked paths went through the git index. That
  is exactly the per-machine split verdict this module exists to remove, applied to the reference
  class this change churned hardest.
- A `documents` entry was accepted because the path existed, not because the doc said anything about
  it, so the map could claim coverage the prose did not have. A claim now has to be backed by a path
  the doc actually names.
- Decision-record ownership was inferred from any occurrence of the filename in raw text, so a record
  path inside a fenced example counted as a second owner, and an orphaned record whose owner link had
  been deleted still looked owned. Ownership is now the `> Decision record:` link, read fence-stripped.

Also fixed: the filesystem fallback no longer applies when the git index is readable, so untracked
local leftovers cannot satisfy a check CI will fail; the manifest goes through a validating loader,
so a malformed file is a failure line instead of an uncaught stack trace; a missing `overview.md` is a
failure rather than silence across every invariant binding; and backticked paths rooted at any
tracked top-level entry are checked, not only the ten directories that were hardcoded.

**One finding is answered rather than implemented.** Validating every filename-shaped token would
reject the runtime files these docs legitimately name — `config.toml`, `models_cache.json`, `ocx.pid` —
which live in a user's home, not in this repository. The boundary is now stated in
`structure/AGENTS.md`, and root documents stay covered because a reference like `MAINTAINERS.md` is
written as a link, and links are checked.

Docs: the rationale left inline in `structure/adapters/registry.md` moves into ADR-0093 with its
evidence intact. All 96 records are retitled to say what they are — the heading names the section a
record was extracted from, not the decision it contains, and a title that reads like a decision name
while being a section name sends maintainers to the wrong record. `src/AGENTS.md` now says every
applicable doc is updated, not one.

Not carried here: the `ADR-0077` finding about binding update-worker liveness to a job identity is a
runtime defect in the update path, not a documentation problem, and does not belong in a docs PR.

## Verification

- `bun run typecheck`
- `bun run structure:check`
- `bun run privacy:scan`
- `bun test tests/ci-workflows/structure-ssot.test.ts` — 33 pass, six of them new, including the two
  cases that must NOT fire: a bare filename is not a repository path, and a record named in prose is
  not an owner

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified how source areas map to multiple supporting documents.
  - Updated decision-record headings to identify their documented topic.
  - Corrected an internal documentation link for Ultra reasoning levels.
  - Added guidance covering staged files, document coverage, links, manifests, and required overview documentation.
  - Expanded decision-record documentation explaining schema safety limits.

- **Bug Fixes**
  - Structure validation now reports actionable errors for malformed manifests, missing documentation, invalid links, and incomplete source-area coverage.
  - Validation more accurately recognizes repository paths and decision-record ownership.
  - Added broader coverage for filesystem, Git-index, and malformed-input validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->