### PR TITLE
fix(codex): normalize the Win32 extended-length prefix in history path identity

### DIFF
--- a/src/codex/history-manifest.ts
+++ b/src/codex/history-manifest.ts
@@ -54,7 +54,32 @@ export type CodexHistoryManifestValidation =
       readonly scope: "manifest" | "entry-shape" | "entry-provenance";
     };
 
+/**
+ * Strip the Win32 extended-length prefix: `\\?\C:\...` becomes `C:\...` and
+ * `\\?\UNC\server\share\...` becomes `\\server\share\...` (forward-slash spellings
+ * included). Codex records some rollout paths with the prefix and others without, and
+ * both spellings name the same file — comparing them literally failed the history
+ * integrity check for intact sessions (#4442). Stripping happens before resolve() so
+ * the identity converges regardless of host path semantics.
+ */
+function withoutWindowsExtendedLengthPrefix(path: string): string {
+  const match = /^(?:[\\/]{2}\?[\\/])(unc[\\/])?/i.exec(path);
+  if (!match) return path;
+  return match[1] ? `\\\\${path.slice(match[0].length)}` : path.slice(match[0].length);
+}
+
 function codexHistoryPathIdentity(path: string): string {
+  if (process.platform !== "win32") return resolve(path);
+  return resolve(withoutWindowsExtendedLengthPrefix(path)).toLowerCase();
+}
+
+/**
+ * Identity as computed before the extended-length prefix was normalized (#4442). A
+ * state database path spelled `\\?\C:\...` hashed to a DIFFERENT backup filename
+ * before the fix; readers still check that name so an existing manifest keeps
+ * shadowing its database instead of reading as absent.
+ */
+function legacyCodexHistoryPathIdentity(path: string): string {
   const canonical = resolve(path);
   return process.platform === "win32" ? canonical.toLowerCase() : canonical;
 }
