### PR TITLE
fix(cursor): capture the conversation checkpoint a suspended tool turn actually sends

### DIFF
--- a/devlog/_plan/260911_cursor_checkpoint_capture/000_plan.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/000_plan.md
@@ -1,0 +1,105 @@
+# Cursor checkpoint capture — why #4245 full-replays
+
+Unit opened 2026-09-11. Tracks issue #4245 (Cursor adapter always full-replays,
+`cached_tokens=0`, while direct `cursor-agent` cache-hits on the same account).
+
+## Why this unit exists
+
+A first triage pass concluded the cause was `isCursorExternalWireModel` excluding
+native router models from the tool-suspended checkpoint commit, and proposed
+relaxing that gate. A live probe disproved it. The gate is not reached: every
+model class dies one condition later, on `capturedBytes === 0`.
+
+That matters beyond this issue. The proposed patch would have shipped a behaviour
+change to a replay path, passed review on plausibility, and fixed nothing — the
+refusal it removed is not the refusal that fires.
+
+## Evidence already captured
+
+macOS, opencodex 2.50.0, real Cursor OAuth account, `ocx debug provider on`,
+requests to the local proxy. Nothing patched.
+
+Same forced-tool-call request, three model classes:
+
+```
+cursor/auto-intelligence  (native router)
+[ocx:cursor:checkpoint-commit-refused] {"replayUnsafe":false,"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":false,"storeCheckpoints":true,"capturedBytes":0}
+
+cursor/claude-4.5-sonnet  (external)
+[ocx:cursor:checkpoint-commit-refused] {"replayUnsafe":false,"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":true,"storeCheckpoints":true,"capturedBytes":0}
+
+cursor/composer-2.5-fast  (native composer)
+[ocx:cursor:checkpoint-commit-refused] {"replayUnsafe":false,"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":false,"storeCheckpoints":true,"capturedBytes":0}
+```
+
+A turn with no client tool commits normally:
+
+```
+[ocx:cursor:checkpoint-continuation] {"mode":"full-replay","checkpointRefHash":"c5609327a9ac1ec4","checkpointBytes":492,"wireModel":"default"}
+[ocx:cursor:checkpoint-continuation] {"mode":"full-replay","checkpointRefHash":"bdd0d48f85f7ebee","checkpointBytes":553,"wireModel":"default"}
+```
+
+Two sequential chat-completions turns, same content:
+
+```
+[ocx:cursor:run-request] {"conversationId":"cursor_f3e3e375188f41b9af0669d7090eb962","continuationMode":"full-replay","checkpointPresent":false,"checkpointInvalidationReason":"missing_ref"}
+[ocx:cursor:run-request] {"conversationId":"cursor_24bbb91416874b53b9a87f97530cfa14","continuationMode":"full-replay","checkpointPresent":false,"checkpointInvalidationReason":"missing_ref"}
+```
+
+And the suspend/cancel sequence on a tool turn, with no
+`conversationCheckpointUpdate` among the 33 frames:
+
+```
+[ocx:cursor:client-tool-suspend] {"reason":"Responses bridge owns client tools; ending turn without fake mcpResult","framesReceived":33,"elapsedMs":2886}
+[ocx:cursor:stream-cancel-expected] {"code":"ERR_HTTP2_STREAM_ERROR","message":"Cursor stream suspended: Stream closed with error code NGHTTP2_CANCEL"}
+```
+
+## Cause map
+
+**C1 — no capture on a client-tool turn.** `capturedCheckpointBytes` is set only by
+the `conversationCheckpointUpdate` frame in `CursorLiveTransport.handleServerMessage`
+(`src/adapters/cursor/live-transport.ts`). On a client-tool turn the finalize-grace
+timer fires, logs `client-tool-suspend`, and calls `cancelCursorRun()`. The frame has
+not arrived by then. Affects every model class equally.
+
+**C2 — unstable conversation identity.** Each chat-completions turn derives a new
+`conversationId`, so a checkpoint committed on turn N is unreachable on turn N+1
+(`checkpointInvalidationReason: missing_ref`). Observed only on the stateless path so
+far; the `/v1/responses` path is untested and is what Codex users actually take.
+
+**Not a cause:** the native/external model split. Recorded so the next reader does
+not retry it.
+
+## Constraints
+
+- No change to `src/router.ts`, `src/server/lifecycle.ts`, `src/server/responses/core.ts`.
+- No change to the checkpoint design or its safety contract: a checkpoint that claims
+  coverage it does not have would send wrong context upstream. Slower and correct
+  beats faster and wrong.
+- Every behavioural claim needs a diagnostic captured in the same session it is
+  claimed in.
+
+## Work-phase map (dependency ordered)
+
+| Phase | Doc | Decides |
+|---|---|---|
+| wp1 | this file + 010/020/030 | roadmap locked, docs only |
+| wp2 | `010_phase1_grace_experiment.md` | C1: does the frame arrive late, or never |
+| wp3 | `020_phase2_responses_identity.md` | C2: is it chat-completions-specific |
+| wp4 | `030_phase3_landing.md` | land the proven fix, or record the verdict |
+
+wp2 and wp3 are independent of each other and both depend only on wp1. wp4 depends on
+wp2; if wp3 finishes first its outcome folds into wp4 as an additional branch.
+
+## Decision tree
+
+- **wp2 = LATE** (frame arrives when the grace is extended): C1 is a grace-computation
+  bug. Land branch A in `030`.
+- **wp2 = NEVER**: upstream does not serialize state for a suspended turn. C1 is not
+  fixable inside this adapter; record the verdict and the evidence.
+- **wp3 = STABLE on /v1/responses**: C2 is an artifact of the stateless path and is not
+  a user-facing defect for Codex. Record and close that half.
+- **wp3 = UNSTABLE on /v1/responses**: C2 is real and general. Land branch B in `030`.
+
+Either NEVER or STABLE is a legitimate terminal outcome for its half. A recorded
+negative with captured evidence is the deliverable when no safe change exists.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/000_plan.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/000_plan.md
@@ -87,9 +87,32 @@ not retry it.
 | wp2 | `010_phase1_grace_experiment.md` | C1: does the frame arrive late, or never |
 | wp3 | `020_phase2_responses_identity.md` | C2: is it chat-completions-specific |
 | wp4 | `030_phase3_landing.md` | land the proven fix, or record the verdict |
+| wp2b | `010` closing section | only if wp2 is INCONCLUSIVE: instrumented rerun that can reach NEVER |
+| wp5 | `030` closing section | only if branch A lands: does a captured snapshot actually cover the tool call |
 
 wp2 and wp3 are independent of each other and both depend only on wp1. wp4 depends on
 wp2; if wp3 finishes first its outcome folds into wp4 as an additional branch.
+
+wp2b and wp5 were appended during wp1's audit (LOOP-UNIT-CHAIN-01). Both are
+conditional: neither runs unless its predecessor returns the outcome that needs it.
+
+## What the wp1 audit changed
+
+The first draft of this roadmap was audited and failed on two high findings, both
+folded before the roadmap was locked:
+
+1. `030` branch A paired the capture fix with dropping the native/external gate,
+   arguing that arrival order became a sound proof. It does not:
+   `conversationCheckpointUpdate` is classified liveness-only, so a snapshot can arrive
+   after the tool call with contents that predate it. The gate edit was removed and
+   became wp5, gated on decoding the snapshot.
+2. `010` used `client-tool-suspend.elapsedMs` to prove which grace branch ran. That
+   field is turn-relative, and this unit's own evidence already shows `elapsedMs: 2886`
+   on the 50 ms path. The experiment was downgraded to positive-only; a NEVER verdict
+   now requires wp2b.
+
+Recording this because both mistakes have the same shape as the one that opened the
+unit: a plausible mechanism asserted without checking what the field actually measures.
 
 ## Decision tree
 

--- a/devlog/_plan/260911_cursor_checkpoint_capture/000_plan.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/000_plan.md
@@ -70,6 +70,17 @@ far; the `/v1/responses` path is untested and is what Codex users actually take.
 **Not a cause:** the native/external model split. Recorded so the next reader does
 not retry it.
 
+## Status of each cause
+
+| Cause | Verdict | Evidence |
+|---|---|---|
+| C1 tool-turn capture | **LATE — real, fixable** | `010` Result, `011`, `012`: 50 ms captures nothing, 1500 ms captures 3036 bytes after `toolCallStarted`, wire held constant |
+| C2 conversation identity | **Closed, no patch** | `020` Result: two threaded `/v1/responses` turns share `conversationHash cursor_cdbed7dcc` and turn 2 resumes with `mode: checkpoint`. Scoped to threaded conversations; an unthreaded one-shot legitimately starts fresh |
+| native/external gate | **Not a cause; gated behind wp5** | every model class refused identically at `capturedBytes: 0` before C1 was fixed |
+
+So the whole of `#4245` reduces to C1, and `030` branch A is the only patch this unit
+will produce. Branch B is dropped.
+
 ## Constraints
 
 - No change to `src/router.ts`, `src/server/lifecycle.ts`, `src/server/responses/core.ts`.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/001_frame_evidence.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/001_frame_evidence.md
