### PR TITLE
feat(usage): register verified Z.AI GLM list prices as expected-cost overlays

### DIFF
--- a/devlog/_plan/260913_unpriced_model_overlays/000_plan.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/000_plan.md
@@ -1,0 +1,45 @@
+# 000 — 가격 미등록 모델 전수조사 로드맵 (2026-09-13)
+
+## Objective
+
+src/generated/model-metadata.ts의 cost 필드가 전부 0(또는 absent)인 모델을 전수조사하고,
+기존 검증 데이터(devlog/_fin/260720_toks_speed_price_columns/003 등)가 있으면 재사용,
+없으면 Aside 브라우저 조사로 공식 출처를 확보해 src/usage/expected-prices.ts의
+EXPECTED_PRICE_OVERLAYS / VERIFIED_PRICE_OVERRIDES에 등재한다.
+PR 생성 → 호스티드 CI → 머지까지 완료한다.
+
+## Constraints (user-declared)
+
+- 로컬 스위트(bun run test / typecheck / build) 절대 실행 금지. NOT RUN으로 표기한다.
+- git push는 --no-verify로 진행한다.
+- 검증은 exact-head 호스티드 CI만 신뢰한다.
+- 상속 서브에이전트 병렬 파견 무제한 허용.
+- unverified 가격은 절대 등재하지 않는다(fail-closed, 003 §4 정책).
+- `:free` 접미사 OpenRouter 모델은 $0이 정직한 값 — 별도 조사 없이 유지하거나
+  명시적 free 근거를 기록한다.
+
+## Inventory (001 이 확정)
+
+전수 스캔 결과 77행이 all-zero/absent:
+
+| bundle | count | disposition |
+|---|---|---|
+| zai | 14 | Z.AI 공식 가격 조사 필요 (GLM Coding Plan = 구독, bigmodel.cn = PAYG) |
+| openrouter | 48 | 대부분 `:free`($0 정직) + alpha/auto/free 등 비과금 — 소수만 확인 |
+| google | 10 | gemini-3.7/3.8-flash는 overlay에 이미 존재(google 표면) — gemma 계열 무료/미공개 확인 |
+| cerebras | 2 | Cerebras 공식 가격 조사 |
+| mistral | 1 | labs-devstral-small-2512 — Mistral 가격 조사 |
+| moonshot | 1 | kimi-k2.5 — KIMI_K25 상수가 이미 존재 (0.6/3/0.1/0.6), moonshot 번들 등재 검토 |
+| xai | 1 | grok-composer-2.5-fast — 003에서 not-published 확인, 재검증만 |
+
+## work-phase map
+
+- wp1 (이 문서 + 001): inventory 확정 + 로드맵. docs-only.
+- wp2 (010): 벤더별 병렬 조사 → overlay 등재 + 커밋.
+- wp3 (020): PR → 호스티드 CI → 머지.
+
+## Out of scope
+
+- model-metadata.source.json 재생성(상류 스냅샷 교체는 별도 단위).
+- 구조 변경, 신규 provider 추가.
+- 로컬 테스트 스위트 실행(사용자 금지).

