### PR TITLE
docs(devlog): roadmap for the add-provider catalog unified search, note clamp and Local tab

### DIFF
--- a/devlog/_plan/260912_provider_catalog_unified_search/000_plan.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/000_plan.md
@@ -1,0 +1,33 @@
+# 000 — Add-provider catalog: unified search, note clamp, Local tab
+
+Three in-app comments on the add-provider modal (2026-09-12), delivered as one docs-
+first unit and a manual stacked PR chain onto `dev`.
+
+| doc | scope |
+|---|---|
+| `010_context.md` | the surface as it is, the three requirements, the standing constraints |
+| `015_codesign_grok.md` | co-design with `xai/grok-4.6`; accepted and rejected decisions |
+| `016_audit_corrections.md` | independent NEAR-PASS audit; **overrides the docs below where they disagree** |
+| `020_r3_local_tab.md` | wp2 — a dedicated Local tab |
+| `030_r2_note_clamp.md` | wp3 — two-line clamp plus a detail popup |
+| `040_r1_unified_search.md` | wp4 — unified search above the tabs |
+| `050_delivery.md` | wp5 — the stacked PR chain |
+| `evidence/grok-4.6-codesign.md` | the co-design report verbatim |
+
+## Work phases
+
+- **wp1** roadmap (this unit) — closed.
+- **wp2** R3 Local tab. First, because every later phase needs the tier set: R1's chip
+  counts and group order, and R2's row renderer, both sit on top of it.
+- **wp3** R2 note clamp and popup. Second, because it restructures the preset row that
+  R1 then has to render in groups.
+- **wp4** R1 unified search, plus the `structure/` and `docs-site/` updates the whole
+  unit owes once the final shape of the surface is known.
+- **wp5** stack finalization and remote-CI evidence.
+
+## Standing rules
+
+No local test suite (`bun run test`, `bun test`, `bun run test:changed`). A GUI build
+or `vite dev` **is** allowed — the user drew the line at the suite — which is what makes
+the mandatory `gui` screenshot on each PR possible. Every push is `--no-verify`.
+Remote CI on each PR's final head is the only test evidence.

--- a/devlog/_plan/260912_provider_catalog_unified_search/010_context.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/010_context.md
@@ -1,0 +1,59 @@
+# 010 — Context and requirements
+
+Source: three in-app browser comments left on `http://localhost:10100/#providers`
+with the add-provider modal open (2026-09-12), plus the follow-up instruction to
+co-design R1 with `xai/grok-4.6` through Aside and land the work as a manual
+stacked PR chain.
+
+## The surface today
+
+`gui/src/components/provider-catalog/ProviderCatalog.tsx` renders, in order:
+
+1. a tablist of three tiers — Accounts / Free / Paid;
+2. an Accounts-only hint line;
+3. a search input **below** the tabs;
+4. one scrolling `.provider-catalog-rows` list for the active tier;
+5. a footer with the "not listed? add a custom one" link.
+
+View state is local: `tier` and `query` in `useState`. Switching tiers resets the
+query to `""`. `filterPresets` (in `provider-presets.ts`) matches case-insensitively
+on `label` and `id` only, and is applied to `buckets[tier]` — one tier at a time.
+
+Tier assignment is delegated: `presetTier` calls `providerTier` in
+`gui/src/provider-workspace/catalog.ts`, which is a three-way classifier shared with
+the providers workspace (rail sort modes, badges, section binning). `isFreeProvider`
+there folds `authMode === "local"` and loopback base URLs into **free**.
+
+## R1 — unified search (highest priority)
+
+> 이거 검색을 상단에 통합할수 는없나 검색창을 통합검색으로 바꾸기
+
+Move the search to the top and make it search every tab at once. The user asked the
+design question explicitly: when a match lives in a tab that is not selected, what
+does the tab strip do? Candidate behaviours are compared in `40_r1_unified_search.md`
+against the grok-4.6 co-design recorded in `15_codesign_grok.md`.
+
+## R2 — long notes
+
+> 이런 설명 너무 긴거 두줄 잘림 클릭하면 팝업에서 보이기
+
+The `.sub` line is `<code>{adapter}</code> · {note}`. `opencode-free` carries a
+~900-character note that renders as ~20 lines and consumes the entire 360px scroll
+viewport, so the row it belongs to is the only row a user can see. Clamp to two lines;
+reveal the rest on demand.
+
+## R3 — local providers
+
+> 로컬 쪽은 확실하게 새로운탭으로 구분하기
+
+Ollama, vLLM, LM Studio and any loopback-base-URL preset currently sit in **Free**,
+interleaved with hosted free tiers. They have a different setup story (nothing to sign
+up for, a runtime to install) and deserve their own tab.
+
+## Constraints carried from the request
+
+- No local test suite, typecheck, or build runs in this worktree. Verification is
+  remote CI on each PR head. Local checks are reported as NOT RUN.
+- Every push uses `--no-verify`.
+- Delivery is a manual dependent PR chain: each PR is based on the previous PR's head
+  branch, retargeted to `dev` after its parent lands.

