### PR TITLE
fix(chat): stop refusal bookkeeping from failing refusal-free turns

### DIFF
--- a/devlog/_plan/260913_chat_refusal_translator/000_plan.md
+++ b/devlog/_plan/260913_chat_refusal_translator/000_plan.md
@@ -1,0 +1,115 @@
+# 000 — Chat 번역기가 거절 없는 턴을 거절 오류로 죽인다
+
+- 단위: `260913_chat_refusal_translator`
+- 세션: `01a0985e-ce1a-7d12-81b9-c2e93a2bce67` (HOTL, cxc-loop)
+- 기준: `origin/dev` `2df82f412`
+
+## 증상
+
+Aside가 `/v1/chat/completions`로 `devin-cli/swe-2`를 호출한 턴이 정상 스트리밍 중에 죽었다.
+
+```text
+There was an error in Opencodex server
+upstream refusal representations are inconsistent
+```
+
+로그 2건 (`ocx-a89175137a2c5faccc95adc49c9d99b6`, `ocx-5b3270175913077e00d2a3fe1ddc4e83`):
+
+| 항목 | 값 |
+|---|---|
+| provider / model | `devin-cli` / `swe-2` |
+| inboundProtocol | `chat` |
+| firstOutputMs | 17148 / 14874 |
+| outputTokens | 1057 / 865 |
+| durationMs | 30989 / 29088 |
+| status | 499 `client_closed_request`, `closeReason: client_cancel` |
+
+모델은 이미 900~1000 토큰을 내보내고 있었다. 번역기가 in-band 오류 프레임을 뱉고
+Aside가 그걸 표시한 뒤 연결을 끊은 모양이라 서버 쪽에는 499로 남는다.
+
+**이 턴에는 거절(refusal)이 하나도 없었다.** 그게 이 버그의 핵심이다.
+
+## 근본 원인 — 두 결함의 합
+
+### 1) 번역기가 거절 없는 메시지까지 거절 장부에 올린다
+
+`src/chat/outbound.ts` `snapshotRefusalItem`:
+
+```ts
+    // Unrelated sparse text messages historically need no position metadata.
+    if (outputIndex === undefined && (!Array.isArray(item.content)
+      || !item.content.some(part => isRec(part) && part.type === "refusal"))) return;
+    const known = refusalItem(outputIndex, item, "id");   // :308
+```
+
+조기 return 조건이 `outputIndex === undefined`로 묶여 있다. 즉 **index가 있기만 하면**
+거절 파트가 하나도 없는 평범한 텍스트 메시지도 :308을 지나 `refusalItem()`을 부르고,
+그 함수는 `refusalItems[index]`를 만들고 `refusalIndexById[item.id] = index`를 등록한다.
+
+그 뒤 `refusalItem`의 일관성 검사가 일반 텍스트에 적용된다.
+
+```ts
+      const knownIndex = refusalIndexById.get(candidate);
+      if (knownIndex !== undefined && knownIndex !== index) throw refusalTranslationError();  // :248
+      if (item.id !== undefined && item.id !== candidate) throw refusalTranslationError();    // :249
+```
+
+비대칭이 증거다. 같은 파일의 **비스트리밍 수집 경로(:788-820)는 이미**
+`part.type === "refusal"`로 좁혀져 있고 맵을 시드하지 않는다. 스트리밍 쪽만 넓다.
+
+### 2) bridge가 열린 메시지와 같은 output_index에 reasoning을 끼워 넣는다
+
+`src/bridge.ts` `flushHiddenReasoningEnvelope`(:514-517)는 `currentMsg`를 닫지 않은 채
+현재 `outputIndex`로 reasoning 아이템의 `added`/`done`을 emit한다. 그래서 한 index에
+서로 다른 두 아이템 id가 실린다.
+
+평소에는 무해하다 — 아무도 index별 id 유일성을 요구하지 않으니까. 결함 1이
+그 요구를 거절과 무관한 아이템에까지 걸면서 치명적이 된다.
+
+### 왜 하필 Devin + Aside인가
+
+Devin 어댑터는 proto #9를 `kind: reasoning`으로 낸다. inbound가 `chat`이고 summary가
+없으면 `hideThinkingSummary = true`가 되어 숨김 reasoning flush 경로를 탄다. 두 조건이
+겹치는 조합이 바로 이것이다.
+
+## 최소 재현 (거절 내용 0건)
+
+| # | event | output_index | item.id | item.type |
+|---|---|---|---|---|
+| 1 | `response.output_item.added` | 0 | `msg_1` | `message` |
+| 2 | `response.output_item.done` | 0 | `rs_1` | `reasoning` |
+
+1이 :308에서 `msg_1`을 심고, 2가 :623 → :299 → :249에서 던진다.
+
+## 고칠 것과 안 고칠 것
+
+**고친다 (wp2):** 번역기가 거절 파트가 실제로 있는 아이템에만 장부를 쓰게 한다.
+사용자에게 잘못된 오류를 보내는 쪽이 여기다.
+
+**고치지 않는다 (후속):** bridge의 index 재사용은 그 자체로 Responses 프로토콜상
+깔끔하지 않지만, 이번 범위에서 건드리면 reasoning 표시 동작까지 회귀 위험이 생긴다.
+별도 단위로 남기고 010에 증거를 기록한다.
+
+## 보존해야 할 계약
+
+`tests/responses/chat-refusal.test.ts`가 유일한 계약 파일이다. 실제 `refusalDelta` 이후의
+모순을 요구하는 18개 케이스(165-182, 루프 185)는 수정 후에도 그대로 던져야 한다.
+
+| throw | 언제 의미 있나 |
+|---|---|
+| :227 :239 :248 :249 | 지금은 일반 텍스트에도 발화 — 좁혀야 함 |
+| :269 :273 :278 :302 :315 :570 | 거절 내용이 있을 때만 의미 있음 — 유지 |
+
+## 작업 단계
+
+| wp | 문서 | 산출물 |
+|---|---|---|
+| wp0 | 이 문서 + 010 + 020 | 로드맵 |
+| wp1 | `010_rootcause_evidence.md` | 재현 테스트로 원인 증명 |
+| wp2 | `020_fix_refusal_scope.md` | 수정 + PR + merge |
+
+## 완료 기준
+
+`c-1`~`c-5`는 goalplan에 등록돼 있다. 요약하면: 로드맵 존재, 원인 증명, 거절 없는
+스트림이 성공, 진짜 거절 모순은 여전히 실패, exact-head hosted CI 성공.
+

