### PR TITLE
test(devin-cli): anchor the empty-data-dir fallback at the host home

### DIFF
--- a/tests/providers/devin-cli-login.test.ts
+++ b/tests/providers/devin-cli-login.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { win32 } from "node:path";
 import {
   DEVIN_CLI_CREDENTIALS_ENV,
   devinCliCredentialsPath,
@@ -149,13 +151,21 @@ describe("devin-cli credential path and read bounds", () => {
     // directory the proxy was started in, and a planted file there would import
     // as the operator's own CLI session.
     // The fallback reads the real home directory rather than env.HOME, so the
-    // assertion is on shape: absolute, and under the home data dir.
+    // assertion is on shape: anchored at that home directory, and under its data
+    // dir. Anchoring is what proves the path is not cwd-relative; asserting a
+    // leading "/" instead would only hold when the HOST is POSIX, because
+    // `homedir()` returns `C:\\Users\\<name>` on Windows no matter which
+    // platform the resolver is asked about.
     for (const empty of ["", "   "]) {
       const resolved = devinCliCredentialsPath({ HOME: "/home/u", XDG_DATA_HOME: empty }, "linux");
-      expect(resolved.startsWith("/")).toBe(true);
+      expect(resolved.startsWith(homedir())).toBe(true);
       expect(resolved.endsWith("/.local/share/devin/credentials.toml")).toBe(true);
     }
     const win = devinCliCredentialsPath({ APPDATA: "" }, "win32");
+    // The win32 branch joins with win32 separators, so a POSIX host home such as
+    // `/Users/runner` comes back as `\\Users\\runner`. Normalize the anchor the
+    // same way rather than comparing a host-shaped string against it.
+    expect(win.startsWith(win32.join(homedir()))).toBe(true);
     expect(win.endsWith("AppData\\Roaming\\devin\\credentials.toml")).toBe(true);
     expect(win.startsWith("devin")).toBe(false);
   });


### PR DESCRIPTION
## Summary

The Windows lane fails `tests/providers/devin-cli-login.test.ts` on current `dev`. The empty-`XDG_DATA_HOME` case added with #4418 asserts that the resolved credential path starts with `/`, but the fallback deliberately resolves against the real home directory, and `homedir()` returns `C:\Users\<name>` regardless of which platform the resolver is asked about. The assertion therefore only holds when the host is POSIX.

Anchor both branches at `homedir()` instead. That is the property the test exists to prove — the path is not cwd-relative — and it holds on either host. The `win32` branch needs one extra step: it joins with `win32` separators, so a POSIX host home such as `/Users/runner` comes back as `\Users\runner` and a raw `homedir()` prefix would not match. The anchor for that branch is normalized with `win32.join(homedir())`, which is a no-op on Windows and rewrites the separators on macOS and Linux. Production behavior is unchanged.

## Scope change from the original PR

This PR originally carried the Devin path-separator fixture repair plus a pnpm shim fixture repair. Both are now obsolete:

- The Devin separator problem was fixed upstream by `293c37d68` (`fix(devin-cli): resolve credential paths for the selected platform`), which made the POSIX expectations correct.
- `tests/providers/devin-cli-adapter.test.ts` no longer exists; `213065e30` retired the ACP adapter.
- The pnpm shim fixtures landed in #4379.

Rather than close this and open a third PR for the same file, I rebuilt the branch on `dev@dcd13b435` with only the one remaining Windows failure fixed. The head is a single commit; the previous two-commit series is gone.

## Verification

- Reproduced first on current `dev`: 17 pass, 1 fail — `an empty XDG_DATA_HOME or APPDATA does not become a cwd-relative path` at `tests/providers/devin-cli-login.test.ts:155`, expected `true`, received `false`.
- After the change: `bun test ./tests/providers/devin-cli-login.test.ts` — **18 pass, 0 fail, 34 assertions**, Bun 1.4.2 on Windows.
- `bun run typecheck`, `bun run structure:check`, `bun run privacy:scan`, `git diff --check` — all passed.
- Cross-platform matrix on this fork caught a second host shape: a first attempt that anchored the `win32` branch at a raw `homedir()` passed Windows and Linux but failed the macOS shard, because `win32.join` had rewritten `/Users/runner` to `\Users\runner`. The normalized anchor is verified for both host shapes: `\Users\runner\AppData\Roaming\devin\credentials.toml` on a POSIX host and `C:\Users\runneradmin\AppData\Roaming\devin\credentials.toml` on Windows both anchor correctly.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed. Not needed for a test-only correction.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. The assertion still proves the anti-cwd-relative property the original hardening added.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved credential-path test coverage across operating systems.
  * Added validation for home-directory fallback paths and Windows-style path normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-ready-progress:start -->
## Current verification (2026-09-13)
Head: 5a57d087405b2c639adf30a14385a0d93a57f922, rebased onto dev@17da84f89.
Focused tests, typecheck, structure check and privacy scan passed on this rebased source:
(pass) devin-cli credential path and read bounds > no thrown message repeats the key [0.13ms]

 18 pass
 0 fail
 40 expect() calls
Ran 18 tests across 1 file. [1423.00ms]

The previous green matrix tested an older PR head with the pending #4384 fix added. It is integration evidence only, not a passing full-suite result for this published head. Full CI readiness remains open. The current dev tip has advanced beyond this tested base; further refresh will be coordinated with the shared Windows fixture fix to avoid repeatedly queuing matrices that inherit the same failure.
<!-- review-ready-progress:end -->