@@ -1,0 +1,60 @@
+# Frame-level record of one suspended tool turn
+
+Research material for `000_plan.md`. No diffs here.
+
+`000_plan.md` asserts that no `conversationCheckpointUpdate` appears among the frames
+of a client-tool turn. That claim carries the whole unit — branch A exists only if the
+frame is absent at 50 ms — so the sequence it rests on is recorded here rather than
+left in a chat transcript.
+
+## Capture conditions
+
+macbookpro-2, macOS, opencodex 2.50.0, proxy PID 70500 on 127.0.0.1:10100, real Cursor
+OAuth account. `ocx debug provider on` (runtime override, no restart). Request:
+`POST /v1/chat/completions`, `model: cursor/auto-intelligence`, one `get_weather` tool,
+`tool_choice: required`, no `parallel_tool_calls` — so the 50 ms base grace applied.
+Response was HTTP 200 with `finish_reason: tool_calls` and
+`prompt_tokens_details.cached_tokens: 0`.
+
+## Sequence
+
+```
+[ocx:cursor:connected]   {"transport":"http2","connectMs":403}
+[ocx:cursor:first-frame] {"latencyMs":630}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"heartbeat"}
+[ocx:cursor:frame] {"case":"kvServerMessage","kv":"getBlobArgs"}       x2
+[ocx:cursor:frame] {"case":"kvServerMessage","kv":"setBlobArgs"}       x4
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"thinkingDelta"}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"tokenDelta"}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"thinkingDelta"}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"tokenDelta"}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"thinkingCompleted"}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"textDelta"}   interleaved with
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"tokenDelta"}  x7 pairs
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"partialToolCall","toolCase":"mcpToolCall","callId":"call-d4f5fcfc-...-0"}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"tokenDelta"}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"toolCallStarted","toolCase":"mcpToolCall","callId":"call-d4f5fcfc-...-0"}
+[ocx:cursor:frame] {"case":"execServerMessage","exec":"mcpArgs"}
+[ocx:cursor:frame] {"case":"kvServerMessage","kv":"setBlobArgs"}       x4
+[ocx:cursor:client-tool-suspend]      {"reason":"Responses bridge owns client tools; ending turn without fake mcpResult","framesReceived":33,"elapsedMs":2886}
+[ocx:cursor:stream-end]               {"committed":true,"framesReceived":33,"expectedClose":true,"elapsedMs":2886}
+[ocx:cursor:checkpoint-commit-refused] {"replayUnsafe":false,"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":false,"storeCheckpoints":true,"capturedBytes":0}
+[ocx:cursor:stream-cancel-expected]   {"message":"Cursor upstream error: Cursor request was aborted","framesReceived":33,"elapsedMs":2887}
+[ocx:cursor:stream-cancel-expected]   {"code":"ERR_HTTP2_STREAM_ERROR","message":"Cursor stream suspended: Stream closed with error code NGHTTP2_CANCEL","framesReceived":33,"elapsedMs":2893}
+```
+
+## What the sequence establishes, and what it does not
+
+Establishes: across all 33 decoded frames there is no `conversationCheckpointUpdate`,
+and the refusal that follows is over-determined — `capturedBytes: 0` fires regardless
+of the model gate one line above it.
+
+Does **not** establish that upstream never sends one. The stream was cancelled 7 ms
+after the suspend (2886 to 2893), so the observation window closes immediately. This is
+precisely why `010` can only return a positive; an absence here is an absence of
+opportunity, not evidence of absence.
+
+The last four `setBlobArgs` frames arriving after `toolCallStarted` are worth noting:
+upstream was still writing blob state when the cancel landed. That is consistent with
+the late-arrival hypothesis, and consistent with the frame simply not existing for a
+suspended turn. It does not discriminate between them.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/010_phase1_grace_experiment.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/010_phase1_grace_experiment.md
@@ -67,3 +67,43 @@ back INCONCLUSIVE: add `graceMs: this.activeClientToolFinalizeGraceMs` to the
 `client-tool-suspend` diagnostic payload, build on macbookpro-2 in a throwaway
 checkout, and rerun arm B. NEVER is then `capturedBytes: 0` with a logged
 `graceMs` of 1500. That instrumented arm is wp2b, appended only if needed.
+
+## Result — LATE
+
+Run 2026-09-11 on macbookpro-2, opencodex 2.50.0, same account and toggle as `001`.
+Both arms used `cursor/auto-intelligence` and `tool_choice: required`.
+
+Arm A, 1 tool, no `parallel_tool_calls` (50 ms path):
+
+```
+[ocx:cursor:client-tool-suspend]       {"framesReceived":33,"elapsedMs":3299}
+[ocx:cursor:checkpoint-commit-refused] {"replayUnsafe":false,"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":false,"storeCheckpoints":true,"capturedBytes":0}
+conversationCheckpointUpdate frames in window: 0
+```
+
+Arm B, 12 tools, `parallel_tool_calls: true` (1500 ms path):
+
+```
+[ocx:cursor:frame]                     {"case":"conversationCheckpointUpdate","usedTokens":0}
+[ocx:cursor:client-tool-suspend]       {"framesReceived":34,"elapsedMs":4553}
+[ocx:cursor:checkpoint-commit-refused] {"replayUnsafe":false,"emittedClientTool":true,"capturedAfterClientTool":true,"externalModel":false,"storeCheckpoints":true,"capturedBytes":2977}
+conversationCheckpointUpdate frames in window: 1
+```
+
+**LATE.** Upstream does send `conversationCheckpointUpdate` on a suspended client-tool
+turn. At 50 ms the stream is cancelled before it lands; given a longer window the frame
+arrives and 2977 bytes are captured. The positive is self-proving, so the `elapsedMs`
+problem that made a NEVER unreachable never had to be solved. **wp2b is not needed.**
+
+### The second barrier, now visible for the first time
+
+Arm B also shows `capturedAfterClientTool: true` with `externalModel: false` — and it
+*still* refused. With bytes finally present, `toolSuspendedCommit` fails on the wire-model
+test alone. So the two barriers are now separated by evidence rather than by argument:
+
+1. capture never happened (all models) — fixed by `030` branch A1;
+2. the native wire-model gate — reachable only after A1, and still gated on wp5
+   proving the snapshot covers the tool call.
+
+The original triage proposed removing barrier 2 while barrier 1 made it unreachable.
+That is exactly what the probe was built to distinguish, and it did.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/010_phase1_grace_experiment.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/010_phase1_grace_experiment.md
@@ -1,0 +1,58 @@
+# wp2 — does `conversationCheckpointUpdate` arrive late, or never
+
+Decides C1. Written at wp1; re-verify against the tree before executing.
+
+## The lever, and why no build is needed
+
+`src/adapters/cursor/live-transport.ts:114`:
+
+```ts
+const CLIENT_TOOL_FINALIZE_GRACE_MS = 50;
+```
+
+Fifty milliseconds. The probe that produced `capturedBytes: 0` sent one tool and no
+`parallel_tool_calls`, so it took the base path and the stream was cancelled 50 ms
+after the turn drained.
+
+`clientToolFinalizeGraceMsForRequest` (same file, line 416) already raises that window
+from the request alone:
+
+```ts
+if (request.parallelToolCalls === true && (request.tools?.length ?? 0) > 1) {
+  const advertised = request.tools?.length ?? 0;
+  return Math.max(baseGraceMs, Math.min(1_800, Math.max(750, advertised * 125)));
+}
+```
+
+A request with `parallel_tool_calls: true` and 12 advertised tools therefore gets
+`min(1800, max(750, 1500)) = 1500 ms` instead of 50 ms — on the shipped binary, with
+no patch, no second proxy and no credential copy. That is the experiment.
+
+This deliberately replaces the instrumented build the roadmap first imagined. It is
+strictly better: it exercises production code rather than a local mutant, and it
+touches nothing on the operator machine.
+
+## Procedure
+
+1. `ocx debug provider on` on macbookpro-2; record the log line count as a baseline.
+2. Request A (control): 1 tool, no `parallel_tool_calls`, `tool_choice: required`,
+   model `cursor/auto-intelligence`. Expect the 50 ms path.
+3. Request B (treatment): 12 tools, `parallel_tool_calls: true`, `tool_choice: required`,
+   same model. Expect the 1500 ms path.
+4. Capture per request: `client-tool-suspend.elapsedMs`, whether any
+   `conversationCheckpointUpdate` frame appears, and
+   `checkpoint-commit-refused.capturedBytes`.
+5. `ocx debug provider off`.
+
+## Decision rule
+
+- **LATE** — B shows `capturedBytes > 0`, or a `conversationCheckpointUpdate` frame
+  that A lacked. The 50 ms base grace is the defect. Go to `030` branch A.
+- **NEVER** — B still shows `capturedBytes: 0` and no such frame, *and* B's
+  `elapsedMs` is clearly larger than A's, proving the longer window was actually
+  taken. Upstream does not serialize state for a suspended turn; no adapter-local fix.
+- **INCONCLUSIVE** — B's `elapsedMs` is not larger than A's, so the branch was not
+  taken. Fix the request shape and rerun; do not read the result.
+
+That third case is the one worth guarding. Without comparing `elapsedMs` the
+experiment can measure the same 50 ms twice and look like a clean NEVER.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/010_phase1_grace_experiment.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/010_phase1_grace_experiment.md
@@ -46,13 +46,24 @@ touches nothing on the operator machine.
 
 ## Decision rule
 