--- a/devlog/_plan/260913_chat_refusal_translator/010_rootcause_evidence.md
+++ b/devlog/_plan/260913_chat_refusal_translator/010_rootcause_evidence.md
@@ -1,0 +1,56 @@
+# 010 — wp1: 원인 증명 (재현 테스트)
+
+수정 전 트리에서 실패하고 수정 후 통과하는 테스트를 먼저 세운다. 그게 이 단계의 전부다.
+
+## NEW: tests/responses/chat-refusal-scope.test.ts
+
+기존 `tests/responses/chat-refusal.test.ts`는 건드리지 않는다. 그 파일은 거절 계약을
+지키는 곳이고, 여기는 "거절이 아닌 것에 거절 규칙이 걸리지 않는다"를 지키는 곳이다.
+
+재현 케이스는 이벤트 두 개면 충분하다.
+
+```ts
+// 거절 파트가 어디에도 없다. 그런데 현재 트리에서는 invalid_refusal로 죽는다.
+const events = [
+  sse("response.output_item.added", {
+    output_index: 0,
+    item: { type: "message", id: "msg_1", status: "in_progress", role: "assistant", content: [] },
+  }),
+  sse("response.output_item.done", {
+    output_index: 0,
+    item: { type: "reasoning", id: "rs_1", summary: [] },
+  }),
+];
+```
+
+기대: 스트림이 `invalid_refusal` 없이 끝난다. 현재 트리에서는 :308이 `msg_1`을 심고
+:623 → :299 → :249가 `rs_1`에서 던진다.
+
+## 추가 케이스
+
+| 케이스 | 기대 (수정 후) |
+|---|---|
+| 한 index에 message → reasoning (위 최소 재현) | 성공 |
+| 거절 없는 텍스트 메시지 2개가 같은 id를 재사용 | 성공 |
+| 같은 message id가 다른 index에 등장 (거절 없음) | 성공 |
+| 실제 `response.refusal.delta` 뒤 같은 id가 다른 index | **여전히 throw** |
+| 실제 거절 뒤 한 index에 다른 거절 id | **여전히 throw** |
+| 거절 스냅샷이 누적 델타의 접두사가 아님 | **여전히 throw** |
+
+마지막 세 줄이 이 수정의 안전망이다. 이것들이 통과해 버리면 수정이 과했다는 뜻이다.
+
+## 레이아웃 등록
+
+`tests/responses/` 도메인이므로 두 파일에 항목을 추가한다.
+
+- `scripts/test-layout/layout.json` `explicit`
+- `tests/fixtures/test-layout-expected.json`
+
+`chat-refusal.test.ts`가 이미 `responses`로 등록돼 있으니 같은 값을 쓴다.
+
+## 증거로 남길 것
+
+수정 전 실행 결과(실패)와 수정 후 실행 결과(통과)를 같은 명령으로 남긴다. 단,
+이 세션은 로컬 제품 스위트 금지이므로 **hosted CI가 판정자**다. 로컬에서는 실행하지
+않고 NOT RUN으로 표기한다.
+

