### PR TITLE
fix(codex): stop carrying an elapsed account-level short window

### DIFF
--- a/devlog/_plan/260912_phantom_account_short_quota/000_plan.md
+++ b/devlog/_plan/260912_phantom_account_short_quota/000_plan.md
@@ -1,0 +1,112 @@
+# Phantom account-level 5h row after Spark attribution (#4122 leftover) — plan
+
+## Reader summary
+
+Problem: one Codex Pro pool account still renders an account-level 5h bar
+(`5시간 리셋 9월 10일 02:24 4%`) even though Pro has no account-level 5h window and
+#4122 already stopped new Spark 5h writes into that slot. Answer: stop
+`mergeAccountQuota` from carrying an elapsed `short*` tuple across a refresh that
+does not include a short window. What changes: the polluted Pro row drops the
+phantom bar on the next ordinary weekly/Spark refresh; Plus/Team accounts whose
+5h window is still open keep it.
+
+## Loop spec
+
+- Loop archetype: satisfy-spec (single work-phase wp1; not multi-cycle, so no
+  extra docs-first roadmap cycle).
+- Trigger: live 2026-09-12 dashboard report on http://localhost:10100/#codex-set
+  plus HOTL objective to land a merged PR on `dev`.
+- Goal: a Pro account whose refresh reports no account-level short window stops
+  showing a 5h row; the stale cache tuple stops feeding policy readers; PR merged
+  to `dev` with exact-head CI.
+- Non-goals: GUI redesign; WHAM Spark-primary remapping (WHAM already files Spark
+  under customWindows and is not rewriting this account's shortObservedAt);
+  dropping still-open Plus/Team 5h windows; routing-policy redesign; release or
+  promotion; docs-site translation; local product suite/typecheck/build/install
+  (standing user rule: NOT RUN; remote CI is the gate).
+- Verifier: remote `.github/workflows/ci.yml` on the PR exact final head. The
+  `test` job's change filter includes `src/**` and `tests/**`;
+  `scripts/ci/run-bun-test-batches.sh` selects
+  `tests/codex-integration/codex-quota-parser-parity.test.ts`. Local
+  `bun test` / `bun run typecheck` / `bun run test` / `bun run build:gui`: NOT RUN
+  by standing user rule (command not executed; no exit code). Conditional paths:
+  (1) elapsed short + weekly/Spark refresh with no short* — activation: seed
+  past `shortResetAt`, apply weekly or Spark headers, observe short* absent;
+  (2) live short + weekly-only refresh — activation: seed future `shortResetAt`,
+  apply weekly headers, observe short* retained; (3) incoming explicit short
+  even if elapsed — activation: `setAccountQuotaFromParsed` with past reset,
+  observe the tuple stored so auto-refresh/scorer fixtures stay intact.
+- Stop condition: fetched `origin/dev` contains the PR commit and the live
+  phantom row is gone after the normal refresh path, or BLOCKED/NEEDS_HUMAN with
+  evidence.
+- Memory artifact: this unit directory plus
+  `.codexclaw/goalplans/hotl-fix-the-opencodex-dashboard-rendering-a-pha/`.
+- Expected terminal outcomes: DONE = c1–c4; BLOCKED = irreducible CI or
+  merge-policy denial; NEEDS_HUMAN = authority gap.
+- Escalation: local suite requirement, push without `--no-verify`, or expanding
+  into GUI/routing redesign returns to the user.
+- Architect consultation gap: this session has no bounded architect-subagent
+  transport (create_thread is user-owned and forbidden for subtasks). Design
+  decisions below are main-owned with file:line evidence.
+- HOTL resource bounds: this worktree shell/git/gh plus read-only local
+  management GETs; existing gh auth; write scope = this worktree and PRs on
+  lidge-jun/opencodex; no token/wall-clock budget set by the user.
+
+## Root cause (evidence)
+
+Live cache `~/.opencodex/codex-quota-cache.json` account `chatgpt-1786626108327`
+(plan `pro`, dashboard email s***@gmail.com) on 2026-09-12 03:05 UTC:
+
+- `shortPercent` 4 / `shortObservedAt` 1788956674678 (2026-09-09 12:24 UTC) /
+  `shortResetAt` 1788974652 (2026-09-09 17:24 UTC = KST 9월 10일 02:24) /
+  `shortWindowSeconds` 18000
+- `updatedAt` 1789182311711 (current)
+- current Spark customWindows (`GPT-5.3-Codex-Spark 5h` percent 0, reset in the
+  future) and weeklyPercent 29
+
+Peer Pro accounts in the same file have weekly + Spark customWindows and no
+account-level short. The Team account `chatgpt-1788220079695` has a *fresh*
+short tuple (`shortObservedAt === updatedAt`, reset in the future) — a real
+Plus/Team 5h window that must be kept.
+
+`mergeAccountQuota` (`src/codex/quota.ts`) treats absence of short* as a partial
+update and copies the entire existing short tuple, then
+`setAccountQuotaFromParsed` always sets `updatedAt = Date.now()`. Disk hydration
+(`QUOTA_DISK_MAX_AGE_MS = 6h`) keys expiry on `updatedAt`
+(`src/codex/quota.ts:14-15,637-640`), so the carry prevents the TTL #4122 relied
+on. The carried `shortResetAt` is already in the past, so the rendered row is
+unreachable, not merely stale-but-plausible.
+
+#4122 (`devlog/_fin/260909_spark_short_quota_attribution`) stopped *new* Spark
+header writes into the account short slot
+(`parseUpstreamQuotaHeaders` Spark branch, `src/codex/quota.ts:466-473`) and
+explicitly left polluted entries to the six-hour TTL. That assertion is false
+once carry rewrites `updatedAt`.
+
+### Alternatives refuted
+
+- GUI inventing the row: `normalizeQuotaForPlan` /
+  `buildQuotaRows` map `shortPercent` to a five-hour row with no expiry check
+  (`gui/src/codex-quota-utils.ts:38-45`, `gui/src/components/QuotaBars.tsx:73-82`).
+  They display what the cache already holds. The KST timestamp matches
+  `shortResetAt`, not a GUI clock bug.
+- WHAM still writing a Pro account-level short: `parseUsageQuota` still files an
+  explicit sub-day *primary* as short (`src/codex/quota.ts:811-814`) and Spark
+  additional limits as customWindows (`src/codex/quota.ts:871`). This account's
+  `shortObservedAt` is frozen on 2026-09-09 while weekly and Spark customWindows
+  keep moving, so current WHAM refreshes are not rewriting short*.
+- auth-api synthesizing a 5h row: DTO mapping copies stored short fields
+  (`src/codex/auth-api.ts:296`) and only filters Spark *custom* windows for
+  display. It does not invent short*.
+
+## File-change map
+
+See `010_phase1_drop_elapsed_short_carry.md`.
+
+## SoT
+
+`src/codex/` is owned via `structure/INDEX.md` → runtime/config docs. No
+structure paragraph currently states the short-carry rule; the executable
+contract lives in `src/codex/quota.ts` and
+`tests/codex-integration/codex-quota-parser-parity.test.ts`. This unit does not
+add a structure page (no new owned area).

--- a/devlog/_plan/260912_phantom_account_short_quota/000_plan.md
+++ b/devlog/_plan/260912_phantom_account_short_quota/000_plan.md
@@ -54,8 +54,8 @@ phantom bar on the next ordinary weekly/Spark refresh; Plus/Team accounts whose
 
 ## Root cause (evidence)
 
-Live cache `~/.opencodex/codex-quota-cache.json` account `chatgpt-1786626108327`
-(plan `pro`, dashboard email s***@gmail.com) on 2026-09-12 03:05 UTC:
+Live cache `~/.opencodex/codex-quota-cache.json`, entry for the affected Pro pool account, on
+2026-09-12 03:05 UTC (account identifiers deliberately omitted: this directory is public):
 
 - `shortPercent` 4 / `shortObservedAt` 1788956674678 (2026-09-09 12:24 UTC) /
   `shortResetAt` 1788974652 (2026-09-09 17:24 UTC = KST 9월 10일 02:24) /
@@ -65,9 +65,9 @@ Live cache `~/.opencodex/codex-quota-cache.json` account `chatgpt-1786626108327`
   future) and weeklyPercent 29
 
 Peer Pro accounts in the same file have weekly + Spark customWindows and no
