### PR TITLE
feat(devin): give both Devin providers a mark and make the CLI one addable

### DIFF
--- a/gui/public/provider-icons/README.md
+++ b/gui/public/provider-icons/README.md
@@ -101,6 +101,24 @@ at 20px.
   `viewBox="0 0 823 823"` by centering the 823x806 trace. Named
   `hermes-agent` rather than `hermes` because Hermes is also a provider name
   and this directory is one flat namespace.
+- `devin.svg` — fetched 2026-09-12 from `https://docs.devin.ai/logo/light.svg`,
+  Devin's own documentation logo, and CROPPED to its symbol. The source is a
+  160x24 horizontal lockup: the three-leaf mark occupies the left 24 units and
+  the `devin` wordmark starts at x=34.2, so a `viewBox="0 0 24 24"` window keeps
+  the whole symbol and excludes every wordmark path. The thirteen symbol paths
+  and all seven gradients are verbatim — nothing is translated, so the
+  `userSpaceOnUse` gradient coordinates stay valid — and only the two wordmark
+  paths are dropped. Cropping a lockup to its symbol is what `cursor-color.svg`
+  and `gajae-code.svg` already do; the alternative here was a wordmark in a 20px
+  box, which this file refuses.
+
+  `devin.ai/favicon.svg` sits behind a Vercel security checkpoint that answers
+  429 with an HTML page, and `cognition.ai` publishes only a raster favicon, so
+  the docs site is the reachable first-party vector. Windsurf does publish
+  `windsurf.com/favicon.svg` — a plated `W` — but that names the retired brand
+  for a provider labelled Cognition. Multi-colour gradient, so it is drawn as an
+  image and is not a candidate for the masked set.
+
 - `gajae-code.svg` — traced 2026-08-31 from `Yeachan-Heo/gajae-code`
   `assets/character.png` (3190496 bytes, 1550x2048 RGBA), the mascot. No SVG
   exists upstream: `assets/` and `docs/` hold only raster, `public/` is a 404,