-- **LATE** — B shows `capturedBytes > 0`, or a `conversationCheckpointUpdate` frame
-  that A lacked. The 50 ms base grace is the defect. Go to `030` branch A.
-- **NEVER** — B still shows `capturedBytes: 0` and no such frame, *and* B's
-  `elapsedMs` is clearly larger than A's, proving the longer window was actually
-  taken. Upstream does not serialize state for a suspended turn; no adapter-local fix.
-- **INCONCLUSIVE** — B's `elapsedMs` is not larger than A's, so the branch was not
-  taken. Fix the request shape and rerun; do not read the result.
+**This experiment can only return a positive.** Folded from the wp1 audit (high):
+`client-tool-suspend.elapsedMs` is `Date.now() - this.turnStartedAt`
+(`live-transport.ts:1015`, `turnStartedAt` set in `open()` at :1033), so it measures
+the whole turn, not the grace delay. `000_plan.md` already records `elapsedMs: 2886`
+on the 50 ms path. Model generation time swamps a 50-vs-1500 ms difference, so
+`elapsedMs` cannot witness which branch of
+`clientToolFinalizeGraceMsForRequest` ran. The original rule below was wrong and is
+replaced.
 
-That third case is the one worth guarding. Without comparing `elapsedMs` the
-experiment can measure the same 50 ms twice and look like a clean NEVER.
+- **LATE** — B shows `capturedBytes > 0`, or a `conversationCheckpointUpdate` frame
+  that A lacked. Self-proving: bytes can only appear if the window outlasted their
+  arrival. The 50 ms base grace is the defect. Go to `030` branch A.
+- **INCONCLUSIVE** — anything else. A `capturedBytes: 0` result here does **not**
+  establish NEVER, because nothing in the emitted diagnostics witnesses the grace that
+  was actually used.
+
+**Reaching a sound NEVER requires instrumentation**, and only if the cheap arm comes
+back INCONCLUSIVE: add `graceMs: this.activeClientToolFinalizeGraceMs` to the
+`client-tool-suspend` diagnostic payload, build on macbookpro-2 in a throwaway
+checkout, and rerun arm B. NEVER is then `capturedBytes: 0` with a logged
+`graceMs` of 1500. That instrumented arm is wp2b, appended only if needed.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/011_wp2_deconfound.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/011_wp2_deconfound.md
@@ -1,0 +1,44 @@
+# wp2 — de-confounding the LATE result
+
+The first LATE run varied two things at once and a reviewer caught it. This records the
+correction, because the correction is the part worth keeping.
+
+## The confound
+
+Arm B raised the finalize grace by sending `parallel_tool_calls: true` with 12 tools.
+But 12 tools is not only a local signal: `buildCursorToolDefinitions` puts them in
+`AgentRunRequest.mcpTools` (`protobuf-request.ts:1607`, `:1711-1712`) and the catalog is
+named in the system note (`:197-201`). A larger catalog could plausibly change Cursor's
+own context accounting and make it emit a `conversationCheckpointUpdate` for reasons
+that have nothing to do with how long we waited.
+
+So the original pair could not tell "we waited longer" from "we asked for more tools".
+
+## The correction
+
+Hold the wire constant, vary only the local knob. `parallelToolCalls` is read at
+`live-transport.ts:423` and `:689` and is never protobuf-encoded
+(`protobuf-request.ts:1736`), so `parallel_tool_calls` changes the grace and nothing
+upstream. Three arms, 12 tools in every one:
+
+| Arm | `parallel_tool_calls` | Grace | `conversationCheckpointUpdate` | `capturedBytes` |
+|---|---|---|---|---|
+| C | false | 50 ms | 0 | 0 |
+| B | true | 1500 ms | 1 | 2742 |
+| C repeat | false | 50 ms | 0 | 0 |
+
+```
+C  [ocx:cursor:checkpoint-commit-refused] {"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":false,"storeCheckpoints":true,"capturedBytes":0}
+B  [ocx:cursor:checkpoint-commit-refused] {"emittedClientTool":true,"capturedAfterClientTool":true,"externalModel":false,"storeCheckpoints":true,"capturedBytes":2742}
+C' [ocx:cursor:checkpoint-commit-refused] {"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":false,"storeCheckpoints":true,"capturedBytes":0}
+```
+
+Identical request bytes, opposite outcomes, reproduced in both directions within one
+session. **LATE is isolated: the 50 ms finalize grace is the cause.**
+
+## Why this is recorded rather than folded silently
+
+Three times in this unit a plausible mechanism was asserted before the field it rested
+on was checked — the native/external gate, `elapsedMs`, and now the tool catalog. Each
+was caught by looking at what the value actually is rather than what it was assumed to
+mean. The pattern is the finding.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/012_wp4_measurement_artifact.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/012_wp4_measurement_artifact.md
@@ -1,0 +1,69 @@
+# wp4 — a measurement artifact that nearly reversed the verdict
+
+While sizing `CHECKPOINT_CAPTURE_GRACE_MS`, a batch of runs returned 0 checkpoint
+frames for **every** arm, including the 12-tool 1500 ms condition that had just
+produced a frame twice. Taken at face value that reverses wp2.
+
+It was an instrumentation bug in the probe, not a behaviour change.
+
+## The artifact
+
+The probes windowed the log by line count: record `L = ocx debug provider logs | wc -l`
+before a request, then read `tail -n +$((L+1))` after. `ocx debug provider logs` is a
+**bounded ring buffer** — measured at exactly 500 lines on this machine. Once the buffer
+is full, `L` equals the cap and every later `tail -n +501` returns nothing. Every arm
+then reports zero, uniformly and convincingly.
+
+Reading `tail -50` after each request instead of a computed offset restores the signal
+immediately.
+
+This is the fourth time in this unit a conclusion rested on a field that did not mean
+what it appeared to mean. The others were the native/external gate, `elapsedMs`, and
+the tool catalog. It is worth saying plainly: **the failure mode of this investigation
+is not bad reasoning about the adapter, it is trusting an observable without checking
+what produces it.**
+
+## Corrected measurement
+
+Tool turn, `parallel_tool_calls: true`, 12 tools (1500 ms):
+
+```
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"toolCallStarted",...}
+[ocx:cursor:frame] {"case":"conversationCheckpointUpdate","usedTokens":0}
+[ocx:cursor:client-tool-suspend] {"framesReceived":33,"elapsedMs":4488}
+[ocx:cursor:checkpoint-commit-refused] {"emittedClientTool":true,"capturedAfterClientTool":true,"externalModel":false,"storeCheckpoints":true,"capturedBytes":3036}
+```
+
+Tool turn, same 12 tools, `parallel_tool_calls` absent (50 ms):
+
+```
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"toolCallStarted",...}
+[ocx:cursor:client-tool-suspend] {"framesReceived":32,"elapsedMs":2827}
+[ocx:cursor:checkpoint-commit-refused] {"emittedClientTool":true,"capturedAfterClientTool":false,"externalModel":false,"storeCheckpoints":true,"capturedBytes":0}
+```
+
+Plain turn, for shape comparison:
+
+```
+[ocx:cursor:frame] {"case":"conversationCheckpointUpdate","usedTokens":0}
+[ocx:cursor:frame] {"case":"conversationCheckpointUpdate","usedTokens":12037}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"stepCompleted"}
+[ocx:cursor:frame] {"case":"conversationCheckpointUpdate","usedTokens":12037}
+[ocx:cursor:frame] {"case":"interactionUpdate","update":"turnEnded"}
+[ocx:cursor:checkpoint-continuation] {"checkpointBytes":492,"wireModel":"default"}
+```
+
+**wp2's LATE verdict stands.** The frame arrives strictly after `toolCallStarted` and is
+cancelled away at 50 ms.
+
+## One hypothesis raised and discarded here
+
+Mid-investigation the `usedTokens: 0` on the tool-turn checkpoint was read as evidence
+that it is an early, pre-tool snapshot, which would have made branch A actively unsafe.
+The ordering above refutes that: the frame arrives **after** `toolCallStarted` within the
+same turn, and carries 3036 bytes against the 492 a plain turn commits.
+
+`usedTokens: 0` therefore looks like an unpopulated field on this update, not an empty
+snapshot. That is a reading, not a proof — and it is exactly the kind of reading this
+unit keeps getting wrong. **wp5 still owns the question of whether those 3036 bytes
+cover the tool call, and branch A2 stays gated behind it.**

--- a/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
@@ -63,9 +63,21 @@ checkpoint turn 1 committed, which is exactly the behaviour `#4245` says is miss
 
 ### What this removes from the issue
 
