### PR TITLE
fix(opencode): replay one Console Go 400 "Invalid upload request."

### DIFF
--- a/src/providers/opencode-zen-rate-limit.ts
+++ b/src/providers/opencode-zen-rate-limit.ts
@@ -190,10 +190,62 @@ export function enrichOpenCodeZenUpstreamMessage(
  * callers replay the byte-identical request once instead of failing the turn.
  * Upstream tracker: anomalyco/opencode#47237.
  */
+/** Canonical Console destinations: the Zen/Go provider rows and any opencode.ai /zen base URL. */
+const CONSOLE_GO_PROVIDER_IDS = new Set(["opencode-go", "opencode-zen", "opencode-free"]);
+
+export function isConsoleGoDestination(opts: {
+  providerName?: string;
+  baseUrl?: string;
+}): boolean {
+  const name = opts.providerName?.trim();
+  if (name && CONSOLE_GO_PROVIDER_IDS.has(name)) return true;
+  const baseUrl = opts.baseUrl?.trim();
+  if (!baseUrl) return false;
+  try {
+    const url = new URL(baseUrl);
+    if (url.hostname !== "opencode.ai") return false;
+    const path = url.pathname.replace(/\/+$/, "");
+    return path === "/zen" || path.startsWith("/zen/");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The canonical refusal envelope, as served on both Console routes:
+ *   {"error":{"param":null,"type":"invalid_request_error","message":"Error from provider
+ *   (Console Go): Upstream request failed: [invalid_request_error] Invalid upload request."}}
+ *
+ * The gateway names itself Console on the Zen key route and Console Go on the Go route, so the
+ * anchor is the shared product name plus the refusal sentence. The message is matched whole: a
+ * bare string, a suffix, or any other envelope is a different refusal and must not be replayed.
+ * Being stricter than necessary is the safe direction: a missed match leaves the turn failing
+ * exactly as it does today, while a loose match spends an extra request on unrelated 400s.
+ */
+const CONSOLE_UPLOAD_REFUSAL_RE =
+  /^Error from provider \(Console(?: Go)?\): Upstream request failed: \[invalid_request_error\] Invalid upload request\.$/;
+
+/**
+ * True only for the canonical Console upload refusal on a canonical Console destination.
+ * Route-gated on purpose: the message alone would let any other upstream that happens to answer
+ * with this English sentence trigger a second send from an unrelated provider.
+ */
 export function isTransientConsoleGoUploadRejection(opts: {
   status: number;
   errorBody: string | undefined;
+  providerName?: string;
+  baseUrl?: string;
 }): boolean {
   if (opts.status !== 400 || !opts.errorBody) return false;
-  return /invalid upload request/i.test(opts.errorBody);
+  if (!isConsoleGoDestination({ providerName: opts.providerName, baseUrl: opts.baseUrl })) return false;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(opts.errorBody);
+  } catch {
+    return false;
+  }
+  const error = (payload as { error?: unknown } | null)?.error;
+  if (!error || typeof error !== "object" || Array.isArray(error)) return false;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" && CONSOLE_UPLOAD_REFUSAL_RE.test(message.trim());
 }

--- a/src/providers/opencode-zen-rate-limit.ts
+++ b/src/providers/opencode-zen-rate-limit.ts
@@ -244,8 +244,12 @@ export function isTransientConsoleGoUploadRejection(opts: {
   } catch {
     return false;
   }
-  const error = (payload as { error?: unknown } | null)?.error;
-  if (!error || typeof error !== "object" || Array.isArray(error)) return false;
-  const message = (error as { message?: unknown }).message;
-  return typeof message === "string" && CONSOLE_UPLOAD_REFUSAL_RE.test(message.trim());
+ const error = (payload as { error?: unknown } | null)?.error;
+ if (!error || typeof error !== "object" || Array.isArray(error)) return false;
+  // The whole envelope, not just the sentence: Console always answers this refusal as
+  // invalid_request_error with a null param, so a partial envelope is a different error.
+  const envelope = error as { param?: unknown; type?: unknown; message?: unknown };
+  if (envelope.type !== "invalid_request_error" || envelope.param !== null) return false;
+  // Matched without trimming: padding means the gateway wrapped or appended something.
+  return typeof envelope.message === "string" && CONSOLE_UPLOAD_REFUSAL_RE.test(envelope.message);
 }

--- a/src/providers/opencode-zen-rate-limit.ts
+++ b/src/providers/opencode-zen-rate-limit.ts
@@ -175,3 +175,25 @@ export function enrichOpenCodeZenUpstreamMessage(
 ): string {
   return enrichOpenCodeZenFreeTierMessage(enrichOpenCodeZenRateLimitMessage(message, opts), opts);
 }
+
+/**
+ * Console Go transient upload rejection.
+ *
+ * Both Go and Zen hand the request to OpenCode's Console gateway, which intermittently answers
+ * a body it accepts moments later with a 400 invalid_request_error / "Invalid upload request." —
+ * a rejection naming an upload step the caller never invoked (the request is plain JSON).
+ *
+ * Live evidence (2026-09-12, usage ledger, conversation a016a2a76ee921d9300342e56bf5824d):
+ * request ocx-ce696fa4a554e4f3e375cf120904b0da failed 400, while ocx-ed78f47b96f7d1bb7c —
+ * sent 22s later with the same model, the same inline-image history and the same tool output —
+ * answered 200. The rejection is therefore an upstream flap, not a verdict on the payload, so
+ * callers replay the byte-identical request once instead of failing the turn.
+ * Upstream tracker: anomalyco/opencode#47237.
+ */
+export function isTransientConsoleGoUploadRejection(opts: {
+  status: number;
+  errorBody: string | undefined;
+}): boolean {
+  if (opts.status !== 400 || !opts.errorBody) return false;
+  return /invalid upload request/i.test(opts.errorBody);
+}

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -102,7 +102,10 @@ import {
 } from "../../lib/errors";
 import { injectionDebugLog } from "../../lib/injection-debug-log";
 import { resolveClientRetryAfter } from "../../lib/retry-after";
-import { enrichOpenCodeZenUpstreamMessage } from "../../providers/opencode-zen-rate-limit";
+import {
+  enrichOpenCodeZenUpstreamMessage,
+  isTransientConsoleGoUploadRejection,
+} from "../../providers/opencode-zen-rate-limit";
 import { CODE_MODE_EXEC_TOOL_NAME, modelInList, namespacedToolName } from "../../types";
 import type {
   AdapterEvent,
@@ -213,6 +216,7 @@ import {
   fetchWithTransientRetry,
   isNonReplayableResponse,
   prepareSameTarget429Wait,
+  sleepWithAbort,
 } from "../../lib/upstream-retry";
 import {
   ForwardAdmissionCredentialError,
@@ -840,6 +844,33 @@ async function opaqueBlobRejectionBodyForRecovery(
     || alreadyAttempted
     || !outboundResponsesBodyCarriesOpaqueBlob(outboundBody)
   ) return undefined;
+  try {
+    const body = await readBoundedResponseBody(response.clone(), { signal });
+    return body.displaySafe && !body.truncated ? body.text : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Console Go transient-400 retry delay. A short pause lets a momentary gateway state clear
+ * before the single byte-identical replay; it is imperceptible inside a turn that already
+ * waits seconds for the model.
+ */
+const CONSOLE_GO_UPLOAD_RETRY_DELAY_MS = 800;
+
+/**
+ * Peek the upstream error body for the Console Go transient-400 recovery. Only a complete,
+ * display-safe body may drive a retry decision (same contract as
+ * opaqueBlobRejectionBodyForRecovery), and reading a clone leaves the original response intact
+ * for the caller's own error surface when no retry is taken.
+ */
+async function consoleGoUploadRejectionBody(
+  response: Response,
+  alreadyAttempted: boolean,
+  signal: AbortSignal,
+): Promise<string | undefined> {
+  if (response.status !== 400 || alreadyAttempted) return undefined;
   try {
     const body = await readBoundedResponseBody(response.clone(), { signal });
     return body.displaySafe && !body.truncated ? body.text : undefined;
@@ -5231,6 +5262,9 @@ async function handleResponsesInner(
     const opaqueBlobRecoveryGuard: OpaqueBlobRecoveryGuard = { attempted: false };
     let oauth401ReplayAttempted = false;
     let codex401ReplayKind: "main" | "stored" | null = null;
+    // Console Go answers a transient 400 "Invalid upload request." for bodies it accepts
+    // moments later; at most one byte-identical replay is allowed per request.
+    const consoleGoUploadRetryGuard: { attempted: boolean } = { attempted: false };
     const rateLimitPolicy = rateLimitRetryPolicyFor(route.provider);
     let rateLimitRetries = 0;
     const rebuildAndRefetch = async (
@@ -5776,6 +5810,34 @@ async function handleResponsesInner(
         logCtx.terminalHttpStatus = preflightLog.terminalHttpStatus;
         logCtx.terminalErrorCode = preflightLog.terminalErrorCode;
         logCtx.terminalIncompleteReason = preflightLog.terminalIncompleteReason;
+      }
+    }
+    // Console Go (opencode-zen / opencode-go) intermittently rejects a body it accepts seconds
+    // later with 400 invalid_request_error / "Invalid upload request." Replay the byte-identical
+    // request once: the same conversation re-sent 22s later answered 200, so surfacing this flap
+    // would fail a turn the upstream would have served. Single-shot guard.
+    if (!consoleGoUploadRetryGuard.attempted) {
+      const uploadRejectionBody = await consoleGoUploadRejectionBody(
+        upstreamResponse,
+        consoleGoUploadRetryGuard.attempted,
+        upstream.signal,
+      );
+      if (uploadRejectionBody !== undefined
+        && isTransientConsoleGoUploadRejection({
+          status: upstreamResponse.status,
+          errorBody: uploadRejectionBody,
+        })) {
+        consoleGoUploadRetryGuard.attempted = true;
+        try { void upstreamResponse.body?.cancel().catch(() => {}); } catch { /* already consumed/closed */ }
+        if (!upstream.signal.aborted) {
+          try {
+            await sleepWithAbort(CONSOLE_GO_UPLOAD_RETRY_DELAY_MS, upstream.signal);
+          } catch { /* client aborted: the replay below settles through the normal abort path */ }
+        }
+        const result = await rebuildAndRefetch("console-go-upload-retry");
+        if ("failed" in result) return result.failed;
+        upstreamResponse = result;
+        continue passthroughRecovery;
       }
     }
     break;
@@ -7267,6 +7329,9 @@ async function handleResponsesInner(
     // 413→429 rotation cannot silently undo the tightening.
     let imageRetryAttempted = false;
     const opaqueBlobRecoveryGuard: OpaqueBlobRecoveryGuard = { attempted: false };
+    // Console Go answers a transient 400 "Invalid upload request." for bodies it accepts
+    // moments later; at most one byte-identical replay is allowed per request.
+    const consoleGoUploadRetryGuard: { attempted: boolean } = { attempted: false };
     let oauth401ReplayAttempted = false;
     /**
      * Rebuild the request from the current parsed input (and any image-tier bias) and refetch
@@ -7650,6 +7715,35 @@ async function handleResponsesInner(
         if ("failed" in result) return result.failed;
         upstreamResponse = result;
         continue recovery;
+      }
+      // Console Go (opencode-zen / opencode-go) intermittently rejects a body it accepts seconds
+      // later with 400 invalid_request_error / "Invalid upload request." Replay the
+      // byte-identical request once: the same conversation re-sent 22s later answered 200, so
+      // surfacing this flap would fail a turn the upstream would have served. Single-shot guard.
+      if (!consoleGoUploadRetryGuard.attempted) {
+        const uploadRejectionBody = await consoleGoUploadRejectionBody(
+          upstreamResponse,
+          consoleGoUploadRetryGuard.attempted,
+          upstream.signal,
+        );
+        if (uploadRejectionBody !== undefined
+          && isTransientConsoleGoUploadRejection({
+            status: upstreamResponse.status,
+            errorBody: uploadRejectionBody,
+          })) {
+          consoleGoUploadRetryGuard.attempted = true;
+          invalidateSameTargetRequest();
+          try { void upstreamResponse.body?.cancel().catch(() => {}); } catch { /* already consumed/closed */ }
+          if (!upstream.signal.aborted) {
+            try {
+              await sleepWithAbort(CONSOLE_GO_UPLOAD_RETRY_DELAY_MS, upstream.signal);
+            } catch { /* client aborted: the replay below settles through the normal abort path */ }
+          }
+          const result = await rebuildAndRefetch("console-go-upload-retry");
+          if ("failed" in result) return result.failed;
+          upstreamResponse = result;
+          continue recovery;
+        }
       }
       break;
     }

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -5816,6 +5816,8 @@ async function handleResponsesInner(
     // later with 400 invalid_request_error / "Invalid upload request." Replay the byte-identical
     // request once: the same conversation re-sent 22s later answered 200, so surfacing this flap
     // would fail a turn the upstream would have served. Single-shot guard.
+    // No same-target cache invalidation here: the passthrough rebuild calls buildRequest on every
+    // attempt, and the cache guarded by invalidateSameTargetRequest() belongs to the generic loop.
     if (!consoleGoUploadRetryGuard.attempted) {
       const uploadRejectionBody = await consoleGoUploadRejectionBody(
         upstreamResponse,
@@ -5826,6 +5828,8 @@ async function handleResponsesInner(
         && isTransientConsoleGoUploadRejection({
           status: upstreamResponse.status,
           errorBody: uploadRejectionBody,
+          providerName: route.providerName,
+          baseUrl: route.provider.baseUrl,
         })) {
         consoleGoUploadRetryGuard.attempted = true;
         try { void upstreamResponse.body?.cancel().catch(() => {}); } catch { /* already consumed/closed */ }
@@ -7730,6 +7734,8 @@ async function handleResponsesInner(
           && isTransientConsoleGoUploadRejection({
             status: upstreamResponse.status,
             errorBody: uploadRejectionBody,
+            providerName: route.providerName,
+            baseUrl: route.provider.baseUrl,
           })) {
           consoleGoUploadRetryGuard.attempted = true;
           invalidateSameTargetRequest();

--- a/src/usage/log.ts
+++ b/src/usage/log.ts
@@ -70,6 +70,7 @@ export type AttemptRecoveryKind =
   | "anthropic-oauth-429"
   | "oauth-account-429"
   | "image-413"
+  | "console-go-upload-retry"
   | "opaque-blob-rejection"
   | "empty-completion";
 
@@ -309,6 +310,7 @@ const ATTEMPT_RECOVERY_KINDS = new Set<AttemptRecoveryKind>([
   "anthropic-oauth-429",
   "oauth-account-429",
   "image-413",
+  "console-go-upload-retry",
   "opaque-blob-rejection",
   "empty-completion",
 ]);

--- a/tests/providers/opencode-zen-rate-limit.test.ts
+++ b/tests/providers/opencode-zen-rate-limit.test.ts
@@ -275,5 +275,20 @@ describe("Console Go transient upload refusal", () => {
       ...GO_ROUTE,
     })).toBe(false);
   });
+
+  test("rejects partial envelopes and padded messages", () => {
+    const withError = (error: unknown) => JSON.stringify({ model: "muse-spark-1.3-contributor", error });
+    // type carries the refusal identity; a partial envelope is a different error.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: withError({ param: null, message: GO_MESSAGE }), ...GO_ROUTE })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: withError({ param: null, type: "server_error", message: GO_MESSAGE }), ...GO_ROUTE })).toBe(false);
+    // param must be present and null.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: withError({ type: "invalid_request_error", message: GO_MESSAGE }), ...GO_ROUTE })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: withError({ param: "input", type: "invalid_request_error", message: GO_MESSAGE }), ...GO_ROUTE })).toBe(false);
+    // Padding means the gateway wrapped or appended something.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: withError({ param: null, type: "invalid_request_error", message: " " + GO_MESSAGE }), ...GO_ROUTE })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: withError({ param: null, type: "invalid_request_error", message: GO_MESSAGE + "\n" }), ...GO_ROUTE })).toBe(false);
+    // The exact canonical envelope still matches.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(GO_MESSAGE), ...GO_ROUTE })).toBe(true);
+  });
 });
 

--- a/tests/providers/opencode-zen-rate-limit.test.ts
+++ b/tests/providers/opencode-zen-rate-limit.test.ts
@@ -233,38 +233,46 @@ describe("opencode-free keyless tier lock-in (#4121)", () => {
 });
 
 describe("Console Go transient upload refusal", () => {
-  // The exact body Console Go returns for a payload it accepts moments later.
-  const UPLOAD_REFUSAL = JSON.stringify({
-    model: "muse-spark-1.3-contributor",
-    error: {
-      param: null,
-      type: "invalid_request_error",
-      message: "Error from provider (Console Go): Upstream request failed: [invalid_request_error] Invalid upload request.",
-    },
+  // The observed Go-route refusal, byte-for-byte as Console serves it.
+  const GO_MESSAGE = "Error from provider (Console Go): Upstream request failed: [invalid_request_error] Invalid upload request.";
+  // The Zen key route names the same gateway without the Go suffix.
+  const ZEN_MESSAGE = "Error from provider (Console): Upstream request failed: [invalid_request_error] Invalid upload request.";
+  const envelope = (message: string) => JSON.stringify({ model: "muse-spark-1.3-contributor", error: { param: null, type: "invalid_request_error", message } });
+  const GO_ROUTE = { providerName: "opencode-go", baseUrl: "https://opencode.ai/zen/go/v1" };
+  const ZEN_ROUTE = { providerName: "opencode-zen", baseUrl: "https://opencode.ai/zen/v1" };
+
+  test("accepts the canonical refusal on both canonical Console routes", () => {
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(GO_MESSAGE), ...GO_ROUTE })).toBe(true);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(ZEN_MESSAGE), ...ZEN_ROUTE })).toBe(true);
+    // A custom row pointed at the same destination is still Console: the base URL decides.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(GO_MESSAGE), providerName: "my-go-row", baseUrl: "https://opencode.ai/zen/go/v1" })).toBe(true);
   });
 
-  test("accepts the 400 upload refusal regardless of casing", () => {
-    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: UPLOAD_REFUSAL })).toBe(true);
-    expect(isTransientConsoleGoUploadRejection({
-      status: 400,
-      errorBody: '{"error":"INVALID UPLOAD REQUEST."}',
-    })).toBe(true);
+  test("rejects the refusal text from a non-Console route", () => {
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(GO_MESSAGE), providerName: "deepseek", baseUrl: "https://api.deepseek.com/v1" })).toBe(false);
+    // opencode.ai without the /zen segment is not the Console gateway.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(GO_MESSAGE), providerName: "other", baseUrl: "https://opencode.ai/v1" })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(GO_MESSAGE) })).toBe(false);
   });
 
-  test("rejects every other status and error body", () => {
-    // Status is part of the identity: only the gateway's 400 is the flap.
-    expect(isTransientConsoleGoUploadRejection({ status: 200, errorBody: UPLOAD_REFUSAL })).toBe(false);
-    expect(isTransientConsoleGoUploadRejection({ status: 500, errorBody: UPLOAD_REFUSAL })).toBe(false);
-    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: undefined })).toBe(false);
-    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: "" })).toBe(false);
-    // Other 400s on the same wire are deterministic verdicts on the request, not flaps.
+  test("rejects noncanonical envelopes, suffixes, and other statuses", () => {
+    // A bare string is not the structured envelope.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: JSON.stringify({ error: "Invalid upload request." }), ...GO_ROUTE })).toBe(false);
+    // A suffix means the gateway said something else; do not guess.
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: envelope(GO_MESSAGE + " Please retry."), ...GO_ROUTE })).toBe(false);
+    // Different status: only the gateway 400 is the flap.
+    expect(isTransientConsoleGoUploadRejection({ status: 500, errorBody: envelope(GO_MESSAGE), ...GO_ROUTE })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: undefined, ...GO_ROUTE })).toBe(false);
+    // Other 400s on the same wire are verdicts on the request, not flaps.
     expect(isTransientConsoleGoUploadRejection({
       status: 400,
-      errorBody: '{"error":{"param":"reasoning.effort","type":"invalid_request_error","message":"Error from provider (Console Go): Upstream request failed: [invalid_request_error] reasoning_effort max requires an active Muse Code subscription for model muse-spark-1.3-contributor."}}',
+      errorBody: envelope("Error from provider (Console Go): Upstream request failed: [invalid_request_error] reasoning_effort max requires an active Muse Code subscription for model muse-spark-1.3-contributor."),
+      ...GO_ROUTE,
     })).toBe(false);
     expect(isTransientConsoleGoUploadRejection({
       status: 400,
-      errorBody: '{"type":"error","error":{"type":"MissingSessionID","message":"Request is missing x-opencode-session"}}',
+      errorBody: JSON.stringify({ type: "error", error: { type: "MissingSessionID", message: "Request is missing x-opencode-session" } }),
+      ...GO_ROUTE,
     })).toBe(false);
   });
 });