--- a/devlog/_plan/260913_unpriced_model_overlays/001_inventory.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/001_inventory.md
@@ -1,0 +1,51 @@
+# 001 — Inventory: all-zero cost rows (전수 스캔, 2026-09-13)
+
+스캔: .tmp/scan-unpriced2.mjs — src/generated/model-metadata.ts의 DATA를 파싱해
+cost 4필드가 전부 0이거나 absent인 행을 추출. 총 77행.
+
+## zai (14) — 핵심 조사 대상
+
+glm-4.5, glm-4.5-air, glm-4.5-flash, glm-4.5v, glm-4.6, glm-4.6v, glm-4.7,
+glm-4.7-flash, glm-5, glm-5-turbo, glm-5.1, glm-5.2, glm-5.3, glm-5v-turbo
+
+기존 근거:
+- 003 §3: zai/GLM = unverified (z.ai 가격 URL 오류, bigmodel.cn 확정 불가).
+- 003 §5 백로그 1: mistral/cerebras/zai 브라우저 렌더 재조사 대상.
+- registry의 `zai` provider는 GLM Coding Plan(구독) — 단가 미공개가 불릴 수 있음.
+- zhipu-bigmodel(PAYG, open.bigmodel.cn)이 jawcodeBundle:"zai"를 씀 — PAYG 단가가
+  공개돼 있으면 bigmodel 쪽은 verified 가능.
+- glm-5.3-flash는 DATA에 없음(registry 수동 시드) — 번들 밖이라 별도 처리 불필요.
+
+## google (10)
+
+gemini-3.7-flash, gemini-3.8-flash — EXPECTED_PRICE_OVERLAYS에 google 표면 verified
+행이 이미 존재(2026-08-14/2026-09-03). 번들 all-zero는 overlay가 커버 → 추가 조치 불요.
+gemma-3-27b-it + gemma-4 계열 7종(26b, 26b-a4b-it, 26b-it, 31b, 31b-it, E2B-it, E4B-it) — Gemma는 Google 무료/오픈 모델로 과금 단가가 없을
+가능성. 확인 후 not-published 기록.
+
+## cerebras (2)
+
+qwen-3-coder-480b, zai-glm-4.6 — 003: cerebras unverified (PAYG 충전/구독 중심,
+모델별 단가표 비노출). 재조사.
+
+## mistral (1)
+
+labs-devstral-small-2512 — 003: mistral 동적 렌더로 추출 실패. Aside로 재조사.
+
+## moonshot (1)
+
+kimi-k2.5 — KIMI_K25 = (0.6, 3, 0.1, 0.6) 상수가 이미 존재하고 kimi/kimi-code/moonshot
+오버레이에 등재돼 있음. moonshot 번들 행이 all-zero인 것은 overlay가 커버.
+→ 조치 불요 또는 번들 등재 검토.
+
+## xai (1)
+
+grok-composer-2.5-fast — 003 §2: not-published (docs.x.ai 미등재, Grok Build 무료).
+재검증만.
+
+## openrouter (48)
+
+- `:free` 접미사 41종 — OpenRouter free tier는 $0. 정직한 값. 별도 조사 없이 유지.
+- openrouter/auto — all-zero 행은 id auto 하나. -1000000 sentinel은 별개 id openrouter/auto와 auto-beta(77행 밖). 동적 라우팅이라 조사 대상 아님.
+- openrouter/free, aurora/elephant/healer/hunter/owl-alpha — OpenRouter 자체
+  무료/알파 모델. $0 또는 미공개.

--- a/devlog/_plan/260913_unpriced_model_overlays/001_inventory.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/001_inventory.md
@@ -14,7 +14,7 @@ glm-4.7-flash, glm-5, glm-5-turbo, glm-5.1, glm-5.2, glm-5.3, glm-5v-turbo
 - registry의 `zai` provider는 GLM Coding Plan(구독) — 단가 미공개가 불릴 수 있음.
 - zhipu-bigmodel(PAYG, open.bigmodel.cn)이 jawcodeBundle:"zai"를 씀 — PAYG 단가가
   공개돼 있으면 bigmodel 쪽은 verified 가능.
-- glm-5.3-flash는 DATA에 없음(registry 수동 시드) — 번들 밖이라 별도 처리 불필요.
+- glm-5.3-flash는 DATA에 없음(registry 수동 시드) — 77행 inventory 밖이지만 overlay는 provider+model exact라 등재 대상에 포함.
 
 ## google (10)
 

