### PR TITLE
test(cli): stop judging a stale record on a port another test can take

### DIFF
--- a/tests/cli/cli-status-json.test.ts
+++ b/tests/cli/cli-status-json.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
-import { createServer } from "node:net";
+import { createConnection, createServer } from "node:net";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -879,6 +879,24 @@ describe("status reports stale process records end to end", () => {
     await new Promise<void>(resolve => { probe.close(() => resolve()); });
     return port;
   }
+
+  /**
+   * Prove the endpoint refuses right now.
+   *
+   * `allocateFreePort` releases the port it reports, and on a sharded runner every other
+   * test binding an ephemeral port is a candidate to take it. A fixture that assumes a
+   * released port is still refusing asserts against whatever happened to bind it.
+   */
+  async function refusesConnection(port: number): Promise<boolean> {
+    return await new Promise<boolean>(resolve => {
+      const socket = createConnection({ port, host: "127.0.0.1" });
+      const settle = (refused: boolean): void => { socket.destroy(); resolve(refused); };
+      socket.setTimeout(1_000);
+      socket.once("connect", () => settle(false));
+      socket.once("timeout", () => settle(false));
+      socket.once("error", () => settle(true));
+    });
+  }
   let freePort: number;
   beforeEach(async () => { freePort = await allocateFreePort(); });
 
@@ -950,17 +968,27 @@ describe("status reports stale process records end to end", () => {
     await new Promise<void>(resolve => { occupied.listen(0, "127.0.0.1", () => resolve()); });
     const occupiedPort = (occupied.address() as AddressInfo).port;
     try {
-      // Allocate after the listener is bound: it can reuse the port released by
-      // beforeEach, so that earlier number no longer proves a refused endpoint.
-      const recordedPort = await allocateFreePort();
-      expect(recordedPort).not.toBe(occupiedPort);
       const pid = findDeadPid();
       writeFileSync(join(home, "config.json"), JSON.stringify({ port: occupiedPort, codexAutoStart: false }), "utf8");
       writeFileSync(join(home, "ocx.pid"), String(pid), "utf8");
-      writeFileSync(join(home, "runtime-port.json"), JSON.stringify({ pid, port: recordedPort, hostname: "127.0.0.1" }), "utf8");
 
-      const parsed = JSON.parse(runStatusJson(home).stdout) as { proxy?: { staleProcessState?: unknown } };
-      expect(parsed.proxy?.staleProcessState).toBe(true);
+      // The recorded port has to refuse for this to discriminate, and `allocateFreePort`
+      // hands back a port it has already released. Confirm refusal immediately before and
+      // immediately after the probe, and re-allocate when something took it in between, so
+      // a stolen port retries instead of failing an assertion it never exercised.
+      let parsed: { proxy?: { staleProcessState?: unknown } } | undefined;
+      for (let attempt = 0; attempt < 5 && parsed === undefined; attempt++) {
+        const recordedPort = await allocateFreePort();
+        if (recordedPort === occupiedPort) continue;
+        if (!await refusesConnection(recordedPort)) continue;
+        writeFileSync(join(home, "runtime-port.json"), JSON.stringify({ pid, port: recordedPort, hostname: "127.0.0.1" }), "utf8");
+        const observed = JSON.parse(runStatusJson(home).stdout) as { proxy?: { staleProcessState?: unknown } };
+        if (!await refusesConnection(recordedPort)) continue;
+        parsed = observed;
+      }
+
+      expect(parsed, "no allocated port stayed refused across the status probe").toBeDefined();
+      expect(parsed?.proxy?.staleProcessState).toBe(true);
     } finally {
       await new Promise<void>(resolve => { occupied.close(() => resolve()); });
       removeTreeWithRetry(home);


### PR DESCRIPTION
## Summary

- Make the `a fallback-port record is judged on the recorded port, not the configured one` fixture deterministic. It records a port from `allocateFreePort`, which returns a port it has already released, so on a sharded runner another test can bind it before `status` probes. When that happens `status` correctly sees a listener, reports the record as live, and the assertion fails against a setup the test never established.
- The recorded port is now confirmed to refuse immediately before and immediately after the probe, and re-allocated when something took it in between. The assertion itself is unchanged: a run only counts when the endpoint demonstrably refused across the whole probe, and exhausting the attempts fails with that reason rather than passing quietly.

## Verification

- Observed on the preview promotion push run [34692523885](https://github.com/lidge-jun/opencodex/actions/runs/34692523885) in `test 3/4`, while the identical product tree passed on dev in [34691465021](https://github.com/lidge-jun/opencodex/actions/runs/34691465021). Same code, different outcome, which is what identifies it as port contention rather than a regression.
- The configured port stays occupied by a real listener, so the test still discriminates between probing the recorded port and probing the configured one — the reason the fixture exists.
- Local tests, build, typecheck and install: NOT RUN under the standing restriction. Hosted CI is the gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for fallback-port status checks by verifying port availability before and after probing.
  * Added retry handling when a port becomes occupied during the test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->