--- a/tests/providers/opencode-zen-rate-limit.test.ts
+++ b/tests/providers/opencode-zen-rate-limit.test.ts
@@ -6,6 +6,7 @@ import {
   enrichOpenCodeZenFreeTierMessage,
   enrichOpenCodeZenRateLimitMessage,
   enrichOpenCodeZenUpstreamMessage,
+  isTransientConsoleGoUploadRejection,
   isOpenCodeZenFreeTierLockIn,
   isOpenCodeZenRateLimitProvider,
 } from "../../src/providers/opencode-zen-rate-limit";
@@ -230,3 +231,41 @@ describe("opencode-free keyless tier lock-in (#4121)", () => {
     expect(lockedOut).not.toContain(OPENCODE_ZEN_OBSERVED_RPM_HINT);
   });
 });
+
+describe("Console Go transient upload refusal", () => {
+  // The exact body Console Go returns for a payload it accepts moments later.
+  const UPLOAD_REFUSAL = JSON.stringify({
+    model: "muse-spark-1.3-contributor",
+    error: {
+      param: null,
+      type: "invalid_request_error",
+      message: "Error from provider (Console Go): Upstream request failed: [invalid_request_error] Invalid upload request.",
+    },
+  });
+
+  test("accepts the 400 upload refusal regardless of casing", () => {
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: UPLOAD_REFUSAL })).toBe(true);
+    expect(isTransientConsoleGoUploadRejection({
+      status: 400,
+      errorBody: '{"error":"INVALID UPLOAD REQUEST."}',
+    })).toBe(true);
+  });
+
+  test("rejects every other status and error body", () => {
+    // Status is part of the identity: only the gateway's 400 is the flap.
+    expect(isTransientConsoleGoUploadRejection({ status: 200, errorBody: UPLOAD_REFUSAL })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 500, errorBody: UPLOAD_REFUSAL })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: undefined })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({ status: 400, errorBody: "" })).toBe(false);
+    // Other 400s on the same wire are deterministic verdicts on the request, not flaps.
+    expect(isTransientConsoleGoUploadRejection({
+      status: 400,
+      errorBody: '{"error":{"param":"reasoning.effort","type":"invalid_request_error","message":"Error from provider (Console Go): Upstream request failed: [invalid_request_error] reasoning_effort max requires an active Muse Code subscription for model muse-spark-1.3-contributor."}}',
+    })).toBe(false);
+    expect(isTransientConsoleGoUploadRejection({
+      status: 400,
+      errorBody: '{"type":"error","error":{"type":"MissingSessionID","message":"Request is missing x-opencode-session"}}',
+    })).toBe(false);
+  });
+});
+

