### PR TITLE
fix(devin-cli): honor platform path semantics in credential discovery

### DIFF
--- a/src/oauth/devin-cli.ts
+++ b/src/oauth/devin-cli.ts
@@ -18,7 +18,7 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { posix, win32 } from "node:path";
 import { DEVIN_CLI_INSTALL_HINT } from "../adapters/devin-cli/binary";
 import { identityFromApiKey } from "./devin";
 import { resolveDevinApiBaseUrl } from "./devin/api-base";
@@ -58,12 +58,13 @@ export function devinCliCredentialsPath(
   // Absolute only. A relative override would resolve against whatever directory
   // the proxy happens to be running in, which is not a location a user can mean.
   if (override && (override.startsWith("/") || /^[A-Za-z]:[\\/]/.test(override))) return override;
+  const paths = platform === "win32" ? win32 : posix;
   if (platform === "win32") {
-    const appData = env.APPDATA ?? join(homedir(), "AppData", "Roaming");
-    return join(appData, "devin", "credentials.toml");
+    const appData = env.APPDATA ?? paths.join(homedir(), "AppData", "Roaming");
+    return paths.join(appData, "devin", "credentials.toml");
   }
-  const dataHome = env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
-  return join(dataHome, "devin", "credentials.toml");
+  const dataHome = env.XDG_DATA_HOME ?? paths.join(homedir(), ".local", "share");
+  return paths.join(dataHome, "devin", "credentials.toml");
 }
 
 export interface DevinCliCredentialFile {

--- a/structure/providers/xai-grok.md
+++ b/structure/providers/xai-grok.md
@@ -65,3 +65,5 @@ see [Combo editor routing quota](../gui-and-management-api.md#combo-editor-routi
 
 Claude replay carries [Go conversation affinity](../data-planes/inbound-compat.md#claude-affinity-at-final-go-dispatch)
 privately to final dispatch; preliminary route selection does not inject Go-only headers.
+
+Devin CLI credential path composition in `src/oauth/devin-cli.ts` follows the selected platform: Windows uses Win32 APPDATA paths, other platforms use POSIX XDG-data paths. The explicit absolute override remains verbatim; credential parsing and login behavior are unchanged.

--- a/structure/runtime.md
+++ b/structure/runtime.md
@@ -233,3 +233,5 @@ Cline CLI joins the existing export/client integration registries. Explicit CLI 
 Config JSON preserves the boolean; only literal true activates the role-changing transform.
 
 The lightweight top-level CLI help counts Cline CLI among the fifteen registered export clients; registry parity remains covered by the client help and integration tests.
+
+Devin CLI credential path composition in `src/oauth/devin-cli.ts` follows the selected platform: Windows uses Win32 APPDATA paths, other platforms use POSIX XDG-data paths. The explicit absolute override remains verbatim; credential parsing and login behavior are unchanged.

--- a/structure/transports/inventory.md
+++ b/structure/transports/inventory.md
@@ -70,3 +70,5 @@ see [Combo editor routing quota](../gui-and-management-api.md#combo-editor-routi
 
 Claude replay carries [Go conversation affinity](../data-planes/inbound-compat.md#claude-affinity-at-final-go-dispatch)
 privately to final dispatch; preliminary route selection does not inject Go-only headers.
+
+Devin CLI credential path composition in `src/oauth/devin-cli.ts` follows the selected platform: Windows uses Win32 APPDATA paths, other platforms use POSIX XDG-data paths. The explicit absolute override remains verbatim; credential parsing and login behavior are unchanged.

--- a/tests/providers/devin-cli-adapter.test.ts
+++ b/tests/providers/devin-cli-adapter.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
   ACP_SESSION_NEW_ID,
@@ -213,13 +214,20 @@ describe("devin cli discovery", () => {
 
   test("known install paths are preferred over a shadowed PATH entry, and absence is undefined", () => {
     const previous = process.env[DEVIN_CLI_BIN_ENV];
+    const previousPath = process.env.PATH;
     delete process.env[DEVIN_CLI_BIN_ENV];
+    process.env.PATH = join("/shadow", "bin");
     try {
-      const only = (p: string) => p === "/home/u/.local/bin/devin";
-      expect(resolveDevinCliBinary({ exists: only, home: "/home/u", useCache: false })).toBe("/home/u/.local/bin/devin");
+      const expected = join("/home/u", ".local", "bin", "devin");
+      const shadowed = join("/shadow", "bin", "devin");
+      const exists = (p: string) => p === expected || p === shadowed;
+      expect(resolveDevinCliBinary({ exists, home: "/home/u", useCache: false })).toBe(expected);
+      expect(resolveDevinCliBinary({ exists: p => p === shadowed, home: "/home/u", useCache: false })).toBe(shadowed);
       expect(resolveDevinCliBinary({ exists: () => false, home: "/home/u", useCache: false })).toBeUndefined();
     } finally {
       if (previous !== undefined) process.env[DEVIN_CLI_BIN_ENV] = previous;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
     }
   });
 });

--- a/tests/providers/devin-cli-login.test.ts
+++ b/tests/providers/devin-cli-login.test.ts
@@ -46,7 +46,7 @@ describe("devin-cli credentials path", () => {
 
   test("Windows uses APPDATA", () => {
     expect(devinCliCredentialsPath({ APPDATA: "C:\\Users\\u\\AppData\\Roaming" }, "win32"))
-      .toContain("devin");
+      .toBe("C:\\Users\\u\\AppData\\Roaming\\devin\\credentials.toml");
   });
 
   test("the override must be absolute", () => {


### PR DESCRIPTION
## Summary

Repairs three Windows path failures observed in hosted run 34674363301 (Windows jobs 103503916543 and 103503916602). Binary discovery fixtures now recognize host-native paths and verify known-install priority over a shadowed PATH candidate, fallback, and absence. Credential path construction honors its explicit platform argument using POSIX or Win32 joins, while keeping absolute override validation unchanged.

The original Linux credential assertions remain intact; Windows APPDATA now has an exact-path assertion. Credential parsing, login, destination allowlisting, and binary search priority are unchanged. The four source/test blobs were identical between the failing run, frozen development baseline, and the implementation base.

## Verification

- git diff --check HEAD^ HEAD: passed; Laplace independent source/security review PASS at 293c37d682c8ac353551fb8cb491285efe2b875f.
- Local suites/focused tests, build, typecheck and install: NOT RUN by explicit maintainer instruction. No credential files or user settings accessed; no login executed.
- Regression execution will be checked on the exact final head using GitHub-hosted CI, including Windows.
- No merge or auto-merge. The coordinating maintainer owns integration.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


## Maintainer integration decision

Owner-authorized dev integration with all local suites forbidden and final cumulative Actions CI tracked after delivery. Reviewed head: `293c37d682c8ac353551fb8cb491285efe2b875f`. Explicit target-platform path joining in Devin credential path helper; native discovery fixture tests actual known-path precedence, PATH fallback and absence. Laplace exact-head independent source/security PASS. Coordinator read the complete actual diff and verified no outstanding review threads/maintainer requests at intake. No real credentials, user configuration, process/service changes or dependency installation.

This repairs inherited Windows failures surfaced by the backlog final-tip run; original failed runs remain failures. Local tests/build/typecheck/install NOT RUN. Existing source review and positive control assertions are not runtime pass claims. After both #4379 and #4400 land, cumulative dev verification will include both and the externally merged Combo active-reactivation #4385; record exact head/run and repair any remaining failures. No workflow/protection/native stack settings changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Devin CLI credentials now resolve using the correct path format for Windows and POSIX-based systems.
  - Explicit credential-path overrides continue to be honored exactly as provided.
  - CLI discovery now reliably prioritizes known installation locations while retaining PATH-based fallback behavior.

- **Documentation**
  - Added guidance describing platform-specific credential locations and path resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->