--- a/devlog/_plan/260913_unpriced_model_overlays/010_wp2_research_and_registration.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/010_wp2_research_and_registration.md
@@ -1,0 +1,43 @@
+# 010 — wp2: 병렬 조사 + overlay 등재
+
+## 목표
+
+001 inventory의 각 모델에 대해 verified/verified-derived 출처를 확보하거나
+not-published/unverified 사유를 기록하고, 확보된 것만 expected-prices.ts에 등재.
+
+## 서브에이전트 레인 (병렬, 상속)
+
+| lane | 대상 | 방법 |
+|---|---|---|
+| zai | GLM 14종 + glm-5.3-flash | Aside repl/exec로 docs.z.ai + bigmodel.cn 가격 페이지 열람 |
+| google-gemma | gemma-3-27b-it, gemma-4-* 8종 | 공식 Gemini API pricing에서 Gemma 과금 여부 확인 |
+| cerebras | qwen-3-coder-480b, zai-glm-4.6 | cloud.cerebras.ai pricing 열람 |
+| mistral | labs-devstral-small-2512 | mistral.ai pricing / docs 열람 |
+| xai | grok-composer-2.5-fast | docs.x.ai pricing 재검증 |
+| openrouter | auto/alpha/free 7종 | openrouter.ai 모델 페이지 확인 |
+
+## 등재 규칙 (003 정책 계승)
+
+- verified: 공식 페이지 직접 열람한 4튜플.
+- verified-derived: 검증된 기반 모델 가격의 매핑(estimated 전파).
+- unverified/not-published: 등재 금지, devlog에 사유만.
+- 구독 전용 표면(zai coding plan 등)은 벤더 정가가 있으면 verified-derived로
+  "list price estimate" 등재 가능 — 003의 anthropic→antigravity 선례.
+- source 문자열에 URL + 확인 날짜 + 주의사항.
+- per-provider 등재: overlay lookup은 exact provider+model이라 zai bundle에 등재해도
+  zhipu-bigmodel / zhipu-bigmodel-coding / zhipu-bigmodel-responses 표면은 커버되지 않는다.
+  kimi/moonshot/kimi-code 선례처럼 노출하는 provider id마다 행을 둔다.
+  PROVIDER_ALIASES에 zai/cerebras/mistral 키가 없어 이들 provider는 bundle exact lookup에
+  도달하지 못하므로 overlay가 유일한 가격 소스다.
+
+## 파일 변경
+
+- MODIFY src/usage/expected-prices.ts — 상수 + EXPECTED_PRICE_OVERLAYS 행 추가.
+- MODIFY tests/usage/usage-cost.test.ts — "16. shipped overlay membership" 카운트 갱신
+  + 신규 키 멤버십 추가.
+- MODIFY devlog/_plan/260913_unpriced_model_overlays/ — 조사 결과 evidence.
+
+## 검증
+
+- 로컬 스위트 실행 금지(사용자 지시). 검증은 호스티드 CI exact-head.
+- 등재 후 node .tmp/scan-unpriced2.mjs 재실행으로 all-zero 감소분 확인(읽기 전용).

--- a/devlog/_plan/260913_unpriced_model_overlays/010_wp2_research_and_registration.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/010_wp2_research_and_registration.md
@@ -10,7 +10,7 @@ not-published/unverified 사유를 기록하고, 확보된 것만 expected-price
 | lane | 대상 | 방법 |
 |---|---|---|
 | zai | GLM 14종 + glm-5.3-flash | Aside repl/exec로 docs.z.ai + bigmodel.cn 가격 페이지 열람 |
-| google-gemma | gemma-3-27b-it, gemma-4-* 8종 | 공식 Gemini API pricing에서 Gemma 과금 여부 확인 |
+| google-gemma | gemma 8종(gemma-3-27b-it + gemma-4 계열 7종) | 공식 Gemini API pricing에서 Gemma 과금 여부 확인 |
 | cerebras | qwen-3-coder-480b, zai-glm-4.6 | cloud.cerebras.ai pricing 열람 |
 | mistral | labs-devstral-small-2512 | mistral.ai pricing / docs 열람 |
 | xai | grok-composer-2.5-fast | docs.x.ai pricing 재검증 |

--- a/devlog/_plan/260913_unpriced_model_overlays/011_wp2_research_results.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/011_wp2_research_results.md
@@ -22,8 +22,8 @@
 
 등재: 4 provider 표면(zai, zhipu-bigmodel, zhipu-bigmodel-coding,
 zhipu-bigmodel-responses) × 노출 모델 = 25행, 전부 verified-derived
-(구독/CNY 표면에 z.ai 정가를 estimate로 표시). cacheWrite=0 — 양쪽 공식 모두
-cache-write 단가 미공개(cache storage limited-time free).
+(구독/CNY 표면에 z.ai 정가를 estimate로 표시). cacheWrite=0 — 양쪽 공식 모두 cache-write 단가 미공개(cache storage는 limited-time free
+오픈베타 프로모션). 2026-09-13 스냅샷이며 종료/변경 가능 — 장기 의존 전 재확인 필요.
 
 ## google gemma — not-published 전원
 