--- a/devlog/_plan/260912_provider_catalog_unified_search/015_codesign_grok.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/015_codesign_grok.md
@@ -1,0 +1,90 @@
+# 015 — Co-design with xai/grok-4.6, and what we took from it
+
+Full report: `evidence/grok-4.6-codesign.md` (verbatim). Run:
+`aside exec --permission full-access -m opencodex/xai/grok-4.6`, session `5NwmGQtOxFLx50YI`,
+2026-09-12. It read the real files (`ProviderCatalog.tsx`, `provider-presets.ts`,
+`catalog.ts`, `kind.ts`, `provider-catalog.css`, the i18n tables and
+`tests/gui/provider-workspace-data.test.ts`) before answering.
+
+Worth noting because it changes how much weight the verdict carries: mid-run the
+model's scratch reasoning picked **B** (tabs keep filtering, auto-switch to the first
+tab with matches). Its final answer reverses that and argues against its own earlier
+pick. The reversal is the useful part, so the reasoning is reproduced below rather
+than just the conclusion.
+
+## Accepted
+
+**R1 = option A: search mode replaces browse mode.** While `query.trim()` is non-empty
+the list shows every match across all tiers, grouped with headings, and the selected
+tab is frozen rather than moved. The argument that settled it: a jump from Free to
+Accounts on `"openai"` does not just change which rows are listed, it changes the
+*kind* of row — a preset-select button becomes a login row with Log in / Add account
+buttons. Auto-switching between those is the VS Code Extensions-view
+Marketplace/Installed/Updates failure. And scroll position cannot be restored honestly
+across a jump because the destination is a different dataset.
+
+**The tab strip stops being a tablist during search.** Empty query: real tablist,
+`aria-selected`, `aria-controls` on the rows container (which needs an `id` it does not
+have today). Non-empty query: the same controls become jump chips —
+`role="button"`, no `aria-selected`, a count each, `disabled` at zero, and a click
+scrolls to that group heading instead of setting `tier`. This is the honest answer to
+"how does the tab move": it does not move, it becomes an index.
+
+**Stop clearing the query on tab click.** `setQuery("")` inside the tab `onClick` is
+the existing bug that makes the current search feel broken.
+
+**Keep the haystack at label + id.** The `filterPresets` comment ("never
+adapter/baseUrl") is load-bearing: `openai-chat` is the adapter on Ollama, vLLM,
+LM Studio, Groq, Cerebras and PackyCode, so matching adapters would dump half the
+catalog on `"openai"`; `localhost` would hit every local row. Widen only through
+explicit rules — an **exact** adapter-id equality match, and local-runtime aliases
+(`ollama`, `vllm`, `lmstudio`, `lm studio`, `localhost`) resolved through
+`isLocalProvider` rather than substring matching.
+
+**Ranking inside a group, never across groups:** exact id/label, then label prefix,
+then the existing sponsor pin, then usage rank, then label. Global re-ranking would let
+a paid sponsor sit above free NVIDIA on `"nim"`, which reads as an ad slot. Group order
+Accounts → Free → Local → Paid.
+
+**Accounts rows participate in search**, rendered as account rows under an Accounts
+group. When a login row and a preset share an id (`openai`), the login row wins and the
+preset is omitted. The Accounts hint and the "provider not listed?" footer are browse
+copy and hide during search.
+
+**R3 = catalog-only fourth bucket.** `providerTier` stays three-way; `bucketPresets`
+peels local out after classification via `isLocalProvider`; `CatalogTier` becomes
+four-way and stops being an alias of `ProviderTier`. The blast radius of the
+alternative is concrete: `sortWorkspaceItems` rank tables, `buildProviderWorkspace`
+ready-item tiers, `ProviderSortMode`, `AddProviderModal.initialTier`, every
+`modal.tab.*` string, `tests/gui/provider-workspace-data.test.ts`, and the workspace
+`freeCount` would silently stop counting Ollama — a product change nobody asked for.
+Tab order Accounts · Free · Local · Paid; default stays Free.
+
+## Rejected, with reasons
+
+**R2: grok says inline disclosure (`aria-expanded` + `aria-controls`, a sibling region
+under the row), explicitly "not a popup and not a stacked modal". We are shipping the
+popup anyway.** Two reasons outrank the advice. First, the user asked for one in
+plain words — "클릭하면 팝업에서 보이기" — and an explicit instruction beats a
+consultant's preference. Second, grok's own objection does not survive contact with
+this container: `.provider-catalog-rows` is `max-height: 360px; overflow-y: auto`, so
+expanding a 1157-character note *inline* pushes every row below it out of view and
+drops the reader's place in the exact list they were scanning. Its nested-dialog
+objection is also weaker than it looks here, because `AddProviderModal` already stacks
+a second `role="dialog"` overlay — `OAuthTosWarningModal` — as a sibling, so the
+pattern is established, reviewed and working in this file.
+
+What we keep from the advice: the two-line clamp is CSS, the reveal control is a nested
+`<button type="button">` with `stopPropagation` so it never selects the provider, the
+control only renders when the note actually overflows, and the full note never goes
+into `title` (not keyboard reachable, and far too long for a tooltip).
+
+**Escape ordering** follows grok: note popup first, then a non-empty query, then the
+dialog. `AddProviderModal` already guards its Escape handler with `oauthTosPending`;
+the note popup joins that guard.
+
+## Failure modes adopted as test targets
+
+Its five are taken as-is and are restated per work-phase in `020`/`030`/`040`. The
+sharpest one is #5: a tab/chip interaction during an in-flight Accounts login must not
+unmount the row that owns the paste field and `LoginHint`.

--- a/devlog/_plan/260912_provider_catalog_unified_search/016_audit_corrections.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/016_audit_corrections.md
@@ -1,0 +1,141 @@
+# 016 — Audit corrections (independent review, grok-4.6 explorer)
+
+A read-only reviewer audited the committed roadmap against the tree and returned
+**NEAR-PASS**. Its blocking findings are folded in here and this doc overrides 015,
+020, 030, 040 and 050 wherever they disagree.
+
+## Blocking: the reveal control cannot be a nested button
+
+A preset row is already `<button type="button" className="list-row">`
+(`ProviderCatalog.tsx:151`). A `<button>` inside a `<button>` is invalid HTML and the
+parser may hoist it out of the row, so `stopPropagation` never gets a chance to run.
+
+Correction: wrap each preset row in
+`<div className="provider-catalog-row-wrap">`, keep the row button as its first child,
+and render the reveal control as the row button's **sibling** inside that wrapper —
+never inside it. The wrapper is the flex item; the extra line appears only on rows
+whose note overflows.
+
+## Blocking: OAuthTosWarningModal is a native dialog, not a role=dialog div
+
+015 and 030 described it wrongly. `OAuthTosWarningModal.tsx:35-45` opens a native
+`<dialog>` with `showModal()` and handles Escape through the dialog `cancel` event;
+`AddProviderModal.tsx:247` is the `div role="dialog"`. The difference matters: only
+`showModal()` restores focus to the control that opened it.
+
+Correction: the note popup copies the real `OAuthTosWarningModal` implementation —
+native `<dialog>`, `showModal()` on mount, `onCancel` forwarding — and is rendered as
+a fragment sibling from `AddProviderModal` (`AddProviderModal.tsx:328`), not from
+`ProviderCatalog`, which sits inside `.modal-card` and cannot produce a sibling
+without a portal. The open flag therefore lives in `AddProviderModal` state and
+`ProviderCatalog` reports the request upward through a callback prop.
+
+## Blocking: the Escape guard must be lifted
+
+`AddProviderModal.tsx:127-132` listens on `window` and does not check
+`defaultPrevented`, which is exactly why the `!oauthTosPending` guard exists. The note
+popup joins it (`&& !noteOpen`), and R1's clear-the-query-on-Escape has to live in the
+same handler: `query` is `ProviderCatalog` state, child effects register after the
+parent, and the parent would close the whole dialog first.
+`gui/tests/add-provider-modal-backdrop.test.tsx:147` still expects a bare Escape to
+close an empty catalog, so the guard must be conditional, not unconditional.
+`tests/gui/oauth-tos-warning.test.ts:62` source-scans for `!oauthTosPending`,
+`showModal()` and `onCancel={handleCancel}`; those substrings must survive.
+
+## Blocking: chip focus can destroy an in-flight login
+
+040 focused the group heading on chip click. During an Accounts login that steals
+focus from the paste field, and a query that does not match the busy provider unmounts
+the row outright — `shouldShowLoginHint` cannot rescue a row that is not rendered.
+
+Correction: a busy Accounts row (`busyProvider`) is pinned into the Accounts group
+regardless of the query, and chip click scrolls without moving focus while a login is
+in flight.
+
+## Correction: bucketPresets types and peel order
+
+`bucketPresets` is `Record<ProviderTier, CatalogPreset[]>` (`provider-presets.ts:77`)
+and cannot grow a `local` key. `CatalogTier` moves into `provider-presets.ts` as the
+four-way type and the return becomes `Record<CatalogTier, CatalogPreset[]>`;
+`ProviderCatalog.tsx:29` stops redeclaring it. 015's claim that `CatalogTier` is an
+alias of `ProviderTier` was wrong — it is a separate three-string redeclaration.
+
+Peel order is accounts first, then local: otherwise a loopback-hosted canonical forward
+provider would leave the Accounts tab.
+
+`tests/gui/provider-workspace-data.test.ts:523` does not go red on its own — its
+fixture is venice/openai/nvidia/groq, so adding `local: []` keeps it green and only
+its name ("all three tiers") goes stale. The peel is locked by adding an ollama row to
+that fixture and asserting `buckets.local` is `["ollama"]` while `buckets.free` stays
+`["nvidia"]`. Line 518's `presetTier(ollama) === "free"` must keep passing untouched.
+
+## Correction: do not widen filterPresets, and do not widen initialTier
+
+`tests/gui/provider-workspace-data.test.ts:538` asserts `filterPresets` never matches
+adapter or baseUrl. The exact-adapter and local-alias rules from 040 go into a **new**
+search function; `filterPresets` keeps its contract for browse mode. Accounts rows are
+`AccountLoginRow`, a different type built in `providers-page-utils.ts`, so they need
+their own label/id filter.
+
+`AddProviderIntent.tier` (`ProviderWorkspaceShell.tsx:42`) and
+`AddProviderModal.initialTier` (line 40) stay three-way. Widening them would let
+empty-state tiles pass `"local"` by accident. Known consequence: the empty-state
+"browse free" tile (`ProviderWorkspaceShell.tsx:620`) opens Free, which no longer
+contains Ollama. A Local entry point there is follow-up work, not part of this unit.
+
+## Correction: clamp selector and note measurements
+
+`.provider-catalog-rows .list-row .sub` also hits account rows
+(`provider-catalog.css:58`). The clamp is scoped away from
+`.provider-catalog-account-row`.
+
+Real note lengths, from `src/providers/registry.ts`: `opencode-free` 1126 characters
+(not ~900), `meta-muse` 1157, `cursor` 663. The short-note fixture is
+`Local — key usually blank` with an em dash (`registry.ts:2102`).
+
+## Correction: i18n is nine catalogs with parity gates
+
+`modal.tab.paid` exists in en, de, fr, ko, zh, zh-TW, ru, ja, tr.
+`gui/tests/i18n-locales.test.ts:35` requires an exact English key set and
+`gui/tests/locale-parity.test.ts` fails a locale that leaves the English string in
+place without an allowlist entry. Every new key — tab label, reveal control, popup
+title and close, the live-region sentence, the group headings — needs a real
+translation in all nine. `gui/AGENTS.md:12` forbids hardcoded UI text.
+
+## Correction: test placement
+
+No new file under `tests/` is needed. Pure tier and search assertions extend the
+existing `tests/gui/provider-workspace-data.test.ts`, which avoids the
+`scripts/test-layout/layout.json` + `tests/fixtures/test-layout-expected.json`
+double registration that `tests/test-layout-tooling.test.ts:248` enforces. React and
+click behaviour goes in `gui/tests/*.tsx`, where the existing catalog component tests
+already live.
+
+## Correction: docs obligations the plan omitted
+
+`structure/gui-and-management-api.md:304` describes the catalog browser and
+`structure/AGENTS.md` obliges updating an owned area's doc when that area changes.
+`gui/AGENTS.md:33` asks for `docs-site/` updates on user-facing dashboard changes.
+Both land with wp4, once the final shape of the surface is known.
+
+## Resolved: the gui screenshot gate versus the no-local-build rule
+
+`.github/PULL_REQUEST_TEMPLATE.md:8` and `AGENTS.md:283` require a screenshot when a
+PR mentions `gui`, and `localhost:10100` serves the installed build's `gui/dist`, not
+this worktree's source — so a screenshot taken there would show the old UI.
+
+Asked and answered (2026-09-12): **a GUI build or `vite dev` in this worktree is
+allowed; the prohibition covers the test suite only.** So each UI-affecting PR gets a
+real screenshot from a dev server running this branch's source. `bun run test`,
+`bun test`, and `bun run test:changed` remain forbidden; remote CI is the only test
+evidence.
+
+## Also noted
+
+- LM Studio's preset id is `lm-studio`, so the `lmstudio` / `lm studio` aliases are
+  required rather than cosmetic.
+- Moving search above the tabs changes first focus on open: `AddProviderModal.tsx:111`
+  focuses the first focusable element, today the Accounts tab, afterwards the search
+  field. That is the desired outcome and is called out so it is not read as a bug.
+- Accounts browse ignores `rows` entirely and always maps `accountRows`
+  (`ProviderCatalog.tsx:175`); search mode is the first time account rows get filtered.

--- a/devlog/_plan/260912_provider_catalog_unified_search/020_r3_local_tab.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/020_r3_local_tab.md
@@ -1,0 +1,46 @@
+# 020 — R3: a dedicated Local tab (work-phase wp2)
+
+First implementation cycle, because every later phase depends on the tier set. R1's
+chip counts and group order need Local to exist; R2 touches the same row renderer.
+
+## Change
+
+`gui/src/components/provider-catalog/provider-presets.ts`
+
+- `export type CatalogTier = "accounts" | "free" | "local" | "paid"` — declared here,
+  deliberately **not** an alias of `ProviderTier`. `ProviderCatalog.tsx` re-exports it
+  for existing importers.
+- `isLocalCatalogPreset(preset)` delegates to `isLocalProvider(presetTierInput(preset))`
+  from `gui/src/provider-workspace/kind.ts`, so loopback base URLs and
+  `authMode === "local"` are classified by the one helper the rail already uses.
+- `bucketPresets` returns four buckets. Local is peeled off **after** `presetTier`
+  runs, so `presetTier` keeps returning `"free"` for Ollama and the existing unit test
+  that asserts it stays green. Accounts still wins over local: a canonical forward
+  provider is an account row regardless of its URL.
+
+`ProviderCatalog.tsx`: the tab array becomes `["accounts", "free", "local", "paid"]`.
+
+i18n: `modal.tab.local` in every locale file that carries `modal.tab.paid`.
+
+## Not changed
+
+`providerTier`, `isFreeProvider`, `sortWorkspaceItems`, `ProviderSortMode`,
+`buildProviderWorkspace`, the workspace free count, and the amber Local badge. A local
+preset keeps whatever badges it has today; the tab is an additional axis, not a
+relabelling.
+
+## Risks
+
+- `AddProviderModal.initialTier` is typed `"accounts" | "free" | "paid"` and is passed
+  from `providers-page-modals.tsx`. Widening it to `CatalogTier` must not make any
+  caller start passing `"local"` implicitly.
+- An empty Local tab on a machine with no local runtime configured is fine — the
+  catalog is a preset list, and Ollama/vLLM presets are always present.
+
+## Verification (remote CI only)
+
+`tests/gui/provider-catalog-tiers.test.ts` (new, pure): local presets bucket to
+`local` and are absent from `free`; `presetTier` still returns `"free"` for them; a
+loopback-base-URL preset with `authMode: "key"` still lands in `local`; the canonical
+forward provider still buckets to `accounts`. New test files need an entry in
+`scripts/test-layout/layout.json` and `tests/fixtures/test-layout-expected.json`.

--- a/devlog/_plan/260912_provider_catalog_unified_search/030_r2_note_clamp.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/030_r2_note_clamp.md
@@ -1,0 +1,38 @@
+# 030 — R2: two-line note clamp with a detail popup (work-phase wp3)
+
+## Problem, measured
+
+The `.sub` line renders `<code>{adapter}</code> · {note}`. The `opencode-free` note is
+~900 characters, Muse Code ~1157, Cursor ~663. At the modal width that is 15-20 lines
+inside a `max-height: 360px` scroller, so one row fills the whole list and the catalog
+stops being browsable. That is the screenshot the user attached.
+
+## Change
+
+**Clamp (CSS).** `.provider-catalog-rows .list-row .sub` gets `display: -webkit-box`,
+`-webkit-line-clamp: 2`, `-webkit-box-orient: vertical`, `overflow: hidden`. The text
+block already carries `min-width: 0`, so this needs no layout change. Account rows keep
+their existing single-line ellipsis; the clamp is scoped to preset rows.
+
+**Reveal control.** A nested `<button type="button">` rendered only when the note
+exceeds the clamp threshold. It calls `stopPropagation()` so the enclosing `.list-row`
+button never fires `onSelectPreset`. Overflow is decided from note length, not from a
+layout read: `scrollHeight > clientHeight` would need a ref per row plus a resize
+observer and would make the decision untestable without a DOM. The threshold lives in
+`provider-presets.ts` as a named constant with its own unit test.
+
+**Popup.** A sibling overlay with the same shape as `OAuthTosWarningModal`: a
+`role="dialog" aria-modal="true"` card rendered next to the add-provider overlay rather
+than inside it, holding the provider label, the adapter chip, the full note, and a close
+button. The argument for a popup over grok's inline disclosure is in `015`.
+
+**Escape ordering.** `AddProviderModal`'s handler is
+`if (e.key === "Escape" && !oauthTosPending) onClose()`. The note popup joins that
+guard, so Escape closes the note first and the add-provider modal second.
+
+## Verification (remote CI only)
+
+- pure: the overflow predicate is true for the opencode-free note and false for
+  `Local - key usually blank`.
+- the reveal control's click does not reach `onSelectPreset`.
+- the popup body carries the full note, not the clamped text.

--- a/devlog/_plan/260912_provider_catalog_unified_search/040_r1_unified_search.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/040_r1_unified_search.md
@@ -1,0 +1,72 @@
+# 040 — R1: unified search across every tab (work-phase wp4)
+
+The design is option A from `015`: while the query is non-empty, search mode replaces
+browse mode and the selected tab is frozen instead of moved.
+
+## Layout
+
+The search input moves **above** the tab strip and stays mounted in both modes. It no
+longer resets on tab click.
+
+```
+[ search input                     ]   <- always first
+[ Accounts | Free | Local | Paid   ]   <- tablist when browsing, jump chips when searching
+[ rows ...                          ]
+```
+
+## Browse mode (query empty)
+
+Exactly today's behaviour plus the Local tab. The strip is a real tablist:
+`role="tablist"`, `role="tab"`, `aria-selected`, and `aria-controls` pointing at the
+rows container, which gains the `id` it does not have today.
+
+## Search mode (query non-empty)
+
+- The rows container renders **every** match, grouped, in the fixed order Accounts →
+  Free → Local → Paid, each group preceded by a heading carrying the tier name and its
+  count.
+- The strip drops `role="tablist"`. Each control becomes a plain button with a count,
+  `aria-controls` on its group heading, no `aria-selected`, and `disabled` at zero.
+  Clicking a non-zero chip scrolls its heading into view and moves focus there
+  (`tabIndex={-1}` then `focus()`); it does not change `tier`.
+- One `aria-live="polite" aria-atomic="true"` node announces the result count and the
+  tiers involved. It is not retargeted on chip click.
+- Accounts login rows are searchable and render as account rows under the Accounts
+  group. When a login row and a preset share an id, the login row wins and the preset
+  is dropped so `openai` cannot appear twice.
+- The Accounts hint line and the `modal.notListed` footer are browse copy and hide.
+- Zero matches: `modal.noMatch` in the list, every chip disabled, the live region says
+  the same thing.
+
+Clearing the query restores the frozen tab, scrolls the container to top, and brings
+the hint and footer back. Scroll offset is deliberately not restored: the list was
+replaced, so restoring an offset would land somewhere meaningless.
+
+## Matching
+
+Haystack stays label + id. Widening to adapter or base URL would dump half the catalog
+on `openai` (the adapter of Ollama, vLLM, LM Studio, Groq, Cerebras, PackyCode) and
+every local row on `localhost`. Two explicit widenings instead:
+
+1. equality-only adapter match, so `cursor` finds Cursor but `openai` does not match
+   `openai-chat`;
+2. local-runtime aliases (`ollama`, `vllm`, `lmstudio`, `lm studio`, `localhost`)
+   resolved through `isLocalProvider`, not through substring matching.
+
+Ranking inside a group: exact id or label, then label prefix, then the existing sponsor
+pin, then usage rank, then label. Never re-ranked across groups — a paid sponsor above
+free NVIDIA on `nim` reads as an ad slot.
+
+## Keyboard
+
+The input keeps focus while typing. ArrowDown from the input moves to the first result
+row, not to a chip. Escape clears a non-empty query before the dialog closes, and after
+the note popup if one is open (`030`).
+
+## Verification (remote CI only)
+
+Pure functions first: grouping, ordering, the login-row/preset dedupe, the ranking
+comparator, and the alias rules all live in `provider-presets.ts` and are unit-tested
+without React. The component test covers: a query with zero hits in the active tab
+leaves `tier` untouched; tab click with a non-empty query does not clear the query; an
+in-flight Accounts login keeps its `LoginHint` and paste field across a chip click.

--- a/devlog/_plan/260912_provider_catalog_unified_search/050_delivery.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/050_delivery.md
@@ -1,0 +1,29 @@
+# 050 — Delivery: stacked PR chain (work-phase wp5)
+
+## Chain
+
+Four branches, each based on the previous one's head, all eventually targeting `dev`:
+
+| PR | branch | base | content |
+|---|---|---|---|
+| 1 | `codex/provider-catalog-plan` | `dev` | this plan unit |
+| 2 | `codex/provider-catalog-local-tab` | PR 1 head | R3 (`020`) |
+| 3 | `codex/provider-catalog-note-popup` | PR 2 head | R2 (`030`) |
+| 4 | `codex/provider-catalog-unified-search` | PR 3 head | R1 (`040`) |
+
+Ordinary dependent PRs, not a GitHub native stack. `enforce-target` skips the
+wrong-base gate for a child whose base is another open PR's head; each child is
+retargeted to `dev` once its parent lands.
+
+## Rules carried from the request
+
+- Every push is `--no-verify`.
+- No local test suite, typecheck, or build runs in this worktree. Local checks are
+  reported as NOT RUN; remote CI on each PR's final head is the evidence.
+- Every PR fills `.github/PULL_REQUEST_TEMPLATE.md` in full. PRs 2-4 mention `gui`, so
+  each needs a screenshot of the UI change in its description.
+
+## Screenshot capture
+
+The proxy is already running on `http://localhost:10100`, so the GUI change can be
+driven in a browser against a dev build of the dashboard for the required screenshots.

--- a/devlog/_plan/260912_provider_catalog_unified_search/evidence/grok-4.6-codesign.md
+++ b/devlog/_plan/260912_provider_catalog_unified_search/evidence/grok-4.6-codesign.md
@@ -1,0 +1,82 @@
+# grok-4.6 co-design report (verbatim)
+
+Produced by: aside exec --permission full-access -m opencodex/xai/grok-4.6, 2026-09-12.
+Session 5NwmGQtOxFLx50YI. Answers the R1/R2/R3 design brief in 10_context.md.
+
+Pick **A**. Do not auto-switch the selected tab.
+
+The current surface is a browse catalog, not a command palette: tabs are pricing/ownership buckets (`accounts` / `free` / `paid`), search currently filters only the active bucket and is wiped on tab click, and Accounts rows are login rows rather than presets. Unified search has to leave that browse model intact when the query is empty, and replace it with a result list when it is not.
+
+**Why not B.** Chrome Settings and JetBrains Settings do count-badges-plus-auto-jump because their tabs are sibling pages of the same object. Here a jump from Free to Paid on `"cursor"` (or from Free to Accounts on `"openai"`) changes the row *kind*: a preset-select button becomes a login row with Log in / Add account. That is the VS Code Extensions-view failure mode (Marketplace vs Installed vs Updates) if search were allowed to steal the selected tab. Keyboard users who Arrow-Right across tabs then type will also lose their place. Zero-match on the active tab plus a silent jump hides the empty state they just caused. Scroll position cannot be restored honestly because the destination list is a different dataset.
+
+**Why not C.** "Other tabs" as a trailing section is Linear/Slack quick-switcher residue: those UIs have one result list and no tablist. Here it keeps `aria-selected` on a tab whose rows are no longer what is on screen, so a screen reader announces "Free, selected" over a Paid Cursor row. It also buries the actual hit under a possibly empty active-tab block. That is the current bug with extra chrome.
+
+**A, with one hard rule the candidate text left soft:** while `query.trim()` is non-empty, the tab strip is no longer a tablist. It becomes in-list jump chips (Raycast category chips, GitHub Marketplace "Filters" counts, Chrome Settings left-nav counts). The selected browse tab is frozen in React state and not visually selected. Clearing the query restores that tab, its scroll container to top, and the Accounts hint / custom-provider footer that belong to it. Do not restore scroll-into-the-old-offset; the list was replaced.
+
+Precedence that actually maps:
+
+- VS Code Extensions: search is global; the Marketplace/Installed/Updates tabs do not jump under you. Results are one list with section headers (`INSTALLED`, `RECOMMENDED`). That is A.
+- Chrome / macOS / JetBrains Settings: search replaces the page with a grouped result list; the previous pane is remembered. Chrome's left nav turns into jump targets with counts. That is A.
+- Raycast / Linear / Slack switcher: no tabs, one ranked list. Use their ranking, not their chrome.
+- GitHub Marketplace category tabs: a query keeps the category as a filter. That is B, and it is wrong here because Accounts is not a category of the same row type.
+
+**Tab strip during search**
+
+- Empty query: keep `role="tablist"` / `role="tab"` / `aria-selected` / `aria-controls` pointing at the rows container. Current markup is already a tablist with no `aria-controls` and no `id` on the panel; add those in this change. Tab click still switches bucket. Stop clearing the query on tab click; that is what makes today's search feel broken.
+- Non-empty query: drop `role="tablist"` from the strip. Each control becomes `role="button"` (or a link) with `aria-controls` on the matching group heading. No `aria-selected`. A `0` count is `disabled` and not focusable. Clicking a non-zero chip `scrollIntoView`s that `<h4>` inside `.provider-catalog-rows`; it does not set `tier`. Visual: remove `.active` underline; show `Free 3` / `Paid 1` / `Local 2` / `Accounts 0`.
+- Live region: one `aria-live="polite"` node, `aria-atomic="true"`, text like `7 providers across Free, Paid, Local`. Do not retarget it on chip click. On zero matches: `No providers match “cursor”` in the list, live region says the same, tab chips all disabled.
+- Accounts in search: include login rows that match on `label` / `id`. Render them under an Accounts group *as account rows*, not as preset-select buttons. If a preset and a login row share an id (`openai`), show the login row in Accounts and omit the preset from other groups. The Accounts hint string stays hidden in search mode; it is browse copy.
+- Footer: hide "Provider not listed?" during search. Custom-add is a browse escape hatch, not a search hit.
+- Focus: search input stays focused while typing. Chip click moves focus to the group heading (`tabIndex={-1}` then `.focus()`). Escape in the input clears the query if non-empty, else closes the dialog (existing dialog Escape). Do not put ArrowDown from the input onto chips; put it onto the first result row, like Raycast / VS Code.
+
+**Search fields and ranking**
+
+Keep label + id as the only default haystack. That comment in `filterPresets` ("never adapter/baseUrl") is load-bearing: `openai-chat` is the adapter on Ollama, vLLM, LM Studio, Groq, Cerebras, PackyCode. Searching `"openai"` would dump half the catalog. Base-url host is worse (`localhost` hits every local row; `api` hits most paid rows). Note-body match is how you get the 1157-char Muse Code note or the 663-char Cursor note lighting up on `"sandbox"` / `"key"` / `"login"`.
+
+Do add three explicit aliases, not substring-in-note:
+
+1. Exact adapter match only when the query equals the adapter id (`cursor`, `ollama-native`), not when it is a prefix of `openai-chat`.
+2. Local-runtime aliases: `ollama`, `vllm`, `lm studio`, `lmstudio`, `localhost` map to the Local group via `isLocalProvider`, not via haystack.
+3. Highlight the matched span on label/id only.
+
+Ranking inside a group, then group order Accounts → Free → Local → Paid:
+
+1. Exact id or exact label, case-insensitive.
+2. Label prefix (Chrome/Raycast "starts with").
+3. Sponsor pin, Main before Standard, then alphabetical among sponsors. Same contract as `pinSponsors`; usage rank must not bury a paid sponsor when the query is `"orca"`.
+4. Usage rank, then label.
+
+Do not globally re-rank across groups. A paid sponsor sitting above Free NVIDIA on `"nim"` is how you get the "search is an ad slot" complaint. Sponsors already have a badge and a pin *inside* their group.
+
+**R2: clamp + disclosure, not a nested dialog**
+
+The row is a `<button class="list-row">` that selects the provider. A 2-line CSS clamp (`-webkit-line-clamp: 2` on `.list-row .sub`, already `min-width: 0`) is the default. Full text is a disclosure, not a popup and not a stacked modal.
+
+- Pattern: `aria-expanded` + `aria-controls` on a nested `<button type="button">` labelled `More` / `Show full note`, with `stopPropagation`. The expanded region is a sibling under the row, `id` tied to `aria-controls`, not `role="dialog"`. Clicking More does not call `onSelectPreset`.
+- Why not popover: the catalog list is `max-height: 360px; overflow-y: auto`. An anchored popover either clips or portals out of the dialog's focus trap. `@floating-ui` in a modal is more code than the note is worth.
+- Why not a nested modal: `AddProviderModal` is already `role="dialog" aria-modal="true"`. A second dialog means nested inert/focus-trap (the OAuth TOS warning already does this once). A 900-character note is not a new task.
+- Why not inline expand of the whole row button: expanding inside the select button makes the click target's height jump and fires selection when the user was reading. Split the targets.
+- Truncate only when the note exceeds ~2 lines (roughly 120 characters, or `scrollHeight > clientHeight`). Short notes (`"Local — key usually blank"`) stay fully visible with no More control.
+- Do not put the full note in `title`. Title is not keyboard accessible and the Cursor/Muse notes are longer than any tooltip.
+
+**R3: catalog-only fourth bucket. Do not touch `providerTier`.**
+
+`ProviderTier` is documented as a three-way pricing/ownership tag from the 2026-07-17 interview: accounts (canonical OpenAI forward) wins over free, else paid. `isFreeProvider` intentionally returns true for `authMode === "local"` and loopback URLs so the workspace Free/Paid filter and `free-paid` sort keep treating Ollama as free. `ProviderRail` already splits that further with `isLocalProvider` from `kind.ts` (`authMode === "local" || hasLoopbackBaseUrl`). The add-provider tabs over-collapsed that distinction; the rail did not.
+
+So:
+
+- Add `isLocalCatalogPreset(preset)` in `provider-presets.ts` that delegates to `isLocalProvider(presetTierInput(preset))`.
+- Change `bucketPresets` to return `{ accounts, free, paid, local }`. Local is peeled out *after* `presetTier`, before the free push. `presetTier()` itself stays three-way. Tests that assert `presetTier(ollama) === "free"` stay green.
+- Catalog tab type (`CatalogTier`) becomes four-way and is *not* `ProviderTier`. Today's alias is the bug.
+- Workspace `isFreeProvider`, rail suffix, `sortWorkspaceItems`, badges: unchanged. Local rows keep the amber Local badge they already have; they do not grow a Free badge.
+- Blast radius if you instead add `"local"` to `ProviderTier`: `sortWorkspaceItems` rank tables, `buildProviderWorkspace` ready-item `tier`, `ProviderSortMode` `"free-paid"` / `"accounts-first"`, `AddProviderModal` `initialTier`, every i18n `modal.tab.*`, and `tests/gui/provider-workspace-data.test.ts`. Local Ollama would also drop out of the workspace Free count (`ProviderWorkspaceShell` `freeCount`), which is a product change nobody asked for.
+
+Default tab remains Free. Local is the fourth tab, after Free, before Paid: Accounts · Free · Local · Paid. That matches how people think ("is it logged-in, is it free cloud, is it my machine, is it billed").
+
+**Failure modes to test**
+
+1. Query `"openai"` on the Free tab: results group is Accounts (login row) only, or Accounts plus any preset whose *label/id* contains openai, never every `openai-chat` adapter. Clearing the query returns to Free, not Accounts. Live region does not say "Free, selected".
+2. Query `"cursor"` with Free active and zero Free hits: no auto-jump, Paid group visible with the Cursor row, Free chip disabled at `0`, browse `tier` still `"free"`. ArrowDown from the input lands on Cursor, not on a chip.
+3. Query `"local"` / `"ollama"` / `"localhost"`: Local group contains ollama/vllm/lm-studio; Free no longer lists them. `presetTier(ollama)` remains `"free"` in unit tests. Workspace Free count unchanged.
+4. Note clamp: Cursor (~663) and Muse Code CLI (~1157) rows stay ~2 lines. Clicking More expands in-row and does not select the preset. Clicking the row body still selects. Escape closes the disclosure first if open, then clears search, then closes the dialog. No second `role="dialog"`.
+5. Accounts + search + in-flight login: a matching Accounts row still renders `LoginHint` / paste field. Switching a jump-chip to Paid and back does not unmount that row's local paste state. A zero-match query does not destroy `busyProvider`. Tab click with a non-empty query does not clear the query (today's `setQuery("")` is the regression).


