### PR TITLE
fix(devin): stop the header deadline from killing turns that are still generating

### DIFF
--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -641,6 +641,7 @@
     "devin-cli-authmode-migration.test.ts": "providers",
     "devin-cli-login.test.ts": "providers",
     "devin-hardening.test.ts": "providers",
+    "devin-stream-deadline.test.ts": "providers",
     "digitalocean-scaleway-provider.test.ts": "providers",
     "docs-429-failover-claims.test.ts": "ci-workflows",
     "docs-bun-source-requirement.test.ts": "ci-workflows",

--- a/src/adapters/devin/cloud-direct/chat.ts
+++ b/src/adapters/devin/cloud-direct/chat.ts
@@ -46,8 +46,33 @@ import { resolveDevinApiBaseUrl } from '../../../oauth/devin/api-base.js';
  * we only trigger when the server has genuinely stopped responding.
  */
 const CLOUD_STREAM_IDLE_MS = 120_000;
-/** Time-to-first-byte timeout. */
-const CLOUD_STREAM_TTFB_MS = 60_000;
+/**
+ * Budget for the response HEADERS, which is not the same thing as a connect
+ * timeout. Cognition holds the headers until the model produces its first
+ * token, so on a high-effort reasoning model this bounds generation. A 60s
+ * value killed live swe-2 high turns at exactly 60000ms with no output while
+ * a sibling call on the same account was still alive at 76s, which is the
+ * defect this constant exists to record.
+ *
+ * It has to be at least as generous as the body idle budget above. The cost of
+ * the larger value is bounded and understood: a peer that goes silent at the
+ * TCP level without sending RST/FIN now hangs for this long instead of 60s. A
+ * peer that actually dies still rejects immediately. This timer is the only
+ * bound on that case once `timeout: 0` is set on the fetch, so it must not be
+ * removed. Override with OPENCODEX_DEVIN_TTFB_MS.
+ */
+const CLOUD_STREAM_HEADERS_DEFAULT_MS = 300_000;
+/** Upper bound for the override, so a stray value cannot wedge a turn forever. */
+const CLOUD_STREAM_HEADERS_MAX_MS = 1_800_000;
+function cloudStreamHeadersMs(): number {
+  const raw = process.env.OPENCODEX_DEVIN_TTFB_MS?.trim();
+  if (!raw) return CLOUD_STREAM_HEADERS_DEFAULT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return CLOUD_STREAM_HEADERS_DEFAULT_MS;
+  return Math.min(parsed, CLOUD_STREAM_HEADERS_MAX_MS);
+}
+/** Test seam for the headers budget; the resolver itself stays private. */
+export const cloudStreamHeadersMsForTests = cloudStreamHeadersMs;
 /** Maximum acceptable Connect-RPC frame length (16 MB). */
 const MAX_FRAME_LEN = 16 * 1024 * 1024;
 
@@ -1115,12 +1140,24 @@ export async function* streamChatEvents(req: CloudChatRequest): AsyncGenerator<C
   const framed = frameConnectStream(proto, false);
   const body = new Blob([new Uint8Array(framed)], { type: "application/connect+proto" });
 
-  // Compose caller signal with a TTFB timeout. If the cloud takes longer
-  // than CLOUD_STREAM_TTFB_MS to start the response, abort. Once any byte
-  // arrives we cancel the TTFB timer and start the per-chunk idle timer
-  // inside the read loop instead.
+  // Compose the caller signal with a deadline on the response HEADERS. The
+  // timer is cleared in the finally below, which runs when `await fetch`
+  // resolves — and fetch resolves on headers, not on the first body byte. An
+  // earlier comment here claimed "once any byte arrives", which was wrong and
+  // hid the defect: Cognition withholds headers until the first token, so this
+  // budget is a generation deadline. Body silence after headers is a separate
+  // budget, the per-chunk idle timer in the read loop below.
   const ttfbController = new AbortController();
-  const ttfbTimer = setTimeout(() => ttfbController.abort(new Error(`cloud-direct: time-to-first-byte timeout (${CLOUD_STREAM_TTFB_MS}ms)`)), CLOUD_STREAM_TTFB_MS);
+  const headersMs = cloudStreamHeadersMs();
+  // Abort with no reason and remember that we are the one who fired. Bun rejects
+  // the fetch with its own AbortError rather than handing back `signal.reason`,
+  // so attaching a typed error to abort() would be discarded; the catch below is
+  // what actually produces a classifiable failure.
+  let headersDeadlineFired = false;
+  const ttfbTimer = setTimeout(() => {
+    headersDeadlineFired = true;
+    ttfbController.abort();
+  }, headersMs);
   const ttfbSignal = ttfbController.signal;
   // Compose req.signal + ttfbSignal. AbortSignal.any was added in Node
   // 20.3 / Bun 1.0; our `engines` allows Node ≥18, so on Node 18-20.2 the
