### PR TITLE
fix(bridge): fail an in-flight search at a truncated terminal

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1293,7 +1293,9 @@ export function bridgeToResponsesSSE(
                 if (isTruncatedStopReason(event.stopReason)) failCurrentToolCall();
                 else closeCurrentToolCall();
               }
-              if (currentWebSearch) closeCurrentWebSearch("completed", []);
+              // A search still in flight when upstream truncates never returned results, so it
+              // takes the same "failed" status as the error/incomplete terminals below.
+              if (currentWebSearch) closeCurrentWebSearch(isTruncatedStopReason(event.stopReason) ? "failed" : "completed", []);
               releasePendingWebSources();
               // Redacted-only turns (or hidden thinking without a trailing signature event) still
               // need their envelope-only reasoning item so the blocks replay next turn.

--- a/structure/adapters/registry.md
+++ b/structure/adapters/registry.md
@@ -81,6 +81,8 @@ Listener startup diagnostics follow [the runtime lifecycle contract](../runtime.
 
 The bridge keeps an open function, custom, or tool-search call incomplete when an adapter ends with a recognized truncated stop reason. Streaming emits no argument/input completion frame for that open call, and buffered JSON applies the same status. A call already closed by its own tool-call end retains its completed state. The response remains incomplete, partial output is preserved, and truncated compaction never replaces history.
 
+A provider web search still in flight at that truncated terminal is finalized as `failed`, the same status it already receives from the error and explicit-incomplete terminals. It never returned results, so reporting it as `completed` would leave the client showing a finished search for a turn the provider cut short.
+
 Chat helper admission in `src/server/responses/core.ts` follows the
 [deferred stored-main contract](../providers/openai-tiers.md): only a needed Direct OpenAI helper
 claims stored main, after terminal vision, routed vision and search exclusions.

--- a/tests/adapters/bridge-nonstreaming-terminal.test.ts
+++ b/tests/adapters/bridge-nonstreaming-terminal.test.ts
@@ -268,6 +268,7 @@ describe("truncated-stop-reason classifier", () => {
       "length", "content-filter",                   // Command Code / AI SDK
       "pause_turn",                                 // Anthropic: turn needs continuation
       "refusal", "model_context_window_exceeded",   // Anthropic
+      "max_output_tokens",                          // Anthropic: same spelling as the mapped reason
       "MAX_TOKENS", "SAFETY", "MALFORMED_FUNCTION_CALL", "IMAGE_SAFETY", "LANGUAGE", // Gemini
       "Safety", "safety",                           // mixed case must not slip through
     ]) {
@@ -285,6 +286,7 @@ describe("truncated-stop-reason classifier", () => {
   test("truncation maps to the right incomplete_details reason", () => {
     expect(truncationReasonFor("length")).toBe("max_output_tokens");
     expect(truncationReasonFor("model_context_window_exceeded")).toBe("max_output_tokens");
+    expect(truncationReasonFor("max_output_tokens")).toBe("max_output_tokens");
     expect(truncationReasonFor("refusal")).toBe("content_filter");
     expect(truncationReasonFor("SAFETY")).toBe("content_filter");
     expect(truncationReasonFor("end_turn")).toBeUndefined();
@@ -318,6 +320,7 @@ describe("truncated done preserves open tool integrity (#4312)", () => {
     ["content_filter", "content_filter"],
     ["max_tokens", "max_output_tokens"],
     ["length", "max_output_tokens"],
+    ["max_output_tokens", "max_output_tokens"],
   ] as const;
   for (const [stopReason, reason] of cases) {
     for (const kind of ["function_call", "custom_tool_call", "tool_search_call"] as const) {
@@ -375,6 +378,25 @@ describe("truncated done preserves open tool integrity (#4312)", () => {
       expect(terminalEventNames(text)).toEqual(["response.incomplete"]);
       expect(text).toContain("event: response.function_call_arguments.done");
       expect(text).toContain('"arguments":"{\\"arg\\":\\"complete\\"}","status":"completed"');
+    });
+
+    test(`${stopReason}: a search still in flight is failed, not completed`, async () => {
+      // The provider cut the turn short, so the search never returned results. Reporting it as
+      // completed would leave the client showing a finished search for a truncated turn.
+      const text = await sseText([
+        { type: "web_search_call_begin", id: "search_in_flight" },
+        { type: "done", stopReason },
+      ]);
+      const item = text.split("\n\n")
+        .flatMap(frame => {
+          const data = frame.split("\n").find(line => line.startsWith("data: {"))?.slice(6);
+          return data ? [JSON.parse(data)] : [];
+        })
+        .find(frame => frame.type === "response.output_item.done"
+          && frame.item?.type === "web_search_call")?.item;
+
+      expect(terminalEventNames(text)).toEqual(["response.incomplete"]);
+      expect(item).toMatchObject({ type: "web_search_call", status: "failed" });
     });
   }
 });


### PR DESCRIPTION
## Summary

Carries #4381 by @luvs01 (source head `aad1d75bc`, fork branch `agent/content-filter-terminal-20260912`) onto the current `dev` tip.

When an adapter ends a turn with a recognized truncated stop reason, the bridge already keeps an open function, custom, or tool-search call incomplete, and the error and explicit-incomplete terminals already close an in-flight provider web search as `failed`. The plain truncated `done` path did not. It closed the search as `completed`, so a client showed a finished search for a turn the provider cut short before any result arrived.

Concretely: an adapter emits `web_search_call_begin`, then `done` with `content_filter`. Before this change the `web_search_call` item reached the client as `status: "completed"` alongside `response.incomplete`; now it reaches the client as `status: "failed"`, matching what the other two terminals already produced for the same situation.

The tests also gain the exact `max_output_tokens` stop-reason value. The classifier vocabulary, the truncation-reason mapping, and the bridge terminal cases each covered `max_tokens` and `length` but not the spelling `src/responses/truncated-stop-reason.ts` actually maps, so a regression that dropped it would have let the bridge emit `response.completed` with an incomplete call or a failed search attached and no test would have caught it.

This is the remainder of #4312's tool-finalization scope after #4341 landed the open function, custom, and tool-search call handling. Nothing from #4341 is duplicated here. #4312 stays open: the client-side half, where Codex reads an incomplete call without its status, is not addressed by this change.

Review findings on the source pull request: CodeRabbit's request for the exact `max_output_tokens` case is included (it is the second source commit). No Codex review findings were outstanding on `aad1d75bc`.

This is the bottom link of lane B in the contributor carry train. The lane tip is the `#4460` carry, and its CI run is this lane's suite proof; this branch's head carries `[skip ci]` deliberately.

## Verification

- `bun test tests/adapters/bridge-nonstreaming-terminal.test.ts` — 51 pass, 0 fail, 310 assertions.
- `bun run typecheck` — passed.
- `bun run structure:check` — passed.
- `bun run privacy:scan` — passed.
- Local full suite: not run. Hosted CI on the lane tip is the suite proof for this branch.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

Co-authored-by: luvs01 <27862058+luvs01@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Web searches interrupted by truncated responses are now correctly reported as failed instead of completed.
  - Responses that stop due to output limits are classified consistently across streaming and non-streaming experiences.

- **Documentation**
  - Updated guidance to clarify how interrupted web searches are finalized.

- **Tests**
  - Added coverage for output-limit truncation and interrupted web search handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->