### PR TITLE
test(combos): drive reactivation expiry callbacks deterministically

### DIFF
--- a/devlog/_plan/260912_combo_carry/050_active_reactivation_repair.md
+++ b/devlog/_plan/260912_combo_carry/050_active_reactivation_repair.md
@@ -1,0 +1,9 @@
+# Deterministic Combo reactivation expiry verification
+
+Hosted run 34674763850, job 103503977506 failed the active reactivation case because Save remained disabled. The test did not explicitly execute the activation effect's zero-delay callback.
+
+The fixture now captures cancellable immediate timers only during active and commit-boundary scenarios, commits inactive/active state synchronously to preserve the cached quota snapshot, requires one new callback and executes it inside act. The old expiry timer must be cancelled. Dirty alias preservation, initial disabled state, final enabled state, timer/visibility scenarios and cleanup assertions remain. Subsequent fetches stay unresolved so a new server response cannot satisfy the assertion.
+
+Independent source review found no blocker and traced the callback to the active-dependent effect in Combos.tsx. This covers reactivation while the resource cache survives; it does not claim coverage after cache eviction.
+
+Local tests, build, typecheck and installation: NOT RUN by maintainer instruction. git diff --check passes. Hosted CI at the published final head remains required before merge.

--- a/gui/tests/page-loading-contract.test.tsx
+++ b/gui/tests/page-loading-contract.test.tsx
@@ -215,7 +215,15 @@ test.each(["timer", "visible", "active", "commit-boundary"])("Combos expires a q
   const cancel = testWindow.clearTimeout.bind(testWindow);
   const expiryTimers = new Set<number>();
   let expire: (() => void) | undefined;
+  let controlImmediate = false;
+  let nextControlledTimer = -1;
+  const immediateTimers = new Map<number, () => void>();
   const scheduleSpy = spyOn(testWindow, "setTimeout").mockImplementation((callback, delay, ...args) => {
+    if (controlImmediate && delay === 0 && typeof callback === "function") {
+      const timer = nextControlledTimer--;
+      immediateTimers.set(timer, () => callback(...args));
+      return timer;
+    }
     const timer = schedule(callback, delay, ...args);
     if (delay === 123_456 && typeof callback === "function") {
       expiryTimers.add(timer);
@@ -225,6 +233,7 @@ test.each(["timer", "visible", "active", "commit-boundary"])("Combos expires a q
   });
   const cancelSpy = spyOn(testWindow, "clearTimeout").mockImplementation(timer => {
     expiryTimers.delete(timer);
+    if (immediateTimers.delete(timer)) return;
     cancel(timer);
   });
   const item = { id: "alpha", model: "combo/alpha", strategy: "failover", stickyLimit: 1,
@@ -286,19 +295,27 @@ test.each(["timer", "visible", "active", "commit-boundary"])("Combos expires a q
     if (wake === "visible") {
       Object.defineProperty(testWindow.document, "visibilityState", { configurable: true, value: "hidden" });
       await act(async () => { testWindow.document.dispatchEvent(new testWindow.Event("visibilitychange")); });
-    } else if (wake === "active" || wake === "commit-boundary") {
-      await act(async () => { root.render(render(false)); });
     }
-    now = startedAt + 123_456 - (wake === "commit-boundary" ? 1 : 0);
-    await act(async () => {
-      if (wake === "timer") expire!();
-      else if (wake === "visible") {
-        Object.defineProperty(testWindow.document, "visibilityState", { configurable: true, value: "visible" });
-        testWindow.document.dispatchEvent(new testWindow.Event("visibilitychange"));
-      } else root.render(render(true, wake === "commit-boundary"));
-    });
-    if (wake === "commit-boundary") {
-      await act(async () => { await new Promise<void>(resolve => schedule(resolve, 0)); });
+    if (wake === "active" || wake === "commit-boundary") {
+      controlImmediate = true;
+      // Do not yield to global resource eviction between the two activation commits.
+      act(() => { root.render(render(false)); });
+      expect(expiryTimers.size).toBe(0);
+      now = startedAt + 123_456 - (wake === "commit-boundary" ? 1 : 0);
+      act(() => { root.render(render(true, wake === "commit-boundary")); });
+      expect(immediateTimers.size).toBe(1);
+      const [timer, recheck] = [...immediateTimers.entries()][0]!;
+      immediateTimers.delete(timer);
+      act(() => { recheck(); });
+    } else {
+      now = startedAt + 123_456;
+      await act(async () => {
+        if (wake === "timer") expire!();
+        else {
+          Object.defineProperty(testWindow.document, "visibilityState", { configurable: true, value: "visible" });
+          testWindow.document.dispatchEvent(new testWindow.Event("visibilitychange"));
+        }
+      });
     }
     expect(container.querySelector<HTMLInputElement>("#cwi-edit-alias")!.value).toBe("kept-draft");
     expect(container.querySelector<HTMLButtonElement>("#cwi-edit-save")!.disabled).toBe(false);
@@ -311,6 +328,7 @@ test.each(["timer", "visible", "active", "commit-boundary"])("Combos expires a q
     clock.mockRestore();
   }
   expect(expiryTimers.size).toBe(0);
+  expect(immediateTimers.size).toBe(0);
 });
 
 


### PR DESCRIPTION
## Summary

- Make the Combo quota-expiry reactivation fixture execute the actual zero-delay callback instead of racing the host event loop. The active and commit-boundary cases retain their cached quota snapshot and require cancellation of the previous expiry timer.
- Preserve the dirty alias, Save-disabled/Save-enabled assertions, timer and visibility scenarios, unresolved later fetches and timer cleanup. This changes test scheduling only; dashboard rendering and runtime behavior are unchanged.

## Verification

- Independent read-only source review: PASS. The captured callback was traced to the active-dependent clock effect, and no assertion was weakened.
- `git diff --check`: passed.
- Failure evidence: [Cross-platform CI job 103503977506](https://github.com/lidge-jun/opencodex/actions/runs/34674763850/job/103503977506), active Combo expiry case, 1977 pass / 1 fail.
- Local tests of every size, build, typecheck and install: NOT RUN under the maintainer's explicit restriction. Final-head hosted CI is pending; draft until that evidence is complete.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
