### PR TITLE
fix(devin): stop a tier suffix from earning a second effort suffix

### DIFF
--- a/src/adapters/devin.ts
+++ b/src/adapters/devin.ts
@@ -10,6 +10,7 @@ import type { AdapterEvent, OcxAssistantMessage, OcxContentPart, OcxMessage, Ocx
 import type { IncomingMeta, ProviderAdapter } from "./base";
 import { streamChatEvents, allocateCascadeId, CloudChatError, type ChatHistoryItem, type ToolDef } from "./devin/cloud-direct";
 import { getCachedCatalog } from "./devin/cloud-direct/catalog";
+import { collapseDevinModelUid } from "./devin/live-models";
 import { buildNonOpenAIToolCatalogNudgeForTools } from "./tool-catalog-nudge";
 import { DEVIN_DEFAULT_API_SERVER, resolveDevinApiServer } from "../oauth/devin";
 
@@ -66,7 +67,15 @@ export function devinErrorClassification(error: unknown): { status?: number; err
 
 export const DEVIN_API_SERVER = DEVIN_DEFAULT_API_SERVER;
 
-const EFFORT_SUFFIXES = new Set(["low", "medium", "high", "xhigh", "max", "none", "1m", "max-1m", "none-1m", "fast"]);
+/**
+ * Reasoning-effort values a CALLER may name. Deliberately not the same set as
+ * the catalog suffix tokens: `priority` is a service tier that appears in a UID
+ * but is not something a caller asks for as effort, and `max-1m` / `none-1m`
+ * are compound values a caller can send that never appear as a trailing token.
+ * The two sets share most members and mean different things; merging them would
+ * both admit a tier as an effort and silently drop the compound values.
+ */
+const CALLER_EFFORT_VALUES = new Set(["low", "medium", "high", "xhigh", "max", "none", "1m", "max-1m", "none-1m", "fast"]);
 
 /**
  * Cognition's catalog spells model ids with hyphens (`swe-1-7`), but the same
@@ -79,9 +88,18 @@ export function normalizeDevinModelId(modelId: string): string {
   return modelId.replace(/\./g, "-");
 }
 
+/**
+ * Does this id already carry a catalog effort/variant suffix?
+ *
+ * Delegates to the collapser so there is one answer to "what is a suffix".
+ * The previous local set had drifted: it was missing `priority`, so
+ * `gpt-5-6-sol-medium-priority` read as unsuffixed and got a second suffix
+ * appended, producing a UID Cognition answers with an opaque permission_denied.
+ * Delegating also handles compound suffixes, which testing only the final
+ * hyphen-separated token never could.
+ */
 function hasEffortSuffix(modelId: string): boolean {
-  const parts = modelId.split("-");
-  return parts.length > 1 && EFFORT_SUFFIXES.has(parts[parts.length - 1]!);
+  return collapseDevinModelUid(modelId) !== modelId;
 }
 
 /**
@@ -89,8 +107,9 @@ function hasEffortSuffix(modelId: string): boolean {
  * not as a separate effort field, so an explicit caller effort has to be resolved
  * to the UID before the suffix shortcut below accepts whatever the picker sent.
  *
- * Kept as a named table rather than an inline branch because EFFORT_SUFFIXES does
- * not carry `ultra`, `off`, or `minimal`, so the two would drift apart silently.
+ * Kept as a named table rather than an inline branch because the caller-effort
+ * set does not carry `ultra`, `off`, or `minimal`, so the two would drift apart
+ * silently.
  * Values below Medium select Medium: SWE-2 has no lane under it, and rounding down
  * to nothing would quietly disable its reasoning.
  */
@@ -145,7 +164,7 @@ async function resolveWireModelUid(
   const catalog = await getCachedCatalog(apiKey, host);
   if (catalog) {
     if (catalog.byUid.has(modelId)) return modelId;
-    const effort = reasoningEffort && EFFORT_SUFFIXES.has(reasoningEffort) ? reasoningEffort : "medium";
+    const effort = reasoningEffort && CALLER_EFFORT_VALUES.has(reasoningEffort) ? reasoningEffort : "medium";
     const suffixed = `${modelId}-${effort}`;
     if (catalog.byUid.has(suffixed)) return suffixed;
     // Fall back to any enabled variant of this base model.
@@ -154,7 +173,7 @@ async function resolveWireModelUid(
     }
   }
   // Degraded mode: append the default effort suffix.
-  const effort = reasoningEffort && EFFORT_SUFFIXES.has(reasoningEffort) ? reasoningEffort : "medium";
+  const effort = reasoningEffort && CALLER_EFFORT_VALUES.has(reasoningEffort) ? reasoningEffort : "medium";
   return `${modelId}-${effort}`;
 }
 

--- a/src/adapters/devin/live-models.ts
+++ b/src/adapters/devin/live-models.ts
@@ -72,7 +72,7 @@ export const DEVIN_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
  * Trailing tokens that the Cognition catalog appends as effort/variant
  * suffixes. Stripped to collapse suffixed UIDs to their base id.
  */
-const EFFORT_TOKENS = new Set([
+export const EFFORT_TOKENS = new Set([
   "low", "medium", "high", "xhigh", "max", "none", "fast", "priority", "1m",
 ]);
 

--- a/tests/providers/devin-adapter.test.ts
+++ b/tests/providers/devin-adapter.test.ts
@@ -236,3 +236,47 @@ describe("SWE-2 wire effort selection", () => {
     }
   });
 });
+
+describe("effort suffix detection and caller effort values are different sets", () => {
+  // The two had drifted: the request path was missing `priority`, so a UID that
+  // already carried it read as unsuffixed and got a second suffix appended —
+  // the exact shape Cognition answers with an opaque permission_denied.
+  test("a UID carrying the priority tier is recognised as already suffixed", async () => {
+    for (const uid of ["gpt-5-6-sol-priority", "gpt-5-6-sol-medium-priority"]) {
+      expect(await resolveWireModelUidForTests(uid, "unused", "unused", "high")).toBe(uid);
+    }
+  });
+
+  test("detection handles a compound suffix, which a last-token test could not", async () => {
+    expect(await resolveWireModelUidForTests("gpt-5-6-sol-medium-priority", "unused", "unused")).toBe(
+      "gpt-5-6-sol-medium-priority",
+    );
+  });
+
+  test("a bare model still receives the caller effort", async () => {
+    expect(await resolveWireModelUidForTests("gpt-5-6-sol", "unused", "unused", "high")).toBe("gpt-5-6-sol-high");
+  });
+
+  // `priority` is a service tier, not something a caller asks for as effort.
+  // Sharing one set between detection and caller validity would admit it.
+  test("priority is not accepted as a caller reasoning effort", async () => {
+    expect(await resolveWireModelUidForTests("gpt-5-6-sol", "unused", "unused", "priority")).toBe(
+      "gpt-5-6-sol-medium",
+    );
+  });
+
+  // These never appear as a trailing token, so they are meaningless to detection,
+  // but a caller can still name them and they must survive.
+  test.each(["max-1m", "none-1m", "1m", "fast"])("the compound caller value %p is preserved", async (effort) => {
+    expect(await resolveWireModelUidForTests("gpt-5-6-sol", "unused", "unused", effort)).toBe(
+      `gpt-5-6-sol-${effort}`,
+    );
+  });
+
+  test("a model name is never mistaken for a suffix", async () => {
+    // Greedy collapse must not eat part of a real model name.
+    for (const uid of ["claude-opus-5", "swe-1-7", "glm-5-3"]) {
+      expect(await resolveWireModelUidForTests(uid, "unused", "unused", "high")).toBe(`${uid}-high`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two sets of effort tokens had drifted. The catalog side (`EFFORT_TOKENS`) carried `priority`; the request side (`EFFORT_SUFFIXES`) did not. `hasEffortSuffix` also tested only the final hyphen-separated token, so:

| model id | detected as suffixed? | sent to Cognition |
|---|---|---|
| `gpt-5-6-sol-medium-priority` | before: **no** | `gpt-5-6-sol-medium-priority-medium` |
| `gpt-5-6-sol-medium-priority` | after: yes | unchanged |

That doubled UID is the exact shape `normalizeDevinModelId` warns about a few lines above: Cognition answers it with an opaque `permission_denied`.

Detection now delegates to `collapseDevinModelUid`, so there is one answer to what counts as a suffix, and compound suffixes work — which a last-token test could never do.

### The two sets stay separate

They answer different questions, so merging them would be a silent behaviour change in both directions:

- `priority` is a **service tier**. It belongs in a UID, but a caller should not be able to request it as reasoning effort.
- `max-1m` and `none-1m` are **compound caller values** that never appear as a trailing token. They are meaningless to detection but must survive as caller input.

So the request-side set is renamed `CALLER_EFFORT_VALUES` to say which question it answers, and the distinction is pinned by tests rather than left to the next reader to rediscover.

## Verification

- Hosted CI on this exact head is the merge proof. Local product tests, typecheck, build and install were **NOT RUN** in the authoring session, by explicit instruction.
- New cases in `tests/providers/devin-adapter.test.ts`: a UID carrying the tier is left alone, a compound suffix is detected, a bare model still receives the caller effort, `priority` is rejected as a caller effort, each compound caller value survives, and a real model name is never eaten by greedy collapse.
- Reviewed independently before implementation. It confirmed the only behaviour change is the two `-priority` forms going false to true (the intended fix), that greedy collapse never eats a real catalog model name, that the import direction creates no cycle, and that the SWE-2 branch is unaffected because it returns before the suffix check.
- The reviewer argued against the original plan of deleting the request-side set and using one set for both jobs, on the grounds above. That correction is what this PR implements.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer integration under `MAINTAINERS.md`: `dev` only, with exact-head CI evidence recorded before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Devin model selection when using effort or variant suffixes.
  - Preserved compound effort values and correctly applied effort settings to models without an existing suffix.
  - Distinguished valid caller effort values from service-specific suffixes, such as `priority`.
  - Prevented model names from being incorrectly interpreted as effort or variant suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->