--- a/devlog/_plan/260913_chat_refusal_translator/020_fix_refusal_scope.md
+++ b/devlog/_plan/260913_chat_refusal_translator/020_fix_refusal_scope.md
@@ -1,0 +1,71 @@
+# 020 — wp2: 거절 장부를 거절에만 건다
+
+## MODIFY: src/chat/outbound.ts — snapshotRefusalItem 조기 return
+
+```ts
+// before
+    // Unrelated sparse text messages historically need no position metadata.
+    if (outputIndex === undefined && (!Array.isArray(item.content)
+      || !item.content.some(part => isRec(part) && part.type === "refusal"))) return;
+    const known = refusalItem(outputIndex, item, "id");
+
+// after
+    // Only items that actually carry refusal content belong in the refusal ledger.
+    // The position guard used to be the only exit, so any message with an index was
+    // enrolled — including ordinary text — and the id/index consistency checks in
+    // refusalItem() then applied to streams that contain no refusal at all. A bridge
+    // that legitimately reuses one output_index for an open message and a hidden
+    // reasoning envelope was enough to fail a healthy turn with invalid_refusal.
+    // The non-streaming collector below already scopes itself this way.
+    const hasRefusalPart = Array.isArray(item.content)
+      && item.content.some(part => isRec(part) && part.type === "refusal");
+    if (!existing && !hasRefusalPart) return;
+    const known = refusalItem(outputIndex, item, "id");
+```
+
+`existing`이 있으면 이미 진짜 거절이 등록된 index이므로 계속 검사한다. 그래야
+"거절이 시작된 뒤의 모순"을 잡는 기존 계약이 유지된다.
+
+## MODIFY: src/chat/outbound.ts — output_item 이벤트의 item_id 시드
+
+```ts
+// :578 before
+              if (Object.hasOwn(data, "item_id")) refusalItem(data.output_index, data, "item_id");
+// :578 after
+              if (Object.hasOwn(data, "item_id") && refusalItems.has(position(data.output_index))) {
+                refusalItem(data.output_index, data, "item_id");
+              }
+```
+
+`:624`도 같은 형태로 바꾼다. 이미 거절 장부에 오른 index에만 id 일관성을 요구한다.
+
+## 유지
+
+`:297-300`의 희소 스냅샷 ID 검사는 그대로 둔다. 거기는 `existing`이나
+`refusalIndexById.has(item.id)`가 이미 참일 때만 동작하므로 원래부터 거절 스코프다.
+
+`:302`, `:315`, `:269`, `:273`, `:278`, `:570`도 그대로. 전부 거절 증거가 있을 때만
+도달하는 지점이다.
+
+## 회귀 테스트
+
+010의 표 그대로. 특히 아래 세 개는 수정 후에도 반드시 던져야 한다.
+
+- 실제 거절 델타 뒤 같은 id가 다른 index
+- 실제 거절 뒤 한 index에 다른 거절 id
+- 거절 스냅샷이 누적 델타의 접두사가 아님
+
+## PR
+
+- base `dev`, 템플릿 3개 절 모두 채움
+- 로컬 제품 스위트/typecheck/build/install은 **NOT RUN**으로 명시
+- exact-final-head hosted CI가 유일한 머지 증거
+- MAINTAINERS.md maintainer-integration 경로로 `dev`에만, 결정과 CI 증거를 PR에 기록
+
+## 범위 밖 (후속)
+
+`src/bridge.ts` `flushHiddenReasoningEnvelope`가 열린 message와 같은 `output_index`에
+reasoning을 emit하는 것. 프로토콜상 한 index에 한 아이템이 맞지만, 고치면 reasoning
+표시 순서와 Codex 쪽 렌더링까지 영향이 가므로 별도 단위로 둔다. 이번 수정만으로도
+사용자에게 보이는 오류는 사라진다.
+

