### PR TITLE
fix(cline): align integration registration contracts

### DIFF
--- a/gui/public/provider-icons/README.md
+++ b/gui/public/provider-icons/README.md
@@ -37,6 +37,14 @@ Export-client marks (used by the API tab's connect rows, not the provider list):
   carries its authoring tool's generator comment).
 - `kimi-color.svg` — already in the baseline as a provider icon; the API tab reuses
   it for the Kimi Code client, which is the same Moonshot AI brand.
+- `cline-color.svg` — the Cline mark introduced by
+  [`ec81f7fef9bb`](https://github.com/lidge-jun/opencodex/blob/ec81f7fef9bb0086d3d527cac234d3845ce4d559/gui/public/provider-icons/cline-color.svg),
+  whose commit identifies it as the official brand mark but records no download
+  URL. That Git object preserves the original 92x96 SVG. `b4820478fcea` removed
+  its fixed dimensions and normalized it to `viewBox="0 0 24 24"` with
+  `translate(0.5000 0.0000) scale(0.25000)`. The path, circle, rectangles, and
+  purple `#9F58FA` fill/strokes are unchanged. The Cline client reuses this
+  provider icon as an image, preserving its brand color.
 - `aside.svg` — extracted 2026-08-31 from the installed Aside application, module
   `Contents/Frameworks/Aside Framework.framework/Versions/1.0.825.1/Libraries/AsideAgentManager/assets/official-brand-symbol-*.js`.
   It is Aside's own brand symbol, named as such by the vendor and rendered by

--- a/gui/tests/fr-localization.test.ts
+++ b/gui/tests/fr-localization.test.ts
@@ -123,6 +123,9 @@ const INTENTIONAL_ENGLISH = new Set<TKey>([
   "api.clientConfig.clientRaycast",
   "integrations.tab.omo",
   "api.clientConfig.clientOmo",
+  // Cline CLI is the product name, identical in French and English.
+  "integrations.tab.cline",
+  "api.clientConfig.clientCline",
   "models.reasoningEffort.minimal",
   "models.reasoningEffort.max",
   "pws.pacingRpmUnit",

--- a/gui/tests/integrations-api.test.ts
+++ b/gui/tests/integrations-api.test.ts
@@ -16,9 +16,9 @@ import {
 
 const originalFetch = globalThis.fetch;
 
-test("DSH, Aside, Raycast and omo are file integration clients", () => {
+test("the complete file integration client registry includes Cline", () => {
   expect(FILE_INTEGRATION_CLIENTS).toEqual([
-    "opencode", "pi", "omp", "hermes", "openclaw", "kimi", "gajae", "dsh", "mcode", "zcode", "prime", "aside", "raycast", "omo",
+    "opencode", "pi", "omp", "hermes", "openclaw", "kimi", "gajae", "dsh", "mcode", "zcode", "prime", "aside", "raycast", "omo", "cline",
   ]);
 });
 

--- a/gui/tests/locale-parity.test.ts
+++ b/gui/tests/locale-parity.test.ts
@@ -135,6 +135,9 @@ const ZH_TW_KEEP_ENGLISH: ReadonlySet<string> = new Set([
   // "omo" is the product's own lowercase spelling, identical in every locale.
   "integrations.tab.omo",
   "api.clientConfig.clientOmo",
+  // Cline CLI is the product name, kept in English like the other client brands.
+  "integrations.tab.cline",
+  "api.clientConfig.clientCline",
   "integrations.codex.title",
   // Provider proper nouns kept in English
   "provider.name.commandCodeAuth",

--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -11,7 +11,7 @@
   "domains": {
     "providers": {
       "match": [
-        "^(?:aside(?!-profile)|auto|azure|baseten|chutes|cline|command|commandcode|context|cyber|deepinfra|deepseek|digitalocean|exa|featherless|forward|hyperbolic|kimi|meta|mimo|minimax|moonshot|muse|new|nous|novita|nscale|nvidia|opencode|openrouter|qwen38|sambanova|umans|vercel|zcode|zhipu)-"
+        "^(?:aside(?!-profile)|auto|azure|baseten|chutes|cline(?!-(?:client|writer)(?:[.-]|$))|command|commandcode|context|cyber|deepinfra|deepseek|digitalocean|exa|featherless|forward|hyperbolic|kimi|meta|mimo|minimax|moonshot|muse|new|nous|novita|nscale|nvidia|opencode|openrouter|qwen38|sambanova|umans|vercel|zcode|zhipu)-"
       ],
       "children": {
         "cursor": [
@@ -109,6 +109,7 @@
     "clients": {
       "match": [
         "^aside-profile(?!s-routes)",
+        "^cline-(?:client|writer)(?:[.-]|$)",
         "^(?:desktop|omp|pi|prime|remote|sync)-"
       ]
     },

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -81,7 +81,7 @@ Usage:
   ocx memory [--json]         Alias of ocx observe memory
   ocx api-key <sub>           Alias of ocx access key
   ocx access <sub>            External API keys and endpoint information
-  ocx export --client <id>    Print a client config wired to the running proxy (14 clients)
+  ocx export --client <id>    Print a client config wired to the running proxy (15 clients)
   ocx integration client <sub> Enable, disable, inspect or roll back a client integration
   ocx grok <sub>              Grok Build model selection and apply
   ocx system <sub>            Runtime settings, startup, sync, OpenCodex updates, and Codex CLI inspection

--- a/tests/gui/integrations-invariants.test.ts
+++ b/tests/gui/integrations-invariants.test.ts
@@ -80,9 +80,9 @@ afterEach(() => {
 });
 
 describe("the client registries cannot drift apart", () => {
-  test("every list of clients holds exactly the same thirteen ids", async () => {
+  test("every list of clients holds exactly the same fifteen ids", async () => {
     /*
-     * Five lists name the same thirteen clients, and two of them are maintained by
+     * Five lists name the same fifteen clients, and two of them are maintained by
      * hand: the GUI cannot import the backend registry, because that would
      * pull node:os and node:path into the browser bundle. A client added
      * server-side renders no row until someone remembers the tuple, and the
@@ -93,7 +93,7 @@ describe("the client registries cannot drift apart", () => {
     const guiRouting = await import("../../gui/src/app-routing");
 
     const expected = [...EXPORT_CLIENT_IDS].sort();
-    expect(expected).toHaveLength(14);
+    expect(expected).toHaveLength(15);
 
     expect([...INTEGRATION_CLIENT_IDS].sort()).toEqual(expected);
     expect([...gui.CLIENTS].sort()).toEqual(expected);


### PR DESCRIPTION
## Summary

Cline is registered as the fifteenth export client, but several surrounding inventories still describe the pre-Cline set. This makes the existing help, localization, registry, asset-provenance, and test-layout checks fail after the integration lands.

Update the help count and complete the explicit client inventories. Keep the two Cline CLI product-name keys in the existing French and Traditional Chinese brand allowlists. Classify Cline client/writer test seeds as client integrations while retaining Cline provider and ClinePass tests in providers. Record the existing icon's Git provenance and normalization without inventing an unrecorded download URL.

The help count stays literal to preserve the existing lightweight help path. The existing registry-derived assertion continues to catch drift. This changes no client writer, translated copy, browser component, or icon bytes.

## Earlier focused verification (before this rebase)

- Reproduced all seven reported failures on `d42a1363dc82330c749f4ce5c5f6b3c507483159` before editing: help count, registry count, test seed classification, and four dashboard contract tests.
- Focused CLI help count/export-name check: 1 passed, 9 assertions.
- Client registry/lifecycle and both test-layout guard files: 60 passed, 778 assertions.
- Four dashboard localization, integration API, and client-mark contract files: 32 passed, 5,629 assertions.
- `bun run typecheck`, `bun run structure:check`, `bun run privacy:scan`, and `git diff --check`: passed.
- Validation ran on Windows with Bun 1.4.2. The hosted cross-platform run completed with failure; this stays a draft.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults. No authentication or credential-handling behavior changed.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [x] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->

<!-- review-ready-progress:start -->
## Current rebase and readiness evidence (2026-09-12)

Current head: `18aba466a1707da27394d396891e56096a4a02cb`, rebased onto `dev@c27a4831a9d1629005ffce626d54c7b60a00c1de`. Range-diff preserves the original patch series. No unresolved review threads were found before publication. The latest-dev and resolved-findings items are checked on this evidence.

Fresh verification on this head:

- `bun run typecheck` — passed.
- `bun run structure:check` — passed.
- `bun run privacy:scan` — passed.
- `bun test --isolate --timeout 60000 ./tests/gui/integrations-invariants.test.ts` — passed.

```text
43 pass
 0 fail
Ran 43 tests across 1 file. [43.36s]
```

These are targeted checks, not a full CI pass. Previous hosted failures belong to the superseded head `5990da5a4fdedf27f8ee75591e511723b9d88bff`. Shared CI blockers (Cline inventories, native restore fixtures, Devin/pnpm fixtures) still require integration; known single-run failures also remain unproven resolved. The CI and Ready items stay unchecked, and the PR stays Draft. This rebase does not incorporate sibling PRs or claim their fixes. The upstream synchronize event supplies the new-head CI/approval entry; no duplicate fork matrix was dispatched merely to repeat known shared failures.
<!-- review-ready-progress:end -->