### PR DESCRIPTION
## Summary

- Adds the plan unit for three changes requested against the add-provider modal on the Providers dashboard page: a unified search that reaches every tab, a two-line clamp on long provider notes with a click-to-open popup, and a dedicated Local tab for on-machine runtimes.
- Documentation only. No runtime, dashboard, or test behaviour changes in this PR; it is the base of a dependent chain and the following PRs implement one work phase each.
- `015_codesign_grok.md` records a co-design pass with an outside model verbatim, including what was taken from it and the one recommendation that was rejected with the reason. `016_audit_corrections.md` folds in an independent review of the roadmap that returned NEAR-PASS and names the places where the original plan contradicted the code.

The design question that drove the unit: when a search matches rows that live in a tab other than the selected one, what should the tab strip do? The answer taken is that it does not move. While a query is active the result list shows every match grouped by tier and the tab strip becomes a set of count-bearing jump chips, because a jump from Free to Accounts does not merely change which rows are listed, it changes the kind of row - a preset-select button becomes a login row with Log in and Add account buttons.

## Verification

- `bun run structure:check` - passed.
- No test suite was run in this worktree by instruction; remote CI is the test evidence.
- Nothing in the build, typecheck, or test path reads from `devlog/`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning and design documentation for provider catalog improvements, including unified search, a dedicated Local tab, expandable provider notes, matching behavior, accessibility requirements, and delivery guidance.
  * Documented catalog categorization, search ranking, keyboard interactions, localization coverage, and verification criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Maintainer integration

The owner explicitly requested merging this four-PR chain into dev. Integrating as lidge-jun (verified repository admin) under MAINTAINERS.md, without representing this as an independent approval. Current head: 67657b96552d941e073cb725d0e8d909d791c56c. Exact-head CI: https://github.com/lidge-jun/opencodex/actions/runs/34666254983 (success; docs-only suite jobs skipped); enforce-target succeeded. No outstanding maintainer change request.

Review disposition: the roadmap contains historical design proposals with explicit corrections in 016; the verbatim external design report remains a historical quotation. Runtime concerns from those comments (narrow tabs, inaccessible clamped notes, and dialog focus restoration) are corrected in the corresponding implementation layers before their integration. Each UI layer now carries its structure documentation. Local tests remain NOT RUN by owner instruction.