--- a/devlog/_plan/260913_chat_refusal_translator/020_fix_refusal_scope.md
+++ b/devlog/_plan/260913_chat_refusal_translator/020_fix_refusal_scope.md
@@ -69,3 +69,26 @@ reasoning을 emit하는 것. 프로토콜상 한 index에 한 아이템이 맞�
 표시 순서와 Codex 쪽 렌더링까지 영향이 가므로 별도 단위로 둔다. 이번 수정만으로도
 사용자에게 보이는 오류는 사라진다.
 
+
+## 감사 반영 (A 단계, BLOCKER-1)
+
+`refusalItems.has(position(data.output_index))`는 쓰면 안 된다. `position()` 자체가
+`:227`에서 잘못된 index에 대해 던지기 때문에, 거절과 무관한 요청에서도 가드가
+가드 역할을 못 하고 오히려 새 throw 지점을 만든다.
+
+```ts
+// :578 / :624 최종형
+              if (Object.hasOwn(data, "item_id")
+                && typeof data.output_index === "number"
+                && refusalItems.has(data.output_index)) {
+                refusalItem(data.output_index, data, "item_id");
+              }
+```
+
+감사가 함께 확인한 것: 18개 계약 케이스는 전부 선행 `refusalDelta`가 있어 `existing`이
+참이므로 조기 return에 걸리지 않는다. 178·179는 `:248`, 180은 `:315`, 208은 `:249`에서
+여전히 던진다. 전역 "거절 본 적 있음" 플래그 안은 더 약하다 — 거절 이후 다른 index의
+평범한 메시지가 다시 시드되기 때문이다. per-item 스코프가 맞다.
+
+bridge 트리거의 정확한 진입점은 `src/bridge.ts:958-960`이다.
+

--- a/scripts/test-layout/layout.json
+++ b/scripts/test-layout/layout.json
@@ -290,6 +290,7 @@
     "chat-conversation-affinity.test.ts": "responses",
     "chat-json-sse-fallback.test.ts": "responses",
     "chat-refusal.test.ts": "responses",
+    "chat-refusal-scope.test.ts": "responses",
     "chatgpt-device-auth.test.ts": "oauth",
     "chatgpt-oauth.test.ts": "oauth",
     "chatgpt-token-expiry.test.ts": "oauth",

--- a/src/chat/outbound.ts
+++ b/src/chat/outbound.ts
@@ -302,9 +302,18 @@ export function responsesSseToChatCompletionsSse(
       if (existing && existing.parts.size > 0 && item.type !== undefined) throw refusalTranslationError();
       return;
     }