--- a/devlog/_plan/260913_unpriced_model_overlays/011_wp2_research_results.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/011_wp2_research_results.md
@@ -1,0 +1,52 @@
+# 011 — wp2 조사 결과 (6레인 병렬, 2026-09-13)
+
+## zai / GLM — verified (docs.z.ai/guides/overview/pricing, USD/1M)
+
+| model | in | out | cacheRead | 비고 |
+|---|---|---|---|---|
+| glm-4.5 | 0.60 | 2.20 | 0.11 | 등재 불요(노출 표면 없음) |
+| glm-4.5-air | 0.20 | 1.10 | 0.03 | 상동 |
+| glm-4.5-flash | Free | | | zero 행은 inert — 미등재 |
+| glm-4.5v | 0.60 | 1.80 | 0.11 | 미등재(노출 표면 없음) |
+| glm-4.6 | 0.60 | 2.20 | 0.11 | 등재 |
+| glm-4.6v | 0.30 | 0.90 | 0.05 | 등재 |
+| glm-4.7 | 0.60 | 2.20 | 0.11 | 등재 |
+| glm-4.7-flash | Free | | | 미등재 |
+| glm-5 | 1.00 | 3.20 | 0.20 | 등재 |
+| glm-5-turbo | ¥5 | ¥22 | ¥1.2 | bigmodel.cn CNY 전용 → hold (xiaomi 선례) |
+| glm-5.1 | 1.40 | 4.40 | 0.26 | 등재 |
+| glm-5.2 | 1.40 | 4.40 | 0.26 | 등재 |
+| glm-5.3 | 1.40 | 4.40 | 0.26 | 등재 |
+| glm-5v-turbo | ¥5 | ¥22 | ¥1.2 | CNY 전용 → hold |
+| glm-5.3-flash | 0.15 | 0.50 | 0.03 | 등재 |
+
+등재: 4 provider 표면(zai, zhipu-bigmodel, zhipu-bigmodel-coding,
+zhipu-bigmodel-responses) × 노출 모델 = 25행, 전부 verified-derived
+(구독/CNY 표면에 z.ai 정가를 estimate로 표시). cacheWrite=0 — 양쪽 공식 모두
+cache-write 단가 미공개(cache storage limited-time free).
+
+## google gemma — not-published 전원
+
+ai.google.dev/gemini-api/docs/pricing: Gemma 4 표는 Free Tier "Free of charge" /
+Paid Tier "Not available". gemma-4-31b-it, gemma-4-26b-a4b-it만 API 서빙 목록에 있고
+나머지 6종은 미서빙. 등재 없음.
+
+## cerebras — not-published (deprecated)
+
+qwen-3-coder-480b(2025-11-05), zai-glm-4.6(2026-01-20) 모두 공식 deprecation,
+public models API 404. cerebras.ai/pricing은 gpt-oss-120b/qwen-3.8-27b만 게재.
+
+## mistral — not-published
+
+labs-devstral-small-2512 = Devstral Small 2, 공식 id는 실재하나 모든 가격표에 없음.
+deprecated(2026-02-27, 후속 Mistral Medium 3.5).
+
+## xai — not-published (재확인)
+
+grok-composer-2.5-fast: docs.x.ai pricing 16개 모델 카탈로그에 없음.
+x.ai/news/composer-2-5 "free to try" 유지.
+
+## openrouter — free 외 전원 not-published
+
+openrouter/free만 $0 verified(API pricing 0/0) — zero 행은 inert라 미등재.
+auto는 routed-model pass-through(-1 sentinel), alpha 5종은 endpoint:null/종료.