-C2 is an artifact of `/v1/chat/completions`, which carries no Responses state and
-derives a fresh conversation per request. It is not a defect on the path Codex takes,
-and it is not the reporter's problem. **This half of `#4245` is closed without a patch.**
+C2 does not affect a `/v1/responses` conversation that threads
+`previous_response_id`, which is what a Codex session does. That is the shape the
+reporter was running.
+
+**Scoped precisely, folded from the wp3 audit (near-pass residual):** the earlier
+wording claimed C2 closes for all `/v1/responses` users. It does not. A Responses
+request with **no** `previous_response_id` drops `_cursorConversationId`
+(`src/server/responses/core.ts:533`) and mints a fresh one
+(`src/adapters/cursor/request-builder.ts:361`) unless a thread owner exists, so that
+call is in the same position as chat-completions. `store: false` *with*
+`previous_response_id` is not a hole (`core.ts:461`, `core.ts:6619`).
+
+So: **closed without a patch for threaded conversations**, which is the reported
+scenario; an unthreaded one-shot Responses call still starts fresh, and that is
+expected rather than defective — there is no prior conversation to resume.
 
 That also sharpens what is left. The reporter sees `cached_tokens: 0` and full replay;
 plain multi-turn conversation on `/v1/responses` demonstrably does not do that. So the

--- a/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
@@ -1,0 +1,38 @@
+# wp3 — is the fresh `conversationId` chat-completions-specific
+
+Decides C2. Independent of wp2.
+
+## What was seen, and what it does not yet prove
+
+Two sequential `/v1/chat/completions` turns produced two different `conversationId`
+values and `checkpointInvalidationReason: missing_ref` on both. That endpoint carries
+no Responses state, so a fresh identity per turn may be correct there rather than a
+defect.
+
+`src/adapters/cursor.ts` reads the prior identity from
+`_parsed._providerContinuation?.cursor?.checkpointRef` and `_parsed._cursorConversationId`,
+and the builder comment says it "may derive a stable provider id from the client thread
+when Responses state is unavailable". Whether that derivation actually holds across
+turns is the open question.
+
+Codex uses `/v1/responses`. If identity is stable there, C2 is not user-facing and the
+honest outcome is to record that and close the half.
+
+## Procedure
+
+1. `ocx debug provider on`; record the baseline line count.
+2. Turn 1: `POST /v1/responses`, `store: true`, model `cursor/auto-intelligence`,
+   trivial prompt. Capture the response `id`.
+3. Turn 2: `POST /v1/responses` with `previous_response_id` set to that `id`.
+4. Compare the two `[ocx:cursor:run-request]` lines on `conversationId`,
+   `checkpointPresent`, `checkpointInvalidationReason`, `continuationMode`.
+5. `ocx debug provider off`.
+
+## Decision rule
+
+- **STABLE** — same `conversationId` on both turns and `checkpointPresent: true` on
+  turn 2. C2 is an artifact of the stateless endpoint. Record and close.
+- **UNSTABLE** — identity changes, or `checkpointPresent` stays false with
+  `missing_ref`. C2 is real on the path users take. Go to `030` branch B.
+- **BLOCKED** — the proxy rejects the Responses shape for this provider. Record what it
+  rejected; do not infer the answer from the chat-completions result.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
@@ -42,3 +42,32 @@ honest outcome is to record that and close the half.
   any patch. Do not route it to branch B.
 - **BLOCKED** — the proxy rejects the Responses shape for this provider. Record what it
   rejected; do not infer the answer from the chat-completions result.
+
+## Result — STABLE
+
+Run 2026-09-11 on macbookpro-2, same account and toggle. Two `/v1/responses` turns,
+`store: true`, second carrying `previous_response_id` from the first. Log read with a
+fixed tail, not the line-count windowing that `012` shows is void.
+
+```
+turn 1  resp_dccfe5a37e224d1e908567403c53db10
+[ocx:cursor:checkpoint-continuation] {"mode":"full-replay","conversationHash":"cursor_cdbed7dcc","checkpointRefHash":"717a262274c68762","checkpointBytes":492,"wireModel":"default"}
+
+turn 2  resp_e023130d5f684c159951cd8458e72914  (previous_response_id set)
+[ocx:cursor:checkpoint-continuation] {"mode":"checkpoint","conversationHash":"cursor_cdbed7dcc","checkpointRefHash":"e28ce47f916e7213","checkpointBytes":595,"wireModel":"default"}
+```
+
+**STABLE.** `conversationHash` is identical across both turns, and turn 2 reports
+`mode: checkpoint` rather than `full-replay` — the continuation resumed from the
+checkpoint turn 1 committed, which is exactly the behaviour `#4245` says is missing.
+
+### What this removes from the issue
+
+C2 is an artifact of `/v1/chat/completions`, which carries no Responses state and
+derives a fresh conversation per request. It is not a defect on the path Codex takes,
+and it is not the reporter's problem. **This half of `#4245` is closed without a patch.**
+
+That also sharpens what is left. The reporter sees `cached_tokens: 0` and full replay;
+plain multi-turn conversation on `/v1/responses` demonstrably does not do that. So the
+surviving defect is C1 — turns that emit a client tool, where the checkpoint is
+cancelled away before it can be captured. Branch B in `030` is not needed.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/020_phase2_responses_identity.md
@@ -32,7 +32,13 @@ honest outcome is to record that and close the half.
 
 - **STABLE** — same `conversationId` on both turns and `checkpointPresent: true` on
   turn 2. C2 is an artifact of the stateless endpoint. Record and close.
-- **UNSTABLE** — identity changes, or `checkpointPresent` stays false with
-  `missing_ref`. C2 is real on the path users take. Go to `030` branch B.
+- **UNSTABLE-IDENTITY** — `conversationId` differs between the two turns. That is C2
+  on the path users take. Go to `030` branch B.
+- **STABLE-IDENTITY-STORE-MISS** — `conversationId` matches but `checkpointPresent`
+  is false with `missing_ref`. Folded from the wp1 audit (medium): the original rule
+  ORed these two, but `request-builder.ts:454` returns `missing_ref` whenever no
+  thread or ref is resolved, which is reachable with a perfectly stable id. This is a
+  different defect — the checkpoint store, not identity — and needs its own doc before
+  any patch. Do not route it to branch B.
 - **BLOCKED** — the proxy rejects the Responses shape for this provider. Record what it
   rejected; do not infer the answer from the chat-completions result.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