-    // Unrelated sparse text messages historically need no position metadata.
-    if (outputIndex === undefined && (!Array.isArray(item.content)
-      || !item.content.some(part => isRec(part) && part.type === "refusal"))) return;
+    // Only an item that actually carries refusal content belongs in the refusal ledger.
+    // The exit used to be the position guard alone, so every message that had an index
+    // was enrolled — ordinary assistant text included — and the id/index consistency
+    // checks inside refusalItem() then governed streams containing no refusal at all.
+    // One index legitimately carrying two item ids was then fatal: a bridge that flushes
+    // a hidden reasoning envelope at the index of a still-open message failed a healthy
+    // turn with invalid_refusal. `existing` keeps a ledger already opened by real refusal
+    // evidence under the same scrutiny as before. The non-streaming collector below has
+    // always scoped itself this way; this is the streaming path catching up.
+    const hasRefusalPart = Array.isArray(item.content)
+      && item.content.some(part => isRec(part) && part.type === "refusal");
+    if (!existing && !hasRefusalPart) return;
     const known = refusalItem(outputIndex, item, "id");
     if (!Array.isArray(item.content)) return;
     item.content.forEach((part: unknown, contentIndex: number) => {
@@ -575,7 +584,15 @@ export function responsesSseToChatCompletionsSse(
             const item = isRec(data.item) ? data.item : null;
             if (item?.type === "message") {
               snapshotRefusalItem(data.output_index, item);
-              if (Object.hasOwn(data, "item_id")) refusalItem(data.output_index, data, "item_id");
+              // Bind the event-level id only for an index the refusal ledger already
+              // tracks. Testing membership directly rather than through position()
+              // matters: position() throws on a malformed index, which would add a
+              // failure to refusal-free streams instead of removing one.
+              if (Object.hasOwn(data, "item_id")
+                && typeof data.output_index === "number"
+                && refusalItems.has(data.output_index)) {
+                refusalItem(data.output_index, data, "item_id");
+              }
             }
             if (!item || item.type !== "function_call") break;
             ensureRole();
@@ -621,7 +638,11 @@ export function responsesSseToChatCompletionsSse(
             const item = isRec(data.item) ? data.item : null;
             if (!item) break;
             snapshotRefusalItem(data.output_index, item);
-            if (item.type === "message" && Object.hasOwn(data, "item_id")) refusalItem(data.output_index, data, "item_id");
+            if (item.type === "message" && Object.hasOwn(data, "item_id")
+              && typeof data.output_index === "number"
+              && refusalItems.has(data.output_index)) {
+              refusalItem(data.output_index, data, "item_id");
+            }
             if (item.type === "function_call") {
               sawToolUse = true;
               const callId = typeof item.call_id === "string" ? item.call_id : "";

--- a/tests/fixtures/test-layout-expected.json
+++ b/tests/fixtures/test-layout-expected.json
@@ -123,6 +123,7 @@
   "chat-conversation-affinity.test.ts": "responses",
   "chat-json-sse-fallback.test.ts": "responses",
   "chat-refusal.test.ts": "responses",
+  "chat-refusal-scope.test.ts": "responses",
   "chatgpt-device-auth.test.ts": "oauth",
   "chatgpt-oauth.test.ts": "oauth",
   "chatgpt-token-expiry.test.ts": "oauth",

--- a/tests/responses/chat-refusal-scope.test.ts
+++ b/tests/responses/chat-refusal-scope.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { responsesSseToChatCompletionsSse } from "../../src/chat/outbound";
+import { createTestTranslatorBudget } from "../helpers/translator-budget";
+
+type Rec = Record<string, unknown>;
+type Frame = { error?: { code: string; type: string }; choices?: Array<{ delta?: Rec; finish_reason?: string | null }> };
+const encoder = new TextEncoder();
+const model = "refusal-scope-fixture/model";
+const event = (type: string, fields: Rec = {}): Rec => ({ type, ...fields });
+const wireEvent = (value: Rec): string => `event: ${value.type}\ndata: ${JSON.stringify(value)}\n\n`;
+
+function bytesSource(chunks: string[]): ReadableStream<Uint8Array> {
+  let next = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (next < chunks.length) controller.enqueue(encoder.encode(chunks[next++]!));
+      else controller.close();
+    },
+  }, { highWaterMark: 0 });
+}
+
+async function translate(events: Rec[]): Promise<string> {
+  const stream = responsesSseToChatCompletionsSse(bytesSource(events.map(wireEvent)), model, {
+    translatorBudget: createTestTranslatorBudget(),
+  });
+  return await new Response(stream).text();
+}
+
+function frames(wire: string): Frame[] {
+  return wire.split("\n\n").filter(b => b.startsWith("data: ") && b !== "data: [DONE]")
+    .map(b => JSON.parse(b.slice(6)) as Frame);
+}
+const errorCodes = (wire: string): string[] => frames(wire).flatMap(f => f.error ? [f.error.code] : []);
+
+const textMessage = (id: string, text = "answer"): Rec => ({
+  type: "message", role: "assistant", id, status: "completed",
+  content: [{ type: "output_text", text }],
+});
+const refusalMessage = (id: string, refusal: string): Rec => ({
+  type: "message", role: "assistant", id, status: "completed",
+  content: [{ type: "refusal", refusal }],
+});
+const completed = (output: unknown[] = []): Rec =>
+  event("response.completed", { response: { status: "completed", output } });
+
+describe("refusal bookkeeping stays out of refusal-free streams", () => {
+  // The reported failure. A bridge may flush a hidden reasoning envelope at the
+  // output_index of a still-open message, so one index carries two item ids. That is
+  // not a refusal contradiction, and it used to fail a healthy turn with
+  // invalid_refusal after the model had already streamed its answer.
+  test("one output_index carrying a message then a reasoning item is not a refusal contradiction", async () => {
+    const wire = await translate([
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { type: "message", role: "assistant", id: "msg_1", status: "in_progress", content: [] },
+      }),
+      event("response.output_item.done", { output_index: 0, item: { type: "reasoning", id: "rs_1", summary: [] } }),
+      completed(),
+    ]);
+    expect(errorCodes(wire)).toEqual([]);
+  });
+
+  test("the same message id appearing at two indices carries no refusal meaning", async () => {
+    const wire = await translate([
+      event("response.output_item.done", { output_index: 0, item: textMessage("msg_dup") }),
+      event("response.output_item.done", { output_index: 1, item: textMessage("msg_dup") }),
+      completed(),
+    ]);
+    expect(errorCodes(wire)).toEqual([]);
+  });
+
+  test("two different plain messages on one index carry no refusal meaning", async () => {
+    const wire = await translate([
+      event("response.output_item.done", { output_index: 0, item: textMessage("msg_a") }),
+      event("response.output_item.done", { output_index: 0, item: textMessage("msg_b") }),
+      completed(),
+    ]);
+    expect(errorCodes(wire)).toEqual([]);
+  });
+
+  test("a terminal snapshot of ordinary text does not enrol the ledger", async () => {
+    const wire = await translate([completed([textMessage("msg_1"), { type: "reasoning", id: "rs_1", summary: [] }])]);
+    expect(errorCodes(wire)).toEqual([]);
+  });
+});
+
+describe("real refusal contradictions still fail closed", () => {
+  // These are the guarantee. Once actual refusal content exists, a contradictory
+  // id or index must still stop the turn rather than emit a mangled refusal.
+  test("a refusal id that moves to another index still fails", async () => {
+    const wire = await translate([
+      event("response.refusal.delta", { output_index: 0, content_index: 0, delta: "no", item_id: "msg_r" }),
+      event("response.output_item.done", { output_index: 1, item: refusalMessage("msg_r", "no") }),
+      completed(),
+    ]);
+    expect(errorCodes(wire)).toEqual(["invalid_refusal"]);
+  });
+
+  test("a second refusal id on one index still fails", async () => {
+    const wire = await translate([
+      event("response.refusal.delta", { output_index: 0, content_index: 0, delta: "no", item_id: "msg_r" }),
+      event("response.output_item.done", { output_index: 0, item: refusalMessage("msg_other", "no") }),
+      completed(),
+    ]);
+    expect(errorCodes(wire)).toEqual(["invalid_refusal"]);
+  });
+
+  test("a refusal snapshot that contradicts the accumulated delta still fails", async () => {
+    const wire = await translate([
+      event("response.refusal.delta", { output_index: 0, content_index: 0, delta: "sorry", item_id: "msg_r" }),
+      event("response.refusal.done", { output_index: 0, content_index: 0, refusal: "different", item_id: "msg_r" }),
+      completed(),
+    ]);
+    expect(errorCodes(wire)).toEqual(["invalid_refusal"]);
+  });
+
+  test("a non-refusal part replacing a retained refusal part still fails", async () => {
+    const wire = await translate([
+      event("response.refusal.delta", { output_index: 0, content_index: 0, delta: "no", item_id: "msg_r" }),
+      event("response.output_item.done", {
+        output_index: 0,
+        item: { type: "message", role: "assistant", id: "msg_r", status: "completed", content: [{ type: "output_text", text: "answer" }] },
+      }),
+      completed(),
+    ]);
+    expect(errorCodes(wire)).toEqual(["invalid_refusal"]);
+  });
+});