--- a/gui/public/provider-icons/devin.svg
+++ b/gui/public/provider-icons/devin.svg
@@ -1,0 +1,49 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61504C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5913 7.95343 21.1394Z" fill="white"/>
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61504C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5913 7.95343 21.1394Z" fill="url(#paint0_radial_115_86)"/>
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61504C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5913 7.95343 21.1394Z" fill="black" fill-opacity="0.5" style="mix-blend-mode:hard-light"/>
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61504C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5913 7.95343 21.1394Z" fill="url(#paint1_linear_115_86)" fill-opacity="0.5" style="mix-blend-mode:hard-light"/>
+<path d="M7.9354 21.1112C4.89702 21.0957 2.27411 19.4306 1.01347 16.279C-0.248375 13.1244 0.135612 9.18218 1.76165 5.64327C4.80004 5.65882 7.42295 7.32385 8.68359 10.4755C9.94543 13.63 9.56144 17.5723 7.9354 21.1112Z" stroke="url(#paint2_linear_115_86)" stroke-opacity="0.05" stroke-width="0.056338"/>
+<path d="M7.31038 21.2574C11.3543 20.2215 14.8836 17.3754 16.6285 13.2361C18.3735 9.09671 17.9448 4.58749 15.8598 0.976291C11.8159 2.01214 8.2866 4.85826 6.54167 8.99762C4.79674 13.137 5.2254 17.6462 7.31038 21.2574Z" fill="white"/>
+<path d="M7.31038 21.2574C11.3543 20.2215 14.8836 17.3754 16.6285 13.2361C18.3735 9.09671 17.9448 4.58749 15.8598 0.976291C11.8159 2.01214 8.2866 4.85826 6.54167 8.99762C4.79674 13.137 5.2254 17.6462 7.31038 21.2574Z" fill="url(#paint3_radial_115_86)"/>
+<path d="M16.6025 13.2251C14.8642 17.349 11.3512 20.1866 7.32411 21.2248C5.25257 17.624 4.82926 13.1324 6.56764 9.00855C8.30603 4.88472 11.819 2.04706 15.8461 1.00889C17.9176 4.60967 18.3409 9.10131 16.6025 13.2251Z" stroke="url(#paint4_linear_115_86)" stroke-opacity="0.05" stroke-width="0.056338"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="white"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="url(#paint5_radial_115_86)"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="black" fill-opacity="0.2" style="mix-blend-mode:hard-light"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="url(#paint6_linear_115_86)" fill-opacity="0.5" style="mix-blend-mode:hard-light"/>
+<path d="M16.5682 22.7874C13.2176 23.9184 9.81361 23.2124 7.2672 21.1975C8.49194 17.9068 11.0444 15.189 14.3959 14.0577C17.7465 12.9266 21.1504 13.6326 23.6968 15.6476C22.4721 18.9383 19.9196 21.656 16.5682 22.7874Z" stroke="url(#paint7_linear_115_86)" stroke-opacity="0.05" stroke-width="0.056338"/>
+<defs>
+<radialGradient id="paint0_radial_115_86" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(-3.00503 15.023) rotate(-10.029) scale(17.9572 17.784)">
+<stop stop-color="#00B0BB"/>
+<stop offset="1" stop-color="#00DB65"/>
+</radialGradient>
+<linearGradient id="paint1_linear_115_86" x1="7.39036" y1="4.81308" x2="1.62975" y2="18.6894" gradientUnits="userSpaceOnUse">
+<stop stop-color="#18E299"/>
+<stop offset="1"/>
+</linearGradient>
+<linearGradient id="paint2_linear_115_86" x1="7.94816" y1="8.01562" x2="1.7612" y2="18.746" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint3_radial_115_86" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(8.11404 20.8822) rotate(-75.7542) scale(21.6246 23.7772)">
+<stop stop-color="#00BBBB"/>
+<stop offset="0.712616" stop-color="#00DB65"/>
+</radialGradient>
+<linearGradient id="paint4_linear_115_86" x1="7.60205" y1="5.8709" x2="15.5561" y2="16.3719" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint5_radial_115_86" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(7.84537 21.5181) rotate(-20.3525) scale(18.5603 17.32)">
+<stop stop-color="#00B0BB"/>
+<stop offset="1" stop-color="#00DB65"/>
+</radialGradient>
+<linearGradient id="paint6_linear_115_86" x1="16.8078" y1="13.0071" x2="10.0409" y2="22.9937" gradientUnits="userSpaceOnUse">
+<stop stop-color="#00B1BC"/>
+<stop offset="1"/>
+</linearGradient>
+<linearGradient id="paint7_linear_115_86" x1="16.8078" y1="13.0071" x2="14.1687" y2="23.841" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/gui/src/provider-icons.ts
+++ b/gui/src/provider-icons.ts
@@ -13,6 +13,15 @@ const PROVIDER_ICON_ALIASES: Record<string, string> = {
   commandcode: "commandcode-color.svg",
   cursor: "cursor-color.svg",
   deepseek: "deepseek-color.svg",
+  /*
+   * One mark for both Devin providers. `devin` is Cognition's cloud, reached
+   * through the Windsurf sign-in, and `devin-cli` drives the installed Devin
+   * CLI; they are two transports into the same product, the meta-model/meta-muse
+   * shape. Windsurf still publishes its own `W` app icon, but showing it next
+   * to a row labelled Cognition would name the retired brand.
+   */
+  devin: "devin.svg",
+  "devin-cli": "devin.svg",
   firepass: "firepass-color.svg",
   fireworks: "fireworks-color.svg",
   github: "github-copilot-color.svg",
@@ -124,6 +133,8 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   xiaomi: "Xiaomi",
   cursor: "Cursor",
   deepseek: "DeepSeek",
+  devin: "Cognition (Devin/Windsurf)",
+  "devin-cli": "Devin CLI",
   github: "GitHub",
   "github-copilot": "GitHub Copilot",
   "gitlab-duo": "GitLab Duo",

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1331,7 +1331,15 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     baseUrl: "https://cli.devin.ai",
     authKind: "local",
     featured: false,
-    dashboardPreset: false,
+    // Reachable from the dashboard's add-provider list. `derive.ts` builds that
+    // list from `featured || authKind === "key" || dashboardPreset`, and this
+    // provider is none of the first two, so without this flag the only way to
+    // add it was to hand-edit config.json — which is how it came to be missing
+    // from a picker that already had the cloud `devin` row. The other local
+    // providers (ollama, vLLM, LM Studio) are reachable through `featured`;
+    // this one stays out of the featured strip because it needs an installed
+    // CLI and a completed `devin auth login` before it can answer anything.
+    dashboardPreset: true,
     note: "Drives the locally installed Devin CLI over the Agent Client Protocol (`devin acp`, newline-delimited JSON-RPC on stdio). Requires the CLI on PATH and a completed `devin auth login`; no API key is stored by opencodex. Set OPENCODEX_DEVIN_CLI_BIN to point at a specific build, and OPENCODEX_DEVIN_CLI_ALLOW_TOOLS=1 to let the CLI read and write files — the default is to refuse.",
     models: [...DEVIN_CLI_MODELS],
     defaultModel: DEVIN_CLI_DEFAULT_MODEL,

--- a/tests/providers/devin-cli-adapter.test.ts
+++ b/tests/providers/devin-cli-adapter.test.ts
@@ -13,6 +13,7 @@ import {
 import { DEVIN_CLI_BIN_ENV, resolveDevinCliBinary } from "../../src/adapters/devin-cli/binary";
 import { createDevinCliAdapter } from "../../src/adapters/devin-cli/adapter";
 import { PROVIDER_REGISTRY } from "../../src/providers/registry";
+import { formatProviderDisplayName, providerIconSrc } from "../../gui/src/provider-icons";
 import type { AdapterEvent, OcxParsedRequest } from "../../src/types";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
@@ -25,8 +26,22 @@ describe("devin-cli registration", () => {
     // The installed CLI carries its own credentials from `devin auth login`,
     // so the proxy must never ask for or hold a key for this provider.
     expect(entry?.authKind).toBe("local");
-    expect(entry?.dashboardPreset).toBe(false);
+    // Addable from the dashboard. It is neither `featured` nor key-auth, so this
+    // flag is the only thing that puts it in the add-provider list; without it
+    // the provider existed but could only be reached by hand-editing config.
+    expect(entry?.dashboardPreset).toBe(true);
     expect(createDevinCliAdapter({ adapter: "devin-cli", baseUrl: "https://cli.devin.ai" }).name).toBe("devin-cli");
+  });
+
+  test("both Devin providers render the Devin mark and a readable name", () => {
+    // Neither id had an icon alias, so the dashboard drew a coloured initial
+    // tile for both, and the title-cased fallback turned the local one into
+    // "Devin Cli".
+    expect(providerIconSrc("devin")).toBe("/provider-icons/devin.svg");
+    expect(providerIconSrc("devin-cli")).toBe("/provider-icons/devin.svg");
+    const englishT = ((_key: string, fallback?: string) => fallback ?? "") as Parameters<typeof formatProviderDisplayName>[1];
+    expect(formatProviderDisplayName("devin", englishT)).toBe("Cognition (Devin/Windsurf)");
+    expect(formatProviderDisplayName("devin-cli", englishT)).toBe("Devin CLI");
   });
 });
 


### PR DESCRIPTION
## Summary

Neither Devin provider had an icon alias, so the dashboard drew a coloured initial tile for both, and the title-cased fallback rendered the local one as "Devin Cli". `devin-cli` also could not be added from the dashboard at all.

![Devin mark on the provider rows, light and dark](https://raw.githubusercontent.com/lidge-jun/opencodex/codex/assets-devin-mark-preview/.preview/devin-mark-provider-rows.png)

`devin.svg` is fetched from `https://docs.devin.ai/logo/light.svg` and cropped to its symbol. The source is a 160x24 horizontal lockup; the three-leaf mark occupies the left 24 units and the `devin` wordmark starts at x=34.2, so a `viewBox="0 0 24 24"` window keeps the whole symbol and excludes every wordmark path. The thirteen symbol paths and all seven gradients are verbatim and nothing is translated, so the `userSpaceOnUse` gradient coordinates stay valid. Cropping a lockup to its symbol is what `cursor-color.svg` and `gajae-code.svg` already do; the alternative was a wordmark in a 20px box, which the provider-icons README refuses.

`devin.ai/favicon.svg` sits behind a Vercel security checkpoint that answers 429 with an HTML page, and `cognition.ai` publishes only a raster favicon, so the docs site is the reachable first-party vector. Windsurf does publish `windsurf.com/favicon.svg`, a plated W, but that names the retired brand for a provider labelled Cognition. Both ids share the one mark, the `meta-model`/`meta-muse` shape: they are two transports into the same product. The mark carries a gradient, so it is drawn as an image and is not a candidate for the masked set.

The second half is discoverability. `derive.ts` builds the add-provider list from `featured || authKind === "key" || dashboardPreset`, and `devin-cli` is none of the first two, so the only way to add it was to hand-edit `config.json` — which is how it came to be missing from a picker that already carried the cloud `devin` row. It is a dashboard preset now. It stays out of the featured strip because it needs an installed CLI and a completed `devin auth login` before it can answer anything, unlike Ollama or LM Studio.

`devin` itself is unchanged: `devlog/_plan/260911_devin_two_providers/001_plan.md` pins it out of the preset and featured lists as the experimental unofficial bridge.

## Verification

Assertions checked directly against the built modules (icon src, display names, registry flags, and that the committed SVG carries the symbol paths and no wordmark path) — all pass. The mark was rendered at 96px and 200px to confirm the crop frames the symbol without clipping.

`tests/providers/devin-cli-adapter.test.ts` carries the regression: both ids resolve to `/provider-icons/devin.svg`, both display names are readable, and `dashboardPreset` is pinned true with the reason.

Repository-wide `bun run test` and `bun run typecheck`: NOT RUN locally, per the operator constraint for this session. CI covers them on this head.

The screenshot above lives on `codex/assets-devin-mark-preview`, a branch that exists only to host PR evidence and is never merged.

## Checklist

- [x] Behavior change has a focused regression test
- [x] Targets `dev`
- [x] Screenshot of the UI change included
- [x] Icon provenance recorded in `gui/public/provider-icons/README.md`
- [ ] Local full suite / typecheck (deferred to CI by operator instruction)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Devin branding support for Devin and Devin CLI providers, including a shared icon and user-friendly display names.
  - Devin CLI is now available as a dashboard provider preset.
- **Documentation**
  - Documented the Devin icon source and design details, along with related branding source decisions.
- **Tests**
  - Added coverage confirming provider registration, icons, and display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->