### PR TITLE
fix(devin): apply explicit SWE-2 effort before model suffix

### DIFF
--- a/docs-site/src/content/docs/reference/adapters.md
+++ b/docs-site/src/content/docs/reference/adapters.md
@@ -451,6 +451,13 @@ Login opens Auth0 browser sign-in, then exchanges the Firebase ID token via
 - Experimental unofficial bridge; not shown in the dashboard preset by default. See the
   [provider guide](/guides/providers/) for login instructions.
 
+For SWE-2, an explicit reasoning effort overrides an effort suffix in the model
+id. For example, `swe-2-high` with `medium` selects the native `swe-2-medium` UID;
+`xhigh`, `ultra`, and `max` select `swe-2-max`. Values below Medium select Medium
+and do not disable SWE-2 reasoning. Without an explicit effort, a suffixed model
+id is preserved. This applies to both Devin account providers through their
+shared adapter; other model families keep their existing suffix precedence.
+
 ## `devin-cli`
 
 **Targets:** Cognition's `exa.api_server_pb.ApiServerService/GetChatMessage`, the same Connect

--- a/src/adapters/devin.ts
+++ b/src/adapters/devin.ts
@@ -85,6 +85,39 @@ function hasEffortSuffix(modelId: string): boolean {
 }
 
 /**
+ * SWE-2 ships exactly three native lanes. Cognition spells them as the model id,
+ * not as a separate effort field, so an explicit caller effort has to be resolved
+ * to the UID before the suffix shortcut below accepts whatever the picker sent.
+ *
+ * Kept as a named table rather than an inline branch because EFFORT_SUFFIXES does
+ * not carry `ultra`, `off`, or `minimal`, so the two would drift apart silently.
+ * Values below Medium select Medium: SWE-2 has no lane under it, and rounding down
+ * to nothing would quietly disable its reasoning.
+ */
+const SWE2_EFFORT: Record<string, "medium" | "high" | "max"> = {
+  none: "medium",
+  off: "medium",
+  minimal: "medium",
+  low: "medium",
+  medium: "medium",
+  high: "high",
+  xhigh: "max",
+  ultra: "max",
+  max: "max",
+};
+
+/**
+ * Resolve an explicit effort onto a SWE-2 lane, or undefined when this is not a
+ * SWE-2 id or the caller named no usable effort. Undefined leaves every existing
+ * path untouched, which is what keeps other model families on suffix precedence.
+ */
+function resolveSwe2Variant(modelId: string, reasoningEffort?: string): string | undefined {
+  if (!/^swe-2(?:-(?:medium|high|max))?$/.test(modelId)) return undefined;
+  const mapped = reasoningEffort ? SWE2_EFFORT[reasoningEffort.toLowerCase()] : undefined;
+  return mapped ? `swe-2-${mapped}` : undefined;
+}
+
+/**
  * Resolve the wire model UID using the live catalog as the source of truth.
  * Cognition's catalog lists most models with an effort suffix
  * (e.g. `gpt-5-6-sol-high`); the base id alone is not accepted for those.
@@ -103,6 +136,11 @@ async function resolveWireModelUid(
   reasoningEffort?: string,
 ): Promise<string> {
   const modelId = normalizeDevinModelId(rawModelId);
+  // Explicit effort wins over a suffix the picker already baked into the id, so
+  // `swe-2-high` asked for at `medium` becomes `swe-2-medium` instead of ignoring
+  // the caller. Runs before the shortcut below, which would otherwise return early.
+  const swe2 = resolveSwe2Variant(modelId, reasoningEffort);
+  if (swe2) return swe2;
   if (hasEffortSuffix(modelId)) return modelId;
   const catalog = await getCachedCatalog(apiKey, host);
   if (catalog) {
@@ -119,6 +157,13 @@ async function resolveWireModelUid(
   const effort = reasoningEffort && EFFORT_SUFFIXES.has(reasoningEffort) ? reasoningEffort : "medium";
   return `${modelId}-${effort}`;
 }
+
+/**
+ * Test seam. The resolver stays module-private because it reaches the catalog;
+ * exporting it under its bare name would make an async network-touching helper
+ * part of the adapter public API. Mirrors sanitizeToolDescriptionForCognitionForTests.
+ */
+export const resolveWireModelUidForTests = resolveWireModelUid;
 
 export class DevinMissingCredentialError extends Error {
   constructor() {

--- a/structure/adapters/registry.md
+++ b/structure/adapters/registry.md
@@ -97,3 +97,10 @@ Live sideband admission and its bounded upstream handshake follow the [runtime c
 
 
 Translated Chat request construction uses the [inline-image budget](../transports/streaming-health.md#translated-chat-inline-image-budget); the shared normalizer counts retained bytes even when a wire-specific drop callback keeps the image attached.
+
+## SWE-2 model effort selection
+
+`src/adapters/devin.ts` resolves an explicit SWE-2 reasoning effort to the native
+medium/high/max UID before accepting a suffix already present in the model id.
+Both Devin provider rows share this resolver. Omitted effort preserves an explicit
+variant; unrelated model families retain their existing suffix precedence.

--- a/tests/providers/devin-adapter.test.ts
+++ b/tests/providers/devin-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createDevinAdapter, mapOcxMessagesToDevin, mapOcxToolsToDevin } from "../../src/adapters/devin";
+import { createDevinAdapter, mapOcxMessagesToDevin, mapOcxToolsToDevin, resolveWireModelUidForTests } from "../../src/adapters/devin";
 import { sanitizeToolDescriptionForCognitionForTests } from "../../src/adapters/devin/cloud-direct/chat";
 import { DEVIN_MODEL_CONTEXT_WINDOWS, DEVIN_STATIC_MODELS, collapseDevinModelUid } from "../../src/adapters/devin/live-models";
 import { parseCatalogBuffer } from "../../src/adapters/devin/cloud-direct/catalog";
@@ -198,6 +198,41 @@ describe("devin adapter", () => {
     // Every statically advertised model needs one, or the picker reports 128k.
     for (const model of DEVIN_STATIC_MODELS) {
       expect(DEVIN_MODEL_CONTEXT_WINDOWS[model]).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("SWE-2 wire effort selection", () => {
+  // Cognition spells SWE-2 effort as the model id, so an explicit effort has to
+  // beat a suffix the picker already chose. Before this, swe-2-high asked for at
+  // medium stayed high and the caller was silently ignored.
+  test.each(["medium", "high", "max"])("an explicit %s effort overrides every SWE-2 variant", async (effort) => {
+    for (const model of ["swe-2", "swe-2-medium", "swe-2-high", "swe-2-max", "swe-2.high"]) {
+      expect(await resolveWireModelUidForTests(model, "unused", "unused", effort)).toBe(`swe-2-${effort}`);
+    }
+  });
+
+  test.each([
+    ["none", "medium"], ["off", "medium"], ["minimal", "medium"],
+    ["low", "medium"], ["xhigh", "max"], ["ultra", "max"],
+  ])("maps %s to the supported SWE-2 %s lane", async (effort, expected) => {
+    expect(await resolveWireModelUidForTests("swe-2-high", "unused", "unused", effort)).toBe(`swe-2-${expected}`);
+  });
+
+  // Case is normalised, which the source contribution did not do: a caller that
+  // sends HIGH means the same lane as high.
+  test("effort matching is case-insensitive", async () => {
+    expect(await resolveWireModelUidForTests("swe-2-medium", "unused", "unused", "HIGH")).toBe("swe-2-high");
+  });
+
+  test("omitted or unknown effort preserves an explicit variant", async () => {
+    expect(await resolveWireModelUidForTests("swe-2-high", "unused", "unused")).toBe("swe-2-high");
+    expect(await resolveWireModelUidForTests("swe-2-max", "unused", "unused", "future-effort")).toBe("swe-2-max");
+  });
+
+  test("other model families keep their existing suffix precedence", async () => {
+    for (const model of ["claude-opus-5-medium", "gpt-5-6-sol-high", "swe-1-7-high", "swe-20-high"]) {
+      expect(await resolveWireModelUidForTests(model, "unused", "unused", "max")).toBe(model);
     }
   });
 });


### PR DESCRIPTION
## Summary

Carries #4420 (@Smartnewb, head `6a456fb2af306a2d30a36e2f884c75318d3dd18b`) onto current `dev`. The source PR sat 27 commits behind its base and never received hosted product CI; the fix itself is still needed.

Cognition spells SWE-2 effort as the model id rather than a separate field, and `resolveWireModelUid` returned early whenever the id already carried an effort suffix:

```ts
const modelId = normalizeDevinModelId(rawModelId);
if (hasEffortSuffix(modelId)) return modelId;   // caller effort never read
```

So asking for `swe-2-high` at `medium` stayed `swe-2-high`. This resolves an explicit SWE-2 effort to the native UID before that shortcut runs.

| requested id | explicit effort | before | after |
|---|---|---|---|
| `swe-2-high` | `medium` | `swe-2-high` | `swe-2-medium` |
| `swe-2` | `xhigh` | `swe-2-medium` | `swe-2-max` |
| `swe-2-high` | none | `swe-2-high` | `swe-2-high` |
| `gpt-5-6-sol-high` | `max` | unchanged | unchanged |

`none`, `off`, `minimal` and `low` select Medium: SWE-2 has no lane below it, and rounding down to nothing would quietly disable its reasoning. Omitted or unknown effort preserves the variant, and other model families keep their existing suffix precedence.

Two deliberate differences from the source PR:

- The effort map is a named table instead of an inline branch. `EFFORT_SUFFIXES` does not carry `ultra`, `off` or `minimal`, so an inline branch and that set would drift apart silently.
- Matching is case-insensitive, so a caller sending `HIGH` reaches the same lane as `high`.

The resolver reaches the catalog and is async, so it is exposed to tests through `resolveWireModelUidForTests` rather than by exporting its bare name, mirroring the existing `sanitizeToolDescriptionForCognitionForTests`.

The source PR also pasted the same ownership sentence into six unrelated `structure/` files. Those hunks are omitted: the structure gate checks that a path is mentioned, not that behavioral prose is duplicated, so ownership is recorded once in `structure/adapters/registry.md` plus the user-facing adapters page.

This is the post-ACP landing of closed #4416 and does not restore ACP.

## Verification

- Hosted CI on this exact head is the merge proof. Local product tests, typecheck, build and install were **NOT RUN** in the authoring session, by explicit instruction.
- `git apply --check` and `git apply --3way --check` of the source patch against `7ca00ffe7`: exit 0, no reject hunks.
- Reviewed independently before implementation. Confirmed the lowercase mapping matches the source PR input-for-input, that the regex matches the source, that no `swe-2-low` or `swe-2-priority` exists in the live catalog, and that omitting the six structure hunks cannot fail the ownership gate.
- Known inherited limit: a dated catalog variant such as `swe-2-high-09102026` falls outside the regex, exactly as in the source PR. Out of scope for a carry.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer integration under `MAINTAINERS.md`: `dev` only, recorded here, with exact-head CI evidence added before merge.

Supersedes #4420.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SWE-2 model selection now honors explicit reasoning-effort settings, choosing the appropriate Medium, High, or Max variant.
  * Effort aliases and capitalization variations are recognized, while lower-than-Medium values select the Medium variant.
  * Explicit settings override model ID suffixes; without an explicit setting, existing SWE-2 variants remain unchanged.
  * Other model families retain their existing selection behavior.

* **Documentation**
  * Added guidance explaining SWE-2 effort selection and supported behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->