### PR DESCRIPTION
## Summary

A Devin turn streamed roughly a thousand tokens through `/v1/chat/completions` and then died with:

```text
upstream refusal representations are inconsistent
```

The turn contained no refusal at all.

`snapshotRefusalItem` exited early only when `outputIndex` was `undefined`, so **any** message item carrying an index was enrolled in the refusal ledger even with zero refusal parts. `refusalItem()` then registered its id, and the id/index consistency checks began governing ordinary assistant text.

That turned a benign shape into a fatal one. `src/bridge.ts` flushes a hidden reasoning envelope at the `output_index` of a still-open message, so one index legitimately carries two item ids. For a refusal that is a real contradiction; for plain text it is nothing.

Minimal reproduction, with no refusal anywhere:

| # | event | output_index | item.id | item.type |
|---|---|---|---|---|
| 1 | `response.output_item.added` | 0 | `msg_1` | `message` |
| 2 | `response.output_item.done` | 0 | `rs_1` | `reasoning` |

Devin emits reasoning items, and a chat inbound without a summary takes the hidden-flush path, which is why this combination surfaced it.

The fix enrols an item only when it actually carries refusal content, or when the ledger already tracks that index because real refusal evidence opened it. **The non-streaming collector in the same file has always scoped itself this way** — the streaming path now matches, which is the asymmetry that identified the bug.