-account-level short. The Team account `chatgpt-1788220079695` has a *fresh*
-short tuple (`shortObservedAt === updatedAt`, reset in the future) — a real
-Plus/Team 5h window that must be kept.
+account-level short. The one Team account there has a *fresh* short tuple
+(`shortObservedAt === updatedAt`, reset in the future) — a real Plus/Team 5h
+window that must be kept.
 
 `mergeAccountQuota` (`src/codex/quota.ts`) treats absence of short* as a partial
 update and copies the entire existing short tuple, then
@@ -102,6 +102,21 @@ once carry rewrites `updatedAt`.
 ## File-change map
 
 See `010_phase1_drop_elapsed_short_carry.md`.
+
+## Accepted consequence
+
+A merge that drops an elapsed tuple also clears `fiveHourAvailable` in
+`codexQuotaAutoRefreshStatus` (`src/codex/quota-auto-refresh.ts:62-65`) until the
+window is observed again, because that flag reads `shortWindowSeconds` and
+`shortResetAt` from the same slot. Bounded on both sides: the scheduler keeps its
+own boundary (`rememberWindows` persists `nextFiveHourResetAt` and
+`dueCodexQuotaAutoRefreshWindows` prefers it over the stored quota,
+`src/codex/quota-auto-refresh.ts:78-101`), and any real Plus/Team response
+re-observes the window as an explicit incoming short, which this change never
+drops. The gap therefore only spans a credits-only or weekly-only refresh
+arriving between a reset instant and the next observation — and for a Pro
+account, where the window does not exist, clearing the flag is the correct
+outcome.
 
 ## SoT
 

--- a/devlog/_plan/260912_phantom_account_short_quota/000_plan.md
+++ b/devlog/_plan/260912_phantom_account_short_quota/000_plan.md
@@ -4,7 +4,7 @@
 
 Problem: one Codex Pro pool account still renders an account-level 5h bar
 (`5시간 리셋 9월 10일 02:24 4%`) even though Pro has no account-level 5h window and
-#4122 already stopped new Spark 5h writes into that slot. Answer: stop
+Issue #4122 already stopped new Spark 5h writes into that slot. Answer: stop
 `mergeAccountQuota` from carrying an elapsed `short*` tuple across a refresh that
 does not include a short window. What changes: the polluted Pro row drops the
 phantom bar on the next ordinary weekly/Spark refresh; Plus/Team accounts whose
@@ -17,7 +17,7 @@ phantom bar on the next ordinary weekly/Spark refresh; Plus/Team accounts whose
 - Trigger: live 2026-09-12 dashboard report on http://localhost:10100/#codex-set
   plus HOTL objective to land a merged PR on `dev`.
 - Goal: a Pro account whose refresh reports no account-level short window stops
