### PR TITLE
fix(devin): shorten the Devin provider label to one word

### DIFF
--- a/gui/src/provider-icons.ts
+++ b/gui/src/provider-icons.ts
@@ -133,7 +133,11 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   xiaomi: "Xiaomi",
   cursor: "Cursor",
   deepseek: "DeepSeek",
-  devin: "Cognition (Devin/Windsurf)",
+  // "Devin", not the registry's "Cognition (Devin/Windsurf)". This label sits in
+  // a narrow provider rail beside one-word names like Cursor and Kimi, and the
+  // long form is the registry's disambiguation for an add-provider list, not a
+  // name to read at a glance.
+  devin: "Devin",
   "devin-cli": "Devin CLI",
   github: "GitHub",
   "github-copilot": "GitHub Copilot",

--- a/tests/providers/devin-cli-adapter.test.ts
+++ b/tests/providers/devin-cli-adapter.test.ts
@@ -41,7 +41,7 @@ describe("devin-cli registration", () => {
     expect(providerIconSrc("devin")).toBe("/provider-icons/devin.svg");
     expect(providerIconSrc("devin-cli")).toBe("/provider-icons/devin.svg");
     const englishT = ((_key: string, fallback?: string) => fallback ?? "") as Parameters<typeof formatProviderDisplayName>[1];
-    expect(formatProviderDisplayName("devin", englishT)).toBe("Cognition (Devin/Windsurf)");
+    expect(formatProviderDisplayName("devin", englishT)).toBe("Devin");
     expect(formatProviderDisplayName("devin-cli", englishT)).toBe("Devin CLI");
   });
 


### PR DESCRIPTION
## Summary

The dashboard provider rail showed `devin` as "Cognition (Devin/Windsurf)". That string is the registry's disambiguation for an add-provider list, and it reads badly in a narrow rail next to one-word neighbours like Cursor, Kimi and Grok. The rail label is now "Devin".

Only the GUI display name changes. The registry label, the provider id, and `devin-cli`'s "Devin CLI" are untouched.

![Devin rail label](https://raw.githubusercontent.com/lidge-jun/opencodex/dev/gui/public/provider-icons/devin.svg)

## Verification

`bun test tests/providers/devin-cli-adapter.test.ts` — 16 pass, 0 fail; the display-name assertion moves with it.

Repository-wide `bun run test` and `bun run typecheck`: NOT RUN locally, per the operator constraint for this session. CI covers them on this head.

## Checklist

- [x] Targets `dev`
- [x] Existing regression test updated
- [ ] Local full suite / typecheck (deferred to CI by operator instruction)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the provider display name from “Cognition (Devin/Windsurf)” to “Devin.”
  - The existing provider icon and command-line label remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->