### PR TITLE
test(devin-cli): anchor the empty-data-dir fallback at the host home

### DIFF
--- a/tests/providers/devin-cli-login.test.ts
+++ b/tests/providers/devin-cli-login.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { win32 } from "node:path";
 import {
   DEVIN_CLI_CREDENTIALS_ENV,
   devinCliCredentialsPath,
@@ -149,13 +151,21 @@ describe("devin-cli credential path and read bounds", () => {
     // directory the proxy was started in, and a planted file there would import
     // as the operator's own CLI session.
     // The fallback reads the real home directory rather than env.HOME, so the
-    // assertion is on shape: absolute, and under the home data dir.
+    // assertion is on shape: anchored at that home directory, and under its data
+    // dir. Anchoring is what proves the path is not cwd-relative; asserting a
+    // leading "/" instead would only hold when the HOST is POSIX, because
+    // `homedir()` returns `C:\\Users\\<name>` on Windows no matter which
+    // platform the resolver is asked about.
     for (const empty of ["", "   "]) {
       const resolved = devinCliCredentialsPath({ HOME: "/home/u", XDG_DATA_HOME: empty }, "linux");
-      expect(resolved.startsWith("/")).toBe(true);
+      expect(resolved.startsWith(homedir())).toBe(true);
       expect(resolved.endsWith("/.local/share/devin/credentials.toml")).toBe(true);
     }
     const win = devinCliCredentialsPath({ APPDATA: "" }, "win32");
+    // The win32 branch joins with win32 separators, so a POSIX host home such as
+    // `/Users/runner` comes back as `\\Users\\runner`. Normalize the anchor the
+    // same way rather than comparing a host-shaped string against it.
+    expect(win.startsWith(win32.join(homedir()))).toBe(true);
     expect(win.endsWith("AppData\\Roaming\\devin\\credentials.toml")).toBe(true);
     expect(win.startsWith("devin")).toBe(false);
   });


### PR DESCRIPTION
## Summary

Carries #4384 (@luvs01, head `fdba29bc1ae1cf262430764221312d729476a551`) onto the current `dev` tip.

`devinCliCredentialsPath` picks `path.win32` or `path.posix` from its *platform argument*, but the empty-value fallback joins the *host* `homedir()`. On a Windows runner, asking about `"linux"` therefore returns `C:\Users\<name>/.local/share/devin/credentials.toml`, and the test asserted a leading `/`:

```text
D:\a\opencodex\opencodex\tests\providers\devin-cli-login.test.ts:155:40
Expected: true
Received: false
```

Anchor both crossings at the host home instead, normalising through `win32.join` for the win32 branch so a POSIX host home is compared with matching separators. Anchoring is what actually proves the path is not cwd-relative, which is the defect this test pins; a leading slash only ever held because the host happened to be POSIX.

Production behaviour is unchanged. Test-only.

## Verification

- Hosted CI on this exact head is the merge proof. Local product tests, typecheck, build and install were **NOT RUN** in the authoring session, by explicit instruction.
- Reviewed independently before landing. Confirmed the resolver reads the platform argument at `src/oauth/devin-cli.ts:71` while `homedir()` reflects the host; walked both host/platform crossings; confirmed the untouched `endsWith` on the next line does **not** leave a second Windows failure, because the posix branch joins with forward slashes; and confirmed `win32.join(homedir())` is a real normalisation rather than a single-argument no-op.
- Noted and accepted: the prefix assertion would be vacuous if `homedir()` were empty or `/`. The original cwd-relative defect stays proven by the surviving `endsWith` assertions and the `startsWith("devin") === false` check.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer integration under `MAINTAINERS.md`: `dev` only, with exact-head CI evidence recorded before merge.

Supersedes #4384.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated login path coverage to validate credential locations against the current user’s home directory.
  * Added platform-specific checks for Windows and POSIX environments.
  * Improved test reliability across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->