### PR TITLE
fix(web-search): bind continuations to the serving API key

### DIFF
--- a/docs-site/src/content/docs/reference/configuration/providers.md
+++ b/docs-site/src/content/docs/reference/configuration/providers.md
@@ -224,6 +224,12 @@ Providers can expose a built-in shorthand, such as `agy` for `google-antigravity
 | `unsafeAllowNativeLocalExec?` | `boolean` | Cursor legacy boolean, equivalent to `nativeLocalExec: "on"` only when the newer field is unset. |
 | `nativeLocalExec?` | `"off" \| "codex-sandbox" \| "on"` | Cursor local-exec policy. `off` is default; `codex-sandbox` currently fails closed like `off`. |
 
+With `webSearchBridge` enabled, a search continuation stays bound to the API-key selection that
+served the first request. Changing the selected key, its reference or resolved value, authentication
+mode, or base URL during search or provider pacing ends the turn with a bridge error before another
+provider request is sent. Changing away and back also ends that continuation. Start a new turn to
+use the new selection. Selection changes before the first provider send retain normal reselection.
+
 Custom-model `reasoningEfforts` normally override discovered provider metadata. The bounded
 exception is an explicit Astra or Daybreak custom row on the canonical `openai` Codex-forward
 destination: its advertised list is intersected with that model's pinned native capabilities.

--- a/src/server/responses/core.ts
+++ b/src/server/responses/core.ts
@@ -6149,6 +6149,8 @@ async function handleResponsesInner(
         isPassthrough: true,
         stream: parsed.stream === true,
       });
+      // Capture the binding that actually served the first leg, after its permitted reselection.
+      const webSearchBridgeBinding = requestBindings.get(request);
       // The bridge wraps the RAW upstream body, so terminal repair below still owns the single
       // client-facing terminal — the bridge drops the terminal of every intercepted leg.
       const upstreamSseBody = webSearchBridgePlan
@@ -6166,7 +6168,14 @@ async function handleResponsesInner(
             connectMs,
             true,
             providerFetch(route.provider, options.codexWsRuntimeIdentity, {
-              dispatchOverride: oauthDispatch(request),
+              // Pacing can outlive a manual selection change. A continuation must retain the
+              // first leg's key and appended search result, never rebuild from the original turn.
+              beforeDispatch: () => {
+                if (webSearchBridgeBinding?.kind !== "api-key"
+                  || !providerApiKeySelectionIsCurrent(config, route.providerName, webSearchBridgeBinding.provider)) {
+                  throw new Error("API key selection changed during a web-search continuation");
+                }
+              },
               providerName: route.providerName,
               modelId: route.modelId,
             }),

--- a/structure/adapters/registry.md
+++ b/structure/adapters/registry.md
@@ -3,6 +3,9 @@
 The configuration-only [plaintext V2 contract](../subagents.md#plaintext-v2-agent-messages)
 is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged.
 
+The server-owned key-auth Responses hosted-search bridge retains the serving adapter's account
+binding as specified in [continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## Decision
 
 Runtime adapter construction has one authority: `src/adapters/registry.ts`.

--- a/structure/catalog.md
+++ b/structure/catalog.md
@@ -218,6 +218,9 @@ real turn depends on it (`src/codex/warmup.ts`).
 
 ## Routed tool discovery and hosted search
 
+For opted-in key-auth Responses providers, the declared hosted-search tool follows the
+[continuation binding contract](runtime.md#hosted-search-continuation-binding).
+
 All routed catalog rows advertise `supports_search_tool: true` together with
 `tool_mode: "code_mode_only"` — the pair is load-bearing. The field selects Codex's deferred
 tool-discovery surface; it does not describe the hosted web-search sidecar. Under code mode,

--- a/structure/clients/claude-desktop.md
+++ b/structure/clients/claude-desktop.md
@@ -3,6 +3,9 @@
 The configuration-only [plaintext V2 contract](../subagents.md#plaintext-v2-agent-messages)
 is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged.
 
+The shared server's key-auth Responses hosted-search continuation policy is documented in
+[continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## Connected Claude Desktop profiles
 
 Connected `ocx claude desktop apply` reads the hub's Desktop snapshot and writes the hub origin

--- a/structure/data-planes/images.md
+++ b/structure/data-planes/images.md
@@ -3,6 +3,9 @@
 The configuration-only [plaintext V2 contract](../subagents.md#plaintext-v2-agent-messages)
 is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged.
 
+For the shared Responses server's hosted-search continuation binding, see
+[continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## Standalone Images
 
 Codex's local `image_gen.imagegen` tool makes a second Images request after the model calls it:

--- a/structure/data-planes/inbound-compat.md
+++ b/structure/data-planes/inbound-compat.md
@@ -42,6 +42,9 @@ to gpt-live-1-codex; gpt-live-1 is an explicit alias. Dictation and Frameless ev
 separate. Coverage lives in `tests/server/audio-client.test.ts`,
 `tests/server/audio-dictation.test.ts` and `tests/server/live-call-bindings.test.ts`.
 
+Requests entering the key-auth Responses hosted-search bridge follow its
+[continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## Chat Completions inbound native path
 
 `POST /v1/chat/completions` sends eligible `openai-chat` routes directly to the provider's Chat

--- a/structure/data-planes/search.md
+++ b/structure/data-planes/search.md
@@ -1,5 +1,8 @@
 # Search Data Plane
 
+The opt-in key-auth Responses hosted-search bridge follows the
+[continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## Standalone Search and exact account selectors
 
 `POST /v1/alpha/search` retains the selected model in its request body. When that value is an

--- a/structure/gui-and-management-api.md
+++ b/structure/gui-and-management-api.md
@@ -1,7 +1,7 @@
 # GUI And Management API
 
 The configuration-only [plaintext V2 contract](subagents.md#plaintext-v2-agent-messages)
-is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged.
+is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged. Changing the selected API key during an opted-in Responses hosted-search turn follows the [continuation binding contract](runtime.md#hosted-search-continuation-binding).
 
 ## Dashboard serving
 

--- a/structure/ops/docs-and-release.md
+++ b/structure/ops/docs-and-release.md
@@ -5,6 +5,9 @@ is scoped to canonical ChatGPT Responses forwarding; other source-area behavior 
 
 ## Public docs
 
+The provider configuration reference documents the user-visible
+[hosted-search continuation binding](../runtime.md#hosted-search-continuation-binding).
+
 The public documentation site lives in `docs-site/` and is built with Astro + Starlight. English is
 served at the site root, with Korean under `/ko`, Simplified Chinese under `/zh-cn`, Traditional Chinese under `/zh-tw`, Russian under `/ru`, and Japanese under `/ja`. `docs-site/astro.config.mjs` is the locale source of truth.
 

--- a/structure/ops/service-and-sidecars.md
+++ b/structure/ops/service-and-sidecars.md
@@ -44,6 +44,9 @@ PATH, so a launcher-backed job is never misreported as an older plist (#3464).
 
 ## Sidecars
 
+The opt-in key-auth Responses hosted-search bridge follows the
+[continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 Web search and vision sidecars run only when the main request needs that capability and a usable
 sidecar authority exists. Vision has two possible backends; web search's config union additionally
 admits `xai`, `gemini`, and `exa`. xAI is a live explicit-only backend through stored Grok OAuth;

--- a/structure/providers/xai-grok.md
+++ b/structure/providers/xai-grok.md
@@ -3,6 +3,9 @@
 The configuration-only [plaintext V2 contract](../subagents.md#plaintext-v2-agent-messages)
 is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged.
 
+The opt-in key-auth Responses hosted-search bridge uses the shared
+[continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## xAI Grok hardening (official Grok Build contract parity)
 
 Grounded in the open-sourced official client (xai-org/grok-build); unit + evidence:

--- a/structure/runtime.md
+++ b/structure/runtime.md
@@ -206,6 +206,19 @@ Routed Responses continuations whose local replay state is missing resolve their
 
 The shared Responses path follows the [bounded multipart recovery contract](subagents.md#multipart-encrypted-task-recovery); credential admission and retry policy remain unchanged.
 
+### Hosted-search continuation binding
+
+The opt-in key-auth Responses hosted-search bridge in `src/server/responses/core.ts` captures the
+request binding that served the first leg, after any permitted initial reselection. Before every
+continuation dispatch, after provider pacing, that binding must remain an API-key selection matching
+the configured entry, reference, revision, resolved key, authentication mode, and base URL; a
+disabled or removed provider fails the same check. Drift produces the bridge's failed terminal
+without another provider request, and an unchanged binding resends the built request with its
+executed search result appended, never re-entering the initial reselection/rebuild path. Initial
+dispatch keeps its normal reselection policy. `tests/web-search/web-search-passthrough-bridge.test.ts`
+covers drift during search, while pacing, and before first-leg headers return, plus successful
+first-dispatch reselection and result preservation.
+
 ## Remote Hub hardening ownership
 
 `src/remote/protocol.ts` owns pure interval/feature negotiation. `src/remote/hub-state.ts` owns the `GET|HEAD /v1/hub-state` contract, its caps, and the parser both sides share. `src/client/hub-client.ts` owns bounded, schema-validated remote catalog consumption, hub-state reads, and key-id probes; `src/client/hub-state.ts` owns the resolution and the owner-stamped 0600 cache, and a failed read reports "unavailable" rather than degrading to the client's own local provider and login state. `src/client/hub-relay.ts` is a fixed-authority management relay with URL, header, body, redirect, and stream bounds. The public data listener remains the direct client→hub path; the loopback management ingress never serves data-plane routes.

--- a/structure/subagents.md
+++ b/structure/subagents.md
@@ -136,6 +136,9 @@ other fragment layouts and mixed readable content retain their documented residu
 
 ## Subagents
 
+Parent and subagent requests using the key-auth Responses hosted-search bridge share the
+[continuation binding contract](runtime.md#hosted-search-continuation-binding).
+
 New non-OAuth provider registrations carry `initialModelSelection` with a unique
 registration identity. Until reliable live/static discovery completes, public
 catalogs and model candidates withhold those providers' models; the provider itself

--- a/structure/transports/inventory.md
+++ b/structure/transports/inventory.md
@@ -3,6 +3,9 @@
 The configuration-only [plaintext V2 contract](../subagents.md#plaintext-v2-agent-messages)
 is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged.
 
+The opt-in key-auth Responses hosted-search bridge has a separate
+[continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## Transport inventory
 
 The sections above cover the transports with load-bearing invariants. The rest of the transport

--- a/structure/transports/responses.md
+++ b/structure/transports/responses.md
@@ -9,7 +9,7 @@ Plaintext collaboration restoration treats a null namespace as absent, rejects n
 
 `/v1/responses` is the main Codex-facing endpoint. The server parses Responses input, routes to a
 provider, lets the selected adapter speak the upstream protocol, then bridges adapter events back to
-Responses-compatible streaming output.
+Responses-compatible streaming output. For an opted-in key-auth provider, a hosted-search continuation stays bound to the API-key selection that served the first leg; the contract is the [hosted-search continuation binding](../runtime.md#hosted-search-continuation-binding).
 
 ### Credential-bearing HTTP redirects
 

--- a/structure/transports/streaming-health.md
+++ b/structure/transports/streaming-health.md
@@ -3,6 +3,9 @@
 The configuration-only [plaintext V2 contract](../subagents.md#plaintext-v2-agent-messages)
 is scoped to canonical ChatGPT Responses forwarding; other source-area behavior described here is unchanged.
 
+Key-auth hosted-search continuations validate account selection after pacing and report a failed
+terminal on drift; see [continuation binding contract](../runtime.md#hosted-search-continuation-binding).
+
 ## Heartbeat and stall deadline
 
 The HTTP/SSE bridge emits an SSE comment-line keep-alive (`: opencodex heartbeat`) during upstream

--- a/tests/web-search/web-search-passthrough-bridge.test.ts
+++ b/tests/web-search/web-search-passthrough-bridge.test.ts
@@ -21,6 +21,11 @@ import {
 import { mapOllamaSearchResponse } from "../../src/web-search/ollama-executor";
 import { UNDECLARED_TOOL_CALL_ERROR_CODE } from "../../src/server/responses-undeclared-tool-guard";
 import { handleResponses } from "../../src/server/responses";
+import {
+  resetProviderRequestPacingForTest,
+  setProviderRequestPacingRuntimeForTest,
+  waitForProviderRequestSlot,
+} from "../../src/providers/request-pacing";
 import type { OcxConfig, OcxParsedRequest, OcxProviderConfig, ProviderWebSearchBridgeConfig } from "../../src/types";
 
 /** One SSE event block without its blank-line delimiter. */
@@ -572,9 +577,16 @@ describe("the reported turn, end to end through handleResponses", () => {
   async function post(
     ocxConfig: OcxConfig,
     legs: string[],
-  ): Promise<{ body: string; outbound: string[]; searches: number }> {
+    hooks: { onSearch?: () => void; onProviderResponse?: (leg: number) => void } = {},
+  ): Promise<{
+    body: string;
+    outbound: string[];
+    destinations: Array<{ url: string; authorization: string | null }>;
+    searches: number;
+  }> {
     const savedFetch = globalThis.fetch;
     const outbound: string[] = [];
+    const destinations: Array<{ url: string; authorization: string | null }> = [];
     let searches = 0;
     let leg = 0;
     globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
@@ -583,13 +595,16 @@ describe("the reported turn, end to end through handleResponses", () => {
         : input instanceof URL ? input.href : (input as Request).url;
       if (url.includes("/api/web_search")) {
         searches += 1;
+        hooks.onSearch?.();
         return new Response(JSON.stringify({
           results: [{ title: "Releases", url: "https://example.test/rel", content: "opencodex 2.50.0" }],
         }), { headers: { "content-type": "application/json" } });
       }
       outbound.push(String(init?.body ?? ""));
+      destinations.push({ url, authorization: new Headers(init?.headers).get("authorization") });
       const text = legs[Math.min(leg, legs.length - 1)]!;
       leg += 1;
+      hooks.onProviderResponse?.(leg);
       return new Response(text, { headers: { "content-type": "text/event-stream" } });
     }) as unknown as typeof fetch;
     try {
@@ -598,7 +613,7 @@ describe("the reported turn, end to end through handleResponses", () => {
         headers: { "content-type": "application/json" },
         body: clientRequest,
       }), ocxConfig, { model: "", provider: "" });
-      return { body: await response.text(), outbound, searches };
+      return { body: await response.text(), outbound, destinations, searches };
     } finally {
       globalThis.fetch = savedFetch;
     }
@@ -624,12 +639,159 @@ describe("the reported turn, end to end through handleResponses", () => {
 
     // The search result reached the SECOND upstream body as a native tool result.
     expect(result.outbound).toHaveLength(2);
+    expect(result.destinations).toEqual([
+      { url: "https://ollama.com/v1/responses", authorization: "Bearer fixture-key" },
+      { url: "https://ollama.com/v1/responses", authorization: "Bearer fixture-key" },
+    ]);
     const continuation = JSON.parse(result.outbound[1]!) as { input: Record<string, unknown>[] };
     const output = continuation.input.find(item => item.type === "function_call_output");
     expect(output).toBeDefined();
     expect(String(output!.output)).toContain("opencodex 2.50.0");
     expect(continuation.input.some(item =>
       item.type === "function_call" && item.name === "web_search")).toBe(true);
+  });
+
+  const selectionChanges: Array<[string, (ocxConfig: OcxConfig) => void]> = [
+    ["selection revision with an unchanged key", cfg => {
+      cfg.providers.fixture!.apiKeySelectionRevision = "selection-after";
+    }],
+    ["key reference with the same resolved value", cfg => {
+      cfg.providers.fixture!.apiKey = "${OCX_BRIDGE_BINDING_ALTERNATE}";
+      cfg.providers.fixture!.apiKeyPool![0]!.key = "${OCX_BRIDGE_BINDING_ALTERNATE}";
+    }],
+    ["selected entry id", cfg => {
+      cfg.providers.fixture!.apiKeyPool![0]!.id = "entry-after";
+    }],
+    ["resolved key behind an unchanged reference", () => {
+      process.env.OCX_BRIDGE_BINDING_KEY = "fixture-key-after";
+    }],
+    ["authentication mode", cfg => { cfg.providers.fixture!.authMode = "forward"; }],
+    ["base URL", cfg => { cfg.providers.fixture!.baseUrl = "https://gateway.example/v1"; }],
+    ["provider disabled", cfg => { cfg.providers.fixture!.disabled = true; }],
+    ["provider removed", cfg => { delete cfg.providers.fixture; }],
+  ];
+
+  test.each(selectionChanges)("refuses the continuation when search changes the %s", async (_name, change) => {
+    const savedKey = process.env.OCX_BRIDGE_BINDING_KEY;
+    const savedAlternate = process.env.OCX_BRIDGE_BINDING_ALTERNATE;
+    process.env.OCX_BRIDGE_BINDING_KEY = "fixture-key";
+    process.env.OCX_BRIDGE_BINDING_ALTERNATE = "fixture-key";
+    const cfg = config(armed);
+    Object.assign(cfg.providers.fixture!, {
+      apiKey: "${OCX_BRIDGE_BINDING_KEY}",
+      apiKeySelectionRevision: "selection-before",
+      apiKeyPool: [{ id: "entry-before", key: "${OCX_BRIDGE_BINDING_KEY}" }],
+    });
+    try {
+      const result = await post(cfg, [searchLeg(), answerLeg()], { onSearch: () => change(cfg) });
+      expect(result.searches).toBe(1);
+      expect(result.outbound).toHaveLength(1);
+      expect(result.destinations).toEqual([
+        { url: "https://ollama.com/v1/responses", authorization: "Bearer fixture-key" },
+      ]);
+      const events = clientEvents(result.body);
+      expect(events.filter(event => event.type === "response.failed")).toHaveLength(1);
+      expect(events.filter(event => event.type === "response.completed")).toHaveLength(0);
+      expect(result.body).toContain(WEB_SEARCH_BRIDGE_ERROR_CODE);
+      expect(result.body).not.toContain("The current release is 2.50.0.");
+    } finally {
+      if (savedKey === undefined) delete process.env.OCX_BRIDGE_BINDING_KEY;
+      else process.env.OCX_BRIDGE_BINDING_KEY = savedKey;
+      if (savedAlternate === undefined) delete process.env.OCX_BRIDGE_BINDING_ALTERNATE;
+      else process.env.OCX_BRIDGE_BINDING_ALTERNATE = savedAlternate;
+    }
+  });
+
+  test("rechecks the continuation binding after its pacing wait", async () => {
+    const cfg = config(armed);
+    cfg.providers.fixture!.requestPacing = { enabled: true, minIntervalMs: 100 };
+    let now = 0;
+    let searches = 0;
+    let waitsAfterSearch = 0;
+    resetProviderRequestPacingForTest();
+    setProviderRequestPacingRuntimeForTest({
+      now: () => now,
+      setTimer: (callback, delayMs) => {
+        queueMicrotask(() => {
+          if (searches > 0) {
+            waitsAfterSearch += 1;
+            cfg.providers.fixture!.apiKeySelectionRevision = "selection-during-pacing";
+          }
+          now += delayMs;
+          callback();
+        });
+        return 1;
+      },
+      clearTimer: () => {},
+      enqueueMicrotask: queueMicrotask,
+    });
+    try {
+      const result = await post(cfg, [searchLeg(), answerLeg()], { onSearch: () => { searches += 1; } });
+      expect(result.searches).toBe(1);
+      expect(waitsAfterSearch).toBe(1);
+      expect(result.outbound).toHaveLength(1);
+      expect(result.body).toContain(WEB_SEARCH_BRIDGE_ERROR_CODE);
+      expect(clientEvents(result.body).filter(event => event.type === "response.completed")).toHaveLength(0);
+    } finally {
+      resetProviderRequestPacingForTest();
+    }
+  });
+
+  test("keeps the dispatched binding if selection changes before first-leg headers return", async () => {
+    const cfg = config(armed);
+    const result = await post(cfg, [searchLeg(), answerLeg()], {
+      onProviderResponse: leg => {
+        if (leg === 1) cfg.providers.fixture!.apiKey = "fixture-key-after";
+      },
+    });
+    expect(result.searches).toBe(1);
+    expect(result.outbound).toHaveLength(1);
+    expect(result.destinations[0]!.authorization).toBe("Bearer fixture-key");
+    expect(result.body).toContain(WEB_SEARCH_BRIDGE_ERROR_CODE);
+    expect(clientEvents(result.body).filter(event => event.type === "response.completed")).toHaveLength(0);
+  });
+
+  test("allows initial dispatch reselection and binds search to the key that served it", async () => {
+    const cfg = config(armed);
+    cfg.providers.fixture!.requestPacing = { enabled: true, minIntervalMs: 100 };
+    let now = 0;
+    let waits = 0;
+    resetProviderRequestPacingForTest();
+    setProviderRequestPacingRuntimeForTest({
+      now: () => now,
+      setTimer: (callback, delayMs) => {
+        queueMicrotask(() => {
+          waits += 1;
+          if (waits === 1) {
+            cfg.providers.fixture!.apiKey = "fixture-key-after";
+            cfg.providers.fixture!.apiKeySelectionRevision = "selection-before-first-send";
+          }
+          now += delayMs;
+          callback();
+        });
+        return 1;
+      },
+      clearTimer: () => {},
+      enqueueMicrotask: queueMicrotask,
+    });
+    try {
+      // Occupy the first slot so the already-built request must wait before credential dispatch.
+      await waitForProviderRequestSlot("fixture", cfg.providers.fixture!, "glm-4.7");
+      const result = await post(cfg, [searchLeg(), answerLeg()]);
+      expect(waits).toBe(2);
+      expect(result.searches).toBe(1);
+      expect(result.destinations).toEqual([
+        { url: "https://ollama.com/v1/responses", authorization: "Bearer fixture-key-after" },
+        { url: "https://ollama.com/v1/responses", authorization: "Bearer fixture-key-after" },
+      ]);
+      const continuation = JSON.parse(result.outbound[1]!) as { input: Record<string, unknown>[] };
+      const output = continuation.input.find(item => item.type === "function_call_output");
+      expect(String(output?.output)).toContain("opencodex 2.50.0");
+      expect(result.body).toContain("The current release is 2.50.0.");
+      expect(result.body).not.toContain("response.failed");
+    } finally {
+      resetProviderRequestPacingForTest();
+    }
   });
 
   test("an unrelated undeclared tool still fails closed through the bridged stream", async () => {


### PR DESCRIPTION
## Summary

- Keep opted-in API-key Responses hosted-search continuations bound to the key selection that served the first leg. Revalidate after provider pacing and fail the bridge before another provider request if the selection, resolved credential, authentication mode, or base URL changed.
- Preserve normal initial-dispatch reselection and the appended search result when the serving binding remains current. Document the behavior and cover both search-time and pacing-time changes.

## Earlier focused verification (before this rebase)

- Baseline regression: 6 failures reproduced an unwanted second mock-provider request when the expected request count was 1.
- `bun test tests/web-search/web-search-passthrough-bridge.test.ts` — 32 passed.
- `bun test tests/providers/api-key-selection-capture.test.ts tests/usage/request-pacing.test.ts tests/lab/core-lab-boundary.test.ts` — 38 passed.
- `bun test tests/web-search/web-search-passthrough-bridge.test.ts -t 'key reference with the same resolved value'` — 1 passed after isolating reference drift from entry-ID drift.
- `bun run typecheck` — passed.
- `bun run privacy:scan` and `bun run structure:check` — passed.
- `cd docs-site && bun run build` — passed, 425 pages. The generated provider configuration page contains the new binding and reselection guidance.
- Validation uses mock providers and the repository test-home guard. The full suite was not run locally; hosted results are recorded below.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [x] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [x] I resolved all correct Codex and CodeRabbit findings.

- [x] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hosted web-search continuations remain tied to the API-key configuration used for the initial request.
  - Changes to credentials, authentication settings, base URL, provider selection, or availability now end the continuation with an error before another provider request is sent.
  - Continuation binding is rechecked after pacing delays.
  - Configuration changes made before the first provider request can still be applied normally.

- **Documentation**
  - Added guidance across provider, transport, runtime, and integration documentation describing continuation binding and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-ready-progress:start -->
## Current verification (2026-09-13)
- Rebased onto dev@dc33113a9, the latest dev commit at push time. Exact head 2a1b3c307 completed the full CI matrix green (run 34738118457, 26/26 jobs, 0 failures); gates typecheck, structure:check, privacy:scan and focused tests passed locally on that head.
Head: 3dcc43c250046c1e6ef5121983d6aa2e2b654295, rebased onto dev@17da84f89.
Focused tests, typecheck, structure check and privacy scan passed on this rebased source:
32 pass, 0 fail.

The previous green matrix tested an older PR head with the pending #4384 fix added. It is integration evidence only, not a passing full-suite result for this published head. Full CI readiness remains open. The current dev tip has advanced beyond this tested base; further refresh will be coordinated with the shared Windows fixture fix to avoid repeatedly queuing matrices that inherit the same failure.
<!-- review-ready-progress:end -->



