### PR TITLE
[WRONG BRANCH] fix(providers): let field-masked writes reach canonical OpenAI past stored overlays

### DIFF
--- a/src/server/auth-cors.ts
+++ b/src/server/auth-cors.ts
@@ -602,6 +602,23 @@ function sameCanonicalProviderSeed(actual: Record<string, unknown>, expected: Oc
   return actualKeys.every(key => JSON.stringify(actual[key]) === JSON.stringify((expected as unknown as Record<string, unknown>)[key]));
 }
 
+/**
+ * Operator-overlay tolerant variant of the canonical seed check: every key the registry
+ * seed defines must still match the submitted provider verbatim, but keys the seed never
+ * defines are ignored instead of failing the comparison. Field-masked writes (PATCH,
+ * the provider editor, reload) merge onto the persisted row, so the submitted candidate
+ * legitimately carries stored operator overlays like `selectedModels` or `disabled`.
+ * Those fields are validated by their own write boundaries and cannot widen what the
+ * forward proxy claims. Full-object writes (POST) keep the strict exact-key comparison
+ * so a forged overlay cannot ride in on a canonical transport seed.
+ */
+function matchesCanonicalProviderSeed(actual: Record<string, unknown>, expected: OcxProviderConfig): boolean {
+  return Object.keys(expected).every(
+    key => Object.hasOwn(actual, key)
+      && JSON.stringify(actual[key]) === JSON.stringify((expected as unknown as Record<string, unknown>)[key]),
+  );
+}
+
 function positiveWindowValue(value: unknown): boolean {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
@@ -638,7 +655,11 @@ function nativeContextOverlayError(raw: Record<string, unknown>): string | null 
  * string, or null when the provider may be persisted. Caller-controlled names/fields are
  * redacted and JSON-escaped so secrets never reach the response.
  */
-export function providerManagementConfigError(name: unknown, provider: unknown): string | null {
+export function providerManagementConfigError(
+  name: unknown,
+  provider: unknown,
+  options?: { allowOperatorOverlays?: boolean },
+): string | null {
   if (typeof name !== "string" || !provider || typeof provider !== "object" || Array.isArray(provider)) {
     return "provider must be a plain object";
   }
@@ -683,7 +704,9 @@ export function providerManagementConfigError(name: unknown, provider: unknown):
     // validation and then rejected by the seed comparison, so canonical OpenAI could never
     // set OR clear it — the value was admitted and then refused in the same request.
     delete canonicalCandidate.annotateEmptyToolOutputs;
-    const canonical = seed && sameCanonicalProviderSeed(canonicalCandidate, seed);
+    const canonical = seed && (options?.allowOperatorOverlays
+      ? matchesCanonicalProviderSeed(canonicalCandidate, seed)
+      : sameCanonicalProviderSeed(canonicalCandidate, seed));
     if (!canonical) {
       return `provider ${name} must equal the canonical built-in provider seed`;
     }

--- a/src/server/management/provider-routes.ts
+++ b/src/server/management/provider-routes.ts
@@ -257,7 +257,10 @@ function providerEditorCandidate(
     if (namespaceCollision) return { ok: false, status: 409, error: namespaceCollision, code: "provider_namespace_conflict" };
     const merged = mergeProviderEditorRow(persisted.providers[name], baseline.providers[name], publicProvider);
     const transportCandidate = providerTransportValidationCandidate(merged as unknown as Record<string, unknown>);
-    const providerError = providerManagementConfigError(name, transportCandidate)
+    // The editor merges onto the persisted row, so stored operator overlays (selectedModels,
+    // disabled, …) ride along in the candidate. They are owned by their own write boundaries;
+    // the seed check must only pin the canonical transport/auth keys.
+    const providerError = providerManagementConfigError(name, transportCandidate, { allowOperatorOverlays: true })
       ?? providerEmptyToolOutputConfigError(name, transportCandidate)
       ?? providerServiceTierConfigError(name, transportCandidate);
     if (providerError) return { ok: false, status: 400, error: providerError, code: "invalid_provider" };
@@ -829,6 +832,9 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
     const providerError = providerManagementConfigError(
       name,
       providerTransportValidationCandidate(provider as unknown as Record<string, unknown>),
+      // Reload validates a row straight off disk, which legitimately carries stored
+      // operator overlays; only the canonical transport/auth keys need to match the seed.
+      { allowOperatorOverlays: true },
     )
       ?? providerEmptyToolOutputConfigError(name, provider);
     if (providerError) return jsonResponse({ error: "provider reload target invalid" }, 409);
@@ -1271,6 +1277,10 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
         : providerManagementConfigError(
             name,
             providerTransportValidationCandidate(next as unknown as Record<string, unknown>),
+            // PATCH merges the mask onto the persisted row, which legitimately carries
+            // stored operator overlays (selectedModels, disabled, …); only the canonical
+            // transport/auth keys need to match the seed.
+            { allowOperatorOverlays: true },
           )
           ?? providerEmptyToolOutputConfigError(name, next);
       if (providerError) return jsonResponse({ error: providerError }, 400);
@@ -1314,6 +1324,7 @@ export async function handleProviderRoutes(ctx: ManagementContext): Promise<Resp
           : providerManagementConfigError(
               name,
               providerTransportValidationCandidate(replay.next as unknown as Record<string, unknown>),
+              { allowOperatorOverlays: true },
             )
             ?? providerEmptyToolOutputConfigError(name, replay.next);
         if (syncError) {

--- a/tests/server/management-provider-validation.test.ts
+++ b/tests/server/management-provider-validation.test.ts
@@ -1490,6 +1490,69 @@ describe("provider management validation", () => {
     }
   });
 
+  // selectedModels is written by the dedicated /api/selected-models route, so a canonical
+  // provider that ever had a model chosen carries it on disk. The exact-key seed comparison
+  // counted that operator overlay as a transport divergence and rejected every later PATCH
+  // (context windows included) with "must equal the canonical built-in provider seed".
+  test("canonical OpenAI with selectedModels can still PATCH modelContextWindows", async () => {
+    if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect, selectedModels: ["gpt-6-astra", "gpt-5.6-luna"] },
+      },
+    } as OcxConfig);
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError").mockResolvedValue(null);
+
+    const server = startServer(0);
+    try {
+      const patch = await fetch(new URL("/api/providers?name=openai", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ modelContextWindows: { "gpt-6-astra": 872000 } }),
+      });
+      expect(patch.status).toBe(200);
+      expect(loadConfig().providers.openai?.modelContextWindows).toEqual({ "gpt-6-astra": 872000 });
+      expect(loadConfig().providers.openai?.selectedModels).toEqual(["gpt-6-astra", "gpt-5.6-luna"]);
+    } finally {
+      resolvedError.mockRestore();
+      await server.stop(true);
+    }
+  });
+
+  test("canonical OpenAI with selectedModels still rejects transport tampering", async () => {
+    if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.OPENCODEX_HOME = TEST_DIR;
+    saveConfig({
+      port: 0,
+      openaiProviderTierVersion: 2,
+      defaultProvider: "openai",
+      providers: {
+        openai: { ...canonicalDirect, selectedModels: ["gpt-6-astra"] },
+      },
+    } as OcxConfig);
+    const resolvedError = spyOn(destinationPolicy, "providerDestinationResolvedError").mockResolvedValue(null);
+
+    const server = startServer(0);
+    try {
+      const patch = await fetch(new URL("/api/providers?name=openai", server.url), {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ baseUrl: "https://attacker.example.com/v1" }),
+      });
+      expect(patch.status).toBe(400);
+      expect(loadConfig().providers.openai?.baseUrl).toBe("https://chatgpt.com/backend-api/codex");
+    } finally {
+      resolvedError.mockRestore();
+      await server.stop(true);
+    }
+  });
+
   // #1409: the add/edit form's payload type has no member for contextWindow or
   test("provider POST overwrite preserves an explicit annotateEmptyToolOutputs: false", async () => {
     if (existsSync(TEST_DIR)) removeTreeWithRetry(TEST_DIR);


### PR DESCRIPTION
## Summary

`PATCH /api/providers?name=openai` fails with `provider openai must equal the canonical built-in provider seed` as soon as the stored provider row carries any operator overlay — most commonly `selectedModels`, which the Models page (`/api/selected-models`) writes onto the provider.

Once that happens, **every** field-masked write to the built-in OpenAI provider is bricked: `modelContextWindows`, `disabled`, `defaultModel`, headers, etc. all return 400, even though the overlays themselves were admitted by their own write boundaries and cannot widen what the forward proxy claims.

## Root cause

`providerManagementConfigError` guards the canonical OpenAI transport/auth surface with `sameCanonicalProviderSeed`, an **exact key-set** comparison between the submitted provider and the built-in registry seed.

That strictness is right for full-object writes (`POST /api/providers`), where an overlay riding on a canonical seed must still be rejected.

But the merge-based write paths — `PATCH /api/providers`, the provider editor `PUT`, and the provider reload path — validate a candidate that was merged onto the persisted row. Once an overlay lands on disk, every later candidate carries that extra key and fails the exact-key check.

## Fix

Add an `allowOperatorOverlays` mode to `providerManagementConfigError` that keeps the seed check strict on every key the seed **defines** (missing key or value mismatch still fails), while ignoring keys the seed never defines. The merge-based paths (PATCH, editor PUT, reload) opt in; `POST` keeps the exact-key comparison.

```ts
function matchesCanonicalProviderSeed(actual, expected) {
  return Object.keys(expected).every(
    key => Object.hasOwn(actual, key)
      && JSON.stringify(actual[key]) === JSON.stringify(expected[key]),
  );
}
```

## Repro

```ts
saveConfig({ ...cfg, providers: {
  openai: { ...canonicalDirect, selectedModels: ["gpt-6-astra"] },
}});
// PATCH {"modelContextWindows":{"gpt-6-astra":872000}} → 400 before, 200 after
// PATCH {"baseUrl":"https://attacker.example"}      → still 400 (seed key mismatch)
```

Two regression tests added: `selectedModels` row can still PATCH `modelContextWindows`, and transport tampering (`baseUrl` override) is still rejected on the same row.

## Testing

- `bun test tests/server/management-provider-validation.test.ts` — 119 pass
- `bun test tests/server/config.test.ts tests/providers/provider-cost-overlay-config.test.ts tests/providers/openrouter-provider-routing.test.ts tests/providers/vercel-gateway-provider-routing.test.ts tests/config/model-pinned-effort-config.test.ts` — 414 pass
- `bun x tsc --noEmit` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider settings can now be updated successfully when operator-selected models are present.
  * Canonical provider validation continues to reject unauthorized transport changes, such as modifying the base URL.
  * Existing selected models and other provider settings are preserved during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality-readiness-checklist:start -->
## Review readiness checklist

This PR stays in draft until every box below is ticked. Tick all four boxes once the requirements are met:

- [ ] All CI tests are green on my local testing.
- [ ] I pushed my PR to the latest dev commit.
- [ ] I resolved all correct Codex and CodeRabbit findings.

- [ ] My PR is ready for review.
<!-- pr-quality-readiness-checklist:end -->
