### PR TITLE
fix(codex): let clear-cooldown lift an avoidance the cooldown outlived

### DIFF
--- a/src/codex/routing.ts
+++ b/src/codex/routing.ts
@@ -1074,12 +1074,20 @@ export function isCodexAccountInCooldown(accountId: string, now = Date.now()): b
  *   bumps it in {@link recordCodexUpstreamOutcome}, so the bump here is not load-bearing
  *   today and is kept so the invariant survives a future change that retains the lease.
  *
- * Returns false when the account carried no live cooldown (already expired or never set).
+ * Returns false when the account carried neither a live cooldown nor a live avoidance window.
+ * The window outlives the cooldown by design — the cooldown caps at fifteen minutes and the
+ * window runs up to six hours — so the moment an operator actually reaches for this escape
+ * hatch is usually after the cooldown lapsed and only the window is still keeping the account
+ * out of rotation. Refusing to look at the window then would leave the hatch shut in the one
+ * case it exists for.
  */
 export function clearCodexAccountCooldown(accountId: string, now = Date.now()): boolean {
   const clear = (health: CodexUpstreamHealth): CodexUpstreamHealth | null => {
     const cooldownUntil = health.cooldownUntil;
-    if (typeof cooldownUntil !== "number" || !Number.isFinite(cooldownUntil) || cooldownUntil <= now) return null;
+    const liveCooldown = typeof cooldownUntil === "number" && Number.isFinite(cooldownUntil) && cooldownUntil > now;
+    const avoidUntil = health.quotaAvoidUntil;
+    const liveAvoidance = typeof avoidUntil === "number" && Number.isFinite(avoidUntil) && avoidUntil > now;
+    if (!liveCooldown && !liveAvoidance) return null;
     const {
       cooldownUntil: _until,
       cooldownSince: _since,

--- a/tests/codex-integration/codex-routing.test.ts
+++ b/tests/codex-integration/codex-routing.test.ts
@@ -1046,6 +1046,28 @@ describe("codex routing", () => {
     expect(resolveCodexAccountForThread("cleared-after", config, now + 61_000, "spark")).toBe("a");
   });
 
+  test("clearing a lapsed cooldown still lifts the avoidance it left behind", () => {
+    const config = makeConfig();
+    const now = 1_800_000_000_000;
+    updateAccountQuota("a", 10);
+    updateAccountQuota("b", 20);
+    recordCodexUpstreamOutcome(config, "a", 429, {
+      now,
+      modelId: "gpt-5.3-codex-spark",
+      resetAt: Math.floor((now + 4 * 60 * 60_000) / 1_000),
+    });
+
+    // The capped cooldown is already gone and only the announced window is still holding the
+    // account out, which is exactly when an operator reaches for this button. Reading the
+    // cooldown alone made the call a no-op for the next several hours.
+    expect(isCodexAccountInCooldown("a", now + 16 * 60_000)).toBe(false);
+    expect(resolveCodexAccountForThread("lapsed-before", config, now + 16 * 60_000, "spark")).toBe("b");
+
+    expect(clearCodexAccountCooldown("a", now + 16 * 60_000)).toBe(true);
+
+    expect(resolveCodexAccountForThread("lapsed-after", config, now + 17 * 60_000, "spark")).toBe("a");
+  });
+
   test("a request the account serves releases the threads its quota refusal moved", () => {
     const config = makeConfig();
     const now = 1_800_000_000_000;


### PR DESCRIPTION
## Summary

- Let `clearCodexAccountCooldown` act on a live avoidance window when the cooldown it belonged to has already lapsed. The two durations differ by design — the cooldown caps at fifteen minutes, the window a refusal announces runs up to six hours — so the point where an operator reaches for this escape hatch is normally after the cooldown expired and only the window is still holding the account out of rotation. The call returned early there, reported `cleared: false`, and left selection passing the account over for hours.
- Regression test for exactly that window: the cooldown is confirmed lapsed, selection is confirmed to be avoiding the account, and the call has to both report success and return the account to selection.

## Verification

- Follow-up to #4396, which fixed the three avoidance gaps the regression sweep found. This is the fourth, raised in review on that PR against the same escape-hatch contract.
- The existing contract is unchanged otherwise: failure counters and `softAvoidUntil` still survive, and an account with neither a live cooldown nor a live window still returns `false`, so the route still cannot be used to tell whether an account exists.
- Local tests, build, typecheck and install: NOT RUN under the standing restriction. Hosted CI is the gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing an expired account cooldown now also removes any remaining quota-avoidance period, allowing the account to become selectable again.
  * Cooldown clearing now accurately reports whether any active restriction was removed.

* **Tests**
  * Added coverage for clearing lingering quota avoidance after a cooldown expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->