@@ -72,6 +97,17 @@ export function codexHistoryStateDbIdentity(path: string): string {
 export function codexHistoryBackupId(stateDbPath: string): string {
   return createHash("sha256")
     .update(codexHistoryStateDbIdentity(stateDbPath))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/**
+ * Backup filename id under the pre-#4442 identity. Differs from codexHistoryBackupId
+ * only for extended-length-prefixed database paths; identical everywhere else.
+ */
+export function legacyCodexHistoryBackupId(stateDbPath: string): string {
+  return createHash("sha256")
+    .update(legacyCodexHistoryPathIdentity(stateDbPath))
     .digest("hex")
     .slice(0, 16);
 }

--- a/src/codex/history-provider.ts
+++ b/src/codex/history-provider.ts
@@ -8,6 +8,7 @@ import { atomicWriteFile, getConfigDir } from "../config";
 import {
   CODEX_HISTORY_RESUMABLE_SOURCES,
   codexHistoryBackupId,
+  legacyCodexHistoryBackupId,
   sameCodexHistoryPath,
   validateCodexHistoryBackupManifest,
   type CodexHistoryBackupEntry,
@@ -30,6 +31,32 @@ export const MAX_ROLLOUT_ZST_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
  */
 export function historyBackupPathFor(stateDbPath: string): string {
   return join(getConfigDir(), `codex-history-backup-${codexHistoryBackupId(stateDbPath)}.json`);
+}
+
+/**
+ * Manifest name a database path spelled with the Win32 extended-length prefix
+ * (`\\?\C:\...`) received before that prefix was normalized out of the identity
+ * (#4442). Identical to historyBackupPathFor for every other spelling.
+ */
+export function legacyHistoryBackupPathFor(stateDbPath: string): string {
+  return join(getConfigDir(), `codex-history-backup-${legacyCodexHistoryBackupId(stateDbPath)}.json`);
+}
+
+/**
+ * The manifest that actually shadows one state database. Canonical name first; when
+ * only a pre-#4442 extended-length name exists, that manifest still shadows the
+ * database rather than reading as absent. When BOTH names exist the canonical
+ * manifest wins and the legacy file is left untouched — a conflict is resolved by
+ * keeping both, never by silently replacing one.
+ */
+export function resolveExistingHistoryBackupPath(
+  stateDbPath: string,
+  exists: (path: string) => boolean = existsSync,
+): string {
+  const canonical = historyBackupPathFor(stateDbPath);
+  if (exists(canonical)) return canonical;
+  const legacy = legacyHistoryBackupPathFor(stateDbPath);
+  return legacy !== canonical && exists(legacy) ? legacy : canonical;
 }
 
 /**
@@ -318,7 +345,7 @@ export function preflightCodexHistoryInjection(
     // A partially restored row may already be native while its manifest still
     // owns work. Match the restore worker's target set before removing routing.
     const restoreEntries = providerTableMode ? []
-      : Object.values(readBackup(historyBackupPathFor(resolvedPath), resolvedPath).manifest.entries);
+      : Object.values(readBackup(resolveExistingHistoryBackupPath(resolvedPath), resolvedPath).manifest.entries);
     if (!existsSync(resolvedPath)) {
       return restoreEntries.length > 0 ? "history_state_database_missing" : null;
     }
@@ -1388,7 +1415,7 @@ function openaiRestoreIsNoop(stateDbPath: string, backupPath: string): boolean {
 export function syncCodexHistoryProvider(
   provider: CodexHistoryProvider,
   stateDbPath = resolveCodexStateDbPath(),
-  backupPath = historyBackupPathFor(stateDbPath),
+  backupPath = resolveExistingHistoryBackupPath(stateDbPath),
   opts: { skipWhenProvablyNoop?: boolean } = {},
 ): CodexHistorySyncResult {
   // Opt-in steady-state gate (Design B loopback callers only): default semantics of
@@ -1714,7 +1741,7 @@ export function restoreLegacyOpenaiHistory(stateDbPath = resolveCodexStateDbPath
  */
 export function migrateHistoryToOpenai(
   stateDbPath = resolveCodexStateDbPath(),
-  backupPath = historyBackupPathFor(stateDbPath),
+  backupPath = resolveExistingHistoryBackupPath(stateDbPath),
   opts: { attempts?: number; delayMs?: number; sleepFn?: (ms: number) => void } = {},
 ): CodexHistorySyncResult {
   // Steady-state gate: this migration is Design-B-specific (inject + guardian callers),
@@ -1747,7 +1774,7 @@ export function snapshotCodexHistoryNoop(
   const stateDbPresent = existsSync(stateDbPath);
   const backupPresent = existsSync(backupPath);
   const base = { canonicalStateDbPath, stateDbPresent, canonicalBackupPath, backupPresent };
-  if (!sameCodexHistoryPath(backupPath, historyBackupPathFor(stateDbPath))) {
+  if (!sameCodexHistoryPath(backupPath, resolveExistingHistoryBackupPath(stateDbPath))) {
     return { kind: "unknown", pendingRows: null, backupEntries: null, ...base, reason: "backup-path" };
   }
   const backup = inspectBackupForNoop(backupPath, stateDbPath);
@@ -1831,7 +1858,7 @@ export interface PendingHistoryCount {
  */
 export function countPendingOpencodexHistory(
   stateDbPath = resolveCodexStateDbPath(),
-  backupPath = historyBackupPathFor(stateDbPath),
+  backupPath = resolveExistingHistoryBackupPath(stateDbPath),
   opts: { validateRestoreTargets?: boolean } = {},
 ): PendingHistoryCount {
   const backup = readBackupStrict(backupPath, stateDbPath);

--- a/src/codex/native-residue.ts
+++ b/src/codex/native-residue.ts
@@ -1,5 +1,6 @@
 import {
   closeSync,
+  existsSync,
   fstatSync,
   lstatSync,
   openSync,
@@ -16,7 +17,7 @@ import { Database } from "bun:sqlite";
 
 import { getConfigDir } from "../config";
 import { catalogHasRoutedEntries, parseCatalogJson } from "./catalog/parsing";
-import { codexHistoryBackupId, validateCodexHistoryBackupManifest } from "./history-manifest";
+import { codexHistoryBackupId, legacyCodexHistoryBackupId, validateCodexHistoryBackupManifest } from "./history-manifest";
 import {
   hasInjectedCodexRouting,
   OCX_SECTION_MARKER,
@@ -590,7 +591,13 @@ function classifyHistoryDatabase(path: string): NativeRoutedResidueResult {
 }
 
 function historyBackupPath(stateDatabasePath: string): string {
-  return join(getConfigDir(), `codex-history-backup-${codexHistoryBackupId(stateDatabasePath)}.json`);
+  const canonical = join(getConfigDir(), `codex-history-backup-${codexHistoryBackupId(stateDatabasePath)}.json`);
+  if (existsSync(canonical)) return canonical;
+  // A database path spelled with the Win32 extended-length prefix hashed to a different
+  // manifest name before #4442; that manifest still shadows the database (and a canonical
+  // file always wins over it, with the legacy one left in place).
+  const legacy = join(getConfigDir(), `codex-history-backup-${legacyCodexHistoryBackupId(stateDatabasePath)}.json`);
+  return legacy !== canonical && existsSync(legacy) ? legacy : canonical;
 }
 
 function classifyHistoryBackup(path: string, stateDatabasePath: string): NativeRoutedResidueResult {

--- a/src/lib/windows-elevation.ts
+++ b/src/lib/windows-elevation.ts
@@ -397,7 +397,7 @@ export function formatWindowsSchtasksError(error: unknown, args: string[]): stri
   const guidance = [
     "Windows access denied while running Task Scheduler.",
     `Command: schtasks ${argsText}`,
-    "Approve the Windows UAC prompt to install the background service, or run `ocx service install` from an elevated PowerShell window.",
+    "The OpenCodex task definition is scoped to the installing account and normally registers without elevation, so this denial is not fixed by approving a UAC prompt. Check `ocx service status`: if an existing `opencodex-proxy` task belongs to a different account, remove it from that account and retry `ocx service install`.",
   ].join(" ");
   if (operation === "create" && ownedCreateAccessDenied) {
     return `${guidance}\n${WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER}`;

--- a/src/service.ts
+++ b/src/service.ts
@@ -2303,9 +2303,12 @@ export function buildWindowsTaskXml(
   // keeps spaces intact, and /b (batch mode) suppresses script error popups.
   const escapedLauncherArgs = taskXmlString(`/b /nologo "${launcher}"`);
   // `UserId` is optional in the schema, and omitting it makes a SessionStateChangeTrigger
-  // fire for ANY account's session change. Production registration resolves and passes the
-  // installing account SID explicitly; the optional parameter remains only for deterministic
-  // builders/tests, and the live validator rejects an unscoped recovery trigger.
+  // fire for ANY account's session change. An unscoped LogonTrigger is read as "any user's
+  // logon", which a non-elevated user may not register: schtasks /create answers "Access is
+  // denied" for a task whose design (InteractiveToken + LeastPrivilege) needs no elevation
+  // (#4425). Production registration resolves and passes the installing account SID
+  // explicitly; the optional parameter remains only for deterministic builders/tests, and
+  // the live validator rejects an unscoped recovery trigger.
   const sessionUserIdElement = sessionTriggerUserId
     ? `\n      <UserId>${taskXmlString(sessionTriggerUserId)}</UserId>`
     : "";
@@ -2316,7 +2319,7 @@ export function buildWindowsTaskXml(
   </RegistrationInfo>
   <Triggers>
     <LogonTrigger>
-      <Enabled>true</Enabled>
+      <Enabled>true</Enabled>${sessionUserIdElement}
     </LogonTrigger>
     ${WINDOWS_SESSION_RECOVERY_STATE_CHANGES.map(stateChange => `<SessionStateChangeTrigger>
       <Enabled>true</Enabled>${sessionUserIdElement}

--- a/structure/config.md
+++ b/structure/config.md
@@ -132,6 +132,15 @@ backup manifest. It owns the accepted provider/source provenance tuples, platfor
 path identity, backup filename id, and validation from unknown JSON to a typed manifest. It does
 not read files, inspect rollouts, open SQLite, retry, fingerprint, write, or delete anything.
 
+On Windows the path identity strips the extended-length prefix (`\\?\` and `\\?\UNC\`)
+before resolution, because Codex records both spellings for the same file and comparing them
+literally failed the integrity check for intact sessions (#4442). A database path spelled with
+that prefix hashed to a different backup filename before the normalization, so the readers
+(`history-provider.ts` for mutation, `native-residue.ts` for observation) fall back to the
+legacy filename when no canonical manifest exists. When both names exist the canonical manifest
+wins and the legacy file is left in place; a conflict is never resolved by silently replacing
+either file.
+
 `history-provider.ts` remains the strict mutation owner and maps shared validation failures to its
 restore/no-op integrity states. `native-residue.ts` remains a read-only observer and maps the same
 result to clean, residue, or indeterminate before inspecting referenced rollout files.

--- a/tests/codex-integration/codex-history-provider.test.ts
+++ b/tests/codex-integration/codex-history-provider.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { classifyRecoverableHistoryError, countPendingOpencodexHistory, historyBackupPathFor, isRecoverableHistoryError, migrateHistoryToOpenai, restoreLegacyOpenaiHistory, restoredUserEventFor, setAfterNoopPendingCountForTests, setAfterStrictHistoryRolloutAppendForTests, setBeforeHistoryApplyTransactionForTests, setBeforeHistoryBackupConsumeForTests, setBeforeStrictHistoryRolloutAppendForTests, setHistoryDbBusyTimeoutForTests, snapshotCodexHistoryNoop, syncCodexHistoryProvider, withHistoryRetry } from "../../src/codex/history-provider";
+import { classifyRecoverableHistoryError, countPendingOpencodexHistory, historyBackupPathFor, isRecoverableHistoryError, legacyHistoryBackupPathFor, migrateHistoryToOpenai, resolveExistingHistoryBackupPath, restoreLegacyOpenaiHistory, restoredUserEventFor, setAfterNoopPendingCountForTests, setAfterStrictHistoryRolloutAppendForTests, setBeforeHistoryApplyTransactionForTests, setBeforeHistoryBackupConsumeForTests, setBeforeStrictHistoryRolloutAppendForTests, setHistoryDbBusyTimeoutForTests, snapshotCodexHistoryNoop, syncCodexHistoryProvider, withHistoryRetry } from "../../src/codex/history-provider";
+import { codexHistoryBackupId, legacyCodexHistoryBackupId, sameCodexHistoryPath } from "../../src/codex/history-manifest";
 import { INVALID_HISTORY_BACKUP_FIXTURES, validHistoryBackupFixture } from "../helpers/codex-history-manifest-fixtures";
 import { preflightCodexHistoryInjection, setHistoryAppendHooksForTests } from "../../src/codex/history-provider";
 
@@ -1512,5 +1513,87 @@ describe("Design B migration helpers", () => {
     const db = new Database(pending.dbPath, { readonly: true });
     expect(db.query("SELECT model_provider FROM threads WHERE id = 'thread-1'").get()).toEqual({ model_provider: "openai" });
     db.close();
+  });
+});
+
+/**
+ * #4442: Codex records some rollout paths with the Win32 extended-length prefix
+ * (`\\?\C:\...`) and others without. Both spellings name the same file, but the
+ * integrity check compared them literally and failed intact sessions. The identity
+ * leaf strips the prefix before resolving, and the manifest filename keeps a
+ * legacy-name fallback so a backup written under the pre-fix identity is still
+ * discovered. These tests fake win32 to pin the path shapes directly; the real
+ * platform is restored after each one.
+ */
+describe("Windows history path identity (#4442)", () => {
+  const originalPlatform = process.platform;
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  });
+  const fakeWin32 = () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+  };
+
+  test("treats extended-length-prefixed spellings as the same file", () => {
+    fakeWin32();
+    expect(sameCodexHistoryPath(
+      "\\\\?\\C:\\Users\\a\\.codex\\sessions\\r.jsonl",
+      "C:\\Users\\a\\.codex\\sessions\\r.jsonl",
+    )).toBe(true);
+    // The case-insensitive contract still holds across the prefix boundary.
+    expect(sameCodexHistoryPath(
+      "c:\\users\\a\\r.jsonl",
+      "\\\\?\\C:\\Users\\A\\r.jsonl",
+    )).toBe(true);
+    // The UNC form maps to its bare-share spelling.
+    expect(sameCodexHistoryPath(
+      "\\\\?\\UNC\\server\\share\\r.jsonl",
+      "\\\\server\\share\\r.jsonl",
+    )).toBe(true);
+    // Prefix normalization must not collapse genuinely different files.
+    expect(sameCodexHistoryPath(
+      "\\\\?\\C:\\Users\\a\\r.jsonl",
+      "C:\\Users\\a\\other.jsonl",
+    )).toBe(false);
+    // An archived_sessions move is a real path change, not a spelling alias (#4442
+    // keeps those cases out of this fix by design).
+    expect(sameCodexHistoryPath(
+      "\\\\?\\C:\\Users\\a\\.codex\\archived_sessions\\r.jsonl",
+      "C:\\Users\\a\\.codex\\sessions\\r.jsonl",
+    )).toBe(false);
+  });
+
+  test("hashes both spellings to one backup id while keeping the pre-fix id reachable", () => {
+    fakeWin32();
+    const plain = "C:\\Users\\a\\.codex\\state_5.sqlite";
+    const prefixed = "\\\\?\\C:\\Users\\a\\.codex\\state_5.sqlite";
+    expect(codexHistoryBackupId(prefixed)).toBe(codexHistoryBackupId(plain));
+    // The prefixed spelling hashed to a DIFFERENT manifest name before #4442; that is
+    // the file a machine that recorded the prefix already has on disk, so the legacy
+    // id must stay computable. Plain spellings are untouched by the whole change.
+    expect(legacyCodexHistoryBackupId(prefixed)).not.toBe(codexHistoryBackupId(prefixed));
+    expect(legacyCodexHistoryBackupId(plain)).toBe(codexHistoryBackupId(plain));
+  });
+
+  test("discovers a manifest named under the pre-#4442 identity and never replaces it silently", () => {
+    fakeWin32();
+    const stateDb = "\\\\?\\C:\\Users\\a\\.codex\\state_5.sqlite";
+    const canonical = historyBackupPathFor(stateDb);
+    const legacy = legacyHistoryBackupPathFor(stateDb);
+    expect(legacy).not.toBe(canonical);
+
+    const present = new Set<string>([legacy]);
+    const exists = (path: string) => present.has(path);
+    // Only the legacy name exists: it still shadows the database, so restore and
+    // no-op probes keep finding its provenance instead of reading it as absent.
+    expect(resolveExistingHistoryBackupPath(stateDb, exists)).toBe(legacy);
+    // Both names exist (conflicting old/new manifests): the canonical manifest wins
+    // and the legacy file is left in place — kept, never silently replaced.
+    present.add(canonical);
+    expect(resolveExistingHistoryBackupPath(stateDb, exists)).toBe(canonical);
+    expect(present.has(legacy)).toBe(true);
+    // Neither exists: a new manifest is written under the canonical name.
+    present.clear();
+    expect(resolveExistingHistoryBackupPath(stateDb, exists)).toBe(canonical);
   });
 });

--- a/tests/service/service.test.ts
+++ b/tests/service/service.test.ts
@@ -45,6 +45,10 @@ const buildWindowsTaskXml = (...args: Parameters<typeof buildWindowsTaskXmlProdu
 const windowsTaskRegistrationHealthy = (...args: Parameters<typeof windowsTaskRegistrationHealthyProduction>) =>
   windowsTaskRegistrationHealthyProduction(args[0], args[1], args[2], args[3] === undefined ? TEST_WINDOWS_TASK_SID : args[3]);
 
+/** The exact LogonTrigger block the builder emits for the default test SID (#4425). */
+const LOGON_TRIGGER_BLOCK =
+  `<LogonTrigger>\n      <Enabled>true</Enabled>\n      <UserId>${TEST_WINDOWS_TASK_SID}</UserId>\n    </LogonTrigger>`;
+
 const TEST_DIR = join(import.meta.dir, ".tmp-service-test");
 const previousOpenCodexHome = process.env.OPENCODEX_HOME;
 const previousCodexHome = process.env.CODEX_HOME;
@@ -850,8 +854,8 @@ describe("Windows service task", () => {
    * `UserId` is optional in the schema, and omitting it makes a SessionStateChangeTrigger fire
    * for any account's session change. Scope it to the installing account when that account is
    * known. The builder is synchronous and cannot force an account lookup, so an unknown
-   * account degrades to the unscoped trigger — the same position the pre-existing
-   * `LogonTrigger` is already in, and still better than having no recovery trigger at all.
+   * account degrades every trigger to the unscoped form — still better than having no
+   * recovery trigger at all, and the position `LogonTrigger` was in before #4425.
    */
   test("scopes session-recovery triggers to the installing account when it is known", () => {
     const scoped = buildWindowsTaskXml("s.cmd", "l.vbs", undefined, "MACHINE\\installer");
@@ -883,6 +887,29 @@ describe("Windows service task", () => {
       expect(stateChangeAt).toBeGreaterThan(-1);
       expect(userIdAt).toBeLessThan(stateChangeAt);
     }
+  });
+
+  /**
+   * #4425: an unscoped LogonTrigger means "any user's logon", which a non-elevated user may
+   * not register — schtasks /create answers "Access is denied" even though the task design
+   * (InteractiveToken + LeastPrivilege) needs no elevation, and the old diagnostic then
+   * misread that denial as a privilege problem. The logon trigger consumes the same
+   * scoped-user element as its sibling session triggers, and logonTriggerType orders
+   * Enabled before UserId.
+   */
+  test("scopes the logon trigger to the installing account so a non-elevated create succeeds", () => {
+    const scoped = buildWindowsTaskXml("s.cmd", "l.vbs", undefined, "MACHINE\\installer");
+    const logon = /<LogonTrigger>[\s\S]*?<\/LogonTrigger>/i.exec(scoped)?.[0] ?? "";
+    expect(logon).toContain("<Enabled>true</Enabled>");
+    expect(logon).toContain("<UserId>MACHINE\\installer</UserId>");
+    expect(logon.indexOf("<Enabled>")).toBeLessThan(logon.indexOf("<UserId>"));
+
+    // Unknown account: unscoped rather than absent — the pre-#4425 shape, which only an
+    // elevated shell can register. Production always resolves a SID before staging.
+    const unscoped = buildWindowsTaskXml("s.cmd", "l.vbs", undefined, "");
+    const unscopedLogon = /<LogonTrigger>[\s\S]*?<\/LogonTrigger>/i.exec(unscoped)?.[0] ?? "";
+    expect(unscopedLogon).toContain("<Enabled>true</Enabled>");
+    expect(unscopedLogon).not.toContain("<UserId>");
   });
 
   test("accepts an explicit session scope only for the known matching identity", () => {
@@ -931,10 +958,13 @@ describe("Windows service task", () => {
     const scoped = buildWindowsTaskXml("ignored.cmd", guardLauncher, undefined, "MACHINE\\installer")
       .replace(/<Command>.*?<\/Command>/, `<Command>${guardWscript}</Command>`);
     const duplicateScope = scoped.replace(
-      "<UserId>MACHINE\\installer</UserId>",
-      "<UserId>MACHINE\\installer</UserId><UserId>MACHINE\\installer</UserId>",
+      "<UserId>MACHINE\\installer</UserId>\n      <StateChange>",
+      "<UserId>MACHINE\\installer</UserId><UserId>MACHINE\\installer</UserId>\n      <StateChange>",
     );
-    const emptyScope = scoped.replace("MACHINE\\installer", "");
+    const emptyScope = scoped.replace(
+      "<UserId>MACHINE\\installer</UserId>\n      <StateChange>",
+      "<UserId></UserId>\n      <StateChange>",
+    );
     expect(windowsTaskRegistrationHealthy(duplicateScope, guardWscript, guardLauncher, "MACHINE\\installer")).toBe(false);
     expect(windowsTaskRegistrationHealthy(emptyScope, guardWscript, guardLauncher, "MACHINE\\installer")).toBe(false);
 
@@ -962,7 +992,7 @@ describe("Windows service task", () => {
     // Windows drops elements equal to their schema default when it exports a task:
     // Trigger/Settings Enabled default to true and RunLevel defaults to LeastPrivilege.
     const canonical = xml
-      .replace("<LogonTrigger>\n      <Enabled>true</Enabled>\n    </LogonTrigger>", "<LogonTrigger />")
+      .replace(LOGON_TRIGGER_BLOCK, "<LogonTrigger />")
       .replace("    <RunLevel>LeastPrivilege</RunLevel>\n", "")
       .replace("    <Enabled>true</Enabled>\n    <Hidden>", "    <Hidden>");
     expect(canonical).toContain("<LogonTrigger />");
@@ -1076,7 +1106,7 @@ describe("Windows service task", () => {
     const launcher = "C:\\Users\\Test\\.opencodex\\service-launcher.vbs";
     const xml = buildWindowsTaskXml("ignored.cmd", launcher)
       .replace(/<Command>.*?<\/Command>/, `<Command>${wscript}</Command>`);
-    const bootOnly = xml.replace("<LogonTrigger>\n      <Enabled>true</Enabled>\n    </LogonTrigger>", "<BootTrigger />");
+    const bootOnly = xml.replace(LOGON_TRIGGER_BLOCK, "<BootTrigger />");
 
     // The schema allows arbitrary XML under Task/Data, and comments could smuggle a
     // decoy too — neither may stand in for a real logon trigger.

--- a/tests/windows/windows-elevation.test.ts
+++ b/tests/windows/windows-elevation.test.ts
@@ -39,7 +39,7 @@ describe("windows elevation helpers", () => {
     expect(isWindowsAccessDeniedError(error)).toBe(true);
   });
 
-  test("formats schtasks create access-denied errors with marker and UAC guidance", () => {
+  test("formats schtasks create access-denied errors with marker and non-elevation guidance", () => {
     const error = Object.assign(new Error("Command failed"), {
       stderr: "FEHLER: Zugriff verweigert\r\n",
       stdout: "",
@@ -55,7 +55,10 @@ describe("windows elevation helpers", () => {
     ]);
     expect(message).toContain("Windows access denied while running Task Scheduler.");
     expect(message).toContain("schtasks /create /tn opencodex-proxy /xml task.xml /f");
-    expect(message).toContain("UAC prompt");
+    // #4425: the scoped task definition registers without elevation, so the diagnostic
+    // must not send the user to approve a UAC prompt as the fix.
+    expect(message).toContain("normally registers without elevation");
+    expect(message).not.toContain("Approve the Windows UAC prompt");
     expect(message).toContain(WINDOWS_SCHTASKS_CREATE_ACCESS_DENIED_MARKER);
     expect(isWindowsSchtasksCreateAccessDenied(message)).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Closes #4442, reported by @SeanChengN. On Windows the history manifest integrity check treated `C:\...` and `\\?\C:\...` as different paths, so intact sessions failed the check ("backup manifest or restore target failed integrity checks") and resume/routing stayed fail-closed until `syncResumeHistory=false` bypassed it.
- `codexHistoryPathIdentity` now strips the Win32 extended-length prefix (drive form `\\?\C:\...` and UNC form `\\?\UNC\server\share\...`) before resolving, so database and rollout path comparisons converge on both spellings. The comparison leaf stays shared by database identity and rollout identity.
- Filename compatibility: a prefixed state-database path hashed to a *different* manifest name before this change. Readers (`history-provider.ts` mutation paths, `native-residue.ts` read-only observation) now fall back to the pre-fix manifest name when no canonical file exists, so an existing backup keeps shadowing its database. When both names exist, the canonical manifest wins and the legacy file is left in place — never silently replaced. Plain (non-prefixed) paths produce identical ids before and after, so nothing changes for the common case.
- Out of scope by design: the 2 entries in the report whose rollouts moved from `sessions` to `archived_sessions`. That is a real path change, not a spelling alias, and how archived rollouts remap is a separate product decision (kept as follow-up on the issue).
- This PR is the lane tip of lane I1 in the contributor-carry train (devlog/_plan/260913_contributor_carry_train). It is stacked on #4483 (the #4425 fix); its head commit carries no [skip ci], and its hosted runs gate the whole lane.

## Verification

- `bun test tests/codex-integration/codex-history-provider.test.ts` — 92 pass, including new #4442 tests that fake win32 and pin the path shapes directly: prefix-pair equality (drive + UNC), case-insensitivity across the prefix boundary, genuinely different files still failing, archived_sessions moves still failing, one backup id for both spellings, and legacy-name discovery/conflict handling.
- `bun test tests/codex-integration/codex-native-residue.test.ts tests/codex-integration/codex-history-worker.test.ts tests/codex-integration/codex-transition-state.test.ts tests/codex-integration/codex-history-reachability.test.ts tests/codex-integration/codex-integration-record.test.ts tests/codex-integration/codex-sqlite-home.test.ts` — 136 pass.
- `bun test tests/codex-integration/codex-inject-integration.test.ts` — 75 pass.
- `bun run typecheck` and `bun run structure:check` — clean; `structure/config.md` updated for the owned history-manifest contract.
- Full suite intentionally not run locally; the hosted run on this tip is the suite proof for the lane. platform-windows is gated on `workflow_dispatch` and never runs on a pull_request event, so Windows evidence comes from an explicit `ci.yml` dispatch with `lane=all` on this tip SHA (run id recorded in the lane report).

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.