@@ -22,26 +22,28 @@ the client the turn is over.
      this.clearPendingFinalize();
      this.pendingFinalize = setTimeout(() => {
        this.pendingFinalize = undefined;
-       if (this.expectedClose) return;
+      if (this.expectedClose) return;
+-      const terminal = finalizeAfterDrain(state);
+-      if (terminal.length === 0) return;
 +      // A suspended tool turn is the turn whose state we most want to resume from,
 +      // and the one turn we cancelled before upstream could send it (#4245). Extend
 +      // once, bounded, rather than raising the blanket grace: the common case stays
 +      // at 50 ms and a stream that never sends a checkpoint still dies at a known
 +      // deadline.
- +      // This MUST run before finalizeAfterDrain(): that call reaches
- +      // finalizeTurnEvents(), which sets state.terminated = true, and
- +      // finalizeAfterDrain() returns [] for a terminated state. Draining first and
- +      // then re-arming would make the retry return [] at the length check and leave
- +      // the stream uncancelled. So mirror its two guards here instead of calling it.
- +      if (!state.terminated
- +        && state.openToolCalls.size === 0
- +        && this.wantsCheckpointCapture
- +        && !this.capturedCheckpointBytes
- +        && !this.checkpointGraceExtended) {
- +        this.checkpointGraceExtended = true;
- +        this.scheduleClientToolFinalize(state, push, CHECKPOINT_CAPTURE_GRACE_MS);
- +        return;
- +      }
++      // This MUST run before finalizeAfterDrain(): that call reaches
++      // finalizeTurnEvents(), which sets state.terminated = true, and
++      // finalizeAfterDrain() returns [] for a terminated state. Draining first and
++      // then re-arming would make the retry return [] at the length check and leave
++      // the stream uncancelled. So mirror its two guards here instead of calling it.
++      if (!state.terminated
++        && state.openToolCalls.size === 0
++        && this.wantsCheckpointCapture
++        && !this.capturedCheckpointBytes
++        && !this.checkpointGraceExtended) {
++        this.checkpointGraceExtended = true;
++        this.scheduleClientToolFinalize(state, push, CHECKPOINT_CAPTURE_GRACE_MS);
++        return;
++      }
 +      const terminal = finalizeAfterDrain(state);
 +      if (terminal.length === 0) return;
        for (const event of terminal) push(event);

--- a/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
@@ -159,6 +159,29 @@ ceiling proves too slow in practice; do not lower it on the void 750/1000 ms dat
 3. `bun test tests/providers/cursor` green.
 4. No change to `src/router.ts`, `src/server/lifecycle.ts`, `src/server/responses/core.ts`.
 
+## Landed
+
+`src/adapters/cursor/live-transport.ts`: `CHECKPOINT_CAPTURE_GRACE_MS = 1_500`, the
+exported pure predicate `shouldExtendForCheckpointCapture`, the one-shot extension inside
+`scheduleClientToolFinalize` placed before `finalizeAfterDrain`, the early fire from the
+`conversationCheckpointUpdate` branch of `handleServerMessage`, and `graceMs` /
+`checkpointGraceExtended` added to the `client-tool-suspend` diagnostic.
+
+Tests in `tests/providers/cursor/cursor-tool-finalize-race.test.ts`, reusing that file's
+existing transport harness. Measured in the suite: the turn that never sends a checkpoint
+finalizes at 1816 ms, the turn whose checkpoint arrives finalizes at 256 ms. That gap is
+A1b doing its job — without it both would sit out the full window.
+
+Two low findings from the implementation audit were folded rather than accepted:
+`pendingFinalizeRun` is restored alongside the early-fire timer so the pair never
+diverges, and `capturedCheckpointBytes` is reset in `open()` so a reused transport cannot
+inherit a stale snapshot. Neither was reachable in production; folding them removes the
+reachability argument.
+
+**Still open:** the native wire-model gate. `capturedAfterClientTool` is an arrival proof,
+not a coverage proof, so wp5 owns decoding the captured `ConversationStateStructure`
+before that gate moves.
+
 ### What branch A is deliberately not doing
 
 The obvious companion edit — dropping `isCursorExternalWireModel` from

--- a/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
@@ -1,0 +1,91 @@
+# wp4 — land what the probes proved, or record the verdict
+
+One branch per wp2/wp3 outcome. Only the branch the evidence selects gets built.
+
+## Branch A — wp2 = LATE
+
+The 50 ms base grace cancels the stream before upstream serializes conversation
+state. Two edits, and the second is only safe *because* of the first.
+
+**A1. MODIFY `src/adapters/cursor/live-transport.ts`**, the client-tool finalize
+timer (currently lines 1006-1018):
+
+```diff
+     this.pendingFinalize = setTimeout(() => {
+       this.pendingFinalize = undefined;
+       if (this.expectedClose) return;
+       const terminal = finalizeAfterDrain(state);
+       if (terminal.length === 0) return;
+       for (const event of terminal) push(event);
++      // A suspended tool turn is exactly the turn whose state we most want to
++      // resume from, and it is the one turn we used to cancel before upstream
++      // could send it. Give the checkpoint frame one bounded extension rather
++      // than a larger blanket grace: the common case stays fast, and a stream
++      // that never sends one is still cancelled at a known deadline (#4245).
++      if (this.wantsCheckpointCapture && !this.capturedCheckpointBytes && !this.checkpointGraceExtended) {
++        this.checkpointGraceExtended = true;
++        this.scheduleClientToolFinalize(state, push, CHECKPOINT_CAPTURE_GRACE_MS);
++        return;
++      }
+       debugProviderDiagnostic("cursor", "client-tool-suspend", { ... });
+       this.cancelCursorRun();
+     }, this.activeClientToolFinalizeGraceMs);
+```
+
+New constant beside the others at line 114-117, sized from the measured B-arm
+latency, not guessed. New fields `checkpointGraceExtended` and
+`wantsCheckpointCapture` (set from `contextUsageStoreCheckpoints !== false`).
+
+**A2. MODIFY `src/adapters/cursor.ts`** `commitCapturedCheckpoint`:
+
+```diff
+           const toolSuspendedCommit =
+             emittedClientTool
+             && capturedAfterClientTool
+-            && isCursorExternalWireModel(activeRequest.modelId);
++            // Once A1 makes the frame actually arrive, capturedAfterClientTool is a
++            // real ordering proof for every model, so the wire-model test stops being
++            // the thing standing in for it. Keep the proof; drop the proxy for it.
++            ;
+```
+
+A2 without A1 is the patch this unit exists to reject: with `capturedBytes: 0` it
+changes nothing, and with a checkpoint captured *before* the tool call it would claim
+coverage the bytes do not have. A1 is what makes `capturedAfterClientTool` mean
+something.
+
+`checkpointUsable` stays `!toolSuspendedCommit`, so a tool-suspended checkpoint is
+still only usable by the immediate trailing-toolResult continuation. This branch does
+not widen what a checkpoint claims.
+
+**Tests.** `tests/providers/cursor/cursor-tool-suspended-checkpoint.test.ts`: a fake
+transport that emits `conversationCheckpointUpdate` after `tool_call_end` but later
+than the base grace must yield `checkpointRef` defined and `checkpointUsable: false`;
+one that never emits must still refuse with `capturedBytes: 0`; and composer-2.5 must
+keep whatever `cursorNeedsExternalToolContinuation` already guarantees.
+
+**Risk.** Every suspended tool turn gets up to one extra bounded wait before the
+stream closes. That is added latency on the tool path, so the constant must come from
+the measurement, and the no-frame case must still terminate.
+
+## Branch B — wp3 = UNSTABLE
+
+Identity, not capture. The checkpoint exists and is simply unreachable because turn
+N+1 derives a different `conversationId`. The fix is in how
+`_cursorConversationId` / `_providerContinuation` are threaded on the Responses path,
+which is request-assembly territory rather than adapter transport.
+
+Do not start this as a patch. Write the observed identity chain into a `021` doc
+first, then decide whether the correct owner is the Cursor adapter or the Responses
+state layer. If it turns out to need `src/server/responses/core.ts`, it is out of this
+unit's scope and becomes NEEDS_HUMAN with the evidence attached.
+
+## Branch C — wp2 = NEVER and wp3 = STABLE
+
+Nothing is safely fixable here. Deliverable is the recorded verdict: this file gains a
+closing section, `000_plan.md` gets the outcome, issue #4245 gets a comment naming
+what was measured and what would change the answer, and the unit moves to `_fin/`.
+
+A recorded negative with captured evidence is a real outcome. The failure mode this
+unit was opened against was a plausible patch that fixed nothing, so shipping nothing
+beats shipping that.

--- a/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
@@ -4,59 +4,88 @@ One branch per wp2/wp3 outcome. Only the branch the evidence selects gets built.
 
 ## Branch A — wp2 = LATE
 
-The 50 ms base grace cancels the stream before upstream serializes conversation
-state. Two edits, and the second is only safe *because* of the first.
+The 50 ms base grace cancels the stream before upstream serializes conversation state.
+**Branch A is one edit.** The wp1 audit removed a second one; see "What branch A is
+deliberately not doing" below.
 
-**A1. MODIFY `src/adapters/cursor/live-transport.ts`**, the client-tool finalize
-timer (currently lines 1006-1018):
+**A1. MODIFY `src/adapters/cursor/live-transport.ts`.** Give a drained client-tool
+turn one bounded extension when a checkpoint is wanted and none has arrived. The
+extension must happen *before* the terminal events are pushed — once `done` reaches
+the client the turn is over.
 
 ```diff
+   private scheduleClientToolFinalize(
+     state: ReturnType<typeof createCursorProtobufEventState>,
+     push: (message: CursorServerMessage) => void,
++    graceMsOverride?: number,
+   ): void {
+     this.clearPendingFinalize();
      this.pendingFinalize = setTimeout(() => {
        this.pendingFinalize = undefined;
        if (this.expectedClose) return;
        const terminal = finalizeAfterDrain(state);
        if (terminal.length === 0) return;
-       for (const event of terminal) push(event);
-+      // A suspended tool turn is exactly the turn whose state we most want to
-+      // resume from, and it is the one turn we used to cancel before upstream
-+      // could send it. Give the checkpoint frame one bounded extension rather
-+      // than a larger blanket grace: the common case stays fast, and a stream
-+      // that never sends one is still cancelled at a known deadline (#4245).
-+      if (this.wantsCheckpointCapture && !this.capturedCheckpointBytes && !this.checkpointGraceExtended) {
++      // A suspended tool turn is the turn whose state we most want to resume from,
++      // and the one turn we cancelled before upstream could send it (#4245). Extend
++      // once, bounded, rather than raising the blanket grace: the common case stays
++      // at 50 ms and a stream that never sends a checkpoint still dies at a known
++      // deadline.
++      if (this.wantsCheckpointCapture
++        && !this.capturedCheckpointBytes
++        && !this.checkpointGraceExtended) {
 +        this.checkpointGraceExtended = true;
 +        this.scheduleClientToolFinalize(state, push, CHECKPOINT_CAPTURE_GRACE_MS);
 +        return;
 +      }
-       debugProviderDiagnostic("cursor", "client-tool-suspend", { ... });
+       for (const event of terminal) push(event);
+       debugProviderDiagnostic("cursor", "client-tool-suspend", {
+         reason: "Responses bridge owns client tools; ending turn without fake mcpResult",
+         framesReceived: this.framesReceived,
+         elapsedMs: Date.now() - this.turnStartedAt,
++        graceMs: graceMsOverride ?? this.activeClientToolFinalizeGraceMs,
++        checkpointGraceExtended: this.checkpointGraceExtended,
+       });
        this.cancelCursorRun();
-     }, this.activeClientToolFinalizeGraceMs);
+-    }, this.activeClientToolFinalizeGraceMs);
++    }, graceMsOverride ?? this.activeClientToolFinalizeGraceMs);
+   }
 ```
 
-New constant beside the others at line 114-117, sized from the measured B-arm
-latency, not guessed. New fields `checkpointGraceExtended` and
-`wantsCheckpointCapture` (set from `contextUsageStoreCheckpoints !== false`).
+Also NEW beside the constants at :114-117:
+`const CHECKPOINT_CAPTURE_GRACE_MS = <measured>;` sized from the arrival latency wp2
+actually observed, not guessed. NEW private fields beside `pendingFinalize`:
+`private checkpointGraceExtended = false;` and
+`private wantsCheckpointCapture = false;` — the latter set where the run request is
+applied (:643, next to `activeClientToolFinalizeGraceMs`) from
+`activeRequest.contextUsageStoreCheckpoints !== false`. Reset
+`checkpointGraceExtended = false` in `open()` (:1033) alongside `framesReceived`.
 
-**A2. MODIFY `src/adapters/cursor.ts`** `commitCapturedCheckpoint`:
+The added `graceMs` field also repays wp2's instrumentation debt: after this lands,
+the NEVER verdict 010 could not reach becomes measurable from shipped diagnostics.
 
-```diff
-           const toolSuspendedCommit =
-             emittedClientTool
-             && capturedAfterClientTool
--            && isCursorExternalWireModel(activeRequest.modelId);
-+            // Once A1 makes the frame actually arrive, capturedAfterClientTool is a
-+            // real ordering proof for every model, so the wire-model test stops being
-+            // the thing standing in for it. Keep the proof; drop the proxy for it.
-+            ;
-```
+### What branch A is deliberately not doing
 
-A2 without A1 is the patch this unit exists to reject: with `capturedBytes: 0` it
-changes nothing, and with a checkpoint captured *before* the tool call it would claim
-coverage the bytes do not have. A1 is what makes `capturedAfterClientTool` mean
-something.
+The obvious companion edit — dropping `isCursorExternalWireModel` from
+`toolSuspendedCommit` in `src/adapters/cursor.ts:190` so native models also commit a
+tool-suspended checkpoint — is **excluded**, folded from the wp1 audit (high).
 
-`checkpointUsable` stays `!toolSuspendedCommit`, so a tool-suspended checkpoint is
-still only usable by the immediate trailing-toolResult continuation. This branch does
-not widen what a checkpoint claims.
+`capturedAfterClientTool` is set at `cursor.ts:312` from *arrival order*
+(`capturedAfterClientTool = emittedClientTool` when the byte-set changes). But
+`live-transport.ts:1221` classifies `conversationCheckpointUpdate` as **liveness-only**,
+the same bucket as a heartbeat. A periodic liveness snapshot can arrive after the tool
+call while its *contents* predate it. Arrival order is therefore not coverage, and
+committing on it would claim a prefix the bytes do not contain — the exact failure this
+unit was opened to prevent.
+
+A1 alone is still a real fix: it makes the external tool-suspended path, which the code
+already intends and which has never once succeeded in production, actually work.
+`checkpointUsable` stays `!toolSuspendedCommit`, so nothing widens what a checkpoint
+claims.
+
+Extending this to native models needs content coverage proven, not assumed. That is a
+separate work-phase (wp5) whose first task is to decode a captured
+`ConversationStateStructure` and check whether the tool call is in it. The wp1 auditor
+explicitly left that decode UNVERIFIED; do not skip it.
 
 **Tests.** `tests/providers/cursor/cursor-tool-suspended-checkpoint.test.ts`: a fake
 transport that emits `conversationCheckpointUpdate` after `tool_call_end` but later

--- a/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
@@ -23,20 +23,27 @@ the client the turn is over.
      this.pendingFinalize = setTimeout(() => {
        this.pendingFinalize = undefined;
        if (this.expectedClose) return;
-       const terminal = finalizeAfterDrain(state);
-       if (terminal.length === 0) return;
 +      // A suspended tool turn is the turn whose state we most want to resume from,
 +      // and the one turn we cancelled before upstream could send it (#4245). Extend
 +      // once, bounded, rather than raising the blanket grace: the common case stays
 +      // at 50 ms and a stream that never sends a checkpoint still dies at a known
 +      // deadline.
-+      if (this.wantsCheckpointCapture
-+        && !this.capturedCheckpointBytes
-+        && !this.checkpointGraceExtended) {
-+        this.checkpointGraceExtended = true;
-+        this.scheduleClientToolFinalize(state, push, CHECKPOINT_CAPTURE_GRACE_MS);
-+        return;
-+      }
+ +      // This MUST run before finalizeAfterDrain(): that call reaches
+ +      // finalizeTurnEvents(), which sets state.terminated = true, and
+ +      // finalizeAfterDrain() returns [] for a terminated state. Draining first and
+ +      // then re-arming would make the retry return [] at the length check and leave
+ +      // the stream uncancelled. So mirror its two guards here instead of calling it.
+ +      if (!state.terminated
+ +        && state.openToolCalls.size === 0
+ +        && this.wantsCheckpointCapture
+ +        && !this.capturedCheckpointBytes
+ +        && !this.checkpointGraceExtended) {
+ +        this.checkpointGraceExtended = true;
+ +        this.scheduleClientToolFinalize(state, push, CHECKPOINT_CAPTURE_GRACE_MS);
+ +        return;
+ +      }
++      const terminal = finalizeAfterDrain(state);
++      if (terminal.length === 0) return;
        for (const event of terminal) push(event);
        debugProviderDiagnostic("cursor", "client-tool-suspend", {
          reason: "Responses bridge owns client tools; ending turn without fake mcpResult",
@@ -62,6 +69,12 @@ applied (:643, next to `activeClientToolFinalizeGraceMs`) from
 
 The added `graceMs` field also repays wp2's instrumentation debt: after this lands,
 the NEVER verdict 010 could not reach becomes measurable from shipped diagnostics.
+
+**Termination.** `checkpointGraceExtended` is set before the re-arm, so at most one
+extension happens per turn; the second pass falls through to `finalizeAfterDrain` and
+cancels. A sibling tool call reopening `openToolCalls` during the window is handled by
+the `size === 0` guard, which also stops the one extension from being spent on a turn
+that was not actually drained.
 
 ### What branch A is deliberately not doing
 

--- a/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
+++ b/devlog/_plan/260911_cursor_checkpoint_capture/030_phase3_landing.md
@@ -78,6 +78,87 @@ cancels. A sibling tool call reopening `openToolCalls` during the window is hand
 the `size === 0` guard, which also stops the one extension from being spent on a turn
 that was not actually drained.
 
+### A1b — fire early when the frame lands (required, not optional)
+
+A1 alone makes every suspended tool turn pay the full extension, including the turns
+that were never going to send a checkpoint. Measured arrival is well inside the window,
+so waiting out the remainder is pure added latency on the tool path.
+
+Make the timer body reusable and let the capture site run it immediately:
+
+```diff
+   private pendingFinalize?: ReturnType<typeof setTimeout>;
++  private pendingFinalizeRun?: () => void;
++  private checkpointGraceExtended = false;
++  private wantsCheckpointCapture = false;
+```
+
+`scheduleClientToolFinalize` stores the callback instead of inlining it:
+
+```diff
+     this.clearPendingFinalize();
+-    this.pendingFinalize = setTimeout(() => {
++    const run = (): void => {
+       ... body from A1 ...
+-    }, graceMsOverride ?? this.activeClientToolFinalizeGraceMs);
++    };
++    this.pendingFinalizeRun = run;
++    this.pendingFinalize = setTimeout(run, graceMsOverride ?? this.activeClientToolFinalizeGraceMs);
+```
+
+and `handleServerMessage`, right after `capturedCheckpointBytes` is set:
+
+```diff
+     if (message.message.case === "conversationCheckpointUpdate") {
+       try {
+         this.capturedCheckpointBytes = toBinary(ConversationStateStructureSchema, message.message.value);
+       } catch {
+         this.capturedCheckpointBytes = undefined;
+       }
++      // We are only still open because the grace was extended waiting for exactly this
++      // frame. Stop waiting. Deferred by one tick so this frame finishes being mapped
++      // and pushed before the terminal events go out — firing inline would reorder them.
++      if (this.checkpointGraceExtended && this.pendingFinalizeRun && this.capturedCheckpointBytes) {
++        const run = this.pendingFinalizeRun;
++        this.clearPendingFinalize();
++        this.pendingFinalizeRun = undefined;
++        this.pendingFinalize = setTimeout(run, 0);
++      }
+     }
+```
+
+Net effect: a turn whose checkpoint arrives pays roughly the real arrival latency; a turn
+whose checkpoint never arrives pays `CHECKPOINT_CAPTURE_GRACE_MS` once and then dies at a
+known deadline, as before.
+
+### Sizing `CHECKPOINT_CAPTURE_GRACE_MS`
+
+Measured on macbookpro-2 against a live account, 12 tools held constant on the wire:
+
+| Local grace | Post-`toolCallStarted` checkpoint | `capturedBytes` |
+|---|---|---|
+| 50 ms | no | 0 |
+| 1500 ms | yes | 3036 |
+
+750 ms and 1000 ms arms were attempted but their results are void — they were collected
+through the line-count windowing that `012` shows returns empty once the 500-line log
+ring fills. They are not evidence and are not used here.
+
+**Choose 1500 ms**, the only window with a clean positive. With A1b the cost is paid only
+when no checkpoint comes. Revisit with a bracketed rerun using tail-based reading if that
+ceiling proves too slow in practice; do not lower it on the void 750/1000 ms data.
+
+### Acceptance criteria for this work-phase
+
+1. `bun run typecheck` clean.
+2. A focused test proves: checkpoint after `tool_call_end` but past the base grace is
+   captured and committed for an external wire model with `checkpointUsable: false`;
+   a transport that never sends one still refuses and still cancels;
+   a native wire model still refuses (the gate is untouched);
+   the extension happens at most once.
+3. `bun test tests/providers/cursor` green.
+4. No change to `src/router.ts`, `src/server/lifecycle.ts`, `src/server/responses/core.ts`.
+
 ### What branch A is deliberately not doing
 
 The obvious companion edit — dropping `isCursorExternalWireModel` from

--- a/src/adapters/cursor/live-transport.ts
+++ b/src/adapters/cursor/live-transport.ts
@@ -115,6 +115,15 @@ const CLIENT_TOOL_FINALIZE_GRACE_MS = 50;
 const GENERIC_TOOL_COUNT_MIN_FINALIZE_GRACE_MS = 750;
 const GENERIC_TOOL_COUNT_MAX_FINALIZE_GRACE_MS = 1_800;
 const GENERIC_TOOL_COUNT_PER_TOOL_GRACE_MS = 125;
+/**
+ * A client-tool turn suspends before `turnEnded`, and upstream sends that turn's conversation
+ * checkpoint right after `toolCallStarted` — after the 50 ms drain grace, so it used to be
+ * cancelled away and every such turn full-replayed with `cached_tokens: 0`. Measured on a live
+ * account with the tool catalog held constant: 50 ms captures nothing, 1500 ms captures 3036
+ * bytes (#4245, devlog 260911_cursor_checkpoint_capture). This window is paid only by a turn
+ * that never sends one; `handleServerMessage` finalizes early as soon as the frame lands.
+ */
+const CHECKPOINT_CAPTURE_GRACE_MS = 1_500;
 const cursorContextUsageTracker = createCursorContextUsageTracker();
 
 /**
@@ -413,6 +422,28 @@ export function finalizeAfterDrain(state: ReturnType<typeof createCursorProtobuf
   return finalizeTurnEvents(state);
 }
 
+/**
+ * Whether a drained client-tool turn should wait one more bounded window for the conversation
+ * checkpoint instead of cancelling now.
+ *
+ * This mirrors `finalizeAfterDrain`'s two guards rather than calling it, and that is load-bearing:
+ * `finalizeAfterDrain` reaches `finalizeTurnEvents`, which sets `state.terminated`, and then returns
+ * `[]` for a terminated state. Draining first and re-arming would make the retry return early at the
+ * length check and leave the stream uncancelled. Pure for unit testing.
+ */
+export function shouldExtendForCheckpointCapture(input: {
+  /** Optional on the event state, so accept its real shape rather than forcing a cast at the call site. */
+  terminated: boolean | undefined;
+  openToolCallCount: number;
+  wantsCheckpointCapture: boolean;
+  hasCapturedCheckpoint: boolean;
+  alreadyExtended: boolean;
+}): boolean {
+  if (input.terminated || input.openToolCallCount > 0) return false;
+  if (!input.wantsCheckpointCapture || input.hasCapturedCheckpoint) return false;
+  return !input.alreadyExtended;
+}
+
 export function clientToolFinalizeGraceMsForRequest(request: CursorRunRequest, baseGraceMs = CLIENT_TOOL_FINALIZE_GRACE_MS): number {
   if (request.rawMessages?.at(-1)?.role === "toolResult") return baseGraceMs;
   const text = activePromptText(request);
@@ -468,6 +499,10 @@ class LiveCursorTransport implements CursorTransport {
    */
   private emittedTerminal = false;
   private pendingFinalize?: ReturnType<typeof setTimeout>;
+  /** The armed finalize body, so the checkpoint frame can run it early instead of waiting out the window. */
+  private pendingFinalizeRun?: () => void;
+  private checkpointGraceExtended = false;
+  private wantsCheckpointCapture = false;
   private readonly clientToolFinalizeGraceMs: number;
   private activeClientToolFinalizeGraceMs: number;
   private readonly token: string;
@@ -641,6 +676,7 @@ class LiveCursorTransport implements CursorTransport {
     };
     const activeText = activePromptText(activeRequest);
     this.activeClientToolFinalizeGraceMs = clientToolFinalizeGraceMsForRequest(activeRequest, this.clientToolFinalizeGraceMs);
+    this.wantsCheckpointCapture = activeRequest.contextUsageStoreCheckpoints !== false;
     const cursorVisibleTools = cursorToolsForActivePrompt(activeRequest.tools, activeText, activeRequest.toolChoice);
     const clientToolDefs = buildCursorToolDefinitions(cursorVisibleTools, activeRequest.toolChoice);
     // `request.tools` is the catalog already filtered and budgeted by request-builder. Derive
@@ -981,6 +1017,7 @@ class LiveCursorTransport implements CursorTransport {
       clearTimeout(this.pendingFinalize);
       this.pendingFinalize = undefined;
     }
+    this.pendingFinalizeRun = undefined;
   }
 
   /**
@@ -1001,11 +1038,26 @@ class LiveCursorTransport implements CursorTransport {
   private scheduleClientToolFinalize(
     state: ReturnType<typeof createCursorProtobufEventState>,
     push: (message: CursorServerMessage) => void,
+    graceMsOverride?: number,
   ): void {
     this.clearPendingFinalize();
-    this.pendingFinalize = setTimeout(() => {
+    const run = (): void => {
       this.pendingFinalize = undefined;
+      this.pendingFinalizeRun = undefined;
       if (this.expectedClose) return;
+      // The checkpoint for THIS turn is the one we most want and the one we used to throw
+      // away. Extend once, bounded, before draining (#4245).
+      if (shouldExtendForCheckpointCapture({
+        terminated: state.terminated,
+        openToolCallCount: state.openToolCalls.size,
+        wantsCheckpointCapture: this.wantsCheckpointCapture,
+        hasCapturedCheckpoint: this.capturedCheckpointBytes !== undefined,
+        alreadyExtended: this.checkpointGraceExtended,
+      })) {
+        this.checkpointGraceExtended = true;
+        this.scheduleClientToolFinalize(state, push, CHECKPOINT_CAPTURE_GRACE_MS);
+        return;
+      }
       const terminal = finalizeAfterDrain(state);
       if (terminal.length === 0) return;
       for (const event of terminal) push(event);
@@ -1013,9 +1065,13 @@ class LiveCursorTransport implements CursorTransport {
         reason: "Responses bridge owns client tools; ending turn without fake mcpResult",
         framesReceived: this.framesReceived,
         elapsedMs: Date.now() - this.turnStartedAt,
+        graceMs: graceMsOverride ?? this.activeClientToolFinalizeGraceMs,
+        checkpointGraceExtended: this.checkpointGraceExtended,
       });
       this.cancelCursorRun();
-    }, this.activeClientToolFinalizeGraceMs);
+    };
+    this.pendingFinalizeRun = run;
+    this.pendingFinalize = setTimeout(run, graceMsOverride ?? this.activeClientToolFinalizeGraceMs);
   }
 
   private open(
@@ -1032,6 +1088,10 @@ class LiveCursorTransport implements CursorTransport {
     }
     this.turnStartedAt = Date.now();
     this.framesReceived = 0;
+    this.checkpointGraceExtended = false;
+    // A turn must not inherit the previous one's snapshot: a stale capture would make
+    // shouldExtendForCheckpointCapture skip the wait this turn actually needs.
+    this.capturedCheckpointBytes = undefined;
     this.sawAssistantText = false;
     this.emittedTerminal = false;
     this.firstFrameAt = undefined;
@@ -1449,6 +1509,18 @@ class LiveCursorTransport implements CursorTransport {
         this.capturedCheckpointBytes = toBinary(ConversationStateStructureSchema, message.message.value);
       } catch {
         this.capturedCheckpointBytes = undefined;
+      }
+      // We are only still open because the grace was extended waiting for exactly this frame.
+      // Stop waiting, so a turn that does send a checkpoint pays arrival latency rather than the
+      // whole window. Deferred one tick so this frame finishes being mapped and pushed first;
+      // finalizing inline would emit the terminal events ahead of it.
+      if (this.checkpointGraceExtended && this.pendingFinalizeRun && this.capturedCheckpointBytes) {
+        const run = this.pendingFinalizeRun;
+        this.clearPendingFinalize();
+        this.pendingFinalize = setTimeout(run, 0);
+        // Keep the pair in step: clearPendingFinalize() drops the callback, and every other
+        // owner of pendingFinalize expects pendingFinalizeRun to describe it.
+        this.pendingFinalizeRun = run;
       }
     }
     if (message.message.case === "kvServerMessage") {

--- a/tests/providers/cursor/cursor-tool-finalize-race.test.ts
+++ b/tests/providers/cursor/cursor-tool-finalize-race.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { create, toBinary } from "@bufbuild/protobuf";
-import { clientToolFinalizeGraceMsForRequest, createLiveCursorTransport } from "../../../src/adapters/cursor/live-transport";
+import {
+  clientToolFinalizeGraceMsForRequest,
+  createLiveCursorTransport,
+  shouldExtendForCheckpointCapture,
+} from "../../../src/adapters/cursor/live-transport";
 import { createTestTranslatorBudget } from "../../helpers/translator-budget";
 import { createCursorProtobufEventState } from "../../../src/adapters/cursor/protobuf-events";
 import type { CursorRunRequest, CursorServerMessage } from "../../../src/adapters/cursor/types";
 import {
   AgentServerMessageSchema,
   ExecServerMessageSchema,
+  ConversationStateStructureSchema,
   McpArgsSchema,
   McpToolCallSchema,
   ToolCallSchema,
@@ -95,18 +100,27 @@ function completedByCallIdFrame(callId: string) {
 }
 
 interface Harness {
-  feed(
-    frame: ReturnType<typeof startedFrame> | ReturnType<typeof completedFrame> | ReturnType<typeof completedByCallIdFrame>,
-  ): Promise<void>;
+  feed(frame: unknown): Promise<void>;
   events: CursorServerMessage[];
   closeCodes: number[];
   cancelled(): boolean;
+}
+
+/** A conversation checkpoint frame: the only thing that sets `capturedCheckpointBytes`. */
+function checkpointFrame() {
+  return create(AgentServerMessageSchema, {
+    message: {
+      case: "conversationCheckpointUpdate",
+      value: create(ConversationStateStructureSchema, { pendingToolCalls: ["suspended-fixture"] }),
+    },
+  });
 }
 
 function makeHarness(
   graceMs: number,
   clientToolNames: string[],
   freeformToolNames: string[] = [],
+  wantsCheckpointCapture = false,
 ): Harness {
   const transport = createLiveCursorTransport({
     provider: { adapter: "cursor", baseUrl: "https://api2.cursor.sh", apiKey: "test-token" },
@@ -115,8 +129,11 @@ function makeHarness(
     clientToolFinalizeGraceMs: graceMs,
   }) as unknown as {
     stream: unknown;
+    wantsCheckpointCapture: boolean;
     handleServerMessage: (m: unknown, s: unknown, p: (e: CursorServerMessage) => void) => Promise<void>;
   };
+  // Normally set from the run request; the harness drives handleServerMessage directly.
+  transport.wantsCheckpointCapture = wantsCheckpointCapture;
   const events: CursorServerMessage[] = [];
   const closeCodes: number[] = [];
   // Fake h2 stream: records RST_STREAM close codes; never touches the network.
@@ -252,6 +269,65 @@ describe("transport finalize race (hidden parallel sibling)", () => {
     await sleep(60);
     expect(h.events.map(e => e.type).filter(t => t === "done")).toHaveLength(1);
     expect(h.events.filter(e => e.type === "tool_call_end")).toHaveLength(1);
+    expect(h.closeCodes).toEqual([NGHTTP2_CANCEL]);
+  });
+});
+
+describe("checkpoint capture grace (#4245)", () => {
+  test("extends only when a checkpoint is wanted, absent, and not already extended", () => {
+    const base = {
+      terminated: false,
+      openToolCallCount: 0,
+      wantsCheckpointCapture: true,
+      hasCapturedCheckpoint: false,
+      alreadyExtended: false,
+    };
+    expect(shouldExtendForCheckpointCapture(base)).toBe(true);
+    // Mirrors finalizeAfterDrain's guards: a terminated state or a reopened sibling set
+    // must fall through to the normal path rather than spend the one extension.
+    expect(shouldExtendForCheckpointCapture({ ...base, terminated: true })).toBe(false);
+    expect(shouldExtendForCheckpointCapture({ ...base, terminated: undefined })).toBe(true);
+    expect(shouldExtendForCheckpointCapture({ ...base, openToolCallCount: 1 })).toBe(false);
+    // Nothing to wait for, or already waited once.
+    expect(shouldExtendForCheckpointCapture({ ...base, wantsCheckpointCapture: false })).toBe(false);
+    expect(shouldExtendForCheckpointCapture({ ...base, hasCapturedCheckpoint: true })).toBe(false);
+    expect(shouldExtendForCheckpointCapture({ ...base, alreadyExtended: true })).toBe(false);
+  });
+
+  test("a turn that never sends a checkpoint waits once, then still finalizes and cancels", async () => {
+    const h = makeHarness(20, ["echo_a"], [], true);
+    await h.feed(startedFrame("call_a", "echo_a"));
+    await h.feed(execFrame(1, "call_a", "echo_a", "A"));
+    // Past the 20 ms base grace the turn is deliberately still open: the extension is running.
+    await sleep(200);
+    expect(h.events.map(e => e.type)).not.toContain("done");
+    expect(h.cancelled()).toBe(false);
+    // The extension is bounded, so the stream still dies at a known deadline.
+    await sleep(1_600);
+    expect(h.events.map(e => e.type).filter(t => t === "done")).toHaveLength(1);
+    expect(h.closeCodes).toEqual([NGHTTP2_CANCEL]);
+  }, 10_000);
+
+  test("a checkpoint arriving during the extension finalizes early instead of waiting it out", async () => {
+    const h = makeHarness(20, ["echo_a"], [], true);
+    await h.feed(startedFrame("call_a", "echo_a"));
+    await h.feed(execFrame(1, "call_a", "echo_a", "A"));
+    await sleep(120);
+    expect(h.events.map(e => e.type)).not.toContain("done");
+
+    await h.feed(checkpointFrame());
+    // Early fire is deferred one tick so the checkpoint frame finishes being processed first.
+    await sleep(120);
+    expect(h.events.map(e => e.type).filter(t => t === "done")).toHaveLength(1);
+    expect(h.closeCodes).toEqual([NGHTTP2_CANCEL]);
+  }, 10_000);
+
+  test("without checkpoint capture wanted, the base grace is unchanged", async () => {
+    const h = makeHarness(20, ["echo_a"], [], false);
+    await h.feed(startedFrame("call_a", "echo_a"));
+    await h.feed(execFrame(1, "call_a", "echo_a", "A"));
+    await sleep(200);
+    expect(h.events.map(e => e.type).filter(t => t === "done")).toHaveLength(1);
     expect(h.closeCodes).toEqual([NGHTTP2_CANCEL]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #4245. A Cursor turn that emits a client tool full-replayed every time, reporting `cached_tokens: 0`, while the same account cache-hits under `cursor-agent` directly.

The cause is not the one the issue was first triaged with. Instrumented against a live Cursor account, the refusal is over-determined: `checkpoint-commit-refused` reports `capturedBytes: 0` for the native router, native composer **and** external Claude alike, so the `isCursorExternalWireModel` gate one line above it is never reached. Relaxing that gate — the obvious-looking fix — changes nothing.

What actually happens: a client-tool turn suspends before `turnEnded`, and upstream sends that turn's `conversationCheckpointUpdate` right after `toolCallStarted`. `CLIENT_TOOL_FINALIZE_GRACE_MS` is **50 ms**, so `cancelCursorRun()` kills the stream first and the bytes never arrive.

Measured on macOS against a real account, with the tool catalog held constant on the wire so only the local grace varies (`parallel_tool_calls` is read locally and never protobuf-encoded):

| Local grace | Post-`toolCallStarted` checkpoint | `capturedBytes` |
|---|---|---|
| 50 ms | no | 0 |
| 1500 ms | yes | 3036 |

Reproduced in both directions within one session.

## What this changes

A drained client-tool turn gets **one** bounded extension when a checkpoint is wanted and none has arrived, and fires early the moment one does.

Three details are load-bearing rather than incidental:

- The extension runs **before** `finalizeAfterDrain`. That call reaches `finalizeTurnEvents`, which sets `state.terminated`, and then returns `[]` for a terminated state — draining first and re-arming would make the retry return early at the length check and leave the stream uncancelled. The new predicate mirrors its two guards instead of calling it.
- The early fire is deferred one tick, so the checkpoint frame finishes being mapped and pushed before the terminal events go out.
- A turn that never sends a checkpoint pays the window once and still dies at a known deadline. Visible in the suite: the no-checkpoint case finalizes at 1816 ms, the checkpoint case at 256 ms.

**The native wire-model gate is deliberately untouched.** `capturedAfterClientTool` is set from arrival order, not snapshot contents, so it proves the bytes arrived after the tool call and not that they cover it. Extending this to native models needs the captured `ConversationStateStructure` decoded first; that is tracked in the plan unit, not assumed here. This PR makes the external tool-suspended path — which the code already intends and which has never once succeeded in production — actually work.

`checkpointUsable` stays `!toolSuspendedCommit`, so nothing widens what a checkpoint claims.

## Verification

- `bun run typecheck` — clean.
- `bun test tests/providers/cursor/cursor-tool-finalize-race.test.ts tests/providers/cursor/cursor-tool-suspended-checkpoint.test.ts tests/providers/cursor/cursor-live-transport.test.ts tests/providers/cursor/cursor-tool-continuation.test.ts` — 57 pass, 0 fail, 291 expect() calls.
- `bun test tests/providers/cursor/cursor-stream-health.test.ts` — 5 pass, 0 fail. The extension adds ~1.5 s, far below the 30 s silence and 90 s heartbeat-only watchdog thresholds.
- `bun run privacy:scan` — passed.
- Full suite left to CI.

New tests cover the pure predicate's guards, the bounded no-checkpoint path, the early fire, and that a turn not wanting checkpoints keeps the old base-grace behaviour exactly.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Closes #4245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cursor tool-turn handling to capture conversation checkpoints that arrive late.
  - Reduced unnecessary full conversation replays, improving cache reuse and potentially lowering latency and token usage.
  - Preserved timely completion when checkpoints are unavailable or arrive outside the capture window.
- **Tests**
  - Added coverage for delayed checkpoint capture, early finalization, cancellation, and unchanged behavior when checkpoint capture is not required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->