### PR TITLE
feat(devin): request prompt caching and give the session cache an identity

### DIFF
--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -646,6 +646,7 @@
     "devin-cli-authmode-migration.test.ts": "providers",
     "devin-cli-login.test.ts": "providers",
     "devin-hardening.test.ts": "providers",
+    "devin-prompt-cache.test.ts": "providers",
     "devin-stream-deadline.test.ts": "providers",
     "digitalocean-scaleway-provider.test.ts": "providers",
     "docs-429-failover-claims.test.ts": "ci-workflows",

--- a/src/adapters/devin/cloud-direct/chat.ts
+++ b/src/adapters/devin/cloud-direct/chat.ts
@@ -77,16 +77,34 @@ export const cloudStreamHeadersMsForTests = cloudStreamHeadersMs;
 const MAX_FRAME_LEN = 16 * 1024 * 1024;
 
 /**
- * Per-(apiKey, host) session/cascade ID cache. Cloud uses these for
- * server-side context caching across turns of the same conversation; if we
- * mint a fresh sessionId on every call (which we used to), every turn looks
- * like a brand-new session and the prompt-cache hit ratio is zero.
+ * PromptCacheOptions.type = EPHEMERAL. Marks the system prefix as a cache entry
+ * the server may reuse on the next turn of the same session.
+ */
+const PROMPT_CACHE_EPHEMERAL = 1;
+
+/**
+ * Per-identity session/cascade ID cache. Cloud uses these for server-side
+ * context caching across turns of the same conversation; if we mint a fresh
+ * sessionId on every call (which we used to), every turn looks like a
+ * brand-new session and the prompt-cache hit ratio is zero.
  * Single-process scope is enough: opencode lives in one runtime for a TUI
  * session, and CLI one-shots don't benefit from caching anyway.
  */
 interface SessionIds {
   sessionId: string;
   cascadeId: string;
+}
+
+/**
+ * Cache key for one Devin credential on one host.
+ *
+ * The credential itself used to be the Map key. Hashing it keeps the raw token
+ * out of any structure a heap dump or debugger would walk, and gives the other
+ * per-account caches a name they can share. 16 hex is 64 bits, which against a
+ * bounded single-process map is not a collision risk worth widening the key for.
+ */
+export function devinCacheIdentity(apiKey: string, host: string): string {
+  return crypto.createHash('sha256').update(`${host}\x1f${apiKey}`).digest('hex').slice(0, 16);
 }
 /**
  * Bounded the same way the adapter bounds its cascade-id map: a long-running
@@ -95,7 +113,7 @@ interface SessionIds {
 const SESSION_CACHE_MAX = 256;
 const sessionCache = new Map<string, SessionIds>();
 function getOrAllocateSessionIds(apiKey: string, host: string, cascadeIdOverride?: string): SessionIds {
-  const key = `${host}\x1f${apiKey}`;
+  const key = devinCacheIdentity(apiKey, host);
   let ids = sessionCache.get(key);
   if (!ids) {
     ids = {
@@ -115,9 +133,21 @@ function getOrAllocateSessionIds(apiKey: string, host: string, cascadeIdOverride
   return ids;
 }
 
-/** Drop the cached session IDs — call after logout so a new sign-in starts fresh. */
-export function clearSessionIds(): void {
-  sessionCache.clear();
+/**
+ * Drop the cached session for ONE identity, after that account signs out or is
+ * switched away from.
+ *
+ * This replaces a global clear(). The proxy serves several accounts from one
+ * process, so clearing every entry on a per-provider logout would strip the
+ * session and cascade of accounts that were mid-turn. That is why the global
+ * version was never safe to call, and why nothing ever called it.
+ *
+ * A turn already in flight is unaffected: it received its SessionIds object at
+ * request start and never re-reads the map, so it finishes on the session it
+ * began with and the next turn allocates fresh.
+ */
+export function invalidateSessionIdentity(identity: string): void {
+  sessionCache.delete(identity);
 }
 
 // ----------------------------------------------------------------------------
@@ -669,6 +699,7 @@ function buildGetChatMessageRequest(args: BuildArgs): Buffer {
   //   #7  request_type (varint enum)
   //   #8  completion_configuration
   //   #10 tools (repeated ChatToolDefinition)
+  //   #13 prompt_cache_options
   //   #16 cascade_id (string)
   //   #21 chat_model_uid (string)
   //   #22 prompt_id (string)
@@ -682,6 +713,13 @@ function buildGetChatMessageRequest(args: BuildArgs): Buffer {
     encodeVarintField(7, args.requestType ?? 5),
     encodeMessage(8, completion),
     ...toolParts,
+    // #13 prompt_cache_options: { type: EPHEMERAL }. Reusing a session id is only
+    // half of prompt caching — without this the server creates no cache entry and
+    // every turn re-reads the whole prefix, which is why the sessionId reuse above
+    // was not producing the hit ratio its comment claims. The native client sends
+    // it and records real savings; sending it unconditionally matches both the
+    // native client and CLIProxyAPIPlus, which places it outside its tools gate.
+    encodeMessage(13, encodeVarintField(1, PROMPT_CACHE_EPHEMERAL)),
     // #15 session model config: { id, turn, 4 }. Present on every verified
     // request.
     encodeMessage(15, Buffer.concat([

--- a/tests/fixtures/test-layout-expected.json
+++ b/tests/fixtures/test-layout-expected.json
@@ -477,6 +477,7 @@
   "destination-policy-resolved.test.ts": "routing",
   "devin-adapter.test.ts": "providers",
   "devin-hardening.test.ts": "providers",
+  "devin-prompt-cache.test.ts": "providers",
   "devin-stream-deadline.test.ts": "providers",
   "digitalocean-scaleway-provider.test.ts": "providers",
   "docs-429-failover-claims.test.ts": "ci-workflows",

--- a/tests/providers/devin-prompt-cache.test.ts
+++ b/tests/providers/devin-prompt-cache.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildGetChatMessageRequestForTests,
+  devinCacheIdentity,
+  invalidateSessionIdentity,
+} from "../../src/adapters/devin/cloud-direct/chat";
+
+function buildRequest(overrides: Record<string, unknown> = {}): Buffer {
+  return buildGetChatMessageRequestForTests({
+    apiKey: "k",
+    modelUid: "swe-2-high",
+    messages: [{ role: "user", content: "hi" }],
+    cascadeId: "cascade-1",
+    sessionId: "session-1",
+    requestId: 1n,
+    triggerId: "trigger-1",
+    ...overrides,
+  } as never);
+}
+
+describe("prompt cache options on the wire", () => {
+  // Reusing a session id is only half of prompt caching. Without this field the
+  // server creates no cache entry and every turn re-reads the whole prefix.
+  // Bytes: tag (13<<3)|2 = 0x6a, length 0x02, inner field 1 varint 1 = 08 01.
+  const EXPECTED = Buffer.from([0x6a, 0x02, 0x08, 0x01]);
+
+  test("the request carries PromptCacheOptions{EPHEMERAL}", () => {
+    expect(buildRequest().includes(EXPECTED)).toBe(true);
+  });
+
+  test("it is sent even when the turn has no tools", () => {
+    // CLIProxyAPIPlus appends it outside its tools gate, and the native client
+    // caches the system prefix regardless of whether tools were declared.
+    expect(buildRequest({ tools: [] }).includes(EXPECTED)).toBe(true);
+    expect(buildRequest({ tools: undefined }).includes(EXPECTED)).toBe(true);
+  });
+
+  test("exactly one cache-options field is emitted", () => {
+    const buf = buildRequest();
+    let count = 0;
+    for (let i = 0; i + EXPECTED.length <= buf.length; i += 1) {
+      if (buf.subarray(i, i + EXPECTED.length).equals(EXPECTED)) count += 1;
+    }
+    expect(count).toBe(1);
+  });
+});
+
+describe("devin cache identity", () => {
+  test("the raw credential never becomes the cache key", () => {
+    const apiKey = "devin-secret-token-value";
+    const identity = devinCacheIdentity(apiKey, "https://server.example");
+    expect(identity).not.toContain(apiKey);
+    expect(identity).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("identity separates accounts and hosts", () => {
+    const a = devinCacheIdentity("key-a", "https://h1");
+    const b = devinCacheIdentity("key-b", "https://h1");
+    const c = devinCacheIdentity("key-a", "https://h2");
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  test("the same credential and host is stable across calls", () => {
+    expect(devinCacheIdentity("key", "https://h")).toBe(devinCacheIdentity("key", "https://h"));
+  });
+
+  test("the host boundary cannot be forged by a crafted credential", () => {
+    // The parts are joined with a separator that cannot appear in either half,
+    // so "h" + key and host + "\x1fh" must not collide.
+    expect(devinCacheIdentity("b", "a")).not.toBe(devinCacheIdentity("", "a\x1fb"));
+  });
+});
+
+describe("session invalidation is scoped to one account", () => {
+  test("invalidating an unknown identity is harmless", () => {
+    expect(() => invalidateSessionIdentity(devinCacheIdentity("nobody", "https://h"))).not.toThrow();
+  });
+
+  test("the unsafe global clear is gone from the module surface", async () => {
+    // A per-provider logout calling a global clear() would strip the session and
+    // cascade of every other account mid-turn, which is why nothing ever called it.
+    const mod = await import("../../src/adapters/devin/cloud-direct/chat");
+    expect("clearSessionIds" in mod).toBe(false);
+    expect(typeof mod.invalidateSessionIdentity).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

We were reusing the Devin session id specifically so the server-side prompt cache would hit, and then never asking for a cache entry. The request encoder emitted fields 1, 2, 3, 7, 8, 10, 15, 16, 20 and 21 and omitted **field 13, `PromptCacheOptions`**, so the server created nothing to reuse and re-read the whole prefix every turn.

Send it, unconditionally. The bytes are `6a 02 08 01` — tag `(13<<3)|2`, length 2, inner field 1 varint 1 — verified against both implementations that already do this.

The comparison is the point: neither reference gets the whole thing.

| | session reuse | asks for a cache entry |
|---|---|---|
| native Devin CLI | yes | yes |
| CLIProxyAPIPlus | **no**, new session per request | yes |
| opencodex before | yes | **no** |
| opencodex after | yes | yes |

CLIProxyAPIPlus asks for a cache it then cannot hit, because it mints a fresh session and cascade on every request. We kept the session and never asked. Both halves now hold.

### Cache identity

The session cache was keyed by the raw credential, which puts the token into a `Map` key that any heap dump or debugger walks, and leaves the other per-account caches without a shared name for an account. It is now keyed by a sha256 identity.

That identity is what makes invalidation safe. `clearSessionIds` was a global `Map.clear()`, and this proxy serves several accounts from one process — a per-provider logout calling it would have stripped the session and cascade of accounts that were mid-turn. It was exported with **zero callers** precisely because there was no safe place to call it. `invalidateSessionIdentity` drops one account.

No epoch is introduced. A turn in flight received its `SessionIds` object at request start and never re-reads the map, so deleting an entry cannot disturb it.

## Verification

- Hosted CI on this exact head is the merge proof. Local product tests, typecheck, build and install were **NOT RUN** in the authoring session, by explicit instruction.
- New coverage in `tests/providers/devin-prompt-cache.test.ts`: the exact 4 bytes are present, they are present with no tools and with `tools: []`, exactly one cache-options field is emitted, the identity never contains the credential and is stable and account/host separating, a crafted credential cannot forge the host boundary, and the module surface no longer exports the global clear.
- Registered in `scripts/test-layout/layout.json` and `tests/fixtures/test-layout-expected.json`.
- Reviewed independently before implementation. It walked both encoders byte for byte and confirmed `6a 02 08 01` matches `devinEncodeSubMessage(13, devinEncodeCacheOptions())`; confirmed field order is not a wire correctness condition and that placing 13 between 10 and 15 is caution; confirmed the unconditional send matches Plus, which appends it outside its tools gate; confirmed 16 hex gives ~1.8e-15 collision at the bounded cache size and that nothing parses the map key; and confirmed `clearSessionIds` is not re-exported by the `cloud-direct` barrel, so removing it cannot break the build.
- The reviewer argued the epoch specified in the plan was dead complexity and I accepted that, so it is not in this change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer integration under `MAINTAINERS.md`: `dev` only, with exact-head CI evidence recorded before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled ephemeral prompt caching for Devin conversations, improving continuity across turns.
  - Added secure, account-specific cache identity handling to keep sessions isolated across hosts and credentials.
  - Added targeted session invalidation so signing out one account no longer affects unrelated sessions.

- **Bug Fixes**
  - Corrected prompt-cache request handling for conversations with or without tools.
  - Improved resilience when invalidating unknown session identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->