### PR TITLE
docs(credits): record the #3988 carry whose merge dropped the trailer

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -155,6 +155,22 @@ use the source authors' verified numeric GitHub account identities.
 A delivered slice is not a statement that every requirement in its original PR
 or umbrella issue is complete. The table deliberately retains the unadopted scope.
 
+### 2026-09-13 follow-up: landing trailer dropped at merge
+
+The last 3,000 commits reachable from current `dev` were scanned the same way
+as the 2026-09-07 audit: carry/reimplement language on the landing, then the
+**actual landing commit**, then GitHub's commit-author mapping. One new miss
+is not already on this page.
+
+[#4031](https://github.com/lidge-jun/opencodex/pull/4031)'s own description
+named the trailer. The merge commit did not keep it. The cherry-picked object
+is authored as an unmapped machine identity, which GitHub maps to no account.
+The only remaining trailer is automation.
+
+| Pull request | Author | Landed as | What landed |
+| --- | --- | --- | --- |
+| [#3988](https://github.com/lidge-jun/opencodex/pull/3988) | [@rrmlima](https://github.com/rrmlima) | [`e2bf1672c`](https://github.com/lidge-jun/opencodex/commit/e2bf1672c974611f8db736cd64a90e1dc443924a) / [`14ce693e5`](https://github.com/lidge-jun/opencodex/commit/14ce693e5846596c823941ce90add538713a25b1) | "Carries #3988 by @rrmlima (`cherry-pick -x`)" — Gemini/CCA/Vertex/AI Studio model-tail `(continue)` nudge in `messagesToGeminiFormat`. |
+
 ## Report and diagnosis
 
 These fixes exist because of the report. The branch's own approach was not the


### PR DESCRIPTION
## Summary

- Record #3988 by @rrmlima on CREDITS.md. Maintainer carry #4031 named the
  trailer in the pull-request description; the merge commit and the
  cherry-pick (`14ce693e5`, authored as an unmapped machine identity) did not
  keep a GitHub-resolvable co-author. Forward attribution uses the account-linked
  noreply trailer on this commit. No history rewrite.

### Maintainer-integration decision

Merging under `MAINTAINERS.md` maintainer integration into `dev`: documentation-only
CREDITS.md repair, same class as #3787 / #3811. Exact-head SHA: `d0360cc6d780e0d5a497a961a5dc3ce62f6b42ad`. Local suite **NOT RUN** (operator instruction). Hosted
Cross-platform CI is not the verifier for this row; GraphQL `Commit.authors` on the
squash object must resolve `rrmlima`. This is maintainer integration, not self-approval.

## Verification

- `git log origin/dev -n 3000` carry scan; GitHub GraphQL `Commit.authors` on
  `14ce693e5` (`user: null` for the unmapped machine author; only CommandCodeBot otherwise).
- `rg '/pull/3988' CREDITS.md`
- Local bun test / typecheck / full suite: **NOT RUN** (operator instruction).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new credits entry documenting a previously missed attribution.
  * Recorded recognition for the contribution that improved continuation prompting across supported AI model integrations.
  * Clarified the relationship between the original contribution, its merged changes, and the associated attribution record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->