### PR TITLE
fix(zai): declare glm-5.3-flash image input on the Chat rows

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -444,6 +444,30 @@ const ZAI_GLM_5X_MODELS = [...ZAI_GLM_53_MODELS, ...ZAI_GLM_52_MODELS];
  * `preserveReasoningContentModels`, where flash DOES belong.
  */
 const ZAI_GLM_5X_SIDECAR_VISION_MODELS = ZAI_GLM_5X_MODELS.filter(id => id !== "glm-5.3-flash");
+/**
+ * Positive input-modality declaration for the Chat-path GLM rows.
+ *
+ * `noVisionModels` already keeps Flash out of the vision sidecar, but that is a NEGATIVE
+ * statement: it stops a detour without telling the catalog what the model can read. With
+ * no `modelInputModalities` entry, `configuredInputModalities` returns undefined and the
+ * catalog falls through to the `["text"]` floor, so every client export (ZCode, Pi, OMP)
+ * listed a native VLM as text-only and its picker refused to attach an image.
+ *
+ * The Responses sibling row below already declares this positively, so the same model was
+ * described two different ways in one registry.
+ *
+ * Authoritative source: `GET https://api.z.ai/api/v1/models` returns `input_modalities:
+ * ["text"]` for glm-5.3 and `["text", "image"]` for glm-5.3-flash (captured in
+ * devlog/_plan/260912_zcode_protocol_and_catalog/evidence/zai-responses-models.json).
+ * docs.z.ai/devpack/latest-model says the same in prose: "GLM-5.3 is a text-only model...
+ * GLM-5.3-FLASH is a multimodal model". Upstream also lists video and file for Flash;
+ * neither the internal vocabulary nor the export vocabulary can express them, so `image`
+ * is where this stops.
+ */
+const ZAI_GLM_5X_INPUT_MODALITIES: Record<string, string[]> = {
+  ...Object.fromEntries(ZAI_GLM_5X_SIDECAR_VISION_MODELS.map(id => [id, ["text"]])),
+  "glm-5.3-flash": ["text", "image"],
+};
 const ZAI_GLM_52_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
 /**
  * GLM-5.3 does NOT share 5.2's five-tier ladder. docs.z.ai/devpack/latest-model folds every
@@ -2604,6 +2628,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     // Z.AI's OpenAI path returns 400 code 1211 for bracketed model ids.
     modelSuffixBracketStrip: true,
     noVisionModels: ZAI_GLM_5X_SIDECAR_VISION_MODELS,
+    modelInputModalities: ZAI_GLM_5X_INPUT_MODALITIES,
     modelReasoningEfforts: ZAI_GLM_5X_REASONING_EFFORTS,
     modelDefaultReasoningEfforts: Object.fromEntries(ZAI_GLM_53_MODELS.map(id => [id, "max"])),
     modelMaxOutputTokens: Object.fromEntries(ZAI_GLM_53_MODELS.map(id => [id, 131_072])),
@@ -2685,6 +2710,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     modelContextWindows: { "glm-5.3": 1_000_000, "glm-5.3[1m]": 1_000_000, "glm-5.3-flash": 1_000_000, "glm-5.2": 1_000_000, "glm-5.2[1m]": 1_000_000 },
     modelSuffixBracketStrip: true,
     noVisionModels: ZAI_GLM_5X_SIDECAR_VISION_MODELS,
+    modelInputModalities: ZAI_GLM_5X_INPUT_MODALITIES,
     modelReasoningEfforts: ZAI_GLM_5X_REASONING_EFFORTS,
     modelSupportsReasoningSummaries: Object.fromEntries(ZAI_GLM_5X_MODELS.map(id => [id, true])),
     preserveReasoningContentModels: ZAI_GLM_5X_MODELS,

--- a/tests/providers/provider-registry-parity.test.ts
+++ b/tests/providers/provider-registry-parity.test.ts
@@ -482,6 +482,21 @@ describe("provider registry parity", () => {
     // The sibling it is most often confused with stays text-only, so the assertion above
     // cannot pass by making every GLM row a VLM.
     expect(zai?.noVisionModels ?? []).toContain("glm-5.3");
+    // The global loop above accepts an ABSENT declaration, which is exactly how the Chat
+    // rows shipped: Flash was kept out of the sidecar but never told the catalog it could
+    // read an image, so `configuredInputModalities` returned undefined and every client
+    // export listed a native VLM as text-only. Pin the positive declaration so the two
+    // Chat rows cannot drift back to describing Flash only by what it is not.
+    for (const id of ["zai", "zhipu-bigmodel-coding"] as const) {
+      const row = PROVIDER_REGISTRY.find(entry => entry.id === id);
+      expect(row?.modelInputModalities?.["glm-5.3-flash"]).toEqual(["text", "image"]);
+      expect(row?.modelInputModalities?.["glm-5.3"]).toEqual(["text"]);
+      // The bracketed aliases are looked up by their exact catalog id, not a stripped one,
+      // so they need their own text-only entries.
+      expect(row?.modelInputModalities?.["glm-5.3[1m]"]).toEqual(["text"]);
+      expect(row?.modelInputModalities?.["glm-5.2[1m]"]).toEqual(["text"]);
+      expect(row?.noVisionModels ?? []).not.toContain("glm-5.3-flash");
+    }
     // `glm-5.3-flash` belongs in all three maps. It was seeded into the model list
     // and the context map alone, so it advertised a 1M window with no effort ladder,
     // no default effort and no output cap - and this assertion pinned that gap in


### PR DESCRIPTION
## Summary

`glm-5.3-flash` is a native VLM, but the two Chat-path Z.AI rows described it only by what it is not. They list the text-only siblings in `noVisionModels` and declared no `modelInputModalities` at all, which keeps Flash out of the vision sidecar but never tells the catalog what the model can read. `configuredInputModalities` returned `undefined`, the catalog fell through to the `["text"]` floor, and every client export — ZCode, Pi, OMP — listed a native multimodal model as text-only, so the picker refused to attach an image.

The Responses sibling row already declared this positively, so one registry described the same model two different ways.

This adds one shared positive declaration and points both Chat rows at it. The values come from the upstream catalog, not from inference:

```
GET https://api.z.ai/api/v1/models
  glm-5.3        input_modalities ["text"]
  glm-5.3-flash  input_modalities ["text", "image"]
```

and docs.z.ai/devpack/latest-model says the same in prose: "GLM-5.3 is a text-only model, so uncheck Support Images; GLM-5.3-FLASH is a multimodal model, so Support Images can be checked".

Nothing else moves. `isModelVisionSidecarConsumer` checks `noVisionModels` first and returns early, so adding `["text"]` for models already on that list changes no behavior; the advertised value stays `["text", "image"]` because the sidecar appends `image`. Flash is on neither path now, which is the point. The bracketed aliases are looked up by their exact catalog id rather than a stripped one, so they carry their own text-only entries. `glm-4.6`, `glm-5` and `glm-5.1` stay undeclared and keep their existing fallback.

Upstream also lists video and file for Flash. Neither the internal modality vocabulary (`text` / `image` / `audio`) nor the export vocabulary (`text` / `image`) can express them, so `image` is where this stops.

The vendored snapshot behind `src/generated/model-metadata.ts` has no `glm-5.3-flash` row at all. That file is byte-synced by `tests/codex-integration/model-metadata-sync.test.ts` and refreshing it is a separate deliberate commit; registry declarations win over that fallback, so the defect closes here.

Closes #4296.

## Verification

- `bun run typecheck` — clean.
- `bun test tests/providers/provider-registry-parity.test.ts tests/codex-integration/catalog-vision-sidecar-modalities.test.ts` — 68 pass, 0 fail.
- No GUI change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

No `structure/` or `docs-site/` update is required: neither states the Chat rows' modality, so neither becomes false. Planning unit: `devlog/_plan/260912_zcode_protocol_and_catalog/020_wp3_glm53_flash_modalities.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer input modality information for Z.AI GLM models.
  - GLM-5.3-Flash is now identified as supporting both text and image inputs.
  - Other listed GLM models remain identified as text-only.

- **Tests**
  - Added coverage to verify modality labels across Z.AI and BigModel Coding Plan model listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->