### PR TITLE
docs: close the omo unit and fix two leftovers it created

### DIFF
--- a/devlog/_plan/260912_omo_client_integration/050_wp6_gjc_rename.md
+++ b/devlog/_plan/260912_omo_client_integration/050_wp6_gjc_rename.md
@@ -47,3 +47,21 @@ catalogs, the CLI summary prose, and `docs-site`. A bare tree-wide search is the
 wrong check and would report itself failing forever, because the internal
 identifiers (`GajaeGeneratedConfig`, `gajaeConfigPath`, `buildGajaeClientConfig`,
 `OPENCODEX_GAJAE_API_KEY`) are exactly what this phase is not touching.
+
+## Verified after merge
+
+An independent audit read `origin/dev` and ran that check against what actually
+landed: zero `Gajae Code` across the nine locale catalogs, `src/cli/registry.ts`
+and `docs-site`. Every surviving `Gajae` is an identifier, the
+`OPENCODEX_GAJAE_API_KEY` env var, an i18n key *name* whose value is now `gjc`,
+an internal type, or a comment. The line this phase promised not to cross held:
+the client id is still `gajae`, the config path is still `~/.gjc/agent/models.yml`,
+the route is still `/api/client-integrations/gajae`, the download filename is
+still `gajae-models.yaml`, and the tab hash is still `integrations/gajae`. So an
+install that had already connected the client keeps resolving its stored enable
+record, which is the whole reason the id stayed put.
+
+The audit did find one mention this plan had missed: the header comment in
+`src/cli/export-command.ts` still said "Eight clients" and listed `Gajae` among
+the YAML dialects. It was stale on both counts — there were thirteen clients
+before omo — and it is corrected alongside the outcome note.

--- a/devlog/_plan/260912_omo_client_integration/090_outcome.md
+++ b/devlog/_plan/260912_omo_client_integration/090_outcome.md
@@ -1,0 +1,65 @@
+# Outcome
+
+Shipped as PR #4290, merged into `dev` on 2026-09-12 as `eb314c53a0` at head
+`9689ee8ceb0d868faa0643b036f8e8d9be4bd03c`. CI on that exact head: 25 pass, 0
+fail, 2 conditional jobs skipped. Merged under the `MAINTAINERS.md` dev-only
+maintainer-integration exception, with the decision and CI evidence recorded on
+the PR.
+
+## What landed
+
+`omo` is the fourteenth export and file-integration client. It reuses the Pi
+builder, opted into session affinity, resolves `~/.omo/agent/models.json` under
+omo's own three-variable precedence, detects on the agent directory, and is
+loopback-only by deferral. `Gajae Code` now reads `gjc` everywhere a user looks,
+with the id, config path, API route and env var deliberately unchanged.
+
+## The evidence that mattered
+
+Three claims could not have been settled by inspection, and each was checked:
+
+1. **senpi accepts the Pi document.** The file a live Apply actually wrote
+   returned true from senpi's own compiled `validateModelsConfig`, while an
+   `audio` input modality and a keyed `models` object both returned false, so
+   the check could not be vacuous.
+2. **The v4 false positive is rejected.** With `~/.omo` holding only
+   `binary-runtime` and no `agent/` — the exact state of the machine this was
+   built on — the row reads *Not installed* with Apply disabled, and creating
+   `~/.omo/agent` flips it to *Not applied*.
+3. **The page renders.** Tab, row and mark captured from the built GUI;
+   `evidence/integrations-omo-tab.png`.
+
+## What the process caught
+
+Four independent audit rounds returned FAIL or NEAR-PASS and changed the work:
+
+- The backend/GUI split was abandoned after two rounds proved no ordering of
+  the halves leaves `tests/gui/integrations-invariants.test.ts` green.
+- `omo` moved to the end of `EXPORT_CLIENTS` rather than beside `prime`, because
+  `EXPORT_CLIENT_IDS` is `Object.keys` order and three tests assert it exactly.
+- `buildOmoContribution` gained the session-affinity flag, which `build` already
+  had; without it `ocx export` and an enabled integration would have written
+  different documents.
+- The catalog-refresh decision was forced to confront four disagreeing fan-out
+  lists instead of the one the checklist named.
+
+Two mistakes are worth keeping visible. The first attempt at the rendered proof
+ran `ocx start` with only `OPENCODEX_HOME` redirected, which is not isolation —
+it rewrote the user's real Codex catalog and pointed `~/.grok/config.toml` at a
+port that was about to die. Both were restored and the second attempt redirected
+`HOME` and `CODEX_HOME` too. And `privacy:scan` passed locally while failing on
+three CI jobs, because the file it objected to was still untracked when the
+local scan ran.
+
+## Left open
+
+- `docs-site/.../zh-tw/reference/management-api.md` lists the
+  `GET /api/client-config` clients only as far as `dsh`. That list already
+  omitted `zcode`, `prime`, `aside` and `raycast` before omo existed, so it is a
+  pre-existing translation gap rather than this unit's debt; widening it quietly
+  here would hide it.
+- `prime` is in none of the catalog-refresh fan-outs. That looks like an
+  oversight from when it landed, and is recorded in `002` so the next person
+  does not read it as a pattern to copy.
+- No CI check compares the docs client tables against `EXPORT_CLIENT_IDS`, so
+  the docs rows stay guarded by review alone.