The event-level `item_id` binding at `output_item.added`/`done` is likewise limited to an index the ledger already tracks. It tests membership directly rather than through `position()`, because `position()` throws on a malformed index and would have added a failure to refusal-free streams instead of removing one.

## Verification

- Hosted CI on this exact head is the merge proof. Local product tests, typecheck, build and install were **NOT RUN** in the authoring session, by explicit instruction.
- New `tests/responses/chat-refusal-scope.test.ts` has two halves. Four cases assert refusal-free streams now succeed, including the exact reproduction above. Four cases assert genuine contradictions **still fail closed**: a refusal id that moves to another index, a second refusal id on one index, a snapshot contradicting the accumulated delta, and a non-refusal part replacing a retained refusal part.
- `tests/responses/chat-refusal.test.ts` is untouched. Its 18 post-`refusalDelta` contract cases still throw, because each has preceding refusal evidence so `existing` is true and the new early return never fires — verified case by case against `:248`, `:315` and `:249`.
- Registered in `scripts/test-layout/layout.json` and `tests/fixtures/test-layout-expected.json`.
- Root cause was derived by two independent reviewers and then re-derived by a third against the real control flow, which also caught the `position()` mistake in the first draft of the guard.

### Not fixed here

The bridge reusing one `output_index` for an open message and a reasoning envelope is untidy against the Responses protocol, but changing it affects reasoning ordering and rendering. It is recorded as a follow-up in the devlog unit; this change alone removes the user-visible error.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Maintainer integration under `MAINTAINERS.md`: `dev` only, with exact-head CI evidence recorded before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed streaming responses that could incorrectly end with an `invalid_refusal` error when no refusal content was present.
  - Improved refusal validation for streams with shared output indexes, duplicate message IDs, or regular text snapshots.
  - Preserved validation for genuine refusal inconsistencies.

- **Tests**
  - Added coverage for refusal-free streaming scenarios and valid refusal error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->