### PR TITLE
fix(bridge): fail an in-flight search at a truncated terminal

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1293,7 +1293,9 @@ export function bridgeToResponsesSSE(
                 if (isTruncatedStopReason(event.stopReason)) failCurrentToolCall();
                 else closeCurrentToolCall();
               }
-              if (currentWebSearch) closeCurrentWebSearch("completed", []);
+              // A search still in flight when upstream truncates never returned results, so it
+              // takes the same "failed" status as the error/incomplete terminals below.
+              if (currentWebSearch) closeCurrentWebSearch(isTruncatedStopReason(event.stopReason) ? "failed" : "completed", []);
               releasePendingWebSources();
               // Redacted-only turns (or hidden thinking without a trailing signature event) still
               // need their envelope-only reasoning item so the blocks replay next turn.

--- a/structure/adapters/registry.md
+++ b/structure/adapters/registry.md
@@ -77,6 +77,8 @@ Listener startup diagnostics follow [the runtime lifecycle contract](../runtime.
 
 The bridge keeps an open function, custom, or tool-search call incomplete when an adapter ends with a recognized truncated stop reason. Streaming emits no argument/input completion frame for that open call, and buffered JSON applies the same status. A call already closed by its own tool-call end retains its completed state. The response remains incomplete, partial output is preserved, and truncated compaction never replaces history.
 
+A provider web search still in flight at that truncated terminal is finalized as `failed`, the same status it already receives from the error and explicit-incomplete terminals. It never returned results, so reporting it as `completed` would leave the client showing a finished search for a turn the provider cut short.
+
 Chat helper admission in `src/server/responses/core.ts` follows the
 [deferred stored-main contract](../providers/openai-tiers.md): only a needed Direct OpenAI helper
 claims stored main, after terminal vision, routed vision and search exclusions.

--- a/tests/adapters/bridge-nonstreaming-terminal.test.ts
+++ b/tests/adapters/bridge-nonstreaming-terminal.test.ts
@@ -376,5 +376,24 @@ describe("truncated done preserves open tool integrity (#4312)", () => {
       expect(text).toContain("event: response.function_call_arguments.done");
       expect(text).toContain('"arguments":"{\\"arg\\":\\"complete\\"}","status":"completed"');
     });
+
+    test(`${stopReason}: a search still in flight is failed, not completed`, async () => {
+      // The provider cut the turn short, so the search never returned results. Reporting it as
+      // completed would leave the client showing a finished search for a truncated turn.
+      const text = await sseText([
+        { type: "web_search_call_begin", id: "search_in_flight" },
+        { type: "done", stopReason },
+      ]);
+      const item = text.split("\n\n")
+        .flatMap(frame => {
+          const data = frame.split("\n").find(line => line.startsWith("data: {"))?.slice(6);
+          return data ? [JSON.parse(data)] : [];
+        })
+        .find(frame => frame.type === "response.output_item.done"
+          && frame.item?.type === "web_search_call")?.item;
+
+      expect(terminalEventNames(text)).toEqual(["response.incomplete"]);
+      expect(item).toMatchObject({ type: "web_search_call", status: "failed" });
+    });
   }
 });