-  showing a 5h row; the stale cache tuple stops feeding policy readers; PR merged
+  showing a 5h row; the stale display tuple is removed while existing main-policy evidence remains protected; PR merged
   to `dev` with exact-head CI.
 - Non-goals: GUI redesign; WHAM Spark-primary remapping (WHAM already files Spark
   under customWindows and is not rewriting this account's shortObservedAt);
@@ -30,10 +30,10 @@ phantom bar on the next ordinary weekly/Spark refresh; Plus/Team accounts whose
   `tests/codex-integration/codex-quota-parser-parity.test.ts`. Local
   `bun test` / `bun run typecheck` / `bun run test` / `bun run build:gui`: NOT RUN
   by standing user rule (command not executed; no exit code). Conditional paths:
-  (1) elapsed short + weekly/Spark refresh with no short* — activation: seed
-  past `shortResetAt`, apply weekly or Spark headers, observe short* absent;
+  (1) elapsed short + weekly/Spark refresh with no `short*` — activation: seed
+  past `shortResetAt`, apply weekly or Spark headers, observe `short*` absent;
   (2) live short + weekly-only refresh — activation: seed future `shortResetAt`,
-  apply weekly headers, observe short* retained; (3) incoming explicit short
+  apply weekly headers, observe `short*` retained; (3) incoming explicit short
   even if elapsed — activation: `setAccountQuotaFromParsed` with past reset,
   observe the tuple stored so auto-refresh/scorer fixtures stay intact.
 - Stop condition: fetched `origin/dev` contains the PR commit and the live
@@ -69,7 +69,7 @@ account-level short. The one Team account there has a *fresh* short tuple
 (`shortObservedAt === updatedAt`, reset in the future) — a real Plus/Team 5h
 window that must be kept.
 
-`mergeAccountQuota` (`src/codex/quota.ts`) treats absence of short* as a partial
+`mergeAccountQuota` (`src/codex/quota.ts`) treats absence of `short*` as a partial
 update and copies the entire existing short tuple, then
 `setAccountQuotaFromParsed` always sets `updatedAt = Date.now()`. Disk hydration
 (`QUOTA_DISK_MAX_AGE_MS = 6h`) keys expiry on `updatedAt`
@@ -77,7 +77,7 @@ update and copies the entire existing short tuple, then
 on. The carried `shortResetAt` is already in the past, so the rendered row is
 unreachable, not merely stale-but-plausible.
 
-#4122 (`devlog/_fin/260909_spark_short_quota_attribution`) stopped *new* Spark
+Issue #4122 (`devlog/_fin/260909_spark_short_quota_attribution`) stopped *new* Spark
 header writes into the account short slot
 (`parseUpstreamQuotaHeaders` Spark branch, `src/codex/quota.ts:466-473`) and
 explicitly left polluted entries to the six-hour TTL. That assertion is false
@@ -94,10 +94,10 @@ once carry rewrites `updatedAt`.
   explicit sub-day *primary* as short (`src/codex/quota.ts:811-814`) and Spark
   additional limits as customWindows (`src/codex/quota.ts:871`). This account's
   `shortObservedAt` is frozen on 2026-09-09 while weekly and Spark customWindows
-  keep moving, so current WHAM refreshes are not rewriting short*.
+  keep moving, so current WHAM refreshes are not rewriting `short*`.
 - auth-api synthesizing a 5h row: DTO mapping copies stored short fields
   (`src/codex/auth-api.ts:296`) and only filters Spark *custom* windows for
-  display. It does not invent short*.
+  display. It does not invent `short*`.
 
 ## File-change map
 
@@ -120,8 +120,14 @@ outcome.
 
 ## SoT
 
-`src/codex/` is owned via `structure/INDEX.md` → runtime/config docs. No
-structure paragraph currently states the short-carry rule; the executable
-contract lives in `src/codex/quota.ts` and
-`tests/codex-integration/codex-quota-parser-parity.test.ts`. This unit does not
-add a structure page (no new owned area).
+The canonical current rule is in `structure/providers/openai-tiers.md`, with links from the
+other Codex structure owners and dashboard documentation. Display expiry never removes main
+hard-lock evidence. Reset-notification history retains omitted short observations separately.
+
+## Final audit refinement
+
+The initial design also expired identity-bound policy evidence. Independent review rejected
+that behavior: an elapsed deadline plus a credits-only update is not quota recovery. The final
+patch preserves policy evidence and removes only obsolete display/rotation carry. A second
+review found that notification history needed separate retention across those display updates;
+Codex now opts into that retention without changing other provider writers.

--- a/devlog/_plan/260912_phantom_account_short_quota/010_phase1_drop_elapsed_short_carry.md
+++ b/devlog/_plan/260912_phantom_account_short_quota/010_phase1_drop_elapsed_short_carry.md
@@ -1,84 +1,34 @@
-# Phase 1 — drop elapsed account-level short carry
+# Phase 1: expire display carry without losing policy or notification evidence
 
-## IN
+## Final implementation
 
-- `src/codex/quota.ts`: carry paths in `mergeAccountQuota` (credits-only +
-  no-incoming-short else branch) and the parallel copy in `updateAccountQuota`.
-- `tests/codex-integration/codex-quota-parser-parity.test.ts`: regression rows
-  next to the #4122 Spark attribution block.
-- this unit's plan/closeout docs.
+- `src/codex/quota.ts`: `assignCarriedShort` drops expired omitted short tuples only for
+  display/rotation merges; credits-only and legacy `updateAccountQuota` use the same rule.
+  `policyEvidence` preserves the previous short tuple, including its observation clock.
+  Explicit incoming short readings retain the original merge semantics.
+- `src/codex/routing.ts`: shares `resetAtToMs` with the carry expiry comparison.
+- `src/quota/reset-observer.ts` and `src/quota/reset-seen-store.ts`: Codex-only opt-in retains
+  absent short history for reset detection without manufacturing an incoming observation.
+  Its original timestamp survives repeated partial updates and persistence. Explicit clear
+  still removes the baseline; provider replacement behavior is unchanged.
+- Structure owners document the cache contract and link to its canonical statement.
 
-## OUT
+## Regression coverage
 
-- GUI row construction (`QuotaBars`, `normalizeQuotaForPlan`).
-- Changing `getAccountQuota` to strip elapsed shorts at read time (would hide
-  the reset instant from five-hour auto-refresh).
-- Changing WHAM `parseUsageQuota` Spark-primary attribution.
-- Hydrate/persist rewrite of already-elapsed tuples except insofar as the next
-  merge persist writes the cleaned snapshot.
+- Parser parity: Spark and WHAM weekly refresh remove stale display short fields; weekly-only,
+  credits-only, future resets, explicit incoming resets, and legacy updates in seconds/ms.
+- Main hard-lock policy: expired short 99 remains blocked across credits-only, weekly-only,
+  and short metadata-only updates. A fresh short zero releases the block.
+- Reset observation: two partial writes after expiry emit nothing, the next real short
+  rollover emits exactly one scheduled notification, and explicit clear removes the baseline.
+- Reset store: retained observation time survives persistence; non-opted-in writers still
+  replace omitted windows.
 
-## Diff (quota.ts)
+## Audit corrections
 
-Add helpers beside `snapshotHasShort`:
+Independent inherited-model reviewers found two regressions in the earlier patch: display
+expiry leaked into the main-policy cache, and dropping display short fields also discarded
+notification history. Both are corrected in the final implementation above.
 
-```ts
-const RESET_AT_SECONDS_MAX = 10_000_000_000; // same split as isTerminalShortWindow
-
-function shortResetHasElapsed(resetAt: number | undefined, now: number): boolean {
-  if (typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt <= 0) return false;
-  const resetAtMs = resetAt < RESET_AT_SECONDS_MAX ? resetAt * 1000 : resetAt;
-  return resetAtMs <= now;
-}
-
-function assignCarriedShort(next, existing, now): void {
-  if (!existing || shortResetHasElapsed(existing.shortResetAt, now)) return;
-  // copy shortPercent/shortObservedAt/shortResetAt/shortWindowSeconds when present
-}
-```
-
-Replace the four unconditional `existing.short*` assignments in the
-`creditsOnly` branch and the `else` (no incoming short) branch with
-`assignCarriedShort(next, existing, updatedAt)`.
-
-Tighten `preserveKnownShort` so an elapsed existing short is not treated as
-known policy evidence:
-
-```ts
-const preserveKnownShort = policyEvidence
-  && quota.shortPercent === undefined
-  && finitePercent(existing?.shortPercent)
-  && !shortResetHasElapsed(existing?.shortResetAt, updatedAt);
-```
-
-In `updateAccountQuota`, skip copying short* when
-`shortResetHasElapsed(existing.shortResetAt, quota.updatedAt)`.
-
-Do **not** drop an incoming snapshot that itself contains short*. Auto-refresh
-and routing tests seed elapsed `shortResetAt` as a stored fact.
-
-## Tests (parser-parity)
-
-1. Seed elapsed short + weekly; apply Spark-model 5h headers from the existing
-   `SPARK_HEADERS` fixture → short* absent, weekly 21, Spark customWindows
-   present. (This is the live Pro failure: #4122 write path plus leftover carry.)
-2. Seed elapsed short; apply a Pro WHAM parse (weekly primary 604800s + Spark
-   additional_rate_limits) → short* absent, weekly and Spark customWindows kept.
-   This is the live refresh path for the affected account.
-3. Seed elapsed short; apply weekly-only headers (10080 minutes) → short* absent,
-   weekly updated.
-4. Seed live short (`shortResetAt = nowSec + 3600`); apply weekly-only headers →
-   short* retained, weekly updated.
-5. Seed elapsed short; `setAccountQuotaFromParsed({ shortPercent, shortResetAt })`
-   as an explicit incoming short → tuple remains (incoming-has-short path).
-6. Seed elapsed short; credits-only `setAccountQuotaFromParsed({ resetCredits })`
-   → short* absent, weekly and credits kept.
-
-Red before the patch: (1) and (2) fail because the else branch recopies
-`shortPercent: 4`. Green after: those rows pass; (3) and (4) keep current
-carry/store behavior.
-
-## Accept
-
-- c1: live cache + `quota.ts` file:line + alternatives in `000_plan.md`.
-- c2: diff + the four rows above (red-green by construction; local suite NOT RUN).
-- c3/c4: PR + merge evidence in closeout.
+No red run, local suite, typecheck, build, or install was executed. Remote CI must verify the
+final pushed head; static comparison alone is not a passing execution result.

--- a/devlog/_plan/260912_phantom_account_short_quota/010_phase1_drop_elapsed_short_carry.md
+++ b/devlog/_plan/260912_phantom_account_short_quota/010_phase1_drop_elapsed_short_carry.md
@@ -1,0 +1,84 @@
+# Phase 1 — drop elapsed account-level short carry
+
+## IN
+
+- `src/codex/quota.ts`: carry paths in `mergeAccountQuota` (credits-only +
+  no-incoming-short else branch) and the parallel copy in `updateAccountQuota`.
+- `tests/codex-integration/codex-quota-parser-parity.test.ts`: regression rows
+  next to the #4122 Spark attribution block.
+- this unit's plan/closeout docs.
+
+## OUT
+
+- GUI row construction (`QuotaBars`, `normalizeQuotaForPlan`).
+- Changing `getAccountQuota` to strip elapsed shorts at read time (would hide
+  the reset instant from five-hour auto-refresh).
+- Changing WHAM `parseUsageQuota` Spark-primary attribution.
+- Hydrate/persist rewrite of already-elapsed tuples except insofar as the next
+  merge persist writes the cleaned snapshot.
+
+## Diff (quota.ts)
+
+Add helpers beside `snapshotHasShort`:
+
+```ts
+const RESET_AT_SECONDS_MAX = 10_000_000_000; // same split as isTerminalShortWindow
+
+function shortResetHasElapsed(resetAt: number | undefined, now: number): boolean {
+  if (typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt <= 0) return false;
+  const resetAtMs = resetAt < RESET_AT_SECONDS_MAX ? resetAt * 1000 : resetAt;
+  return resetAtMs <= now;
+}
+
+function assignCarriedShort(next, existing, now): void {
+  if (!existing || shortResetHasElapsed(existing.shortResetAt, now)) return;
+  // copy shortPercent/shortObservedAt/shortResetAt/shortWindowSeconds when present
+}
+```
+
+Replace the four unconditional `existing.short*` assignments in the
+`creditsOnly` branch and the `else` (no incoming short) branch with
+`assignCarriedShort(next, existing, updatedAt)`.
+
+Tighten `preserveKnownShort` so an elapsed existing short is not treated as
+known policy evidence:
+
+```ts
+const preserveKnownShort = policyEvidence
+  && quota.shortPercent === undefined
+  && finitePercent(existing?.shortPercent)
+  && !shortResetHasElapsed(existing?.shortResetAt, updatedAt);
+```
+
+In `updateAccountQuota`, skip copying short* when
+`shortResetHasElapsed(existing.shortResetAt, quota.updatedAt)`.
+
+Do **not** drop an incoming snapshot that itself contains short*. Auto-refresh
+and routing tests seed elapsed `shortResetAt` as a stored fact.
+
+## Tests (parser-parity)
+
+1. Seed elapsed short + weekly; apply Spark-model 5h headers from the existing
+   `SPARK_HEADERS` fixture → short* absent, weekly 21, Spark customWindows
+   present. (This is the live Pro failure: #4122 write path plus leftover carry.)
+2. Seed elapsed short; apply a Pro WHAM parse (weekly primary 604800s + Spark
+   additional_rate_limits) → short* absent, weekly and Spark customWindows kept.
+   This is the live refresh path for chatgpt-1786626108327.
+3. Seed elapsed short; apply weekly-only headers (10080 minutes) → short* absent,
+   weekly updated.
+4. Seed live short (`shortResetAt = nowSec + 3600`); apply weekly-only headers →
+   short* retained, weekly updated.
+5. Seed elapsed short; `setAccountQuotaFromParsed({ shortPercent, shortResetAt })`
+   as an explicit incoming short → tuple remains (incoming-has-short path).
+6. Seed elapsed short; credits-only `setAccountQuotaFromParsed({ resetCredits })`
+   → short* absent, weekly and credits kept.
+
+Red before the patch: (1) and (2) fail because the else branch recopies
+`shortPercent: 4`. Green after: those rows pass; (3) and (4) keep current
+carry/store behavior.
+
+## Accept
+
+- c1: live cache + `quota.ts` file:line + alternatives in `000_plan.md`.
+- c2: diff + the four rows above (red-green by construction; local suite NOT RUN).
+- c3/c4: PR + merge evidence in closeout.

--- a/devlog/_plan/260912_phantom_account_short_quota/010_phase1_drop_elapsed_short_carry.md
+++ b/devlog/_plan/260912_phantom_account_short_quota/010_phase1_drop_elapsed_short_carry.md
@@ -63,7 +63,7 @@ and routing tests seed elapsed `shortResetAt` as a stored fact.
    present. (This is the live Pro failure: #4122 write path plus leftover carry.)
 2. Seed elapsed short; apply a Pro WHAM parse (weekly primary 604800s + Spark
    additional_rate_limits) → short* absent, weekly and Spark customWindows kept.
-   This is the live refresh path for chatgpt-1786626108327.
+   This is the live refresh path for the affected account.
 3. Seed elapsed short; apply weekly-only headers (10080 minutes) → short* absent,
    weekly updated.
 4. Seed live short (`shortResetAt = nowSec + 3600`); apply weekly-only headers →

--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -44,6 +44,21 @@ const MONTHLY_WINDOW_MIN_MINUTES = MONTHLY_WINDOW_MIN_SECONDS / 60;
 // Derived, never written as a literal: the header parser and the WHAM parser must not be able
 // to drift to different thresholds, which is the class of defect this pair exists to prevent.
 const WEEKLY_WINDOW_MIN_MINUTES = WEEKLY_WINDOW_MIN_SECONDS / 60;
+/**
+ * Seconds/milliseconds split for a stored reset instant: below it the value is Unix seconds,
+ * at or above it milliseconds.
+ *
+ * Both units reach storage — `normalizeResetAt` does not scale, and the GUI disambiguates by
+ * magnitude at read time — so a comparison written against one assumption is off by 1000x
+ * against the other. In the seconds-read-as-milliseconds direction every reading looks like it
+ * elapsed in 1970, which is a check that passes its own test and does nothing. Exported so
+ * `isTerminalShortWindow` in routing.ts shares this one split instead of repeating the literal.
+ */
+const RESET_AT_SECONDS_MAX = 10_000_000_000;
+
+export function resetAtToMs(resetAt: number): number {
+  return resetAt < RESET_AT_SECONDS_MAX ? resetAt * 1000 : resetAt;
+}
 
 const accountQuota = new Map<string, StoredAccountQuota>();
 let lastReconciledGeneration = 0;
@@ -221,6 +236,24 @@ function snapshotHasShort(quota: Omit<StoredAccountQuota, "updatedAt">): boolean
     || quota.shortWindowSeconds !== undefined;
 }
 
+function shortResetHasElapsed(resetAt: number | undefined, now: number): boolean {
+  if (typeof resetAt !== "number" || !Number.isFinite(resetAt) || resetAt <= 0) return false;
+  return resetAtToMs(resetAt) <= now;
+}
+
+/** Copy a still-open short tuple. An elapsed reset is not a current window. */
+function assignCarriedShort(
+  next: StoredAccountQuota,
+  existing: StoredAccountQuota | undefined,
+  now: number,
+): void {
+  if (!existing || shortResetHasElapsed(existing.shortResetAt, now)) return;
+  if (existing.shortPercent !== undefined) next.shortPercent = existing.shortPercent;
+  if (existing.shortObservedAt !== undefined) next.shortObservedAt = existing.shortObservedAt;
+  if (existing.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
+  if (existing.shortWindowSeconds !== undefined) next.shortWindowSeconds = existing.shortWindowSeconds;
+}
+
 function snapshotHasCustom(quota: Omit<StoredAccountQuota, "updatedAt">): boolean {
   return quota.customWindows !== undefined;
 }
@@ -282,10 +315,7 @@ function mergeAccountQuota(
     if (existing?.monthlyPercent !== undefined) next.monthlyPercent = existing.monthlyPercent;
     if (existing?.monthlyResetAt !== undefined) next.monthlyResetAt = existing.monthlyResetAt;
     if (existing?.monthlyIsPrimaryWindow === true) next.monthlyIsPrimaryWindow = true;
-    if (existing?.shortPercent !== undefined) next.shortPercent = existing.shortPercent;
-    if (existing?.shortObservedAt !== undefined) next.shortObservedAt = existing.shortObservedAt;
-    if (existing?.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
-    if (existing?.shortWindowSeconds !== undefined) next.shortWindowSeconds = existing.shortWindowSeconds;
+    assignCarriedShort(next, existing, updatedAt);
     if (existing?.customWindows !== undefined) next.customWindows = existing.customWindows;
     next.resetCredits = quota.resetCredits;
     return next;
@@ -318,7 +348,10 @@ function mergeAccountQuota(
     if (existing.monthlyIsPrimaryWindow === true) next.monthlyIsPrimaryWindow = true;
   }
 
-  const preserveKnownShort = policyEvidence && quota.shortPercent === undefined && finitePercent(existing?.shortPercent);
+  const preserveKnownShort = policyEvidence
+    && quota.shortPercent === undefined
+    && finitePercent(existing?.shortPercent)
+    && !shortResetHasElapsed(existing?.shortResetAt, updatedAt);
   if (snapshotHasShort(quota) && !preserveKnownShort) {
     if (quota.shortPercent !== undefined) {
       next.shortPercent = quota.shortPercent;
@@ -329,10 +362,10 @@ function mergeAccountQuota(
   } else {
     // Unknown usage is not a lower reading. Retain the entire known tuple: pairing
     // its percentage with new metadata would silently extend or shorten its reset.
-    if (existing?.shortPercent !== undefined) next.shortPercent = existing.shortPercent;
-    if (existing?.shortObservedAt !== undefined) next.shortObservedAt = existing.shortObservedAt;
-    if (existing?.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
-    if (existing?.shortWindowSeconds !== undefined) next.shortWindowSeconds = existing.shortWindowSeconds;
+    // An elapsed reset is the exception. It describes a window that has already rolled over,
+    // and carrying it republishes updatedAt, which is exactly what kept a Spark-polluted Pro
+    // row alive past the six-hour disk TTL that #4122 expected to expire it.
+    assignCarriedShort(next, existing, updatedAt);
   }
 
   if (snapshotHasCustom(quota)) next.customWindows = quota.customWindows;
@@ -561,14 +594,11 @@ export function updateAccountQuota(
       : {}),
     ...(existing?.weeklyResetAt !== undefined ? { weeklyResetAt: existing.weeklyResetAt } : {}),
     ...(existing?.monthlyResetAt !== undefined ? { monthlyResetAt: existing.monthlyResetAt } : {}),
-    ...(existing?.shortPercent !== undefined ? { shortPercent: existing.shortPercent } : {}),
-    ...(existing?.shortObservedAt !== undefined ? { shortObservedAt: existing.shortObservedAt } : {}),
-    ...(existing?.shortResetAt !== undefined ? { shortResetAt: existing.shortResetAt } : {}),
-    ...(existing?.shortWindowSeconds !== undefined ? { shortWindowSeconds: existing.shortWindowSeconds } : {}),
     ...(existing?.customWindows !== undefined ? { customWindows: existing.customWindows } : {}),
     ...(existing?.resetCredits !== undefined ? { resetCredits: existing.resetCredits } : {}),
     updatedAt: Date.now(),
   };
+  assignCarriedShort(quota, existing, quota.updatedAt);
 
   const nextWeeklyResetAt = normalizeResetAt(weeklyResetAt);
   const nextMonthlyResetAt = normalizeResetAt(monthlyResetAt);

--- a/src/codex/quota.ts
+++ b/src/codex/quota.ts
@@ -241,13 +241,14 @@ function shortResetHasElapsed(resetAt: number | undefined, now: number): boolean
   return resetAtToMs(resetAt) <= now;
 }
 
-/** Copy a still-open short tuple. An elapsed reset is not a current window. */
+/** Display/rotation carry expires; a reset clock cannot retract hard-lock evidence. */
 function assignCarriedShort(
   next: StoredAccountQuota,
   existing: StoredAccountQuota | undefined,
   now: number,
+  policyEvidence = false,
 ): void {
-  if (!existing || shortResetHasElapsed(existing.shortResetAt, now)) return;
+  if (!existing || (!policyEvidence && shortResetHasElapsed(existing.shortResetAt, now))) return;
   if (existing.shortPercent !== undefined) next.shortPercent = existing.shortPercent;
   if (existing.shortObservedAt !== undefined) next.shortObservedAt = existing.shortObservedAt;
   if (existing.shortResetAt !== undefined) next.shortResetAt = existing.shortResetAt;
@@ -315,7 +316,7 @@ function mergeAccountQuota(
     if (existing?.monthlyPercent !== undefined) next.monthlyPercent = existing.monthlyPercent;
     if (existing?.monthlyResetAt !== undefined) next.monthlyResetAt = existing.monthlyResetAt;
     if (existing?.monthlyIsPrimaryWindow === true) next.monthlyIsPrimaryWindow = true;
-    assignCarriedShort(next, existing, updatedAt);
+    assignCarriedShort(next, existing, updatedAt, policyEvidence);
     if (existing?.customWindows !== undefined) next.customWindows = existing.customWindows;
     next.resetCredits = quota.resetCredits;
     return next;
@@ -348,10 +349,7 @@ function mergeAccountQuota(
     if (existing.monthlyIsPrimaryWindow === true) next.monthlyIsPrimaryWindow = true;
   }
 
-  const preserveKnownShort = policyEvidence
-    && quota.shortPercent === undefined
-    && finitePercent(existing?.shortPercent)
-    && !shortResetHasElapsed(existing?.shortResetAt, updatedAt);
+  const preserveKnownShort = policyEvidence && quota.shortPercent === undefined && finitePercent(existing?.shortPercent);
   if (snapshotHasShort(quota) && !preserveKnownShort) {
     if (quota.shortPercent !== undefined) {
       next.shortPercent = quota.shortPercent;
@@ -365,7 +363,7 @@ function mergeAccountQuota(
     // An elapsed reset is the exception. It describes a window that has already rolled over,
     // and carrying it republishes updatedAt, which is exactly what kept a Spark-polluted Pro
     // row alive past the six-hour disk TTL that #4122 expected to expire it.
-    assignCarriedShort(next, existing, updatedAt);
+    assignCarriedShort(next, existing, updatedAt, policyEvidence);
   }
 
   if (snapshotHasCustom(quota)) next.customWindows = quota.customWindows;
@@ -427,6 +425,7 @@ function notifyCodexQuotaSnapshot(accountId: string, next: StoredAccountQuota): 
         scope: "codex",
         accountKey: accountId,
         windows: codexWindowObservations(snapshot),
+        retainAbsentShortWindow: true,
       });
     })
     .catch(() => {

--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -18,7 +18,7 @@ import {
   seedPoolRotationAccount,
   selectPriorityTier,
 } from "./pool-rotation";
-import { CODEX_EXHAUSTED_USAGE_PERCENT, CODEX_UNKNOWN_USAGE_SCORE, getAccountQuota } from "./quota";
+import { CODEX_EXHAUSTED_USAGE_PERCENT, CODEX_UNKNOWN_USAGE_SCORE, getAccountQuota, resetAtToMs } from "./quota";
 import { codexPlanKey, isThirtyDayOnlyCodexPlan } from "./plan";
 import {
   MAIN_CODEX_ACCOUNT_ID,
@@ -429,9 +429,11 @@ export function computeCodexUsageScore(quota: {
  * A short-only reading that proves the account is blocked NOW.
  *
  * Freshness is not optional. `getAccountQuota` performs no expiry check, partial updates
- * carry the old short tuple forward, and disk hydration accepts a persisted reading for
+ * carry a still-open short tuple forward, and disk hydration accepts a persisted reading for
  * hours — so scoring 100 from `shortPercent` alone would keep excluding an account whose
- * five-hour window has since reset. That is #3029 pointed the other way: the issue is that
+ * five-hour window has since reset. Merge no longer carries an elapsed shortResetAt, but an
+ * explicit incoming elapsed tuple is still stored, and a missing reset cannot be aged there.
+ * That is #3029 pointed the other way: the issue is that
  * an exhausted account stays selected, and "a recovered account stays excluded" trades one
  * unusable pool for another.
  *
@@ -457,12 +459,9 @@ function isTerminalShortWindow(
     const age = now - observedAt;
     return age >= 0 && age <= TERMINAL_SHORT_WINDOW_FRESHNESS_MS;
   }
-  // Both units reach storage: `normalizeResetAt` does not scale, and the GUI disambiguates
-  // by magnitude at read time. A comparison written against one assumption is off by 1000x
-  // against the other, and in the seconds-read-as-milliseconds direction every terminal
-  // reading looks like it reset in 1970 — a fix that passes its own test and does nothing.
-  const resetAtMs = resetAt < 10_000_000_000 ? resetAt * 1000 : resetAt;
-  return resetAtMs > now;
+  // Seconds and milliseconds both reach storage, so the split lives in one place next to the
+  // merge that also ages a stored reset instant (`resetAtToMs`, src/codex/quota.ts).
+  return resetAtToMs(resetAt) > now;
 }
 
 export function classifyCodexUpstreamOutcome(

--- a/src/quota/reset-observer.ts
+++ b/src/quota/reset-observer.ts
@@ -55,6 +55,7 @@ export function observeQuotaSnapshot(input: {
   readonly accountKey: string;
   readonly windows: ReadonlyArray<QuotaWindowObservation>;
   readonly now?: number;
+  readonly retainAbsentShortWindow?: boolean;
 }): QuotaResetEvent[] {
   try {
     if (!sink) return [];
@@ -65,7 +66,7 @@ export function observeQuotaSnapshot(input: {
     // between two observations to tell a rolling window's natural decay from a real reset,
     // and only this layer knows when the snapshot was taken.
     const stamped = input.windows.map(window => ({ ...window, observedAt: now }));
-    const previous = swapLastObservedWindows(input.scope, accountTag, stamped);
+    const previous = swapLastObservedWindows(input.scope, accountTag, stamped, input.retainAbsentShortWindow);
     if (!previous) return [];
 
     const detected = detectQuotaResets({

--- a/src/quota/reset-seen-store.ts
+++ b/src/quota/reset-seen-store.ts
@@ -306,6 +306,7 @@ export function swapLastObservedWindows(
   scope: string,
   accountTag: string,
   windows: ReadonlyArray<QuotaWindowObservation>,
+  retainAbsentShortWindow = false,
 ): ReadonlyArray<QuotaWindowObservation> | undefined {
   hydrate();
   const key = observedKey(scope, accountTag);
@@ -317,7 +318,14 @@ export function swapLastObservedWindows(
   // Measured: the hottest scope was evicted and its next genuine scheduled reset was
   // silently missed, because a re-baselined row has no previous value to diff against.
   observed.delete(key);
-  observed.set(key, windows.map(window => ({ ...window })));
+  const next = windows.map(window => ({ ...window }));
+  // Codex display eviction is not a new short observation. Retain notification history
+  // with its original clock until a real reading replaces it or account cleanup forgets it.
+  if (retainAbsentShortWindow && !next.some(window => window.window === "5h")) {
+    const short = previous?.find(window => window.window === "5h");
+    if (short) next.push({ ...short });
+  }
+  observed.set(key, next);
   if (observed.size > MAX_OBSERVED_SCOPES) {
     // Least-recently-observed first. Evicting only costs a re-baseline, never a duplicate
     // notification, because the claim ledger is separate — but a re-baseline DOES cost the

--- a/structure/catalog.md
+++ b/structure/catalog.md
@@ -261,3 +261,6 @@ provider wire mapping; unpinned native requests retain their existing pass-throu
 > Decision record: [ADR-0025](decisions/ADR-0025-ultra-reasoning-level.md)
 
 > Decision record: [ADR-0026](decisions/ADR-0026-ultra-reasoning-level.md)
+
+Codex display-cache expiry, retained main-policy evidence, and reset history follow the
+[quota cache contract](providers/openai-tiers.md#quota-cache-and-short-window-history).

--- a/structure/codex-home.md
+++ b/structure/codex-home.md
@@ -223,3 +223,6 @@ a deliberate user choice:
 - Project-level Codex config that bypasses managed routing
   (`src/codex/project-config-warnings.ts`), surfaced by `ocx doctor` as a warning rather than an
   override.
+
+Codex display-cache expiry, retained main-policy evidence, and reset history follow the
+[quota cache contract](providers/openai-tiers.md#quota-cache-and-short-window-history).

--- a/structure/config.md
+++ b/structure/config.md
@@ -192,3 +192,6 @@ the residual directory for manual review; there is no recursive-delete fallback.
 ## Remote client key files
 
 Client connection metadata stores a stable `apiKeyId` and a non-secret rotation `pendingOperation`. The current data secret remains only in `service-api-token`; a bounded rotation temporarily keeps the old secret in owner-only `service-api-token.prev`. Commit or recovery clears the marker before orphan cleanup. `ocx disconnect` is local-only and leaves remote revocation to the hub's **Integrations → API Keys** page. Hub and local usage stores are not mirrored.
+
+Codex display-cache expiry, retained main-policy evidence, and reset history follow the
+[quota cache contract](providers/openai-tiers.md#quota-cache-and-short-window-history).

--- a/structure/gui-and-management-api.md
+++ b/structure/gui-and-management-api.md
@@ -282,6 +282,12 @@ recovery; operators no longer need to delete `update-job.json` after a dead work
 The dashboard is a local control surface, not a separate service. It should reflect the same config
 and catalog invariants documented in this folder rather than inventing parallel state.
 
+Codex quota cards consume the display cache from `src/codex/quota.ts`. A partial refresh
+removes an omitted short tuple whose reset deadline has elapsed, so a stale Spark-derived
+5h row does not persist on a weekly-only account. This is independent of the main-account
+hard-lock evidence and reset-notification history; their retention rules are documented in
+[OpenAI account modes](providers/openai-tiers.md#quota-cache-and-short-window-history).
+
 ## Dashboard surfaces
 
 Provider Overview consumes the existing shared `add-provider-presets` resource for sponsor

--- a/structure/ops/docs-and-release.md
+++ b/structure/ops/docs-and-release.md
@@ -300,3 +300,6 @@ This keeps release runs short and makes release a deployment of a verified commi
 ## Remote Hub locale and release gate
 
 The Remote Hub guide and affected CLI, server-config, management-API, and dashboard references have eight sources: root English plus `fr`, `ko`, `zh-cn`, `zh-tw`, `ru`, `ja`, and `tr`. English is canonical; commands, defaults, endpoint auth, and warnings remain exact in translations. A release requires the remote-only focused/full gates, privacy scan, GUI/docs builds, protocol compatibility receipts, and the MAINTAINERS security review for the exact head.
+
+Codex display-cache expiry, retained main-policy evidence, and reset history follow the
+[quota cache contract](../providers/openai-tiers.md#quota-cache-and-short-window-history).

--- a/structure/providers/openai-tiers.md
+++ b/structure/providers/openai-tiers.md
@@ -151,6 +151,27 @@ ordinary Luna or another account. Native vision/search helpers and standalone se
 under this compatibility opt-in; ordinary helper/default behavior is unchanged.
 Upstream remains the entitlement authority.
 
+### Quota cache and short-window history
+
+`src/codex/quota.ts` drops an omitted account-level short tuple from the display/rotation
+cache when its stored reset instant has elapsed. Seconds and milliseconds are accepted;
+future or missing deadlines remain carried, and explicit incoming short readings remain stored.
+This stops partial weekly/Spark or credits-only refreshes from renewing obsolete Spark-derived
+5h rows through the cache-wide `updatedAt` timestamp. Plan labels do not suppress real windows.
+
+The separately retained main-policy snapshot preserves omitted short evidence even after its
+reset clock passes. Credits-only, weekly-only, and metadata-only updates cannot remove an
+existing short usage reading or release its hard lock; a fresh short reading can replace it.
+
+The Codex writer explicitly asks `src/quota/reset-observer.ts` to retain an absent short window
+in `src/quota/reset-seen-store.ts`, with its original observation time. Detection compares only
+incoming windows, so eviction emits nothing and a later real rollover still has its baseline.
+Account cleanup forgets that baseline; other provider writers keep replacement semantics.
+Auto-refresh uses its separately retained reset boundary after display eviction.
+Regression coverage lives in `tests/codex-integration/codex-quota-parser-parity.test.ts`,
+`tests/codex-integration/main-account-hard-lock-policy.test.ts`,
+`tests/usage/quota-reset-observation.test.ts`, and `tests/usage/quota-reset-seen-store.test.ts`.
+
 `codexMainAccountHardLock` is a separate opt-in local admission policy, off by default.
 It blocks newly admitted identity-matched main-account requests at 99% of the 5h/short window
 when present, otherwise the weekly window (monthly for monthly-only accounts). It does not take

--- a/structure/runtime.md
+++ b/structure/runtime.md
@@ -185,3 +185,6 @@ not an authentication or entitlement decision.
 ## Remote Hub hardening ownership
 
 `src/remote/protocol.ts` owns pure interval/feature negotiation. `src/remote/hub-state.ts` owns the `GET|HEAD /v1/hub-state` contract, its caps, and the parser both sides share. `src/client/hub-client.ts` owns bounded, schema-validated remote catalog consumption, hub-state reads, and key-id probes; `src/client/hub-state.ts` owns the resolution and the owner-stamped 0600 cache, and a failed read reports "unavailable" rather than degrading to the client's own local provider and login state. `src/client/hub-relay.ts` is a fixed-authority management relay with URL, header, body, redirect, and stream bounds. The public data listener remains the direct client→hub path; the loopback management ingress never serves data-plane routes.
+
+Codex display-cache expiry, retained main-policy evidence, and reset history follow the
+[quota cache contract](providers/openai-tiers.md#quota-cache-and-short-window-history).

--- a/structure/subagents.md
+++ b/structure/subagents.md
@@ -195,3 +195,6 @@ Claude ModelInfo ordering receives optional `{ modelPickerOrder, featured }` aft
 It orders routed output groups after alias deduplication, preserving the collision winner and
 base/1M/Fast siblings. Native groups and explicit Desktop profile ownership are unchanged.
 Native Codex advertisements still follow display priority; private guidance ranks do not freeze them.
+
+Codex display-cache expiry, retained main-policy evidence, and reset history follow the
+[quota cache contract](providers/openai-tiers.md#quota-cache-and-short-window-history).

--- a/tests/codex-integration/codex-quota-parser-parity.test.ts
+++ b/tests/codex-integration/codex-quota-parser-parity.test.ts
@@ -124,6 +124,141 @@ describe("Spark-model header responses attribute the 5h window to the model limi
     expect(getAccountQuota("legacy-5h")?.shortPercent).toBe(97);
     expect(getAccountQuota("legacy-5h")?.shortWindowSeconds).toBe(18_000);
   });
+
+  it("drops an elapsed account-level short tuple when a Spark refresh omits the account short slot", () => {
+    // #4122 stopped new Spark writes into short*, but mergeAccountQuota kept carrying the
+    // already-polluted tuple and rewriting updatedAt, so the six-hour disk TTL never fired.
+    clearAccountQuota();
+    setAccountQuotaFromParsed("spark-stale", {
+      weeklyPercent: 29,
+      weeklyResetAt: 1789436116,
+      shortPercent: 4,
+      shortObservedAt: 1788956674678,
+      shortResetAt: 1788974652,
+      shortWindowSeconds: 18_000,
+    });
+    applyAccountQuotaFromUpstreamHeaders("spark-stale", new Headers(SPARK_HEADERS), undefined, undefined, {
+      modelId: "gpt-5.3-codex-spark",
+    });
+    const quota = getAccountQuota("spark-stale");
+    expect(quota?.shortPercent).toBeUndefined();
+    expect(quota?.shortResetAt).toBeUndefined();
+    expect(quota?.shortObservedAt).toBeUndefined();
+    expect(quota?.shortWindowSeconds).toBeUndefined();
+    expect(quota?.weeklyPercent).toBe(21);
+    expect(quota?.customWindows).toEqual([{ label: "GPT-5.3-Codex-Spark 5h", percent: 4, resetAt: 1788974652 }]);
+  });
+
+  it("drops an elapsed account-level short tuple on a WHAM weekly+Spark refresh", () => {
+    // Live path for the 2026-09-12 Pro row: WHAM reports weekly primary + Spark additional
+    // limits and never rewrites shortObservedAt, so merge must drop the elapsed carry.
+    clearAccountQuota();
+    setAccountQuotaFromParsed("wham-stale", {
+      weeklyPercent: 29,
+      shortPercent: 4,
+      shortObservedAt: 1788956674678,
+      shortResetAt: 1788974652,
+      shortWindowSeconds: 18_000,
+    });
+    const refreshed = parseUsageQuota({
+      plan_type: "pro",
+      rate_limit: { primary_window: { used_percent: 29, limit_window_seconds: 604_800, reset_at: 1789436116 } },
+      additional_rate_limits: [{
+        metered_feature: "codex_bengalfox",
+        limit_name: "GPT-5.3-Codex-Spark",
+        rate_limit: {
+          primary_window: { used_percent: 0, reset_at: 1789200311, limit_window_seconds: 18_000 },
+          secondary_window: { used_percent: 2, reset_at: 1789561452, limit_window_seconds: 604_800 },
+        },
+      }],
+    });
+    setAccountQuotaFromParsed("wham-stale", refreshed);
+    const quota = getAccountQuota("wham-stale");
+    expect(quota?.shortPercent).toBeUndefined();
+    expect(quota?.shortResetAt).toBeUndefined();
+    expect(quota?.shortObservedAt).toBeUndefined();
+    expect(quota?.shortWindowSeconds).toBeUndefined();
+    expect(quota?.weeklyPercent).toBe(29);
+    expect(quota?.customWindows?.map(window => window.label)).toEqual([
+      "GPT-5.3-Codex-Spark 5h",
+      "GPT-5.3-Codex-Spark Weekly",
+    ]);
+  });
+
+  it("drops an elapsed account-level short tuple on a weekly-only refresh", () => {
+    clearAccountQuota();
+    const elapsedSec = Math.floor(Date.now() / 1000) - 60;
+    setAccountQuotaFromParsed("pro-stale", {
+      weeklyPercent: 29,
+      shortPercent: 4,
+      shortObservedAt: Date.now() - 3 * 60 * 60_000,
+      shortResetAt: elapsedSec,
+      shortWindowSeconds: 18_000,
+    });
+    applyAccountQuotaFromUpstreamHeaders("pro-stale", new Headers({
+      "x-codex-primary-used-percent": "31",
+      "x-codex-primary-window-minutes": "10080",
+    }));
+    const quota = getAccountQuota("pro-stale");
+    expect(quota?.shortPercent).toBeUndefined();
+    expect(quota?.shortResetAt).toBeUndefined();
+    expect(quota?.shortWindowSeconds).toBeUndefined();
+    expect(quota?.weeklyPercent).toBe(31);
+  });
+
+  it("keeps a still-open account-level short window across a weekly-only refresh", () => {
+    clearAccountQuota();
+    const futureSec = Math.floor(Date.now() / 1000) + 3600;
+    setAccountQuotaFromParsed("plus-live", {
+      weeklyPercent: 4,
+      shortPercent: 0,
+      shortObservedAt: Date.now(),
+      shortResetAt: futureSec,
+      shortWindowSeconds: 18_000,
+    });
+    applyAccountQuotaFromUpstreamHeaders("plus-live", new Headers({
+      "x-codex-primary-used-percent": "5",
+      "x-codex-primary-window-minutes": "10080",
+    }));
+    const quota = getAccountQuota("plus-live");
+    expect(quota?.shortPercent).toBe(0);
+    expect(quota?.shortResetAt).toBe(futureSec);
+    expect(quota?.shortWindowSeconds).toBe(18_000);
+    expect(quota?.weeklyPercent).toBe(5);
+  });
+
+  it("still stores an explicit incoming short tuple even when its reset is already elapsed", () => {
+    clearAccountQuota();
+    const elapsedSec = Math.floor(Date.now() / 1000) - 60;
+    setAccountQuotaFromParsed("incoming-elapsed", {
+      shortPercent: 100,
+      shortResetAt: elapsedSec,
+      shortWindowSeconds: 18_000,
+    });
+    const quota = getAccountQuota("incoming-elapsed");
+    expect(quota?.shortPercent).toBe(100);
+    expect(quota?.shortResetAt).toBe(elapsedSec);
+    expect(quota?.shortWindowSeconds).toBe(18_000);
+  });
+
+  it("drops an elapsed short tuple on a credits-only update", () => {
+    clearAccountQuota();
+    const elapsedSec = Math.floor(Date.now() / 1000) - 60;
+    setAccountQuotaFromParsed("credits-stale", {
+      weeklyPercent: 29,
+      shortPercent: 4,
+      shortObservedAt: Date.now() - 3 * 60 * 60_000,
+      shortResetAt: elapsedSec,
+      shortWindowSeconds: 18_000,
+    });
+    setAccountQuotaFromParsed("credits-stale", { resetCredits: 2 });
+    const quota = getAccountQuota("credits-stale");
+    expect(quota?.shortPercent).toBeUndefined();
+    expect(quota?.shortResetAt).toBeUndefined();
+    expect(quota?.shortWindowSeconds).toBeUndefined();
+    expect(quota?.weeklyPercent).toBe(29);
+    expect(quota?.resetCredits).toBe(2);
+  });
 });
 
 /**

--- a/tests/codex-integration/codex-quota-parser-parity.test.ts
+++ b/tests/codex-integration/codex-quota-parser-parity.test.ts
@@ -6,10 +6,19 @@ import {
   parseUpstreamQuotaHeaders,
   parseUsageQuota,
   setAccountQuotaFromParsed,
+  updateAccountQuota,
 } from "../../src/codex/quota";
 import { codexPoolQuotaEvidence } from "../../src/routing/quota";
 
 describe("Spark quota survives partial header updates", () => {
+  it.each([1, 1000])("legacy quota updates expire short reset units (divisor %s)", divisor => {
+    clearAccountQuota();
+    setAccountQuotaFromParsed("legacy-expiry", { shortPercent: 4,
+      shortResetAt: (Date.now() - 60_000) / divisor, shortWindowSeconds: 18_000 });
+    updateAccountQuota("legacy-expiry", 29);
+    expect(getAccountQuota("legacy-expiry")).toEqual({ weeklyPercent: 29, updatedAt: expect.any(Number) });
+  });
+
   it("keeps the WHAM Spark window when an ordinary response updates standard quota", () => {
     clearAccountQuota();
     const refreshed = parseUsageQuota({

--- a/tests/codex-integration/main-account-hard-lock-policy.test.ts
+++ b/tests/codex-integration/main-account-hard-lock-policy.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getMainAccountHardLockStatus, isMainAccountHardLocked } from "../../src/codex/main-account-hard-lock";
 import { captureMainQuotaWriter, clearMainAccountInfoCache, observeMainQuotaIdentity } from "../../src/codex/main-account-cache";
-import { clearAccountQuota, setAccountQuotaFromParsed, type StoredAccountQuota } from "../../src/codex/quota";
+import { clearAccountQuota, getAccountQuota, getMainPolicyQuota, setAccountQuotaFromParsed, type StoredAccountQuota } from "../../src/codex/quota";
 import { removeTreeWithRetry } from "../helpers/remove-tree";
 
 const now = Date.UTC(2026, 8, 5);
@@ -65,6 +65,28 @@ describe("identity-bound main-account hard-lock policy", () => {
     expect(getMainAccountHardLockStatus(enabled, now + 120_000)).toEqual({ enabled: true, state: "blocked" });
     observe({ shortPercent: 0 });
     expect(getMainAccountHardLockStatus(enabled, now + 120_000)).toEqual({ enabled: true, state: "ready" });
+  });
+
+  test.each([
+    { resetCredits: 2 },
+    { weeklyPercent: 20 },
+    { shortWindowSeconds: 18_000, shortResetAt: 4_000_000_000 },
+  ])("partial update %j preserves expired main blocking evidence", partial => {
+    const elapsed = Math.floor(Date.now() / 1000) - 60;
+    observe({ shortPercent: 99, shortWindowSeconds: 18_000, shortResetAt: elapsed, weeklyPercent: 20 });
+    expect(getMainAccountHardLockStatus(enabled).state).toBe("blocked");
+    const before = getMainPolicyQuota();
+    observe(partial);
+    expect(getMainPolicyQuota()).toMatchObject({
+      shortPercent: 99,
+      shortResetAt: elapsed,
+      shortWindowSeconds: 18_000,
+      shortObservedAt: before?.shortObservedAt,
+    });
+    expect(getAccountQuota("__main__")?.shortPercent).toBeUndefined();
+    expect(getMainAccountHardLockStatus(enabled).state).toBe("blocked");
+    observe({ shortPercent: 0 });
+    expect(getMainAccountHardLockStatus(enabled).state).toBe("ready");
   });
 
   test("one missing reset prevents a false scheduled-unlock promise", () => {

--- a/tests/usage/quota-reset-observation.test.ts
+++ b/tests/usage/quota-reset-observation.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   clearAccountQuota,
+  getAccountQuota,
   flushQuotaObservationsForTests,
   setAccountQuotaFromParsed,
 } from "../../src/codex/quota";
@@ -55,6 +56,50 @@ afterEach(async () => {
 });
 
 describe("codex quota seam", () => {
+  test("short rollover survives repeated display eviction", async () => {
+    const start = Date.now();
+    let now = start;
+    const clock = spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      setAccountQuotaFromParsed(ACCOUNT, { shortPercent: 96, shortResetAt: start + 60_000,
+        shortWindowSeconds: 18_000, weeklyPercent: 20, weeklyResetAt: start + 7 * 24 * HOUR });
+      await settle();
+      for (const percent of [21, 22]) {
+        now = start + 61_000 + (percent - 21) * 1000;
+        setAccountQuotaFromParsed(ACCOUNT, { weeklyPercent: percent });
+        await settle();
+        const quota = getAccountQuota(ACCOUNT);
+        for (const key of ["shortPercent", "shortResetAt", "shortObservedAt", "shortWindowSeconds"] as const) {
+          expect(quota?.[key]).toBeUndefined();
+        }
+        expect(captured).toEqual([]);
+      }
+      now = start + 63_000;
+      const fresh = { shortPercent: 2, shortResetAt: now + 5 * HOUR, shortWindowSeconds: 18_000 };
+      setAccountQuotaFromParsed(ACCOUNT, fresh);
+      await settle();
+      expect(captured).toHaveLength(1);
+      expect(captured[0]).toMatchObject({ kind: "scheduled", window: "5h", percentBefore: 96, percentAfter: 2 });
+      setAccountQuotaFromParsed(ACCOUNT, fresh);
+      await settle();
+      expect(captured).toHaveLength(1);
+
+      // Leave a new high baseline whose deadline then expires, making a missed clear
+      // observable as a scheduled reset rather than an ignored two-point drop.
+      setAccountQuotaFromParsed(ACCOUNT, { shortPercent: 96, shortResetAt: now + 60_000, shortWindowSeconds: 18_000 });
+      await settle();
+      now += 61_000;
+      setAccountQuotaFromParsed(ACCOUNT, { weeklyPercent: 23 });
+      await settle();
+      clearAccountQuota(ACCOUNT);
+      await settle();
+      captured = [];
+      setAccountQuotaFromParsed(ACCOUNT, { shortPercent: 0, shortResetAt: now + 6 * HOUR });
+      await settle();
+      expect(captured).toEqual([]);
+    } finally { clock.mockRestore(); }
+  });
+
   test("a weekly rollover through the real writer fires exactly one scheduled event", async () => {
     const expired = Date.now() - 60_000;
     setAccountQuotaFromParsed(ACCOUNT, { weeklyPercent: 96, weeklyResetAt: expired });

--- a/tests/usage/quota-reset-seen-store.test.ts
+++ b/tests/usage/quota-reset-seen-store.test.ts
@@ -7,6 +7,7 @@ import {
   claimCountForTests,
   claimQuotaReset,
   forgetLastObservedWindows,
+  flushQuotaResetStoreForTests,
   hasSeenQuotaReset,
   listRecentQuotaResetEvents,
   recordQuotaResetEvent,
@@ -37,6 +38,27 @@ function event(key: string): QuotaResetEvent {
 
 beforeEach(() => {
   resetQuotaResetStoreForTests();
+});
+
+test("opted-in missing short history keeps its observation clock across persistence", () => {
+  const short = { window: "5h", percent: 96, resetAt: NOW + 60_000, observedAt: NOW };
+  const weekly = { window: "weekly", percent: 20, observedAt: NOW + 61_000 };
+  swapLastObservedWindows("codex", "retain00", [short], true);
+  swapLastObservedWindows("codex", "retain00", [weekly], true);
+  flushQuotaResetStoreForTests();
+  resetQuotaResetStoreForTests();
+  expect(swapLastObservedWindows("codex", "retain00", [weekly], true)).toContainEqual(short);
+  expect(swapLastObservedWindows("codex", "retain00", [weekly], true)).toContainEqual(short);
+  forgetLastObservedWindows("codex", "retain00");
+  expect(swapLastObservedWindows("codex", "retain00", [weekly], true)).toBeUndefined();
+});
+
+test("omitted windows are still replaced when retention is not requested", () => {
+  const short = { window: "5h", percent: 96, observedAt: NOW };
+  const weekly = { window: "weekly", percent: 20, observedAt: NOW + 61_000 };
+  swapLastObservedWindows("provider", "replace0", [short]);
+  swapLastObservedWindows("provider", "replace0", [weekly]);
+  expect(swapLastObservedWindows("provider", "replace0", [weekly])).toEqual([weekly]);
 });
 
 describe("quota reset claim store", () => {


### PR DESCRIPTION
## Summary

Fixes a stale account-level 5h quota bar remaining on a weekly-only Codex Pro pool account after the Spark attribution fix (#4122). Partial refreshes copied the obsolete short tuple while renewing the cache-wide timestamp, so the six-hour disk TTL never removed it.

The display/rotation merge now discards an omitted short tuple after its reset deadline. Explicit incoming readings, future deadlines, and unknown deadlines retain their previous behavior. Main-account hard-lock evidence remains separate and cannot be cleared by elapsed time or partial updates. Codex reset-notification history retains the absent short baseline and original observation time, so the next real rollover still produces one notification; explicit account cleanup clears it.

The current retention contract is documented in the owned structure pages. No layout or component change.

## Verification

- Added regression coverage for WHAM/Spark/weekly/credits-only cleanup, seconds/milliseconds and legacy updates, main-policy preservation until fresh zero, repeated partial updates followed by exactly one reset notification, persisted observation clocks, account clear, and unchanged provider replacement behavior.
- Two independent reviewers using the parent model found the policy and notification regressions; both were corrected and re-reviewed.
- Local tests, typecheck, builds and dependency installation: **NOT RUN**, per the user's instruction. Pushes use `--no-verify`; remote CI on the final PR head is the merge gate.
- `git diff --check`: passed.

Review disposition: the earlier CodeRabbit suggestion to replace a known main-policy short reading with percentage-free short metadata is rejected. That would discard measured blocking evidence without recovery. The original policy merge semantics are preserved and `main-account-hard-lock-policy.test.ts` now asserts retention across credits-only, weekly-only, and metadata-only updates followed by fresh-zero recovery.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

## Maintainer integration

Maintainer `lidge-jun` elects integration into `dev` under MAINTAINERS.md without a second maintainer approval. This is not self-approval. Final reviewed head: `d7b4cc9ba26242eb48e0841a869f5fb0ef6670f8`.

[Cross-platform CI run 34671020142](https://github.com/lidge-jun/opencodex/actions/runs/34671020142) succeeded: 19 jobs passed, two conditional jobs skipped. All four Linux test shards, both macOS test shards and gates passed. Current PR checks, including CodeRabbit, are successful; the full Windows suite was conditionally skipped, while Windows keyring and npm smoke ran successfully. Local product suites remain NOT RUN by user instruction. Independent inherited-model reviews verified the main-policy and notification corrections; existing review threads are resolved.