--- a/tests/responses/responses-console-go-upload-retry.test.ts
+++ b/tests/responses/responses-console-go-upload-retry.test.ts
@@ -48,17 +48,23 @@ function config(): OcxConfig {
   return {
     defaultProvider: "go",
     providers: {
-      go: {
+     go: {
+       adapter: "openai-responses",
+       baseUrl: "https://opencode.ai/zen/go/v1",
+       authMode: "key",
+       apiKey: "go-test-key",
+     },
+      other: {
         adapter: "openai-responses",
-        baseUrl: "https://opencode.ai/zen/go/v1",
+        baseUrl: "https://other.example.test/v1",
         authMode: "key",
-        apiKey: "go-test-key",
+        apiKey: "other-test-key",
       },
-    },
-  } as OcxConfig;
+   },
+ } as OcxConfig;
 }
 
-function request(stream = false): Request {
+function request(stream = false, provider = "go"): Request {
   return new Request("http://localhost/v1/responses", {
     method: "POST",
     headers: {
@@ -66,7 +72,7 @@ function request(stream = false): Request {
       "session_id": "thread-console-go-upload-retry",
     },
     body: JSON.stringify({
-      model: "go/muse-spark-1.3-contributor",
+      model: provider + "/muse-spark-1.3-contributor",
       stream,
       store: false,
       input: [
@@ -129,6 +135,19 @@ describe("Console Go transient upload refusal recovery", () => {
     expect(response.status).toBe(400);
     expect(sends).toBe(2);
     expect(logCtx.activeAttempt?.recoveryKinds).toEqual(["console-go-upload-retry"]);
+  });
+
+  test("does not replay the same refusal text from a non-Console provider", async () => {
+    let sends = 0;
+    globalThis.fetch = (async () => {
+      sends += 1;
+      return refusal();
+    }) as typeof fetch;
+
+    const response = await handleResponses(request(false, "other"), config(), { model: "", provider: "" });
+
+    expect(response.status).toBe(400);
+    expect(sends).toBe(1);
   });
 });
 

--- a/tests/responses/responses-console-go-upload-retry.test.ts
+++ b/tests/responses/responses-console-go-upload-retry.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleResponses } from "../../src/server/responses/core";
+import type { RequestLogContext } from "../../src/server/request-log";
+import type { OcxConfig } from "../../src/types";
+import { removeTreeWithRetry } from "../helpers/remove-tree";
+
+const originalFetch = globalThis.fetch;
+const originalOpenCodexHome = process.env.OPENCODEX_HOME;
+
+/** The exact Console Go rejection for a payload it accepts moments later. */
+const UPLOAD_REFUSAL = JSON.stringify({
+  model: "muse-spark-1.3-contributor",
+  error: {
+    param: null,
+    type: "invalid_request_error",
+    message: "Error from provider (Console Go): Upstream request failed: [invalid_request_error] Invalid upload request.",
+  },
+});
+
+/** A deterministic 400 on the same wire: a verdict on the request, never a flap. */
+const EFFORT_REFUSAL = JSON.stringify({
+  model: "muse-spark-1.3-contributor",
+  error: {
+    param: "reasoning.effort",
+    type: "invalid_request_error",
+    message: "Error from provider (Console Go): Upstream request failed: [invalid_request_error] reasoning_effort max requires an active Muse Code subscription for model muse-spark-1.3-contributor.",
+  },
+});
+
+let testDir = "";
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "ocx-console-go-upload-retry-"));
+  process.env.OPENCODEX_HOME = testDir;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalOpenCodexHome === undefined) delete process.env.OPENCODEX_HOME;
+  else process.env.OPENCODEX_HOME = originalOpenCodexHome;
+  removeTreeWithRetry(testDir);
+});
+
+function config(): OcxConfig {
+  return {
+    defaultProvider: "go",
+    providers: {
+      go: {
+        adapter: "openai-responses",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        authMode: "key",
+        apiKey: "go-test-key",
+      },
+    },
+  } as OcxConfig;
+}
+
+function request(stream = false): Request {
+  return new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "session_id": "thread-console-go-upload-retry",
+    },
+    body: JSON.stringify({
+      model: "go/muse-spark-1.3-contributor",
+      stream,
+      store: false,
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      ],
+    }),
+  });
+}
+
+function refusal(status = 400, body = UPLOAD_REFUSAL): Response {
+  return new Response(body, { status, headers: { "content-type": "application/json" } });
+}
+
+function success(id: string): Response {
+  return Response.json({ id, object: "response", status: "completed", model: "muse-spark-1.3-contributor", output: [] });
+}
+
+describe("Console Go transient upload refusal recovery", () => {
+  test("replays the refusal once and serves the retry with a byte-identical body", async () => {
+    const outbound: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      outbound.push(String(init?.body));
+      return outbound.length === 1 ? refusal() : success("resp-upload-retry-recovered");
+    }) as typeof fetch;
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+
+    const response = await handleResponses(request(), config(), logCtx);
+
+    expect(response.status).toBe(200);
+    expect(outbound).toHaveLength(2);
+    // The replay must be the same request, not a reshaped one. Evidence: usage ledger
+    // ocx-ce696fa4a554e4f3e375cf120904b0da (400) vs ocx-ed78f47b96f7d1bb7c (200, +22s).
+    expect(outbound[1]).toBe(outbound[0]);
+    expect(logCtx.activeAttempt?.recoveryKinds).toEqual(["console-go-upload-retry"]);
+  });
+
+  test("does not replay a different 400 from the same wire", async () => {
+    let sends = 0;
+    globalThis.fetch = (async () => {
+      sends += 1;
+      return refusal(400, EFFORT_REFUSAL);
+    }) as typeof fetch;
+
+    const response = await handleResponses(request(), config(), { model: "", provider: "" });
+
+    expect(response.status).toBe(400);
+    expect(sends).toBe(1);
+  });
+
+  test("keeps a repeated refusal visible after the single bounded replay", async () => {
+    let sends = 0;
+    globalThis.fetch = (async () => {
+      sends += 1;
+      return refusal();
+    }) as typeof fetch;
+    const logCtx: RequestLogContext = { model: "", provider: "" };
+
+    const response = await handleResponses(request(), config(), logCtx);
+
+    expect(response.status).toBe(400);
+    expect(sends).toBe(2);
+    expect(logCtx.activeAttempt?.recoveryKinds).toEqual(["console-go-upload-retry"]);
+  });
+});
+