--- a/tests/adapters/bridge-nonstreaming-terminal.test.ts
+++ b/tests/adapters/bridge-nonstreaming-terminal.test.ts
@@ -268,6 +268,7 @@ describe("truncated-stop-reason classifier", () => {
       "length", "content-filter",                   // Command Code / AI SDK
       "pause_turn",                                 // Anthropic: turn needs continuation
       "refusal", "model_context_window_exceeded",   // Anthropic
+      "max_output_tokens",                          // Anthropic: same spelling as the mapped reason
       "MAX_TOKENS", "SAFETY", "MALFORMED_FUNCTION_CALL", "IMAGE_SAFETY", "LANGUAGE", // Gemini
       "Safety", "safety",                           // mixed case must not slip through
     ]) {
@@ -285,6 +286,7 @@ describe("truncated-stop-reason classifier", () => {
   test("truncation maps to the right incomplete_details reason", () => {
     expect(truncationReasonFor("length")).toBe("max_output_tokens");
     expect(truncationReasonFor("model_context_window_exceeded")).toBe("max_output_tokens");
+    expect(truncationReasonFor("max_output_tokens")).toBe("max_output_tokens");
     expect(truncationReasonFor("refusal")).toBe("content_filter");
     expect(truncationReasonFor("SAFETY")).toBe("content_filter");
     expect(truncationReasonFor("end_turn")).toBeUndefined();
@@ -318,6 +320,7 @@ describe("truncated done preserves open tool integrity (#4312)", () => {
     ["content_filter", "content_filter"],
     ["max_tokens", "max_output_tokens"],
     ["length", "max_output_tokens"],
+    ["max_output_tokens", "max_output_tokens"],
   ] as const;
   for (const [stopReason, reason] of cases) {
     for (const kind of ["function_call", "custom_tool_call", "tool_search_call"] as const) {


### PR DESCRIPTION
## Summary

Finalize an in-flight provider web search as `failed` when an adapter ends with a truncated stop reason. The error and explicit-incomplete terminals already do this; the `done` + truncated path still reported `completed`, so a client showed a finished search for a turn the provider cut short before any results arrived.

This is the remaining piece of #4312's tool-finalization scope after #4341 landed. Rebased onto `dev` at `ec065aa0c`, and reduced to only what #4341 did not already cover: the open function, custom, and tool-search call handling is now upstream and is not duplicated here.

## Earlier focused verification (before this rebase)

- Reproduced first: the three truncated stop reasons failed on `dev` before the change, with `content_filter`, `max_output_tokens` and the search reported as `completed`.
- `bun test ./tests/adapters/bridge-nonstreaming-terminal.test.ts ./tests/adapters/bridge.test.ts ./tests/adapters/anthropic/anthropic-error-stop-reason.test.ts` — 127 passed, 0 failed.
- `bun test ./tests/web-search` — 202 passed, 0 failed.
- `bun run typecheck`, `bun run structure:check`, `bun run privacy:scan`, `git diff --check` — all passed.
- The exact-head hosted cross-platform run completed with failure; see Current rebase and readiness evidence below. No full-suite pass is claimed.

## Open question for the maintainer, not included here

While validating #4341 I found one case its tests deliberately pin the other way, so I did not change it: `failCurrentToolCall` still emits `response.output_item.done` for the unfinished call, and `tests/adapters/bridge-nonstreaming-terminal.test.ts` asserts that frame exists with `status: "incomplete"`.

That matters only if the client derives an executable call from the item frame without reading its status, in which case withholding the argument frames would not be enough to prevent an issued call with half-written arguments. I could not re-verify the Codex-side deserialization behavior with evidence I can cite here, so reopening that contract is your call rather than a silent change in this PR. I left the details on #4312.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Web searches that remain in progress when a response is truncated are now marked as failed instead of completed.
  - Normally completed responses continue to report web searches as completed.
- **Tests**
  - Added coverage for truncated responses caused by refusal, content filtering, token limits, and length limits.
- **Documentation**
  - Updated guidance to reflect failure handling for in-progress web searches during truncated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-ready-progress:start -->
## Current verification (2026-09-13)
- Rebased onto dev@dc33113a9, the latest dev commit at push time. Exact head aad1d75bc completed the full CI matrix green (run 34737864854, 26/26 jobs, 0 failures); gates typecheck, structure:check, privacy:scan and focused tests passed locally on that head.
Head: 9bcf2be0bc965ce753958c54c3ec84fdea7d1c32, rebased onto dev@17da84f89.
Focused tests, typecheck, structure check and privacy scan passed on this rebased source:
51 pass, 0 fail, including max_output_tokens classifier and bridge terminal cases.

The previous green matrix tested an older PR head with the pending #4384 fix added. It is integration evidence only, not a passing full-suite result for this published head. Full CI readiness remains open. The current dev tip has advanced beyond this tested base; further refresh will be coordinated with the shared Windows fixture fix to avoid repeatedly queuing matrices that inherit the same failure.
<!-- review-ready-progress:end -->



