### PR TITLE
fix(chat): accept Pi and Anthropic-shaped image parts on the chat wire

### DIFF
--- a/src/chat/inbound.ts
+++ b/src/chat/inbound.ts
@@ -46,10 +46,35 @@ function contentToText(content: unknown): string {
 }
 
 function imageUrlFromPart(part: Rec): string | null {
-  if (part.type !== "image_url") return null;
-  const imageUrl = part.image_url;
-  if (typeof imageUrl === "string" && imageUrl.length > 0) return imageUrl;
-  if (isRec(imageUrl) && typeof imageUrl.url === "string" && imageUrl.url.length > 0) return imageUrl.url;
+  if (part.type === "image_url") {
+    const imageUrl = part.image_url;
+    if (typeof imageUrl === "string" && imageUrl.length > 0) return imageUrl;
+    if (isRec(imageUrl) && typeof imageUrl.url === "string" && imageUrl.url.length > 0) return imageUrl.url;
+    return null;
+  }
+  // Agent clients whose native wire shape is not OpenAI's still send images over
+  // Chat Completions: Pi/MCP-style parts carry {type:"image", data, mimeType}
+  // (Aside read_file tool results), Anthropic-shaped clients carry a source
+  // object. Dropping either silently blinds a vision model, so normalize both
+  // to the URL/data-URI form the Responses pipeline already understands.
+  if (part.type === "image") {
+    const data = part.data;
+    if (typeof data === "string" && data.length > 0) {
+      if (data.startsWith("data:")) return data;
+      const media = typeof part.mimeType === "string" && part.mimeType.length > 0 ? part.mimeType
+        : typeof part.mediaType === "string" && part.mediaType.length > 0 ? part.mediaType
+        : "image/png";
+      return "data:" + media + ";base64," + data;
+    }
+    const source = part.source;
+    if (isRec(source)) {
+      if (source.type === "base64" && typeof source.data === "string" && source.data.length > 0) {
+        const media = typeof source.media_type === "string" && source.media_type.length > 0 ? source.media_type : "image/png";
+        return "data:" + media + ";base64," + source.data;
+      }
+      if (source.type === "url" && typeof source.url === "string" && source.url.length > 0) return source.url;
+    }
+  }
   return null;
 }
 

--- a/tests/responses/chat-completions-endpoint.test.ts
+++ b/tests/responses/chat-completions-endpoint.test.ts
@@ -242,6 +242,11 @@ describe("chatCompletionsToResponsesBody image parts", () => {
     { part: { type: "image_url", image_url: "https://example.com/image.png" }, expected: { type: "input_image", image_url: "https://example.com/image.png" } },
     { part: { type: "image_url", image_url: "https://example.com/image.png", detail: "low" }, expected: { type: "input_image", image_url: "https://example.com/image.png", detail: "low" } },
     { part: { type: "image_url", image_url: { url: "https://example.com/image.png" } }, expected: { type: "input_image", image_url: "https://example.com/image.png" } },
+    { part: { type: "image", data: "aGVsbG8=", mimeType: "image/png" }, expected: { type: "input_image", image_url: "data:image/png;base64,aGVsbG8=" } },
+    { part: { type: "image", data: "aGVsbG8=", mediaType: "image/jpeg" }, expected: { type: "input_image", image_url: "data:image/jpeg;base64,aGVsbG8=" } },
+    { part: { type: "image", data: "data:image/webp;base64,aGVsbG8=", mimeType: "image/png" }, expected: { type: "input_image", image_url: "data:image/webp;base64,aGVsbG8=" } },
+    { part: { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "aGVsbG8=" } }, expected: { type: "input_image", image_url: "data:image/jpeg;base64,aGVsbG8=" } },
+    { part: { type: "image", source: { type: "url", url: "https://example.com/claude.png" } }, expected: { type: "input_image", image_url: "https://example.com/claude.png" } },
   ])("preserves user image shorthand and omitted detail: %j", ({ part, expected }) => {
     const body = chatCompletionsToResponsesBody({ model: "mock/test-model", messages: [{ role: "user", content: [part] }] });
     expect(body.input).toEqual([{ type: "message", role: "user", content: [expected] }]);


### PR DESCRIPTION
## Summary

- Aside (Pi agent core, openai-completions API) returns read_file screenshots as tool-result parts shaped {type:"image", data, mimeType}. The chat inbound translator (src/chat/inbound.ts) only recognized image_url parts and silently dropped these, so vision models answered that the image data never arrived.
- Live-reproduced against the running proxy (2.53.0 dev dogfood): claude-opus-5 with a Pi-style tool image reports the image missing; the identical request in image_url form is described correctly. Anthropic-messages, chat user-message, and Responses inbound image paths were probed and are unaffected.
- Fix: normalize Pi/MCP-style {type:"image", data, mimeType} and Anthropic source-object ({type:"base64", media_type, data} / {type:"url", url}) parts to the data-URI form the Responses pipeline already handles. This restores screenshot reading for every Pi-adapter client, any model.
- Regression tests added to the chatCompletionsToResponsesBody image-parts table (5 new cases: Pi base64+mimeType, mediaType alias, pre-formed data URI, Anthropic base64 source, Anthropic URL source).

## Verification

- Local suite/build/typecheck: NOT RUN (maintainer rule for this task; hosted exact-head CI is the gate).
- Live probes against the running proxy (user's own instance, tiny 200px screenshot): bug reproduced pre-fix (model: "the image data didn't come through"); standard shapes confirmed working pre-existing.
- Translator-level regression cases added under tests/responses/chat-completions-endpoint.test.ts.

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Docs or release notes were updated when needed.
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
