### PR TITLE
fix(devin-cli): stop sending a permission mode the CLI rejects

### DIFF
--- a/src/adapters/devin-cli/adapter.ts
+++ b/src/adapters/devin-cli/adapter.ts
@@ -119,7 +119,18 @@ export function createDevinCliAdapter(provider: OcxProviderConfig, deps?: { spaw
               // otherwise inherit every credential this process holds.
               ...baseScopedEnv(),
               NO_COLOR: "1",
-              DEVIN_PERMISSION_MODE: toolsAllowed ? (process.env.DEVIN_PERMISSION_MODE ?? "bypass") : "ask",
+              // "normal" is the CLI's own refuse-by-default mode. "ask" reads like
+              // the right name for it but is not a value the binary accepts: Devin
+              // CLI 3000.10.21 exits 2 with
+              //   invalid value 'ask' for '--permission-mode <PERMISSION_MODE>'
+              //   Valid options: normal (auto), accept-edits, dangerous (yolo,
+              //   bypass), autonomous (requires --sandbox)
+              // before answering a single prompt, so every turn on this provider
+              // failed with the default (tools not allowed) configuration — the
+              // one path most operators are on. Found by running a real turn
+              // against an installed, signed-in CLI; no unit test could see it,
+              // because the spawn is injected and the fake child accepts anything.
+              DEVIN_PERMISSION_MODE: toolsAllowed ? (process.env.DEVIN_PERMISSION_MODE ?? "bypass") : "normal",
             },
           });
         } catch (error) {


### PR DESCRIPTION
## Summary

The `devin-cli` provider could not complete a single turn in its default configuration. The adapter passed `DEVIN_PERMISSION_MODE=ask` whenever `OPENCODEX_DEVIN_CLI_ALLOW_TOOLS` was unset — the default, and the path most operators are on — and the CLI rejects that value outright:

```
ERROR: stream disconnected before completion: Devin CLI exited (code 2) before
answering the prompt: error: invalid value 'ask' for '--permission-mode
<PERMISSION_MODE>': Invalid permission mode: ask. Valid options: normal (auto),
accept-edits, dangerous (yolo, bypass), autonomous (requires --sandbox)
```

`normal` is the CLI's own refuse-by-default mode, so the intent the `ask` value was reaching for is preserved exactly. The tools-allowed branch (`bypass`) is untouched.

## Why no test caught it

`tests/providers/devin-cli-adapter.test.ts` drives the adapter through an injected `spawn`, and the fake child accepts any environment. The value is only validated by the real binary, so this is reachable only from a live run.

## Verification

Devin CLI 3000.10.21 installed and signed in (`devin auth status` reports logged in), provider configured against the running proxy:

Before — five retries, every one `exited (code 2)`.

After:

```
$ codex exec -m devin-cli/swe-2 "reply with exactly: DEVINCLI-OK"
DEVINCLI-OK
tokens used  18,343
```

`GET /v1/models` lists all 11 `devin-cli/*` rows.

Repository-wide `bun run test` and `bun run typecheck`: NOT RUN locally, per the operator constraint for this session. CI covers them on this head.

## Checklist

- [x] Targets `dev`
- [x] Fix proven by a live turn against the real CLI
- [ ] Local full suite / typecheck (deferred to CI by operator instruction)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Devin CLI interactions failing when tool access is restricted.
  - Updated permission handling to use a valid CLI mode, allowing turns to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->