--- a/devlog/_plan/260913_unpriced_model_overlays/020_wp3_pr_merge.md
+++ b/devlog/_plan/260913_unpriced_model_overlays/020_wp3_pr_merge.md
@@ -1,0 +1,17 @@
+# 020 — wp3: PR → 호스티드 CI → 머지
+
+## 절차
+
+1. 브랜치 codex/260913-unpriced-model-overlays를 origin에 push --no-verify.
+2. gh pr create --base dev, 템플릿 전 섹션 충족(Summary/Verification/Checklist).
+   Verification에는 "로컬 스위트 NOT RUN(사용자 지시), 호스티드 CI만" 명시.
+3. PR head SHA의 호스티드 CI를 gh run list / checks로 감시. 실패 시 원인 분석 후
+   수정 커밋 → 재푸시.
+4. Codex/CodeRabbit 리뷰 확인, 정당한 finding 반영.
+5. CI 그린 확인 후 머지(스쿼시). dev로의 머지는 MAINTAINERS 정책 범위 내에서 진행 —
+   사용자가 "머지까지 완료해줘"로 명시 승인.
+
+## 완료 조건
+
+- PR merged 상태, dev에 커밋 반영.
+- goalplan criteria c-1..c-4 전부 met.

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -73,8 +73,10 @@ const KIMI_K25: Cost4 = { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0.6
 /*
  * Z.AI GLM list prices (USD / 1M tokens), verified 2026-09-13 against
  * https://docs.z.ai/guides/overview/pricing. Neither z.ai nor bigmodel.cn
- * publishes a cache-write rate — both list cache storage as limited-time free —
- * so cacheWrite is 0 everywhere. glm-4.5-flash and glm-4.7-flash are officially
+ * publishes a cache-write rate — both list cache storage as limited-time free,
+ * an open-beta promotion the vendor may change or end — so cacheWrite is 0 as a
+ * 2026-09-13 snapshot, not a guaranteed rate; re-check the pricing page before
+ * relying on it long-term. glm-4.5-flash and glm-4.7-flash are officially
  * "Free" and deliberately get no rows: a zero-cost overlay is inert in the
  * resolver, which requires a nonzero tuple. glm-5-turbo / glm-5v-turbo are
  * published only in CNY on bigmodel.cn and stay unregistered — the same hold

--- a/src/usage/expected-prices.ts
+++ b/src/usage/expected-prices.ts
@@ -70,6 +70,27 @@ const KIMI_K27_CODE: Cost4 = { input: 0.95, output: 4, cacheRead: 0.19, cacheWri
 const KIMI_K27_CODE_HIGHSPEED: Cost4 = { input: 1.9, output: 8, cacheRead: 0.38, cacheWrite: 1.9 };
 const KIMI_K26: Cost4 = { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0.95 };
 const KIMI_K25: Cost4 = { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0.6 };
+/*
+ * Z.AI GLM list prices (USD / 1M tokens), verified 2026-09-13 against
+ * https://docs.z.ai/guides/overview/pricing. Neither z.ai nor bigmodel.cn
+ * publishes a cache-write rate — both list cache storage as limited-time free —
+ * so cacheWrite is 0 everywhere. glm-4.5-flash and glm-4.7-flash are officially
+ * "Free" and deliberately get no rows: a zero-cost overlay is inert in the
+ * resolver, which requires a nonzero tuple. glm-5-turbo / glm-5v-turbo are
+ * published only in CNY on bigmodel.cn and stay unregistered — the same hold
+ * the xiaomi CNY rows took in devlog/_fin/260720_toks_speed_price_columns/003.
+ * glm-4.5 (0.6/2.2/0.11), glm-4.5-air (0.2/1.1/0.03) and glm-4.5v (0.6/1.8/0.11)
+ * are verified on the same page but no registered provider exposes them, so
+ * they have no constants here.
+ */
+const GLM_46: Cost4 = { input: 0.6, output: 2.2, cacheRead: 0.11, cacheWrite: 0 };
+const GLM_46V: Cost4 = { input: 0.3, output: 0.9, cacheRead: 0.05, cacheWrite: 0 };
+const GLM_47: Cost4 = { input: 0.6, output: 2.2, cacheRead: 0.11, cacheWrite: 0 };
+const GLM_5: Cost4 = { input: 1, output: 3.2, cacheRead: 0.2, cacheWrite: 0 };
+const GLM_51: Cost4 = { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 };
+const GLM_52: Cost4 = { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 };
+const GLM_53: Cost4 = { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 };
+const GLM_53_FLASH: Cost4 = { input: 0.15, output: 0.5, cacheRead: 0.03, cacheWrite: 0 };
 const QWEN38_MAX: Cost4 = { input: 2, output: 6, cacheRead: 0, cacheWrite: 0 };
 // Anthropic official list prices (USD / 1M tokens). Cache write uses the published 5-minute rate.
 const CLAUDE_SONNET_46: Cost4 = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 };
@@ -104,6 +125,13 @@ const DEEPSEEK_PRICING = "https://api-docs.deepseek.com/quick_start/pricing-deta
 // Kimi official tables publish input/output/cache-hit only; cacheWrite is mapped to the
 // cache-miss input price (Kimi auto-caches with no separate write billing). 2026-07-20 re-verified.
 const KIMI_PRICING = "https://platform.kimi.ai/docs/pricing (official table; cacheWrite derived = input, Kimi auto-cache has no write billing)";