@@ -1148,7 +1185,28 @@ export async function* streamChatEvents(req: CloudChatRequest): AsyncGenerator<C
       body,
       redirect: 'error',
       signal: initialSignal,
-    });
+      // Bun applies its own fetch idle timeout (~5 minutes) on top of ours.
+      // Two independent deadlines on the same hop means the shorter one wins
+      // silently and this function can no longer explain its own failure, so
+      // the deadline above is made the single authority. Same reason as
+      // src/server/responses/fetch-helpers.ts.
+      timeout: 0,
+    } as RequestInit);
+  } catch (err) {
+    if (headersDeadlineFired) {
+      // Ours, not the upstream failing. Raised as a typed error with an explicit
+      // status because devinErrorClassification reads CloudChatError.status and
+      // would otherwise return {} for a bare Error, leaving src/lib/errors.ts to
+      // guess from the message text. The message deliberately no longer says
+      // "timeout", so the status is the only thing carrying the classification.
+      throw new CloudChatError(
+        `cloud-direct: no response headers within ${headersMs}ms`,
+        undefined,
+        undefined,
+        504,
+      );
+    }
+    throw err;
   } finally {
     clearTimeout(ttfbTimer);
     // The composed signal only guards the headers hop; the body is cancelled

--- a/tests/fixtures/test-layout-expected.json
+++ b/tests/fixtures/test-layout-expected.json
@@ -472,6 +472,7 @@
   "destination-policy-resolved.test.ts": "routing",
   "devin-adapter.test.ts": "providers",
   "devin-hardening.test.ts": "providers",
+  "devin-stream-deadline.test.ts": "providers",
   "digitalocean-scaleway-provider.test.ts": "providers",
   "docs-429-failover-claims.test.ts": "ci-workflows",
   "docs-bun-source-requirement.test.ts": "ci-workflows",

--- a/tests/providers/devin-stream-deadline.test.ts
+++ b/tests/providers/devin-stream-deadline.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { cloudStreamHeadersMsForTests, CloudChatError } from "../../src/adapters/devin/cloud-direct/chat";
+import { devinErrorClassification } from "../../src/adapters/devin";
+import { repoPath } from "../helpers/repo-root";
+
+const CHAT_SRC = readFileSync(repoPath("src/adapters/devin/cloud-direct/chat.ts"), "utf8");
+
+function withEnv(value: string | undefined, run: () => void): void {
+  const key = "OPENCODEX_DEVIN_TTFB_MS";
+  const before = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    run();
+  } finally {
+    if (before === undefined) delete process.env[key];
+    else process.env[key] = before;
+  }
+}
+
+describe("cloud-direct response-headers deadline", () => {
+  // A 60s budget killed live swe-2 high turns at exactly 60000ms with no output
+  // while a sibling call on the same account was still alive at 76s. Cognition
+  // withholds headers until the first token, so this budget bounds generation.
+  test("the default outlives a reasoning model that thinks past a minute", () => {
+    withEnv(undefined, () => {
+      expect(cloudStreamHeadersMsForTests()).toBe(300_000);
+    });
+  });
+
+  test("the headers budget is not shorter than the body idle budget", () => {
+    // Inverting these is what made the pre-header window the tightest part of a
+    // long turn, which is backwards.
+    const idle = Number(/CLOUD_STREAM_IDLE_MS = ([0-9_]+)/.exec(CHAT_SRC)?.[1]?.replace(/_/g, ""));
+    expect(idle).toBeGreaterThan(0);
+    withEnv(undefined, () => {
+      expect(cloudStreamHeadersMsForTests()).toBeGreaterThanOrEqual(idle);
+    });
+  });
+
+  test("an operator override is honoured", () => {
+    withEnv("1000", () => {
+      expect(cloudStreamHeadersMsForTests()).toBe(1000);
+    });
+  });
+
+  test("an override is clamped so a stray value cannot wedge a turn forever", () => {
+    withEnv("999999999", () => {
+      expect(cloudStreamHeadersMsForTests()).toBe(1_800_000);
+    });
+  });
+
+  test.each(["", "   ", "0", "-5", "not-a-number"])("a useless override %p falls back to the default", (raw) => {
+    withEnv(raw, () => {
+      expect(cloudStreamHeadersMsForTests()).toBe(300_000);
+    });
+  });
+});
+
+describe("cloud-direct headers-deadline failure is ours, not the upstream", () => {
+  // The old abort raised a bare Error, so devinErrorClassification returned {}
+  // and the failure was inferred from message text as an upstream 502/504.
+  test("the deadline error classifies as a gateway timeout the caller may retry", () => {
+    const err = new CloudChatError("cloud-direct: no response headers within 300000ms", undefined, undefined, 504);
+    expect(devinErrorClassification(err)).toEqual({ status: 504, retryable: true });
+  });
+
+  test("a bare Error still classifies as nothing, which is why the status is set explicitly", () => {
+    expect(devinErrorClassification(new Error("cloud-direct: no response headers within 300000ms"))).toEqual({});
+  });
+
+  test("the message no longer claims a first-byte measurement it cannot make", () => {
+    // Nothing is on the wire before headers, so "time-to-first-byte" described a
+    // measurement that does not exist. Dropping the word "timeout" from it is why
+    // the explicit 504 above is mandatory rather than cosmetic.
+    expect(CHAT_SRC).not.toContain("time-to-first-byte");
+  });
+});
+
+describe("cloud-direct headers deadline guards", () => {
+  test("the abort callback records that we fired before aborting", () => {
+    // Bun rejects the fetch with its own AbortError instead of handing back
+    // signal.reason, so a typed error passed to abort() would be discarded and
+    // the catch could not tell our deadline from a caller cancel.
+    expect(CHAT_SRC).toMatch(/headersDeadlineFired = true;\s*\n\s*ttfbController\.abort\(\);/);
+    expect(CHAT_SRC).not.toMatch(/ttfbController\.abort\(new /);
+  });
+
+  test("the GetChatMessage fetch disables the competing runtime timeout", () => {
+    // Two independent deadlines on one hop means the shorter wins silently and
+    // this function can no longer explain its own failure.
+    const call = CHAT_SRC.slice(CHAT_SRC.indexOf("ApiServerService/GetChatMessage"));
+    expect(call.slice(0, call.indexOf("} as RequestInit"))).toContain("timeout: 0");
+  });
+
+  test("a caller cancel is re-thrown unchanged", () => {
+    expect(CHAT_SRC).toMatch(/if \(headersDeadlineFired\) \{[\s\S]*?\}\s*\n\s*throw err;/);
+  });
+});


### PR DESCRIPTION
## Summary

A live `swe-2` turn at high effort died with:

```text
stream disconnected before completion: cloud-direct: time-to-first-byte timeout (60000ms)
```

Three such failures were logged, all at ~60s with no output, while a sibling call on the same account was still alive at 76s. The upstream was healthy; we hung up on it.

The comment claimed the timer was cancelled "once any byte arrives". It was not — the timer is cleared in the `finally` that runs when `await fetch` resolves, and **fetch resolves on response headers**. Cognition withholds headers until the model emits its first token, so the 60s budget was a generation deadline on the pre-header window. Nothing is on the wire before headers either, so "time-to-first-byte" named a measurement a client cannot take; the constant and message are renamed to say what they actually bound.

| window | budget before | budget after |
|---|---|---|
| response headers | 60s | 300s, `OPENCODEX_DEVIN_TTFB_MS`, clamped at 30m |
| body silence after headers | 120s | 120s, untouched |

The header budget being the shorter of the two made the pre-header window the tightest part of a long turn, which is backwards.

The failure is now classifiable. The old abort raised a bare `Error`, so `devinErrorClassification` returned `{}` and `src/lib/errors.ts` guessed the status from message text. Bun rejects the fetch with its own `AbortError` rather than handing back `signal.reason`, so attaching a typed error to `abort()` would be discarded — a flag plus an explicit throw in the `catch` is what produces a `CloudChatError` carrying `504`. A caller cancel leaves the flag false and re-throws unchanged.

## Verification

- Hosted CI on this exact head is the merge proof. Local product tests, typecheck, build and install were **NOT RUN** in the authoring session, by explicit instruction.
- New regression coverage in `tests/providers/devin-stream-deadline.test.ts`: the default outlives a model that thinks past a minute, the header budget is asserted **not shorter than** the body idle budget, override honoured and clamped, useless overrides fall back, the deadline error classifies as a retryable 504 while a bare `Error` still classifies as nothing, and guards pinning the fired-flag ordering, `timeout: 0`, and the unchanged caller-cancel rethrow.
- Registered in `scripts/test-layout/layout.json` and `tests/fixtures/test-layout-expected.json` as the layout guard requires.
- Reviewed independently before implementation. It confirmed the 60s budget bounds only the header wait, that Bun throws `AbortError` so the catch-based rethrow is the correct shape, that the caller-cancel path is preserved, and that `CLOUD_STREAM_IDLE_MS` remains independent.

### Accepted tradeoff

`timeout: 0` makes our deadline the single authority on this hop, matching `src/server/responses/fetch-helpers.ts`. It removes the runtime's own ~5 minute net, so a peer that goes silent at the TCP level **without** sending RST/FIN now hangs for the budget instead of 60s. A peer that actually dies still rejects immediately. This timer is the only bound left on that case, which is recorded in the constant so it is not removed later. The reviewer independently defended 300000 and rejected 120000, since a live sibling call survived `ageMs=137197`.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer integration under `MAINTAINERS.md`: `dev` only, with exact-head CI evidence recorded before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable response-header deadline for Devin cloud connections.
  * The deadline defaults to 5 minutes, can be adjusted through configuration, and is capped at 30 minutes.

* **Bug Fixes**
  * Improved timeout handling so stalled connections report a clear, retryable error when response headers are not received in time.
  * Preserved the original error when a request is canceled by the caller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->