### PR TITLE
fix(live): disarm sideband connect watchdog on the pre-opened path

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -790,6 +790,13 @@ export function attachLiveSidebandUpstream(
       return;
     }
     ws.data.liveOpened = true;
+    // The upstream opened before this socket existed, so the "open" listener
+    // below can never fire for it. Disarm the connect watchdog exactly as that
+    // listener would, or every session with a max lifetime is force-closed ten
+    // seconds after attach. The session timer stays armed: it bounds the whole
+    // session, not the connect phase.
+    if (ws.data.liveConnectTimer !== undefined) clearTimeout(ws.data.liveConnectTimer);
+    ws.data.liveConnectTimer = undefined;
     for (const frame of takeover.frames) {
       try {
         // Mirror the live message listener exactly: same ceiling, same diagnostic

--- a/tests/server/server-live.test.ts
+++ b/tests/server/server-live.test.ts
@@ -1876,6 +1876,27 @@ describe("attachLiveSidebandUpstream ownership", () => {
     expect(upstream.readyState).toBe(WebSocket.CLOSED);
     expect(client.releases()).toBe(1);
   });
+
+  test("disarms the connect watchdog when the upstream was pre-opened", () => {
+    const upstream = new FakeUpstreamSocket();
+    upstream.readyState = WebSocket.OPEN;
+    const client = fakeSidebandClient(upstream, {
+      failure: () => undefined,
+      take: () => ({ ok: true, frames: ["session.created"] }),
+    });
+    client.ws.data.liveMaxSessionMs = 60_000;
+
+    attachLiveSidebandUpstream(client.ws as never);
+
+    // The pre-opened upstream's "open" event fired before attach, so the
+    // listener that would clear the connect timer can never run. The timer
+    // must be disarmed on the takeover path instead; the session timer stays
+    // armed because it bounds the whole session.
+    expect(client.ws.data.liveConnectTimer).toBeUndefined();
+    expect(client.ws.data.liveSessionTimer).toBeDefined();
+    upstream.emit("close", { code: 1000 });
+    expect(client.releases()).toBe(1);
+  });
 });
 
 describe("openLiveSidebandUpstream", () => {


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by 321b9b1cd1 (pre-opened live sideband upstream): attachLiveSidebandUpstream arms the 10s liveConnectTimer whenever liveMaxSessionMs is set, but the only non-teardown clear site is the upstream "open" listener, which can never fire for a socket that was already OPEN at attach time.
- Net effect on current dev: every dictation (DICTATION_SESSION_MAX_MS) and live-call (LIVE_CALL_TTL_MS) audio session is force-closed with "audio connection timed out" exactly 10 seconds after attach.
- Fix: on the successful pre-opened takeover path, disarm the connect watchdog exactly as the open listener does. The session timer (whole-session bound) stays armed.
- Found by the 2.53.0 release regression audit (parallel commit audit of origin/main..origin/dev). Release blocker for 2.53.0; 2.52.0 is unaffected (pre-open flow is not on main).

## Verification

- Local suite/build/typecheck: NOT RUN (maintainer rule for this task; hosted exact-head CI is the gate).
- Root cause verified against HEAD source: src/server/index.ts:744 (arm), :813 (only non-teardown clear, unreachable for pre-opened sockets), :429/:519 (teardown-only clears).
- Regression test added: tests/server/server-live.test.ts "disarms the connect watchdog when the upstream was pre-opened" — asserts the connect timer is cleared on the takeover path while the session timer stays armed. No new test file, so no layout.json change.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed live sessions being closed prematurely when the upstream connection was already open before attachment.
  - Ensured the connection watchdog is cleared correctly while the overall session lifetime limit remains active.

- **Tests**
  - Added coverage for pre-opened upstream connections and timer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->