+// Z.AI publishes one USD table for the international surface; the Coding Plan
+// subscription and the domestic bigmodel.cn endpoints bill differently
+// (subscription quota / CNY tiers), so every GLM row below is verified-derived:
+// the numbers are the verified z.ai list prices shown as estimates.
+const ZAI_PRICING = "https://docs.z.ai/guides/overview/pricing (official USD table, 2026-09-13; cacheWrite=0 — cache storage is limited-time free on both z.ai and bigmodel.cn)";
+const ZAI_CODING_PLAN_NOTE = "z.ai list price shown as estimate; GLM Coding Plan is subscription-billed";
+const BIGMODEL_NOTE = "z.ai international list price shown as estimate; domestic bigmodel.cn billing is CNY tiered (docs.bigmodel.cn/cn/guide/start/pricing)";
 // 260804: Qwen3.8-Max shipped as a stable model and Qwen published a per-token rate, which
 // is the exit condition the previous Routeway reseller overlay named. Two caveats are
 // deliberately in the source string rather than dropped: the figure comes from Qwen's own
@@ -236,6 +264,45 @@ export const EXPECTED_PRICE_OVERLAYS: readonly ExpectedPriceOverlay[] = [
   { provider: "alibaba-token-plan-intl", modelId: "qwen3.8-max", cost4: QWEN38_MAX, source: QWEN38_MAX_PRICING, verifiedAt: "2026-08-04", status: "verified" },
   // Cursor Auto router — Cursor's published fixed token price (verified).
   { provider: "cursor", modelId: "auto", cost4: { input: 1.25, output: 6, cacheRead: 0.25, cacheWrite: 1.25 }, source: "https://docs.cursor.com/account/pricing + https://cursor.com/blog/aug-2025-pricing", verifiedAt: "2026-07-20", status: "verified" },
+  // Z.AI GLM family — the zai bundle's rows are all-zero upstream, and the four
+  // provider surfaces below resolve overlays by exact provider id, so each one
+  // needs its own rows (same pattern as kimi/moonshot/kimi-code). All rows are
+  // verified-derived: the tuples are the verified z.ai USD list prices, while
+  // the Coding Plan rows are subscription products and zhipu-bigmodel is the
+  // domestic CNY-tiered PAYG — see ZAI_CODING_PLAN_NOTE / BIGMODEL_NOTE.
+  // zai (api.z.ai Coding Plan) exposes: glm-5.3, glm-5.3[1m], glm-5.3-flash,
+  // glm-5.2, glm-5.2[1m], glm-5.1, glm-5, glm-4.6.
+  { provider: "zai", modelId: "glm-5.3", cost4: GLM_53, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zai", modelId: "glm-5.3[1m]", cost4: GLM_53, source: `derived: glm-5.3 1M-context compat notation; ${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zai", modelId: "glm-5.3-flash", cost4: GLM_53_FLASH, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zai", modelId: "glm-5.2", cost4: GLM_52, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zai", modelId: "glm-5.2[1m]", cost4: GLM_52, source: `derived: glm-5.2 1M-context compat notation; ${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zai", modelId: "glm-5.1", cost4: GLM_51, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zai", modelId: "glm-5", cost4: GLM_5, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zai", modelId: "glm-4.6", cost4: GLM_46, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  // zhipu-bigmodel (open.bigmodel.cn PAYG) exposes: glm-4.6, glm-4.7,
+  // glm-4.7-flash (officially free — no row), glm-5, glm-5.1, glm-5.2, glm-5.3,
+  // glm-4.6v.
+  { provider: "zhipu-bigmodel", modelId: "glm-4.6", cost4: GLM_46, source: `${BIGMODEL_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel", modelId: "glm-4.6v", cost4: GLM_46V, source: `${BIGMODEL_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel", modelId: "glm-4.7", cost4: GLM_47, source: `${BIGMODEL_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel", modelId: "glm-5", cost4: GLM_5, source: `${BIGMODEL_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel", modelId: "glm-5.1", cost4: GLM_51, source: `${BIGMODEL_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel", modelId: "glm-5.2", cost4: GLM_52, source: `${BIGMODEL_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel", modelId: "glm-5.3", cost4: GLM_53, source: `${BIGMODEL_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  // zhipu-bigmodel-coding exposes the same roster as the zai Coding Plan row.
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-5.3", cost4: GLM_53, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-5.3[1m]", cost4: GLM_53, source: `derived: glm-5.3 1M-context compat notation; ${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-5.3-flash", cost4: GLM_53_FLASH, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-5.2", cost4: GLM_52, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-5.2[1m]", cost4: GLM_52, source: `derived: glm-5.2 1M-context compat notation; ${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-5.1", cost4: GLM_51, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-5", cost4: GLM_5, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-coding", modelId: "glm-4.6", cost4: GLM_46, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  // zhipu-bigmodel-responses exposes glm-5.3, glm-5.3-flash, glm-5-turbo; the
+  // turbo id is CNY-only upstream and stays unregistered (see the GLM_* note).
+  { provider: "zhipu-bigmodel-responses", modelId: "glm-5.3", cost4: GLM_53, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
+  { provider: "zhipu-bigmodel-responses", modelId: "glm-5.3-flash", cost4: GLM_53_FLASH, source: `${ZAI_CODING_PLAN_NOTE}; ${ZAI_PRICING}`, verifiedAt: "2026-09-13", status: "verified-derived" },
 ];
 
 /**

--- a/structure/gui-and-management-api.md
+++ b/structure/gui-and-management-api.md
@@ -433,6 +433,11 @@ selectors, a vendor-only inferred price is unavailable; exact provider and user 
 eligible. Missing trace evidence is not reconstructed from today's configuration. Provider-detail
 model shares use that provider's token total, not the global total. Unknown reserved `policy/`
 selectors are rejected before upstream dispatch; historical rows remain unchanged.
+Expected-price overlays are estimates, not billing reproductions: the Z.AI GLM rows
+(`zai`, `zhipu-bigmodel`, `zhipu-bigmodel-coding`, `zhipu-bigmodel-responses`) display the
+published z.ai USD list price on surfaces that actually bill by Coding Plan subscription or
+CNY-tiered domestic PAYG, and every such row is marked `verified-derived` so the estimate flag
+reaches the UI.
 
 The management API retains the compact accumulator plus bounded query summaries; it never retains
 normalized per-request rows after a response. File identity changes, shrinkage, same-size metadata

--- a/tests/usage/usage-cost.test.ts
+++ b/tests/usage/usage-cost.test.ts
@@ -298,8 +298,8 @@ describe("resolveMatchedPrice", () => {
     expect(resolveMatchedPrice("openrouter", "anthropic-claude-3.5-sonnet")).toBeNull();
   });
 
-  test("16. shipped overlay membership: 70 keys, including canonical Fable 5.1, Opus 5 and compatibility prices", () => {
-    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(70);
+  test("16. shipped overlay membership: 95 keys, including canonical Fable 5.1, Opus 5 and compatibility prices", () => {
+    expect(EXPECTED_PRICE_OVERLAYS.length).toBe(95);
     expect(EXPECTED_PRICE_OVERLAYS.some(row => row.status === "unverified")).toBe(false);
     const keys = new Set(EXPECTED_PRICE_OVERLAYS.map(row => `${row.provider}/${row.modelId}`));
     for (const expected of [
@@ -370,6 +370,33 @@ describe("resolveMatchedPrice", () => {
       "alibaba-token-plan/qwen3.8-max",
       "alibaba-token-plan-intl/qwen3.8-max",
       "cursor/auto",
+      // Z.AI GLM family — the zai bundle is all-zero upstream, so each exposing
+      // provider surface carries its own verified-derived rows (z.ai USD list).
+      "zai/glm-5.3",
+      "zai/glm-5.3[1m]",
+      "zai/glm-5.3-flash",
+      "zai/glm-5.2",
+      "zai/glm-5.2[1m]",
+      "zai/glm-5.1",
+      "zai/glm-5",
+      "zai/glm-4.6",
+      "zhipu-bigmodel/glm-4.6",
+      "zhipu-bigmodel/glm-4.6v",
+      "zhipu-bigmodel/glm-4.7",
+      "zhipu-bigmodel/glm-5",
+      "zhipu-bigmodel/glm-5.1",
+      "zhipu-bigmodel/glm-5.2",
+      "zhipu-bigmodel/glm-5.3",
+      "zhipu-bigmodel-coding/glm-5.3",
+      "zhipu-bigmodel-coding/glm-5.3[1m]",
+      "zhipu-bigmodel-coding/glm-5.3-flash",
+      "zhipu-bigmodel-coding/glm-5.2",
+      "zhipu-bigmodel-coding/glm-5.2[1m]",
+      "zhipu-bigmodel-coding/glm-5.1",
+      "zhipu-bigmodel-coding/glm-5",
+      "zhipu-bigmodel-coding/glm-4.6",
+      "zhipu-bigmodel-responses/glm-5.3",
+      "zhipu-bigmodel-responses/glm-5.3-flash",
     ]) {
       expect(keys.has(expected)).toBe(true);
     }

--- a/tests/usage/usage-cost.test.ts
+++ b/tests/usage/usage-cost.test.ts
@@ -415,6 +415,19 @@ describe("resolveMatchedPrice", () => {
       cost4: { input: 1.5, output: 7.5, cacheRead: 0.15, cacheWrite: 0 },
       status: "verified",
     });
+    // GLM overlays: every surface resolves the verified z.ai list price as a
+    // derived estimate, including the bracket-alias and the native-VLM Flash row.
+    for (const [provider, modelId, cost4] of [
+      ["zai", "glm-5.3", { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }],
+      ["zai", "glm-5.3[1m]", { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }],
+      ["zai", "glm-5.3-flash", { input: 0.15, output: 0.5, cacheRead: 0.03, cacheWrite: 0 }],
+      ["zhipu-bigmodel", "glm-4.7", { input: 0.6, output: 2.2, cacheRead: 0.11, cacheWrite: 0 }],
+      ["zhipu-bigmodel-coding", "glm-5.2", { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }],
+      ["zhipu-bigmodel-responses", "glm-5.3-flash", { input: 0.15, output: 0.5, cacheRead: 0.03, cacheWrite: 0 }],
+    ] as const) {
+      const price = resolveMatchedPrice(provider, modelId);
+      expect(price, `${provider}/${modelId}`).toMatchObject({ cost4, source: "expected", status: "verified-derived" });
+    }
     for (const modelId of [
       "gemini-3.5-flash-extra-low",
       "gemini-3.5-flash-low",


### PR DESCRIPTION
## Summary

- Registers verified Z.AI GLM list prices as expected-cost overlays so the Logs `~$` column stops rendering an em dash on the four GLM provider surfaces.
- All 15 rows in the `zai` metadata bundle were all-zero upstream; 25 overlay rows now cover `zai`, `zhipu-bigmodel`, `zhipu-bigmodel-coding`, and `zhipu-bigmodel-responses` (exact provider+model matching, same pattern as the kimi/moonshot/kimi-code rows).
- Prices verified 2026-09-13 against the official tables: docs.z.ai/guides/overview/pricing (USD) cross-checked with docs.bigmodel.cn (CNY tiers). All rows are `verified-derived` — Coding Plan surfaces are subscription-billed and BigModel PAYG is CNY-tiered, so the z.ai USD list price is shown as an estimate.
- Deliberately not registered: glm-4.5-flash / glm-4.7-flash (officially free — a zero tuple is inert in the resolver), glm-5-turbo / glm-5v-turbo (CNY-only on bigmodel.cn, held per the xiaomi CNY precedent), and the models re-confirmed not-published (Gemma family, deprecated Cerebras ids, labs-devstral-small-2512, grok-composer-2.5-fast, OpenRouter alpha/cloaked ids).
- Research ledger: devlog/_plan/260913_unpriced_model_overlays/ (inventory, per-lane results, audit trail).

## Verification

- Local suite NOT RUN — maintainer instruction for this task; verification is hosted CI on the exact head.
- Read-only checks run: full-catalog scan of src/generated/model-metadata.ts (77 all-zero rows enumerated, script in .tmp/), overlay row count = 95 matching the updated membership test, independent reviewer subagent PASS on the diff (provider/model coverage exact, no duplicate keys, resolver path verified).
- Hosted CI on this PR head is the gate.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added verified-derived pricing coverage for Z.AI GLM models across supported provider surfaces.
  - Added pricing details for multiple GLM variants, including cache-write rates where applicable.
  - Pricing estimates are clearly identified when provider billing may differ from published USD list prices.

- **Documentation**
  - Added research, inventory, roadmap, and release procedure documentation for models with missing pricing metadata.
  - Clarified how estimated overlay pricing is presented.

- **Tests**
  - Expanded pricing overlay validation for the newly supported GLM entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->