### PR DESCRIPTION
## Summary

`opencode-zen` and `opencode-go` requests intermittently fail with an upstream 400 that names an
upload step the caller never invoked:

```
Error from provider (Console Go): Upstream request failed: [invalid_request_error] Invalid upload request.
```

The rejection is a gateway flap, not a verdict on the payload. Evidence from the usage ledger
(`usage.jsonl`, conversation `a016a2a76ee921d9300342e56bf5824d`, 2026-09-12): request
`ocx-ce696fa4a554e4f3e375cf120904b0da` was refused (400, 1330ms), while
`ocx-ed78f47b96f7d1bb7c` -- sent 22s later with the same model, the same inline-image history and
the same tool output -- was served 200. A third request in that thread was refused and the next
one served, so the wire accepts the identical body moments later. Upstream tracker:
[anomalyco/opencode#47237](https://github.com/anomalyco/opencode/issues/47237).

Before this change neither recovery loop retried the refusal (attempts stayed at `sendCount: 1`
with no `recoveryKinds`), so Codex surfaced the 400 and the turn ended.

This adds the `console-go-upload-retry` recovery kind: when the upstream answers with the canonical
Console refusal, the proxy waits 800ms and replays the **byte-identical** request once.

- `src/providers/opencode-zen-rate-limit.ts` -- `isTransientConsoleGoUploadRejection()` plus
  `isConsoleGoDestination()`. A replay requires all of:
  - a canonical Console destination (`opencode-go`, `opencode-zen`, `opencode-free`, or any
    `opencode.ai` base URL under `/zen`, so a custom row pointed at the same gateway still recovers),
  - status 400,
  - the full structured envelope -- `error.type === "invalid_request_error"` and
    `error.param === null`,
  - and `error.message` matching the whole refusal, without trimming: the `(Console Go)` spelling
    and the `(Console)` spelling the Zen key route uses.
  Bare strings, suffixes, partial envelopes, padded messages, and non-400 statuses are rejected.
- `src/server/responses/core.ts` -- the single-shot guard plus a bounded body peek, wired into both
  the native Responses passthrough loop and the generic recovery loop. The peek reads a `clone()`
  under the same display-safe contract as `opaqueBlobRejectionBodyForRecovery`, so the original
  body stays intact for the error path when no replay is taken.
- `src/usage/log.ts` -- the new recovery kind, so the retry is visible in the usage ledger.

Deliberately narrow: other 400s on the same wire (`reasoning_effort max` subscription gates,
`MissingSessionID`) stay single-send verdicts, a non-Console route never replays, and a second
refusal after the bounded replay is still surfaced unchanged.

## Verification

```
bun test tests/providers/opencode-zen-rate-limit.test.ts \
         tests/responses/responses-console-go-upload-retry.test.ts   # 23 pass, 0 fail
bun test tests/responses                                           # 2038 pass, 0 fail
bun test tests/providers tests/usage                               # 4415 pass, 29 fail (pre-existing)
./node_modules/typescript/bin/tsc --noEmit                        # clean
```

The 29 failures under `tests/providers` are Kiro/xAI credential-store cases that fail identically
on a clean `dev` checkout in this environment (compared name-by-name against a stashed tree), and
are untouched by this change.

The integration test drives `handleResponses` against a stubbed upstream: the first send is
refused with the real Console Go body, the second returns a completion, and the assertions pin
(a) exactly two sends, (b) `outbound[1] === outbound[0]` so the replay is byte-identical, and
(c) `recoveryKinds === ["console-go-upload-retry"]`. Sibling cases pin the negative paths: a different
400 sends once, a repeated refusal stays visible after the single bounded replay, the same refusal
text from a non-Console provider sends once, and unit cases cover a bare string, a suffix, a wrong
status, a missing or mismatched `type`, a missing or non-null `param`, and padded messages.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transient Console Go and Zen upload rejections now automatically retry once before being surfaced.
  * Retries preserve the original request content and occur only for recognized temporary upload errors.
  * Other HTTP 400 errors, malformed responses, and unrelated provider responses are not retried.
  * Repeated upload rejections remain visible after the single retry attempt.
  * Recovery activity is recorded for improved troubleshooting and usage visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

