### PR TITLE
docs(structure): record what clear-cooldown does to a lapsed window

### DIFF
--- a/structure/providers/openai-tiers.md
+++ b/structure/providers/openai-tiers.md
@@ -104,6 +104,12 @@ cooldown it belonged to, and both operator escapes remove it: clearing a cooldow
 account each clear the window from the account-wide entry and from every scoped entry, because a
 reset-derived refusal records only the scoped one.
 
+Clearing a cooldown is also the management operation for a window whose cooldown has already
+lapsed. Because the cooldown is the shorter of the two durations, the state an operator usually
+finds is an expired cooldown and a live window, so a live window alone makes the operation
+succeed and report a clear. An account with neither reports no change, which is what keeps the
+route from disclosing whether an account exists.
+
 A confirmed manual reset-credit consumption may immediately reconcile that account's
 eligible pre-existing ordinary reset-derived cooldown after a complete, non-exhausted usage
 observation started after the reset. Paused or reauthentication-required accounts and


### PR DESCRIPTION
## Summary

- Record in `structure/providers/openai-tiers.md` what #4397 changed about the operator-facing `clear-cooldown` contract: because the cooldown is the shorter of the two durations, the state an operator usually finds is an expired cooldown with a live avoidance window, and that window alone now makes the operation succeed and report a clear. An account with neither still reports no change, which is what keeps the route from disclosing whether an account exists.

## Verification

- Closes the documentation-ownership finding raised by review on #4397. `structure/INDEX.md` maps `src/codex/` to this document, and `bun run structure:check` runs in CI as part of `gates`.
- Documentation only; no source or test behaviour changes.
- Local tests, build, typecheck and install: NOT RUN under the standing restriction. Hosted CI is the gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the behavior of the OpenAI provider cooldown-clear operation when an avoidance window remains active after cooldown expiry.
  * Documented outcomes for accounts with an active window and for accounts with neither state, including consistent “no change” reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->