--- a/docs-site/src/content/docs/guides/integrations.md
+++ b/docs-site/src/content/docs/guides/integrations.md
@@ -212,7 +212,7 @@ typed values into quoted strings. This includes values inside arrays and inline
 tables. Quoted date strings remain supported; an unquoted date must be preserved
 by editing the configuration manually.
 
-**Pi, Kimi Code, gjc, MiniMax Code, Prime Agent and the managed DSH integration only work against a loopback bind.**
+**Pi, Kimi Code, gjc, MiniMax Code, Prime Agent, Aside, Raycast, omo and the managed DSH integration only work against a loopback bind.**
 The first four have no config field for the `x-opencodex-api-key` header a non-loopback bind
 requires. DSH has a generic headers map, but rc.6 does not document that dedicated admission
 header as a supported integration contract, so the managed writer fails closed instead of

--- a/src/cli/export-command.ts
+++ b/src/cli/export-command.ts
@@ -1,8 +1,10 @@
 /**
  * `ocx export --client <id>` — print a client config for the live proxy.
  *
- * Eight clients, four formats: OpenCode and Pi are JSON; OMP, Hermes, Gajae and
- * MiniMax Code are YAML; OpenClaw is JSON5; Kimi is TOML.
+ * Fourteen clients, five formats. The accepted list is `EXPORT_CLIENT_IDS`, not
+ * this comment: OpenCode, Pi, Prime, Aside, ZCode and omo are JSON; OMP,
+ * Hermes, gjc, DSH, MiniMax Code and Raycast are YAML; OpenClaw is JSON5; Kimi
+ * is TOML.
  *
  * Two consumers, one payload (devlog 260731_client_config_export/020):
  *


### PR DESCRIPTION
## Summary

Follow-up to #4290. A post-merge audit of `dev` found three documentation mirrors the omo change had missed. Two are its own debt and are fixed here:

- The integrations guide's loopback sentence did not name `omo`, even though it ships `loopbackOnly: true`. The same sentence was also already missing Aside, Raycast and ZCode, so all four are added.
- The header comment in `src/cli/export-command.ts` still said "Eight clients" and listed `Gajae` among the YAML dialects. Stale on both counts — there were thirteen clients before omo, and that product is now `gjc`. It now points at `EXPORT_CLIENT_IDS` as the authority rather than restating a list that goes stale.

The third is deliberately left alone: `docs-site/.../zh-tw/reference/management-api.md` lists the `GET /api/client-config` clients only as far as `dsh`, which already omitted `zcode`, `prime`, `aside` and `raycast` before omo existed. Widening it quietly here would hide a pre-existing translation gap instead of fixing it; it is recorded in the outcome note.

`090_outcome.md` closes the plan unit — what landed, the three claims that were checked rather than assumed, what four audit rounds changed, and two mistakes worth keeping visible.

## Verification

- `bun run privacy:scan` — passed.
- `bun run typecheck` — clean.
- `bun test tests/cli/cli-help.test.ts tests/config/client-config-export.test.ts` — 91 pass / 0 fail (the two files that read the CLI help text and the ordered client list).
- `rg -c 'Gajae Code' gui/src/i18n src/cli/registry.ts docs-site` — no matches, asserted rather than eyeballed.
- No GUI source changes in this PR; the screenshot gate does not apply.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `omo` client integration, including file-based configuration and session-affinity handling.
  - Added `omo` to the documented loopback-only integrations.
  - Expanded export documentation to cover 14 supported clients and five output formats.

- **Documentation**
  - Updated user-facing references from “Gajae Code” to `gjc`.
  - Added integration outcome and verification documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->